### PR TITLE
feat: allow install dir as a param

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 export enum Integration {
   nextjs = 'nextjs',
 }
@@ -32,10 +30,6 @@ export interface Args {
 
 export const DEFAULT_URL = 'http://us.posthog.com';
 export const ISSUES_URL = 'https://github.com/posthog/wizard/issues';
-export const INSTALL_DIR = path.join(
-  process.cwd(),
-  process.env.POSTHOG_WIZARD_INSTALL_DIR ?? '',
-);
 export const CLOUD_URL = 'https://us.posthog.com';
 export const DEFAULT_HOST_URL = 'https://us.i.posthog.com';
 export const DUMMY_PROJECT_API_KEY = '_YOUR_POSTHOG_PROJECT_API_KEY_';

--- a/src/nextjs/docs.ts
+++ b/src/nextjs/docs.ts
@@ -1,15 +1,15 @@
-import { getAssetHostFromHost } from './utils';
+import { getAssetHostFromHost, getUiHostFromHost } from "./utils";
 
 export const getNextjsAppRouterDocs = ({
   host,
   language,
 }: {
   host: string;
-  language: 'typescript' | 'javascript';
+  language: "typescript" | "javascript";
 }) => {
   return `
 ==============================
-FILE: app/components/PostHogProvider.${language === 'typescript' ? 'tsx' : 'jsx'
+FILE: app/components/PostHogProvider.${language === "typescript" ? "tsx" : "jsx"
     }
 ==============================
 Changes:
@@ -17,18 +17,18 @@ Changes:
 
 Example:
 --------------------------------------------------
-'use client'
+"use client"
 
-import posthog from 'posthog-js'
-import { PostHogProvider as PHProvider, usePostHog } from 'posthog-js/react'
-import { Suspense, useEffect } from 'react'
+import posthog from "posthog-js"
+import { PostHogProvider as PHProvider, usePostHog } from "posthog-js/react"
+import { Suspense, useEffect } from "react"
 import { usePathname, useSearchParams } from "next/navigation"
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
       api_host: "/ingest",
-      ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+      ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "${getUiHostFromHost(host)}",
       capture_pageview: false, // We capture pageviews manually
       capture_pageleave: true, // Enable pageleave capture
     })
@@ -55,7 +55,7 @@ function PostHogPageView() {
       if (search) {
         url += "?" + search
       }
-      posthog.capture('$pageview', { '$current_url': url })
+      posthog.capture("$pageview", { "$current_url": url })
     }
   }, [pathname, searchParams, posthog])
 
@@ -72,7 +72,7 @@ function SuspendedPostHogPageView() {
 --------------------------------------------------
 
 ==============================
-FILE: app/layout.${language === 'typescript' ? 'tsx' : 'jsx'}
+FILE: app/layout.${language === "typescript" ? "tsx" : "jsx"}
 ==============================
 Changes:
 - Import the PostHogProvider from the providers file and wrap the app in it.
@@ -80,7 +80,7 @@ Changes:
 Example:
 --------------------------------------------------
 // other imports
-import { PostHogProvider } from './components/providers'
+import { PostHogProvider } from "./components/providers"
 
 export default function RootLayout({ children }) {
   return (
@@ -98,14 +98,14 @@ export default function RootLayout({ children }) {
 --------------------------------------------------
 
 ==============================
-FILE: app/lib/server/posthog.${language === 'typescript' ? 'ts' : 'js'}
+FILE: app/lib/server/posthog.${language === "typescript" ? "ts" : "js"}
 ==============================
 Changes:
 - Initialize the PostHog Node.js client
 
 Example:
 --------------------------------------------------
-import { PostHog } from 'posthog-node'
+import { PostHog } from "posthog-node"
 
 export default function PostHogClient() {
   const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
@@ -156,11 +156,11 @@ export const getNextjsPagesRouterDocs = ({
   language,
 }: {
   host: string;
-  language: 'typescript' | 'javascript';
+  language: "typescript" | "javascript";
 }) => {
   return `
 ==============================
-FILE: pages/_app.${language === 'typescript' ? 'tsx' : 'jsx'}
+FILE: pages/_app.${language === "typescript" ? "tsx" : "jsx"}
 ==============================
 Changes:
 - Initialize PostHog in _app.js.
@@ -169,25 +169,26 @@ Changes:
 
 Example:
 --------------------------------------------------
-import { useEffect } from 'react'
-import { Router } from 'next/router'
-import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
+import { useEffect } from "react"
+import { Router } from "next/router"
+import posthog from "posthog-js"
+import { PostHogProvider } from "posthog-js/react"
 
 export default function App({ Component, pageProps }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+      api_host: "/ingest",
+      ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "${getUiHostFromHost(host)}",
       loaded: (posthog) => {
-        if (process.env.NODE_ENV === 'development') posthog.debug()
+        if (process.env.NODE_ENV === "development") posthog.debug()
       },
     })
 
-    const handleRouteChange = () => posthog?.capture('$pageview')
-    Router.events.on('routeChangeComplete', handleRouteChange)
+    const handleRouteChange = () => posthog?.capture("$pageview")
+    Router.events.on("routeChangeComplete", handleRouteChange)
 
     return () => {
-      Router.events.off('routeChangeComplete', handleRouteChange)
+      Router.events.off("routeChangeComplete", handleRouteChange)
     }
   }, [])
 
@@ -200,18 +201,18 @@ export default function App({ Component, pageProps }) {
 --------------------------------------------------
 
 ==============================
-FILE: lib/server/posthog.${language === 'typescript' ? 'ts' : 'js'}
+FILE: lib/server/posthog.${language === "typescript" ? "ts" : "js"}
 ==============================
 Changes:
 - Initialize the PostHog Node.js client for server-side tracking.
 
 Example:
 --------------------------------------------------
-import { PostHog } from 'posthog-node'
+import { PostHog } from "posthog-node"
 
 export default function PostHogClient() {
   return new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "${host},
     flushAt: 1,
     flushInterval: 0,
   })

--- a/src/nextjs/docs.ts
+++ b/src/nextjs/docs.ts
@@ -1,16 +1,18 @@
-import { getAssetHostFromHost, getUiHostFromHost } from "./utils";
+import { getAssetHostFromHost, getUiHostFromHost } from './utils';
 
 export const getNextjsAppRouterDocs = ({
   host,
   language,
 }: {
   host: string;
-  language: "typescript" | "javascript";
+  language: 'typescript' | 'javascript';
 }) => {
   return `
 ==============================
-FILE: app/components/PostHogProvider.${language === "typescript" ? "tsx" : "jsx"
-    }
+FILE: PostHogProvider.${
+    language === 'typescript' ? 'tsx' : 'jsx'
+  } (put it somewhere where client files are, like the components folder)
+LOCATION: Wherever other providers are, or the components folder
 ==============================
 Changes:
 - Create a PostHogProvider component that will be imported into the layout file.
@@ -28,7 +30,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
       api_host: "/ingest",
-      ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "${getUiHostFromHost(host)}",
+      ui_host: "${getUiHostFromHost(host)}",
       capture_pageview: false, // We capture pageviews manually
       capture_pageleave: true, // Enable pageleave capture
     })
@@ -72,7 +74,8 @@ function SuspendedPostHogPageView() {
 --------------------------------------------------
 
 ==============================
-FILE: app/layout.${language === "typescript" ? "tsx" : "jsx"}
+FILE: layout.${language === 'typescript' ? 'tsx' : 'jsx'}
+LOCATION: Wherever the root layout is
 ==============================
 Changes:
 - Import the PostHogProvider from the providers file and wrap the app in it.
@@ -80,7 +83,7 @@ Changes:
 Example:
 --------------------------------------------------
 // other imports
-import { PostHogProvider } from "./components/providers"
+import { PostHogProvider } from "LOCATION_OF_POSTHOG_PROVIDER"
 
 export default function RootLayout({ children }) {
   return (
@@ -98,7 +101,8 @@ export default function RootLayout({ children }) {
 --------------------------------------------------
 
 ==============================
-FILE: app/lib/server/posthog.${language === "typescript" ? "ts" : "js"}
+FILE: posthog.${language === 'typescript' ? 'ts' : 'js'}
+LOCATION: Wherever works best given the project structure
 ==============================
 Changes:
 - Initialize the PostHog Node.js client
@@ -109,7 +113,7 @@ import { PostHog } from "posthog-node"
 
 export default function PostHogClient() {
   const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    host: "${host}",
     flushAt: 1,
     flushInterval: 0,
   })
@@ -119,6 +123,7 @@ export default function PostHogClient() {
 
 ==============================
 FILE: next.config.{js,ts,mjs,cjs}
+LOCATION: Wherever the root next config is
 ==============================
 Changes:
 - Add rewrites to the Next.js config to support PostHog, if there are existing rewrites, add the PostHog rewrites to them.
@@ -156,11 +161,14 @@ export const getNextjsPagesRouterDocs = ({
   language,
 }: {
   host: string;
-  language: "typescript" | "javascript";
+  language: 'typescript' | 'javascript';
 }) => {
   return `
 ==============================
-FILE: pages/_app.${language === "typescript" ? "tsx" : "jsx"}
+FILE: _app.${language === 'typescript' ? 'tsx' : 'jsx'}
+LOCATION: Wherever the root _app.${
+    language === 'typescript' ? 'tsx' : 'jsx'
+  } file is
 ==============================
 Changes:
 - Initialize PostHog in _app.js.
@@ -178,7 +186,7 @@ export default function App({ Component, pageProps }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
       api_host: "/ingest",
-      ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "${getUiHostFromHost(host)}",
+      ui_host: "${getUiHostFromHost(host)}",
       loaded: (posthog) => {
         if (process.env.NODE_ENV === "development") posthog.debug()
       },
@@ -201,7 +209,8 @@ export default function App({ Component, pageProps }) {
 --------------------------------------------------
 
 ==============================
-FILE: lib/server/posthog.${language === "typescript" ? "ts" : "js"}
+FILE: posthog.${language === 'typescript' ? 'ts' : 'js'}
+LOCATION: Wherever works best given the project structure
 ==============================
 Changes:
 - Initialize the PostHog Node.js client for server-side tracking.
@@ -212,7 +221,7 @@ import { PostHog } from "posthog-node"
 
 export default function PostHogClient() {
   return new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "${host},
+    host: "${host}",
     flushAt: 1,
     flushInterval: 0,
   })
@@ -221,6 +230,7 @@ export default function PostHogClient() {
 
 ==============================
 FILE: next.config.{js,ts,mjs,cjs}
+LOCATION: Wherever the root next config is
 ==============================
 Changes:
 - Add rewrites to support PostHog tracking.
@@ -232,8 +242,8 @@ const nextConfig = {
   async rewrites() {
     return [
       { source: "/ingest/static/:path*", destination: "${getAssetHostFromHost(
-    host,
-  )}/static/:path*" },
+        host,
+      )}/static/:path*" },
       { source: "/ingest/:path*", destination: "${host}/:path*" },
       { source: "/ingest/decide", destination: "${host}/decide" },
     ]

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -382,10 +382,20 @@ export async function addOrUpdateEnvironmentVariables({
       );
     } else {
       try {
-        const newContent = dotEnvFileContent.replace(
-          /^NEXT_PUBLIC_POSTHOG_KEY=.*$/m,
-          `NEXT_PUBLIC_POSTHOG_KEY=${projectApiKey}`,
-        );
+        let newContent = dotEnvFileContent;
+
+        if (dotEnvFileContent.match(/^NEXT_PUBLIC_POSTHOG_KEY=.*$/m)) {
+          newContent = dotEnvFileContent.replace(
+            /^NEXT_PUBLIC_POSTHOG_KEY=.*$/m,
+            `NEXT_PUBLIC_POSTHOG_KEY=${projectApiKey}`,
+          );
+        } else {
+          if (!dotEnvFileContent.endsWith('\n')) {
+            newContent += '\n';
+          }
+          newContent += envVarContent;
+        }
+
         await fs.promises.writeFile(targetEnvFilePath, newContent, {
           encoding: 'utf8',
           flag: 'w',

--- a/src/nextjs/utils.ts
+++ b/src/nextjs/utils.ts
@@ -34,23 +34,37 @@ export const IGNORE_PATTERNS = [
   '**/dist/**',
   '**/build/**',
   '**/public/**',
-]
-export async function getNextJsRouter({ installDir }: Pick<WizardOptions, 'installDir'>): Promise<NextJsRouter> {
-  const pagesMatches = await fg('**/pages/_app.@(ts|tsx|js|jsx)', { dot: true, cwd: installDir ?? process.cwd(), ignore: IGNORE_PATTERNS });
+];
+export async function getNextJsRouter({
+  installDir,
+}: Pick<WizardOptions, 'installDir'>): Promise<NextJsRouter> {
+  const pagesMatches = await fg('**/pages/_app.@(ts|tsx|js|jsx)', {
+    dot: true,
+    cwd: installDir,
+    ignore: IGNORE_PATTERNS,
+  });
 
   const hasPagesDir = pagesMatches.length > 0;
 
-  const appMatches = await fg('**/app/**/layout.@(ts|tsx|js|jsx)', { dot: true, cwd: installDir ?? process.cwd(), ignore: IGNORE_PATTERNS });
+  const appMatches = await fg('**/app/**/layout.@(ts|tsx|js|jsx)', {
+    dot: true,
+    cwd: installDir,
+    ignore: IGNORE_PATTERNS,
+  });
 
   const hasAppDir = appMatches.length > 0;
 
   if (hasPagesDir && !hasAppDir) {
-    clack.log.info(`Detected ${getNextJsRouterName(NextJsRouter.PAGES_ROUTER)} 📃`);
+    clack.log.info(
+      `Detected ${getNextJsRouterName(NextJsRouter.PAGES_ROUTER)} 📃`,
+    );
     return NextJsRouter.PAGES_ROUTER;
   }
 
   if (hasAppDir && !hasPagesDir) {
-    clack.log.info(`Detected ${getNextJsRouterName(NextJsRouter.APP_ROUTER)} 📱`);
+    clack.log.info(
+      `Detected ${getNextJsRouterName(NextJsRouter.APP_ROUTER)} 📱`,
+    );
     return NextJsRouter.APP_ROUTER;
   }
 
@@ -58,10 +72,16 @@ export async function getNextJsRouter({ installDir }: Pick<WizardOptions, 'insta
     clack.select({
       message: 'What router are you using?',
       options: [
-        { label: getNextJsRouterName(NextJsRouter.APP_ROUTER), value: NextJsRouter.APP_ROUTER },
-        { label: getNextJsRouterName(NextJsRouter.PAGES_ROUTER), value: NextJsRouter.PAGES_ROUTER },
+        {
+          label: getNextJsRouterName(NextJsRouter.APP_ROUTER),
+          value: NextJsRouter.APP_ROUTER,
+        },
+        {
+          label: getNextJsRouterName(NextJsRouter.PAGES_ROUTER),
+          value: NextJsRouter.PAGES_ROUTER,
+        },
       ],
-    })
+    }),
   );
 
   return result;
@@ -69,7 +89,7 @@ export async function getNextJsRouter({ installDir }: Pick<WizardOptions, 'insta
 
 export const getNextJsRouterName = (router: NextJsRouter) => {
   return router === NextJsRouter.APP_ROUTER ? 'app router' : 'pages router';
-}
+};
 
 export const getAssetHostFromHost = (host: string) => {
   if (host.includes('us.i.posthog.com')) {
@@ -81,7 +101,7 @@ export const getAssetHostFromHost = (host: string) => {
   }
 
   return host;
-}
+};
 
 export const getUiHostFromHost = (host: string) => {
   if (host.includes('us.i.posthog.com')) {
@@ -93,4 +113,4 @@ export const getUiHostFromHost = (host: string) => {
   }
 
   return host;
-}
+};

--- a/src/nextjs/utils.ts
+++ b/src/nextjs/utils.ts
@@ -2,7 +2,7 @@ import { major, minVersion } from 'semver';
 import fg from 'fast-glob';
 import { abortIfCancelled } from '../utils/clack-utils';
 import clack from '../utils/clack';
-import { INSTALL_DIR } from '../lib/constants';
+import type { WizardOptions } from '../utils/types';
 
 export function getNextJsVersionBucket(version: string | undefined) {
   if (!version) {
@@ -35,12 +35,12 @@ export const IGNORE_PATTERNS = [
   '**/build/**',
   '**/public/**',
 ]
-export async function getNextJsRouter(): Promise<NextJsRouter> {
-  const pagesMatches = await fg('**/pages/_app.@(ts|tsx|js|jsx)', { dot: true, cwd: INSTALL_DIR, ignore: IGNORE_PATTERNS });
+export async function getNextJsRouter({ installDir }: Pick<WizardOptions, 'installDir'>): Promise<NextJsRouter> {
+  const pagesMatches = await fg('**/pages/_app.@(ts|tsx|js|jsx)', { dot: true, cwd: installDir ?? process.cwd(), ignore: IGNORE_PATTERNS });
 
   const hasPagesDir = pagesMatches.length > 0;
 
-  const appMatches = await fg('**/app/**/layout.@(ts|tsx|js|jsx)', { dot: true, cwd: INSTALL_DIR, ignore: IGNORE_PATTERNS });
+  const appMatches = await fg('**/app/**/layout.@(ts|tsx|js|jsx)', { dot: true, cwd: installDir ?? process.cwd(), ignore: IGNORE_PATTERNS });
 
   const hasAppDir = appMatches.length > 0;
 
@@ -78,6 +78,18 @@ export const getAssetHostFromHost = (host: string) => {
 
   if (host.includes('eu.i.posthog.com')) {
     return 'https://eu-assets.i.posthog.com';
+  }
+
+  return host;
+}
+
+export const getUiHostFromHost = (host: string) => {
+  if (host.includes('us.i.posthog.com')) {
+    return 'https://us.posthog.com';
+  }
+
+  if (host.includes('eu.i.posthog.com')) {
+    return 'https://eu.posthog.com';
   }
 
   return host;

--- a/src/run.ts
+++ b/src/run.ts
@@ -11,6 +11,7 @@ type Args = {
   integration?: Integration;
   debug?: boolean;
   forceInstall?: boolean;
+  installDir?: string;
 };
 export async function run(argv: Args) {
   const finalArgs = {
@@ -21,13 +22,14 @@ export async function run(argv: Args) {
 
   clack.intro(`Welcome to the PostHog setup wizard ✨`);
 
-  const integration = finalArgs.integration ?? await getIntegrationForSetup();
+  const integration = finalArgs.integration ?? await getIntegrationForSetup({ installDir: finalArgs.installDir });
 
 
   const wizardOptions: WizardOptions = {
     debug: finalArgs.debug ?? false,
     forceInstall: finalArgs.forceInstall ?? false,
     telemetryEnabled: false,
+    installDir: finalArgs.installDir,
   };
 
   switch (integration) {
@@ -41,23 +43,23 @@ export async function run(argv: Args) {
 }
 
 
-async function detectIntegration(): Promise<Integration | undefined> {
+async function detectIntegration(options: Pick<WizardOptions, 'installDir'>): Promise<Integration | undefined> {
 
   const detectors = [
     detectNextJs
   ]
 
   for (const detector of detectors) {
-    const integration = await detector();
+    const integration = await detector(options);
     if (integration) {
       return integration;
     }
   }
 }
 
-async function getIntegrationForSetup() {
+async function getIntegrationForSetup(options: Pick<WizardOptions, 'installDir'>) {
 
-  const detectedIntegration = await detectIntegration();
+  const detectedIntegration = await detectIntegration(options);
 
   if (detectedIntegration) {
     clack.log.success(`Detected integration: ${getIntegrationDescription(detectedIntegration)}`);

--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -75,7 +75,6 @@ export function printWelcome(options: {
   message?: string;
   telemetryEnabled?: boolean;
 }): void {
-
   // eslint-disable-next-line no-console
   console.log('');
   clack.intro(chalk.inverse(` ${options.wizardName} `));
@@ -226,7 +225,7 @@ export async function confirmContinueIfPackageVersionNotSupported({
 
     clack.note(
       note ??
-      `Please upgrade to ${acceptableVersions} if you wish to use the PostHog Wizard.`,
+        `Please upgrade to ${acceptableVersions} if you wish to use the PostHog Wizard.`,
     );
     const continueWithUnsupportedVersion = await abortIfCancelled(
       clack.confirm({
@@ -268,7 +267,7 @@ export async function installPackage({
   packageManager?: PackageManager;
   /** Add force install flag to command to skip install precondition fails */
   forceInstall?: boolean;
-  installDir?: string;
+  installDir: string;
 }): Promise<{ packageManager?: PackageManager }> {
   return traceStep('install-package', async () => {
     if (alreadyInstalled && askBeforeUpdating) {
@@ -287,7 +286,8 @@ export async function installPackage({
 
     const sdkInstallSpinner = clack.spinner();
 
-    const pkgManager = packageManager || (await getPackageManager({ installDir }));
+    const pkgManager =
+      packageManager || (await getPackageManager({ installDir }));
 
     sdkInstallSpinner.start(
       `${alreadyInstalled ? 'Updating' : 'Installing'} ${chalk.bold.cyan(
@@ -298,9 +298,10 @@ export async function installPackage({
     try {
       await new Promise<void>((resolve, reject) => {
         childProcess.exec(
-          `${pkgManager.installCommand} ${packageName} ${pkgManager.flags} ${forceInstall ? pkgManager.forceInstallFlag : ''
+          `${pkgManager.installCommand} ${packageName} ${pkgManager.flags} ${
+            forceInstall ? pkgManager.forceInstallFlag : ''
           }`,
-          { cwd: installDir ?? process.cwd() },
+          { cwd: installDir },
           (err, stdout, stderr) => {
             if (err) {
               // Write a log file so we can better troubleshoot issues
@@ -346,7 +347,9 @@ export async function installPackage({
   });
 }
 
-export async function runPrettierIfInstalled({ installDir }: Pick<WizardOptions, 'installDir'>): Promise<void> {
+export async function runPrettierIfInstalled({
+  installDir,
+}: Pick<WizardOptions, 'installDir'>): Promise<void> {
   return traceStep('run-prettier', async () => {
     if (!isInGitRepo()) {
       // We only run formatting on changed files. If we're not in a git repo, we can't find
@@ -438,9 +441,11 @@ export async function ensurePackageIsInstalled(
   });
 }
 
-export async function getPackageDotJson({ installDir }: Pick<WizardOptions, 'installDir'>): Promise<PackageDotJson> {
+export async function getPackageDotJson({
+  installDir,
+}: Pick<WizardOptions, 'installDir'>): Promise<PackageDotJson> {
   const packageJsonFileContents = await fs.promises
-    .readFile(join(installDir ?? process.cwd(), 'package.json'), 'utf8')
+    .readFile(join(installDir, 'package.json'), 'utf8')
     .catch(() => {
       clack.log.error(
         'Could not find package.json. Make sure to run the wizard in the root of your app!',
@@ -468,11 +473,11 @@ export async function getPackageDotJson({ installDir }: Pick<WizardOptions, 'ins
 
 export async function updatePackageDotJson(
   packageDotJson: PackageDotJson,
-  { installDir }: Pick<WizardOptions, 'installDir'>
+  { installDir }: Pick<WizardOptions, 'installDir'>,
 ): Promise<void> {
   try {
     await fs.promises.writeFile(
-      join(installDir ?? process.cwd(), 'package.json'),
+      join(installDir, 'package.json'),
       // TODO: maybe figure out the original indentation
       JSON.stringify(packageDotJson, null, 2),
       {
@@ -487,7 +492,9 @@ export async function updatePackageDotJson(
   }
 }
 
-export async function getPackageManager({ installDir }: Pick<WizardOptions, 'installDir'>): Promise<PackageManager> {
+export async function getPackageManager({
+  installDir,
+}: Pick<WizardOptions, 'installDir'>): Promise<PackageManager> {
   const detectedPackageManager = detectPackageManger({ installDir });
 
   if (detectedPackageManager) {
@@ -510,9 +517,11 @@ export async function getPackageManager({ installDir }: Pick<WizardOptions, 'ins
   return selectedPackageManager;
 }
 
-export function isUsingTypeScript({ installDir }: Pick<WizardOptions, 'installDir'>) {
+export function isUsingTypeScript({
+  installDir,
+}: Pick<WizardOptions, 'installDir'>) {
   try {
-    return fs.existsSync(join(installDir ?? process.cwd(), 'tsconfig.json'));
+    return fs.existsSync(join(installDir, 'tsconfig.json'));
   } catch {
     return false;
   }
@@ -547,8 +556,8 @@ ${chalk.cyan(ISSUES_URL)}`);
 
     clack.log
       .info(`In the meantime, we'll add a dummy project API key (${chalk.cyan(
-        `"${DUMMY_PROJECT_API_KEY}"`,
-      )}) for you to replace later.
+      `"${DUMMY_PROJECT_API_KEY}"`,
+    )}) for you to replace later.
 You can find your Project API key here:
 ${chalk.cyan(`${CLOUD_URL}/settings/project#variables`)}`);
   }
@@ -718,7 +727,8 @@ export async function showCopyPasteInstructions(
   hint?: string,
 ): Promise<void> {
   clack.log.step(
-    `Add the following code to your ${chalk.cyan(basename(filename))} file:${hint ? chalk.dim(` (${chalk.dim(hint)})`) : ''
+    `Add the following code to your ${chalk.cyan(basename(filename))} file:${
+      hint ? chalk.dim(` (${chalk.dim(hint)})`) : ''
     }`,
   );
 
@@ -806,7 +816,7 @@ export async function createNewConfigFile(
     return false;
   }
 
-  const prettyFilename = chalk.cyan(relative(installDir ?? process.cwd(), filepath));
+  const prettyFilename = chalk.cyan(relative(installDir, filepath));
 
   try {
     await fs.promises.writeFile(filepath, codeSnippet);

--- a/src/utils/package-manager.ts
+++ b/src/utils/package-manager.ts
@@ -16,7 +16,11 @@ export interface PackageManager {
   flags: string;
   forceInstallFlag: string;
   detect: ({ installDir }: Pick<WizardOptions, 'installDir'>) => boolean;
-  addOverride: (pkgName: string, pkgVersion: string, { installDir }: Pick<WizardOptions, 'installDir'>) => Promise<void>;
+  addOverride: (
+    pkgName: string,
+    pkgVersion: string,
+    { installDir }: Pick<WizardOptions, 'installDir'>,
+  ) => Promise<void>;
 }
 
 export const BUN: PackageManager = {
@@ -29,19 +33,26 @@ export const BUN: PackageManager = {
   forceInstallFlag: '--force',
   detect: ({ installDir }: Pick<WizardOptions, 'installDir'>) =>
     ['bun.lockb', 'bun.lock'].some((lockFile) =>
-      fs.existsSync(path.join(installDir ?? process.cwd(), lockFile)),
+      fs.existsSync(path.join(installDir, lockFile)),
     ),
-  addOverride: async (pkgName, pkgVersion, { installDir }: Pick<WizardOptions, 'installDir'>): Promise<void> => {
-    const packageDotJson = await getPackageDotJson({ installDir: installDir ?? process.cwd() });
+  addOverride: async (
+    pkgName,
+    pkgVersion,
+    { installDir }: Pick<WizardOptions, 'installDir'>,
+  ): Promise<void> => {
+    const packageDotJson = await getPackageDotJson({ installDir });
     const overrides = packageDotJson.overrides || {};
 
-    await updatePackageDotJson({
-      ...packageDotJson,
-      overrides: {
-        ...overrides,
-        [pkgName]: pkgVersion,
+    await updatePackageDotJson(
+      {
+        ...packageDotJson,
+        overrides: {
+          ...overrides,
+          [pkgName]: pkgVersion,
+        },
       },
-    }, { installDir: installDir ?? process.cwd() });
+      { installDir: installDir },
+    );
   },
 };
 export const YARN_V1: PackageManager = {
@@ -55,24 +66,31 @@ export const YARN_V1: PackageManager = {
   detect: ({ installDir }: Pick<WizardOptions, 'installDir'>) => {
     try {
       return fs
-        .readFileSync(path.join(installDir ?? process.cwd(), 'yarn.lock'), 'utf-8')
+        .readFileSync(path.join(installDir, 'yarn.lock'), 'utf-8')
         .slice(0, 500)
         .includes('yarn lockfile v1');
     } catch (e) {
       return false;
     }
   },
-  addOverride: async (pkgName, pkgVersion, { installDir }: Pick<WizardOptions, 'installDir'>): Promise<void> => {
-    const packageDotJson = await getPackageDotJson({ installDir: installDir ?? process.cwd() });
+  addOverride: async (
+    pkgName,
+    pkgVersion,
+    { installDir }: Pick<WizardOptions, 'installDir'>,
+  ): Promise<void> => {
+    const packageDotJson = await getPackageDotJson({ installDir });
     const resolutions = packageDotJson.resolutions || {};
 
-    await updatePackageDotJson({
-      ...packageDotJson,
-      resolutions: {
-        ...resolutions,
-        [pkgName]: pkgVersion,
+    await updatePackageDotJson(
+      {
+        ...packageDotJson,
+        resolutions: {
+          ...resolutions,
+          [pkgName]: pkgVersion,
+        },
       },
-    }, { installDir: installDir ?? process.cwd() });
+      { installDir },
+    );
   },
 };
 /** YARN V2/3/4 */
@@ -87,24 +105,31 @@ export const YARN_V2: PackageManager = {
   detect: ({ installDir }: Pick<WizardOptions, 'installDir'>) => {
     try {
       return fs
-        .readFileSync(path.join(installDir ?? process.cwd(), 'yarn.lock'), 'utf-8')
+        .readFileSync(path.join(installDir, 'yarn.lock'), 'utf-8')
         .slice(0, 500)
         .includes('__metadata');
     } catch (e) {
       return false;
     }
   },
-  addOverride: async (pkgName, pkgVersion, { installDir }: Pick<WizardOptions, 'installDir'>): Promise<void> => {
-    const packageDotJson = await getPackageDotJson({ installDir: installDir ?? process.cwd() });
+  addOverride: async (
+    pkgName,
+    pkgVersion,
+    { installDir }: Pick<WizardOptions, 'installDir'>,
+  ): Promise<void> => {
+    const packageDotJson = await getPackageDotJson({ installDir });
     const resolutions = packageDotJson.resolutions || {};
 
-    await updatePackageDotJson({
-      ...packageDotJson,
-      resolutions: {
-        ...resolutions,
-        [pkgName]: pkgVersion,
+    await updatePackageDotJson(
+      {
+        ...packageDotJson,
+        resolutions: {
+          ...resolutions,
+          [pkgName]: pkgVersion,
+        },
       },
-    }, { installDir: installDir ?? process.cwd() });
+      { installDir },
+    );
   },
 };
 export const PNPM: PackageManager = {
@@ -116,22 +141,29 @@ export const PNPM: PackageManager = {
   flags: '--ignore-workspace-root-check',
   forceInstallFlag: '--force',
   detect: ({ installDir }: Pick<WizardOptions, 'installDir'>) =>
-    fs.existsSync(path.join(installDir ?? process.cwd(), 'pnpm-lock.yaml')),
-  addOverride: async (pkgName, pkgVersion, { installDir }: Pick<WizardOptions, 'installDir'>): Promise<void> => {
-    const packageDotJson = await getPackageDotJson({ installDir: installDir ?? process.cwd() });
+    fs.existsSync(path.join(installDir, 'pnpm-lock.yaml')),
+  addOverride: async (
+    pkgName,
+    pkgVersion,
+    { installDir }: Pick<WizardOptions, 'installDir'>,
+  ): Promise<void> => {
+    const packageDotJson = await getPackageDotJson({ installDir });
     const pnpm = packageDotJson.pnpm || {};
     const overrides = pnpm.overrides || {};
 
-    await updatePackageDotJson({
-      ...packageDotJson,
-      pnpm: {
-        ...pnpm,
-        overrides: {
-          ...overrides,
-          [pkgName]: pkgVersion,
+    await updatePackageDotJson(
+      {
+        ...packageDotJson,
+        pnpm: {
+          ...pnpm,
+          overrides: {
+            ...overrides,
+            [pkgName]: pkgVersion,
+          },
         },
       },
-    }, { installDir: installDir ?? process.cwd() });
+      { installDir },
+    );
   },
 };
 export const NPM: PackageManager = {
@@ -143,27 +175,36 @@ export const NPM: PackageManager = {
   flags: '',
   forceInstallFlag: '--force',
   detect: ({ installDir }: Pick<WizardOptions, 'installDir'>) =>
-    fs.existsSync(path.join(installDir ?? process.cwd(), 'package-lock.json')),
-  addOverride: async (pkgName, pkgVersion, { installDir }: Pick<WizardOptions, 'installDir'>): Promise<void> => {
-    const packageDotJson = await getPackageDotJson({ installDir: installDir ?? process.cwd() });
+    fs.existsSync(path.join(installDir, 'package-lock.json')),
+  addOverride: async (
+    pkgName,
+    pkgVersion,
+    { installDir }: Pick<WizardOptions, 'installDir'>,
+  ): Promise<void> => {
+    const packageDotJson = await getPackageDotJson({ installDir });
     const overrides = packageDotJson.overrides || {};
 
-    await updatePackageDotJson({
-      ...packageDotJson,
-      overrides: {
-        ...overrides,
-        [pkgName]: pkgVersion,
+    await updatePackageDotJson(
+      {
+        ...packageDotJson,
+        overrides: {
+          ...overrides,
+          [pkgName]: pkgVersion,
+        },
       },
-    }, { installDir: installDir ?? process.cwd() });
+      { installDir },
+    );
   },
 };
 
 export const packageManagers = [BUN, YARN_V1, YARN_V2, PNPM, NPM];
 
-export function detectPackageManger({ installDir }: Pick<WizardOptions, 'installDir'>): PackageManager | null {
+export function detectPackageManger({
+  installDir,
+}: Pick<WizardOptions, 'installDir'>): PackageManager | null {
   return traceStep('detect-package-manager', () => {
     for (const packageManager of packageManagers) {
-      if (packageManager.detect({ installDir: installDir ?? process.cwd() })) {
+      if (packageManager.detect({ installDir })) {
         Analytics.setTag('package-manager', packageManager.name);
         return packageManager;
       }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -29,7 +29,7 @@ export type WizardOptions = {
   /**
    * The directory to run the wizard in.
    */
-  installDir?: string;
+  installDir: string;
 };
 
 export interface Feature {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -25,6 +25,11 @@ export type WizardOptions = {
    * Does not apply to all wizard flows (currently NPM only)
    */
   forceInstall: boolean;
+
+  /**
+   * The directory to run the wizard in.
+   */
+  installDir?: string;
 };
 
 export interface Feature {

--- a/test/utils/clack-utils.test.ts
+++ b/test/utils/clack-utils.test.ts
@@ -92,7 +92,7 @@ describe('createNewConfigFile', () => {
     const filename = '/webpack.config.js';
     const code = 'module.exports = {/*config...*/}';
 
-    const result = await createNewConfigFile(filename, code);
+    const result = await createNewConfigFile(filename, code, {});
 
     expect(result).toBe(true);
     expect(writeFileSpy).toHaveBeenCalledWith(filename, code);
@@ -105,7 +105,7 @@ describe('createNewConfigFile', () => {
     const code = 'module.exports = {/*config...*/}';
     const moreInfo = 'More information...';
 
-    await createNewConfigFile(filename, code, moreInfo);
+    await createNewConfigFile(filename, code, {}, moreInfo);
 
     expect(clack.log.info).toHaveBeenCalledTimes(1);
     expect(clack.log.info).toHaveBeenCalledWith(
@@ -121,7 +121,7 @@ describe('createNewConfigFile', () => {
     const filename = '/webpack.config.js';
     const code = 'module.exports = {/*config...*/}';
 
-    const result = await createNewConfigFile(filename, code);
+    const result = await createNewConfigFile(filename, code, {});
 
     expect(result).toBe(false);
     expect(writeFileSpy).toHaveBeenCalledWith(filename, code);
@@ -132,6 +132,7 @@ describe('createNewConfigFile', () => {
     const result = await createNewConfigFile(
       './relative/webpack.config.js',
       '',
+      {},
     );
 
     expect(result).toBe(false);

--- a/test/utils/clack-utils.test.ts
+++ b/test/utils/clack-utils.test.ts
@@ -92,7 +92,9 @@ describe('createNewConfigFile', () => {
     const filename = '/webpack.config.js';
     const code = 'module.exports = {/*config...*/}';
 
-    const result = await createNewConfigFile(filename, code, {});
+    const result = await createNewConfigFile(filename, code, {
+      installDir: process.cwd(),
+    });
 
     expect(result).toBe(true);
     expect(writeFileSpy).toHaveBeenCalledWith(filename, code);
@@ -105,7 +107,14 @@ describe('createNewConfigFile', () => {
     const code = 'module.exports = {/*config...*/}';
     const moreInfo = 'More information...';
 
-    await createNewConfigFile(filename, code, {}, moreInfo);
+    await createNewConfigFile(
+      filename,
+      code,
+      {
+        installDir: process.cwd(),
+      },
+      moreInfo,
+    );
 
     expect(clack.log.info).toHaveBeenCalledTimes(1);
     expect(clack.log.info).toHaveBeenCalledWith(
@@ -121,7 +130,9 @@ describe('createNewConfigFile', () => {
     const filename = '/webpack.config.js';
     const code = 'module.exports = {/*config...*/}';
 
-    const result = await createNewConfigFile(filename, code, {});
+    const result = await createNewConfigFile(filename, code, {
+      installDir: process.cwd(),
+    });
 
     expect(result).toBe(false);
     expect(writeFileSpy).toHaveBeenCalledWith(filename, code);
@@ -132,7 +143,7 @@ describe('createNewConfigFile', () => {
     const result = await createNewConfigFile(
       './relative/webpack.config.js',
       '',
-      {},
+      { installDir: process.cwd() },
     );
 
     expect(result).toBe(false);
@@ -174,6 +185,7 @@ describe('installPackage', () => {
       forceInstall: true,
       askBeforeUpdating: false,
       packageManager: packageManagerMock,
+      installDir: process.cwd(),
     });
 
     expect(execSpy).toHaveBeenCalledWith(
@@ -214,6 +226,7 @@ describe('installPackage', () => {
         forceInstall: flag,
         askBeforeUpdating: false,
         packageManager: packageManagerMock,
+        installDir: process.cwd(),
       });
 
       expect(execSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
We use this locally when testing, so it's helpful to have it as a param rather than as an env var so you can switch between test apps.