### PR TITLE
chore: use env vars for api key and host in installation

### DIFF
--- a/src/nextjs/docs.ts
+++ b/src/nextjs/docs.ts
@@ -114,7 +114,7 @@ import { PostHog } from "posthog-node"
 
 export default function PostHogClient() {
   const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    host: "${host}",
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     flushAt: 1,
     flushInterval: 0,
   })
@@ -224,7 +224,7 @@ import { PostHog } from "posthog-node"
 
 export default function PostHogClient() {
   const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    host: "${host}",
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     flushAt: 1,
     flushInterval: 0,
   })

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -131,6 +131,7 @@ export async function runNextjsWizard(options: WizardOptions): Promise<void> {
   await addOrUpdateEnvironmentVariables({
     variables: {
       NEXT_PUBLIC_POSTHOG_KEY: projectApiKey,
+      NEXT_PUBLIC_POSTHOG_HOST: host,
     },
     installDir: options.installDir,
     integration: Integration.nextjs,
@@ -163,7 +164,7 @@ ${chalk.cyan('Changes made:')}
 • Created a PostHogClient to use PostHog server-side
 • Setup a reverse proxy to avoid ad blockers blocking analytics requests
 • Added your Project API key to your .env file
-${addedEditorRules ? `• Added cursor rules for PostHog` : ''}
+${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
   
 ${chalk.yellow('Next steps:')}
 • Call posthog.identify() when a user signs into your app

--- a/src/react/docs.ts
+++ b/src/react/docs.ts
@@ -1,9 +1,7 @@
 export const getReactDocumentation = ({
-  host,
   language,
   envVarPrefix,
 }: {
-  host: string;
   language: 'typescript' | 'javascript';
   envVarPrefix: string;
 }) => {
@@ -11,11 +9,16 @@ export const getReactDocumentation = ({
     envVarPrefix === 'VITE_PUBLIC_'
       ? 'import.meta.env.VITE_PUBLIC_POSTHOG_KEY'
       : `process.env.${envVarPrefix}POSTHOG_KEY`;
+
+  const hostText =
+    envVarPrefix === 'VITE_PUBLIC_'
+      ? 'import.meta.env.VITE_PUBLIC_POSTHOG_HOST'
+      : `process.env.${envVarPrefix}POSTHOG_HOST`;
+
   return `
 ==============================
-FILE: {index / App}.${
-    language === 'typescript' ? 'tsx' : 'jsx'
-  } (wherever the root of the app is)
+FILE: {index / App}.${language === 'typescript' ? 'tsx' : 'jsx'
+    } (wherever the root of the app is)
 LOCATION: Wherever the root of the app is
 ==============================
 Changes:
@@ -36,12 +39,11 @@ root.render(
     <PostHogProvider
       apiKey={${apiKeyText}}
       options={{
-        api_host: ${host},
-        debug: ${
-          envVarPrefix === 'VITE_PUBLIC_'
-            ? 'import.meta.env.MODE === "development"'
-            : 'process.env.NODE_ENV === "development"'
-        },
+        api_host: ${hostText},
+        debug: ${envVarPrefix === 'VITE_PUBLIC_'
+      ? 'import.meta.env.MODE === "development"'
+      : 'process.env.NODE_ENV === "development"'
+    },
       }}
     >
       <App />

--- a/src/react/docs.ts
+++ b/src/react/docs.ts
@@ -17,8 +17,9 @@ export const getReactDocumentation = ({
 
   return `
 ==============================
-FILE: {index / App}.${language === 'typescript' ? 'tsx' : 'jsx'
-    } (wherever the root of the app is)
+FILE: {index / App}.${
+    language === 'typescript' ? 'tsx' : 'jsx'
+  } (wherever the root of the app is)
 LOCATION: Wherever the root of the app is
 ==============================
 Changes:
@@ -40,10 +41,11 @@ root.render(
       apiKey={${apiKeyText}}
       options={{
         api_host: ${hostText},
-        debug: ${envVarPrefix === 'VITE_PUBLIC_'
-      ? 'import.meta.env.MODE === "development"'
-      : 'process.env.NODE_ENV === "development"'
-    },
+        debug: ${
+          envVarPrefix === 'VITE_PUBLIC_'
+            ? 'import.meta.env.MODE === "development"'
+            : 'process.env.NODE_ENV === "development"'
+        },
       }}
     >
       <App />

--- a/src/react/react-wizard.ts
+++ b/src/react/react-wizard.ts
@@ -90,7 +90,6 @@ export async function runReactWizard(options: WizardOptions): Promise<void> {
   const envVarPrefix = await detectEnvVarPrefix(options);
 
   const installationDocumentation = getReactDocumentation({
-    host,
     language: typeScriptDetected ? 'typescript' : 'javascript',
     envVarPrefix,
   });
@@ -117,6 +116,7 @@ export async function runReactWizard(options: WizardOptions): Promise<void> {
   await addOrUpdateEnvironmentVariables({
     variables: {
       [envVarPrefix + 'POSTHOG_KEY']: projectApiKey,
+      [envVarPrefix + 'POSTHOG_HOST']: host,
     },
     installDir: options.installDir,
     integration: Integration.react,
@@ -138,29 +138,28 @@ export async function runReactWizard(options: WizardOptions): Promise<void> {
   });
 
   clack.outro(`
-${chalk.green('Successfully installed PostHog!')} ${`\n\n${
-    aiConsent
+${chalk.green('Successfully installed PostHog!')} ${`\n\n${aiConsent
       ? `Note: This uses experimental AI to setup your project. It might have got it wrong, please check!\n`
       : ``
-  }
+    }
 ${chalk.cyan('Changes made:')}
 • Installed posthog-js package
-• Added PostHogProvider to the root of the app, to initialize PostHog
+• Added PostHogProvider to the root of the app, to initialize PostHog and enable autocapture
 • Added your Project API key to your .env file
-${addedEditorRules ? `• Added cursor rules for PostHog` : ''}
+${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
   
 ${chalk.yellow('Next steps:')}
 • Call posthog.identify() when a user signs into your app
 • Upload environment variables to your production environment
 
 You should validate your setup by (re)starting your dev environment (e.g. ${chalk.cyan(
-    `${packageManagerForOutro.runScriptCommand} dev`,
-  )})`}
+      `${packageManagerForOutro.runScriptCommand} dev`,
+    )})`}
 
     
 ${chalk.blue(
-  `Learn more about PostHog + React: https://posthog.com/docs/libraries/react`,
-)}
+      `Learn more about PostHog + React: https://posthog.com/docs/libraries/react`,
+    )}
 
 ${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`);
 

--- a/src/react/react-wizard.ts
+++ b/src/react/react-wizard.ts
@@ -138,10 +138,11 @@ export async function runReactWizard(options: WizardOptions): Promise<void> {
   });
 
   clack.outro(`
-${chalk.green('Successfully installed PostHog!')} ${`\n\n${aiConsent
+${chalk.green('Successfully installed PostHog!')} ${`\n\n${
+    aiConsent
       ? `Note: This uses experimental AI to setup your project. It might have got it wrong, please check!\n`
       : ``
-    }
+  }
 ${chalk.cyan('Changes made:')}
 • Installed posthog-js package
 • Added PostHogProvider to the root of the app, to initialize PostHog and enable autocapture
@@ -153,13 +154,13 @@ ${chalk.yellow('Next steps:')}
 • Upload environment variables to your production environment
 
 You should validate your setup by (re)starting your dev environment (e.g. ${chalk.cyan(
-      `${packageManagerForOutro.runScriptCommand} dev`,
-    )})`}
+    `${packageManagerForOutro.runScriptCommand} dev`,
+  )})`}
 
     
 ${chalk.blue(
-      `Learn more about PostHog + React: https://posthog.com/docs/libraries/react`,
-    )}
+  `Learn more about PostHog + React: https://posthog.com/docs/libraries/react`,
+)}
 
 ${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`);
 

--- a/src/svelte/svelte-wizard.ts
+++ b/src/svelte/svelte-wizard.ts
@@ -155,7 +155,7 @@ ${chalk.cyan('Changes made:')}
 • Setup event auto-capture to capture events as users interact with your app
 • Added a getPostHogClient() function to use PostHog server-side
 • Added your Project API key to your .env file
-${addedEditorRules ? `• Added cursor rules for PostHog` : ''}
+${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
   
 ${chalk.yellow('Next steps:')}
 • Call posthog.identify() when a user signs into your app


### PR DESCRIPTION
- We should always use env vars for the host as users prefer them