### PR TITLE
feat: add --signup flag for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
   <img alt="posthoglogo" src="https://user-images.githubusercontent.com/65415371/205059737-c8a4f836-4889-4654-902e-f302b187b6a0.png">
 </p>
 
-> **⚠️ Experimental:** This wizard is still in an experimental phase. 
-> If you have any feedback, please drop an email to **joshua** [at] **posthog** [dot] **com**.
+> **⚠️ Experimental:** This wizard is still in an experimental phase. If you
+> have any feedback, please drop an email to **joshua** [at] **posthog** [dot]
+> **com**.
 
 <h1>PostHog Wizard ✨</h1>
 <h4>The PostHog Wizard helps you quickly add PostHog to your project using AI.</h4>
@@ -16,7 +17,9 @@ To use the wizard, you can run it directly using:
 npx @posthog/wizard
 ```
 
-Currently the wizard can be used for React, NextJS, Svelte and React Native projects. If you have other integrations you would like the wizard to support, please open a [GitHub issue](https://github.com/posthog/wizard/issues)!
+Currently the wizard can be used for React, NextJS, Svelte and React Native
+projects. If you have other integrations you would like the wizard to support,
+please open a [GitHub issue](https://github.com/posthog/wizard/issues)!
 
 # Options
 
@@ -32,5 +35,8 @@ The following CLI arguments are available:
 | `--install-dir`   | Relative path to install in                                                | string  | `.`                             |                                             | `POSTHOG_WIZARD_INSTALL_DIR` |
 | `--region`        | PostHog region to use                                                      | choices |                                 | "us", "eu"                                  | `POSTHOG_WIZARD_REGION`      |
 | `--default`       | Select the default option for all questions automatically (where possible) | boolean | `false`                         |                                             | `POSTHOG_WIZARD_DEFAULT`     |
+| `--signup`        | Create a new PostHog account during setup                                  | boolean | `false`                         |                                             | `POSTHOG_WIZARD_SIGNUP`      |
 
-> Note: A large amount of the scaffolding for this came from the amazing Sentry wizard, which you can find [here](https://github.com/getsentry/sentry-wizard) 💖
+> Note: A large amount of the scaffolding for this came from the amazing Sentry
+> wizard, which you can find [here](https://github.com/getsentry/sentry-wizard)
+> 💖

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/wizard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "homepage": "https://github.com/posthog/wizard",
   "repository": "https://github.com/posthog/wizard",
   "description": "The PostHog wizard helps you to configure your project",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,6 +10,9 @@ type IntegrationConfig = {
   detect: (options: Pick<WizardOptions, 'installDir'>) => Promise<boolean>;
   generateFilesRules: string;
   filterFilesRules: string;
+  docsUrl: string;
+  changes: string;
+  nextSteps: string;
 };
 
 export const INTEGRATION_CONFIG = {
@@ -30,6 +33,9 @@ export const INTEGRATION_CONFIG = {
     },
     generateFilesRules: '',
     filterFilesRules: '',
+    docsUrl: 'https://posthog.com/docs/libraries/next-js',
+    changes: '• Installed posthog-js & posthog-node packages\n• Initialized PostHog, and added pageview tracking\n• Created a PostHogClient to use PostHog server - side\n• Setup a reverse proxy to avoid ad blockers blocking analytics requests\n• Added your Project API key to your.env file',
+    nextSteps: '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app\n• Upload environment variables to your production environment',
   },
   [Integration.react]: {
     name: 'React',
@@ -48,6 +54,9 @@ export const INTEGRATION_CONFIG = {
     },
     generateFilesRules: '',
     filterFilesRules: '',
+    docsUrl: 'https://posthog.com/docs/libraries/react',
+    changes: '• Installed posthog-js package\n• Added PostHogProvider to the root of the app, to initialize PostHog and enable autocapture\n• Added your Project API key to your.env file',
+    nextSteps: '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app\n• Upload environment variables to your production environment',
   },
   [Integration.svelte]: {
     name: 'Svelte',
@@ -59,6 +68,9 @@ export const INTEGRATION_CONFIG = {
     },
     generateFilesRules: '',
     filterFilesRules: '',
+    docsUrl: 'https://posthog.com/docs/libraries/svelte',
+    changes: '• Installed posthog-js & posthog-node packages\n• Added PostHog initialization to your Svelte app\n• Setup pageview & pageleave tracking\n• Setup event auto - capture to capture events as users interact with your app\n• Added a getPostHogClient() function to use PostHog server - side\n• Added your Project API key to your.env file',
+    nextSteps: '• Call posthog.identify() when a user signs into your app\n• Use getPostHogClient() to start capturing events server - side\n• Upload environment variables to your production environment',
   },
   [Integration.reactNative]: {
     name: 'React Native',
@@ -70,6 +82,9 @@ export const INTEGRATION_CONFIG = {
     },
     generateFilesRules: '',
     filterFilesRules: '',
+    docsUrl: 'https://posthog.com/docs/libraries/react-native',
+    changes: '• Installed required packages\n• Added PostHogProvider to the root of the app\n• Enabled autocapture and session replay',
+    nextSteps: '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app',
   },
 } as const satisfies Record<Integration, IntegrationConfig>;
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -35,7 +35,7 @@ export const INTEGRATION_CONFIG = {
     filterFilesRules: '',
     docsUrl: 'https://posthog.com/docs/libraries/next-js',
     changes:
-      '• Installed posthog-js & posthog-node packages\n• Initialized PostHog, and added pageview tracking\n• Created a PostHogClient to use PostHog server - side\n• Setup a reverse proxy to avoid ad blockers blocking analytics requests\n• Added your Project API key to your.env file',
+      '• Installed posthog-js & posthog-node packages\n• Initialized PostHog, and added pageview tracking\n• Created a PostHogClient to use PostHog server-side\n• Setup a reverse proxy to avoid ad blockers blocking analytics requests\n• Added your Project API key to your .env/.env.local file',
     nextSteps:
       '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app\n• Upload environment variables to your production environment',
   },
@@ -58,7 +58,7 @@ export const INTEGRATION_CONFIG = {
     filterFilesRules: '',
     docsUrl: 'https://posthog.com/docs/libraries/react',
     changes:
-      '• Installed posthog-js package\n• Added PostHogProvider to the root of the app, to initialize PostHog and enable autocapture\n• Added your Project API key to your.env file',
+      '• Installed posthog-js package\n• Added PostHogProvider to the root of the app, to initialize PostHog and enable autocapture\n• Added your Project API key to your .env/.env.local file',
     nextSteps:
       '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app\n• Upload environment variables to your production environment',
   },
@@ -74,7 +74,7 @@ export const INTEGRATION_CONFIG = {
     filterFilesRules: '',
     docsUrl: 'https://posthog.com/docs/libraries/svelte',
     changes:
-      '• Installed posthog-js & posthog-node packages\n• Added PostHog initialization to your Svelte app\n• Setup pageview & pageleave tracking\n• Setup event auto - capture to capture events as users interact with your app\n• Added a getPostHogClient() function to use PostHog server - side\n• Added your Project API key to your.env file',
+      '• Installed posthog-js & posthog-node packages\n• Added PostHog initialization to your Svelte app\n• Setup pageview & pageleave tracking\n• Setup event auto - capture to capture events as users interact with your app\n• Added a getPostHogClient() function to use PostHog server-side\n• Added your Project API key to your .env/.env.local file',
     nextSteps:
       '• Call posthog.identify() when a user signs into your app\n• Use getPostHogClient() to start capturing events server - side\n• Upload environment variables to your production environment',
   },

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -34,8 +34,10 @@ export const INTEGRATION_CONFIG = {
     generateFilesRules: '',
     filterFilesRules: '',
     docsUrl: 'https://posthog.com/docs/libraries/next-js',
-    changes: '• Installed posthog-js & posthog-node packages\n• Initialized PostHog, and added pageview tracking\n• Created a PostHogClient to use PostHog server - side\n• Setup a reverse proxy to avoid ad blockers blocking analytics requests\n• Added your Project API key to your.env file',
-    nextSteps: '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app\n• Upload environment variables to your production environment',
+    changes:
+      '• Installed posthog-js & posthog-node packages\n• Initialized PostHog, and added pageview tracking\n• Created a PostHogClient to use PostHog server - side\n• Setup a reverse proxy to avoid ad blockers blocking analytics requests\n• Added your Project API key to your.env file',
+    nextSteps:
+      '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app\n• Upload environment variables to your production environment',
   },
   [Integration.react]: {
     name: 'React',
@@ -55,8 +57,10 @@ export const INTEGRATION_CONFIG = {
     generateFilesRules: '',
     filterFilesRules: '',
     docsUrl: 'https://posthog.com/docs/libraries/react',
-    changes: '• Installed posthog-js package\n• Added PostHogProvider to the root of the app, to initialize PostHog and enable autocapture\n• Added your Project API key to your.env file',
-    nextSteps: '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app\n• Upload environment variables to your production environment',
+    changes:
+      '• Installed posthog-js package\n• Added PostHogProvider to the root of the app, to initialize PostHog and enable autocapture\n• Added your Project API key to your.env file',
+    nextSteps:
+      '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app\n• Upload environment variables to your production environment',
   },
   [Integration.svelte]: {
     name: 'Svelte',
@@ -69,8 +73,10 @@ export const INTEGRATION_CONFIG = {
     generateFilesRules: '',
     filterFilesRules: '',
     docsUrl: 'https://posthog.com/docs/libraries/svelte',
-    changes: '• Installed posthog-js & posthog-node packages\n• Added PostHog initialization to your Svelte app\n• Setup pageview & pageleave tracking\n• Setup event auto - capture to capture events as users interact with your app\n• Added a getPostHogClient() function to use PostHog server - side\n• Added your Project API key to your.env file',
-    nextSteps: '• Call posthog.identify() when a user signs into your app\n• Use getPostHogClient() to start capturing events server - side\n• Upload environment variables to your production environment',
+    changes:
+      '• Installed posthog-js & posthog-node packages\n• Added PostHog initialization to your Svelte app\n• Setup pageview & pageleave tracking\n• Setup event auto - capture to capture events as users interact with your app\n• Added a getPostHogClient() function to use PostHog server - side\n• Added your Project API key to your.env file',
+    nextSteps:
+      '• Call posthog.identify() when a user signs into your app\n• Use getPostHogClient() to start capturing events server - side\n• Upload environment variables to your production environment',
   },
   [Integration.reactNative]: {
     name: 'React Native',
@@ -83,8 +89,10 @@ export const INTEGRATION_CONFIG = {
     generateFilesRules: '',
     filterFilesRules: '',
     docsUrl: 'https://posthog.com/docs/libraries/react-native',
-    changes: '• Installed required packages\n• Added PostHogProvider to the root of the app\n• Enabled autocapture and session replay',
-    nextSteps: '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app',
+    changes:
+      '• Installed required packages\n• Added PostHogProvider to the root of the app\n• Enabled autocapture and session replay',
+    nextSteps:
+      '• Call posthog.identify() when a user signs into your app\n• Call posthog.capture() to capture custom events in your app',
   },
 } as const satisfies Record<Integration, IntegrationConfig>;
 

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,11 +1,23 @@
-import chalk from "chalk"
-import type { CloudRegion, WizardOptions } from "../utils/types";
-import { getCloudUrlFromRegion } from "../utils/urls";
-import type { PackageManager } from "../utils/package-manager";
-import { ISSUES_URL, Integration } from "./constants";
-import { INTEGRATION_CONFIG } from "./config";
+import chalk from 'chalk';
+import type { CloudRegion, WizardOptions } from '../utils/types';
+import { getCloudUrlFromRegion } from '../utils/urls';
+import type { PackageManager } from '../utils/package-manager';
+import { ISSUES_URL, Integration } from './constants';
+import { INTEGRATION_CONFIG } from './config';
 
-export const getOutroMessage = ({ options, integration, cloudRegion, addedEditorRules, packageManager }: { options: WizardOptions, integration: Integration, cloudRegion: CloudRegion, addedEditorRules: boolean, packageManager?: PackageManager }) => {
+export const getOutroMessage = ({
+  options,
+  integration,
+  cloudRegion,
+  addedEditorRules,
+  packageManager,
+}: {
+  options: WizardOptions;
+  integration: Integration;
+  cloudRegion: CloudRegion;
+  addedEditorRules: boolean;
+  packageManager?: PackageManager;
+}) => {
   const continueUrl = options.signup
     ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
     : undefined;
@@ -23,20 +35,23 @@ ${chalk.yellow('Next steps:')}
 ${integrationConfig.nextSteps}
 
 ${chalk.blue(
-    `Learn more about PostHog + ${integrationConfig.name}: ${integrationConfig.docsUrl}`,
-  )}
-${continueUrl
-      ? `\n\n${chalk.blue(
+  `Learn more about PostHog + ${integrationConfig.name}: ${integrationConfig.docsUrl}`,
+)}
+${
+  continueUrl
+    ? `\n\n${chalk.blue(
         `Continue your PostHog journey: ${chalk.cyan(continueUrl)}`,
       )}`
-      : ``
-    }
+    : ``
+}
 
 Note: This uses experimental AI to setup your project. It might have got it wrong, please check!
 
-You should validate your setup by (re)starting your dev environment${packageManager ? ` (e.g. ${chalk.cyan(
-      `${packageManager.runScriptCommand} dev`,
-    )}).` : `.`}
+You should validate your setup by (re)starting your dev environment${
+    packageManager
+      ? ` (e.g. ${chalk.cyan(`${packageManager.runScriptCommand} dev`)}).`
+      : `.`
+  }
 
 ${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`;
-}
+};

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -34,17 +34,10 @@ ${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
 ${chalk.yellow('Next steps:')}
 ${integrationConfig.nextSteps}
 
-${chalk.blue(
-  `Learn more about PostHog + ${integrationConfig.name}: ${integrationConfig.docsUrl}`,
-)}
-${
-  continueUrl
-    ? `\n\n${chalk.blue(
-        `Continue your PostHog journey: ${chalk.cyan(continueUrl)}`,
-      )}`
-    : ``
-}
-
+Learn more about PostHog + ${integrationConfig.name}: ${chalk.cyan(
+    integrationConfig.docsUrl,
+  )}
+${continueUrl ? `\nContinue onboarding: ${chalk.cyan(continueUrl)}\n` : ``}
 Note: This uses experimental AI to setup your project. It might have got it wrong, please check!
 
 You should validate your setup by (re)starting your dev environment${

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,42 @@
+import chalk from "chalk"
+import type { CloudRegion, WizardOptions } from "../utils/types";
+import { getCloudUrlFromRegion } from "../utils/urls";
+import type { PackageManager } from "../utils/package-manager";
+import { ISSUES_URL, Integration } from "./constants";
+import { INTEGRATION_CONFIG } from "./config";
+
+export const getOutroMessage = ({ options, integration, cloudRegion, addedEditorRules, packageManager }: { options: WizardOptions, integration: Integration, cloudRegion: CloudRegion, addedEditorRules: boolean, packageManager?: PackageManager }) => {
+  const continueUrl = options.signup
+    ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
+    : undefined;
+
+  const integrationConfig = INTEGRATION_CONFIG[integration];
+
+  return `
+${chalk.green('Successfully installed PostHog!')}  
+  
+${chalk.cyan('Changes made:')}
+${integrationConfig.changes}
+${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
+  
+${chalk.yellow('Next steps:')}
+${integrationConfig.nextSteps}
+
+${chalk.blue(
+    `Learn more about PostHog + ${integrationConfig.name}: ${integrationConfig.docsUrl}`,
+  )}
+${continueUrl
+      ? `\n\n${chalk.blue(
+        `Continue your PostHog journey: ${chalk.cyan(continueUrl)}`,
+      )}`
+      : ``
+    }
+
+Note: This uses experimental AI to setup your project. It might have got it wrong, please check!
+
+You should validate your setup by (re)starting your dev environment${packageManager ? ` (e.g. ${chalk.cyan(
+      `${packageManager.runScriptCommand} dev`,
+    )}).` : `.`}
+
+${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`;
+}

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -34,6 +34,7 @@ import {
 import type { WizardOptions } from '../utils/types';
 import { askForCloudRegion } from '../utils/clack-utils';
 import { addEditorRules } from '../utils/rules/add-editor-rules';
+import { getCloudUrlFromRegion } from '../utils/urls';
 
 export async function runNextjsWizard(options: WizardOptions): Promise<void> {
   printWelcome({
@@ -152,12 +153,15 @@ export async function runNextjsWizard(options: WizardOptions): Promise<void> {
     default: options.default,
   });
 
+  const continueUrl = options.signup
+    ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
+    : undefined;
+
   clack.outro(`
-${chalk.green('Successfully installed PostHog!')} ${`\n\n${
-    aiConsent
+${chalk.green('Successfully installed PostHog!')} ${`\n\n${aiConsent
       ? `Note: This uses experimental AI to setup your project. It might have got it wrong, please check!\n`
       : ``
-  }
+    }
 ${chalk.cyan('Changes made:')}
 • Installed posthog-js & posthog-node packages
 • Initialized PostHog, and added pageview tracking
@@ -172,13 +176,19 @@ ${chalk.yellow('Next steps:')}
 • Upload environment variables to your production environment
 
 You should validate your setup by (re)starting your dev environment (e.g. ${chalk.cyan(
-    `${packageManagerForOutro.runScriptCommand} dev`,
-  )})`}
+      `${packageManagerForOutro.runScriptCommand} dev`,
+    )})`}
 
     
 ${chalk.blue(
-  `Learn more about PostHog + Next.js: https://posthog.com/docs/libraries/next-js`,
-)}
+      `Learn more about PostHog + Next.js: https://posthog.com/docs/libraries/next-js`,
+    )}
+${continueUrl
+      ? `\n\n${chalk.blue(
+        `Continue your PostHog journey: ${chalk.cyan(continueUrl)}`,
+      )}`
+      : ``
+    }
 
 ${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`);
 

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -1,6 +1,4 @@
 /* eslint-disable max-lines */
-
-import chalk from 'chalk';
 import {
   abort,
   askForAIConsent,
@@ -22,7 +20,7 @@ import {
   NextJsRouter,
 } from './utils';
 import clack from '../utils/clack';
-import { Integration, ISSUES_URL } from '../lib/constants';
+import { Integration } from '../lib/constants';
 import { getNextjsAppRouterDocs, getNextjsPagesRouterDocs } from './docs';
 import { analytics } from '../utils/analytics';
 import { addOrUpdateEnvironmentVariables } from '../utils/environment';
@@ -34,7 +32,7 @@ import {
 import type { WizardOptions } from '../utils/types';
 import { askForCloudRegion } from '../utils/clack-utils';
 import { addEditorRules } from '../utils/rules/add-editor-rules';
-import { getCloudUrlFromRegion } from '../utils/urls';
+import { getOutroMessage } from '../lib/messages';
 
 export async function runNextjsWizard(options: WizardOptions): Promise<void> {
   printWelcome({
@@ -153,46 +151,15 @@ export async function runNextjsWizard(options: WizardOptions): Promise<void> {
     default: options.default,
   });
 
-  const continueUrl = options.signup
-    ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
-    : undefined;
+  const outroMessage = getOutroMessage({
+    options,
+    integration: Integration.nextjs,
+    cloudRegion,
+    addedEditorRules,
+    packageManager: packageManagerForOutro,
+  });
 
-  clack.outro(`
-${chalk.green('Successfully installed PostHog!')} ${`\n\n${
-    aiConsent
-      ? `Note: This uses experimental AI to setup your project. It might have got it wrong, please check!\n`
-      : ``
-  }
-${chalk.cyan('Changes made:')}
-• Installed posthog-js & posthog-node packages
-• Initialized PostHog, and added pageview tracking
-• Created a PostHogClient to use PostHog server-side
-• Setup a reverse proxy to avoid ad blockers blocking analytics requests
-• Added your Project API key to your .env file
-${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
-  
-${chalk.yellow('Next steps:')}
-• Call posthog.identify() when a user signs into your app
-• Call posthog.capture() to capture custom events in your app
-• Upload environment variables to your production environment
-
-You should validate your setup by (re)starting your dev environment (e.g. ${chalk.cyan(
-    `${packageManagerForOutro.runScriptCommand} dev`,
-  )})`}
-
-    
-${chalk.blue(
-  `Learn more about PostHog + Next.js: https://posthog.com/docs/libraries/next-js`,
-)}
-${
-  continueUrl
-    ? `\n\n${chalk.blue(
-        `Continue your PostHog journey: ${chalk.cyan(continueUrl)}`,
-      )}`
-    : ``
-}
-
-${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`);
+  clack.outro(outroMessage);
 
   await analytics.shutdown('success');
 }

--- a/src/nextjs/nextjs-wizard.ts
+++ b/src/nextjs/nextjs-wizard.ts
@@ -158,10 +158,11 @@ export async function runNextjsWizard(options: WizardOptions): Promise<void> {
     : undefined;
 
   clack.outro(`
-${chalk.green('Successfully installed PostHog!')} ${`\n\n${aiConsent
+${chalk.green('Successfully installed PostHog!')} ${`\n\n${
+    aiConsent
       ? `Note: This uses experimental AI to setup your project. It might have got it wrong, please check!\n`
       : ``
-    }
+  }
 ${chalk.cyan('Changes made:')}
 • Installed posthog-js & posthog-node packages
 • Initialized PostHog, and added pageview tracking
@@ -176,19 +177,20 @@ ${chalk.yellow('Next steps:')}
 • Upload environment variables to your production environment
 
 You should validate your setup by (re)starting your dev environment (e.g. ${chalk.cyan(
-      `${packageManagerForOutro.runScriptCommand} dev`,
-    )})`}
+    `${packageManagerForOutro.runScriptCommand} dev`,
+  )})`}
 
     
 ${chalk.blue(
-      `Learn more about PostHog + Next.js: https://posthog.com/docs/libraries/next-js`,
-    )}
-${continueUrl
-      ? `\n\n${chalk.blue(
+  `Learn more about PostHog + Next.js: https://posthog.com/docs/libraries/next-js`,
+)}
+${
+  continueUrl
+    ? `\n\n${chalk.blue(
         `Continue your PostHog journey: ${chalk.cyan(continueUrl)}`,
       )}`
-      : ``
-    }
+    : ``
+}
 
 ${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`);
 

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines */
 
-import chalk from 'chalk';
 import {
   abort,
   askForAIConsent,
@@ -8,6 +7,7 @@ import {
   ensurePackageIsInstalled,
   getOrAskForProjectData,
   getPackageDotJson,
+  getPackageManager,
   installPackage,
   isUsingTypeScript,
   printWelcome,
@@ -15,7 +15,7 @@ import {
 } from '../utils/clack-utils';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import clack from '../utils/clack';
-import { Integration, ISSUES_URL } from '../lib/constants';
+import { Integration } from '../lib/constants';
 import { getReactNativeDocumentation } from './docs';
 import { analytics } from '../utils/analytics';
 import {
@@ -27,6 +27,7 @@ import type { WizardOptions } from '../utils/types';
 import { askForCloudRegion } from '../utils/clack-utils';
 import { addEditorRules } from '../utils/rules/add-editor-rules';
 import { EXPO } from '../utils/package-manager';
+import { getOutroMessage } from '../lib/messages';
 
 export async function runReactNativeWizard(
   options: WizardOptions,
@@ -80,19 +81,19 @@ export async function runReactNativeWizard(
 
   const packagesToInstall = isUsingExpo
     ? [
-        'posthog-react-native',
-        'posthog-react-native-session-replay',
-        'expo-file-system',
-        'expo-application',
-        'expo-device',
-        'expo-localization',
-      ]
+      'posthog-react-native',
+      'posthog-react-native-session-replay',
+      'expo-file-system',
+      'expo-application',
+      'expo-device',
+      'expo-localization',
+    ]
     : [
-        'posthog-react-native',
-        '@react-native-async-storage/async-storage',
-        'react-native-device-info',
-        'react-native-localize',
-      ];
+      'posthog-react-native',
+      '@react-native-async-storage/async-storage',
+      'react-native-device-info',
+      'react-native-localize',
+    ];
 
   for (const packageName of packagesToInstall) {
     await installPackage({
@@ -119,8 +120,7 @@ export async function runReactNativeWizard(
   });
 
   clack.log.info(
-    `Reviewing PostHog documentation for ${
-      isUsingExpo ? 'Expo' : 'React Native'
+    `Reviewing PostHog documentation for ${isUsingExpo ? 'Expo' : 'React Native'
     }`,
   );
 
@@ -153,30 +153,17 @@ export async function runReactNativeWizard(
     default: options.default,
   });
 
-  clack.outro(`
-${chalk.green('Successfully installed PostHog!')} ${`\n\n${
-    aiConsent
-      ? `Note: This uses experimental AI to setup your project. It might have got it wrong, please check!\n`
-      : ``
-  }
-${chalk.cyan('Changes made:')}
-• Installed required packages
-• Added PostHogProvider to the root of the app
-• Enabled autocapture and session replay
-${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
-  
-${chalk.yellow('Next steps:')}
-• Call posthog.identify() when a user signs into your app
-• Call posthog.capture() to capture custom events in your app
+  const packageManagerForOutro = await getPackageManager({ installDir: options.installDir });
 
-You should validate your setup by (re)starting your dev environment and launching your app`}
+  const outroMessage = getOutroMessage({
+    options,
+    integration: Integration.reactNative,
+    cloudRegion,
+    addedEditorRules,
+    packageManager: packageManagerForOutro
+  });
 
-    
-${chalk.blue(
-  `Learn more about PostHog + React Native: https://posthog.com/docs/libraries/react-native`,
-)}
-
-${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`);
+  clack.outro(outroMessage);
 
   await analytics.shutdown('success');
 }

--- a/src/react-native/react-native-wizard.ts
+++ b/src/react-native/react-native-wizard.ts
@@ -81,19 +81,19 @@ export async function runReactNativeWizard(
 
   const packagesToInstall = isUsingExpo
     ? [
-      'posthog-react-native',
-      'posthog-react-native-session-replay',
-      'expo-file-system',
-      'expo-application',
-      'expo-device',
-      'expo-localization',
-    ]
+        'posthog-react-native',
+        'posthog-react-native-session-replay',
+        'expo-file-system',
+        'expo-application',
+        'expo-device',
+        'expo-localization',
+      ]
     : [
-      'posthog-react-native',
-      '@react-native-async-storage/async-storage',
-      'react-native-device-info',
-      'react-native-localize',
-    ];
+        'posthog-react-native',
+        '@react-native-async-storage/async-storage',
+        'react-native-device-info',
+        'react-native-localize',
+      ];
 
   for (const packageName of packagesToInstall) {
     await installPackage({
@@ -120,7 +120,8 @@ export async function runReactNativeWizard(
   });
 
   clack.log.info(
-    `Reviewing PostHog documentation for ${isUsingExpo ? 'Expo' : 'React Native'
+    `Reviewing PostHog documentation for ${
+      isUsingExpo ? 'Expo' : 'React Native'
     }`,
   );
 
@@ -153,14 +154,16 @@ export async function runReactNativeWizard(
     default: options.default,
   });
 
-  const packageManagerForOutro = await getPackageManager({ installDir: options.installDir });
+  const packageManagerForOutro = await getPackageManager({
+    installDir: options.installDir,
+  });
 
   const outroMessage = getOutroMessage({
     options,
     integration: Integration.reactNative,
     cloudRegion,
     addedEditorRules,
-    packageManager: packageManagerForOutro
+    packageManager: packageManagerForOutro,
   });
 
   clack.outro(outroMessage);

--- a/src/react/react-wizard.ts
+++ b/src/react/react-wizard.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines */
 
-import chalk from 'chalk';
 import {
   abort,
   askForAIConsent,
@@ -16,7 +15,7 @@ import {
 } from '../utils/clack-utils';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import clack from '../utils/clack';
-import { Integration, ISSUES_URL } from '../lib/constants';
+import { Integration } from '../lib/constants';
 import { getReactDocumentation } from './docs';
 import { analytics } from '../utils/analytics';
 import {
@@ -31,6 +30,7 @@ import {
 import type { WizardOptions } from '../utils/types';
 import { askForCloudRegion } from '../utils/clack-utils';
 import { addEditorRules } from '../utils/rules/add-editor-rules';
+import { getOutroMessage } from '../lib/messages';
 
 export async function runReactWizard(options: WizardOptions): Promise<void> {
   printWelcome({
@@ -137,32 +137,15 @@ export async function runReactWizard(options: WizardOptions): Promise<void> {
     default: options.default,
   });
 
-  clack.outro(`
-${chalk.green('Successfully installed PostHog!')} ${`\n\n${
-    aiConsent
-      ? `Note: This uses experimental AI to setup your project. It might have got it wrong, please check!\n`
-      : ``
-  }
-${chalk.cyan('Changes made:')}
-• Installed posthog-js package
-• Added PostHogProvider to the root of the app, to initialize PostHog and enable autocapture
-• Added your Project API key to your .env file
-${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
-  
-${chalk.yellow('Next steps:')}
-• Call posthog.identify() when a user signs into your app
-• Upload environment variables to your production environment
+  const outroMessage = getOutroMessage({
+    options,
+    integration: Integration.react,
+    cloudRegion,
+    addedEditorRules,
+    packageManager: packageManagerForOutro,
+  });
 
-You should validate your setup by (re)starting your dev environment (e.g. ${chalk.cyan(
-    `${packageManagerForOutro.runScriptCommand} dev`,
-  )})`}
-
-    
-${chalk.blue(
-  `Learn more about PostHog + React: https://posthog.com/docs/libraries/react`,
-)}
-
-${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`);
+  clack.outro(outroMessage);
 
   await analytics.shutdown('success');
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -20,6 +20,7 @@ type Args = {
   installDir?: string;
   region?: CloudRegion;
   default?: boolean;
+  signup?: boolean;
 };
 
 export async function run(argv: Args) {
@@ -40,6 +41,7 @@ async function runWizard(argv: Args) {
       : process.cwd(),
     cloudRegion: finalArgs.region ?? undefined,
     default: finalArgs.default ?? false,
+    signup: finalArgs.signup ?? false,
   };
 
   clack.intro(`Welcome to the PostHog setup wizard ✨`);

--- a/src/svelte/svelte-wizard.ts
+++ b/src/svelte/svelte-wizard.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines */
 
-import chalk from 'chalk';
 import {
   abort,
   askForAIConsent,
@@ -16,7 +15,7 @@ import {
 } from '../utils/clack-utils';
 import { getPackageVersion, hasPackageInstalled } from '../utils/package-json';
 import clack from '../utils/clack';
-import { Integration, ISSUES_URL } from '../lib/constants';
+import { Integration } from '../lib/constants';
 import { getSvelteDocumentation } from './docs';
 import { analytics } from '../utils/analytics';
 import { addOrUpdateEnvironmentVariables } from '../utils/environment';
@@ -28,6 +27,7 @@ import {
 import type { WizardOptions } from '../utils/types';
 import { askForCloudRegion } from '../utils/clack-utils';
 import { addEditorRules } from '../utils/rules/add-editor-rules';
+import { getOutroMessage } from '../lib/messages';
 
 export async function runSvelteWizard(options: WizardOptions): Promise<void> {
   printWelcome({
@@ -142,36 +142,15 @@ export async function runSvelteWizard(options: WizardOptions): Promise<void> {
     default: options.default,
   });
 
-  clack.outro(`
-${chalk.green('Successfully installed PostHog!')} ${`\n\n${
-    aiConsent
-      ? `Note: This uses experimental AI to setup your project. It might have got it wrong, please check!\n`
-      : ``
-  }
-${chalk.cyan('Changes made:')}
-• Installed posthog-js & posthog-node packages
-• Added PostHog initialization to your Svelte app
-• Setup pageview & pageleave tracking
-• Setup event auto-capture to capture events as users interact with your app
-• Added a getPostHogClient() function to use PostHog server-side
-• Added your Project API key to your .env file
-${addedEditorRules ? `• Added Cursor rules for PostHog` : ''}
-  
-${chalk.yellow('Next steps:')}
-• Call posthog.identify() when a user signs into your app
-• Use getPostHogClient() to start capturing events server-side
-• Upload environment variables to your production environment
+  const outroMessage = getOutroMessage({
+    options,
+    integration: Integration.svelte,
+    cloudRegion,
+    addedEditorRules,
+    packageManager: packageManagerForOutro
+  })
 
-You should validate your setup by (re)starting your dev environment (e.g. ${chalk.cyan(
-    `${packageManagerForOutro.runScriptCommand} dev`,
-  )})`}
-
-    
-${chalk.blue(
-  `Learn more about PostHog + Svelte: https://posthog.com/docs/libraries/svelte`,
-)}
-
-${chalk.dim(`If you encounter any issues, let us know here: ${ISSUES_URL}`)}`);
+  clack.outro(outroMessage);
 
   await analytics.shutdown('success');
 }

--- a/src/svelte/svelte-wizard.ts
+++ b/src/svelte/svelte-wizard.ts
@@ -147,8 +147,8 @@ export async function runSvelteWizard(options: WizardOptions): Promise<void> {
     integration: Integration.svelte,
     cloudRegion,
     addedEditorRules,
-    packageManager: packageManagerForOutro
-  })
+    packageManager: packageManagerForOutro,
+  });
 
   clack.outro(outroMessage);
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -35,6 +35,11 @@ export type WizardOptions = {
    * Whether to select the default option for all questions automatically.
    */
   default: boolean;
+
+  /**
+   * Whether to create a new PostHog account during setup.
+   */
+  signup: boolean;
 };
 
 export interface Feature {


### PR DESCRIPTION
Add a --signup flag that new users can use to be redirected to the signup flow instead of the login flow.