### PR TITLE
fix: remove newline char for vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/wizard",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "homepage": "https://github.com/posthog/wizard",
   "repository": "https://github.com/posthog/wizard",
   "description": "The PostHog wizard helps you to configure your project",

--- a/src/steps/upload-environment-variables/providers/vercel.ts
+++ b/src/steps/upload-environment-variables/providers/vercel.ts
@@ -93,7 +93,7 @@ export class VercelEnvironmentProvider extends EnvironmentProvider {
         stderr += data.toString();
       });
 
-      proc.stdin.write(value + '\n');
+      proc.stdin.write(value);
       proc.stdin.end();
 
       proc.on('close', (code) => {


### PR DESCRIPTION
The environment variable uploading for Vercel was suppling a newline char unnecessarily