### PR TITLE
chore: skip mcp on eu cloud region for now

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4,7 +4,7 @@ import {
   removeMCPServerFromClientsStep,
 } from './steps/add-mcp-server-to-clients';
 import clack from './utils/clack';
-import { abort, askForCloudRegion } from './utils/clack-utils';
+import { abort } from './utils/clack-utils';
 import type { CloudRegion } from './utils/types';
 import opn from 'opn';
 import { getCloudUrlFromRegion } from './utils/urls';
@@ -50,11 +50,9 @@ export const runMCPRemove = async () => {
 };
 
 export const getPersonalApiKey = async (options: {
-  region?: CloudRegion;
+  cloudRegion: CloudRegion;
 }): Promise<string> => {
-  const cloudRegion = options.region ?? (await askForCloudRegion());
-
-  const cloudUrl = getCloudUrlFromRegion(cloudRegion);
+  const cloudUrl = getCloudUrlFromRegion(options.cloudRegion);
 
   const urlToOpen = `${cloudUrl}/settings/user-api-keys?preset=mcp_server`;
 


### PR DESCRIPTION
The MCP server currently does not support EU cloud, we shouldn't try to install it on EU wizard flows.