### PR TITLE
Fix getSupportedClients

### DIFF
--- a/src/steps/add-mcp-server-to-clients/__tests__/index.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/index.test.ts
@@ -1,0 +1,85 @@
+import { getSupportedClients } from '../index';
+import { CursorMCPClient } from '../clients/cursor';
+import { ClaudeMCPClient } from '../clients/claude';
+
+jest.mock('../clients/cursor');
+jest.mock('../clients/claude');
+
+describe('getSupportedClients', () => {
+  const MockedCursorMCPClient = CursorMCPClient as jest.MockedClass<
+    typeof CursorMCPClient
+  >;
+  const MockedClaudeMCPClient = ClaudeMCPClient as jest.MockedClass<
+    typeof ClaudeMCPClient
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    MockedCursorMCPClient.mockImplementation(() => ({
+      name: 'Cursor',
+      isClientSupported: jest.fn().mockResolvedValue(true),
+      getConfigPath: jest.fn(),
+      isServerInstalled: jest.fn(),
+      addServer: jest.fn(),
+      removeServer: jest.fn(),
+    }));
+
+    MockedClaudeMCPClient.mockImplementation(() => ({
+      name: 'Claude Desktop',
+      isClientSupported: jest.fn().mockResolvedValue(true),
+      getConfigPath: jest.fn(),
+      isServerInstalled: jest.fn(),
+      addServer: jest.fn(),
+      removeServer: jest.fn(),
+    }));
+  });
+
+  it('should return all clients when both are supported', () => {
+    const result = getSupportedClients();
+
+    expect(result).toHaveLength(2);
+    expect(MockedCursorMCPClient).toHaveBeenCalledTimes(1);
+    expect(MockedClaudeMCPClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return only supported clients when some are not supported', () => {
+    MockedCursorMCPClient.mockImplementation(() => ({
+      name: 'Cursor',
+      isClientSupported: jest.fn().mockResolvedValue(false),
+      getConfigPath: jest.fn(),
+      isServerInstalled: jest.fn(),
+      addServer: jest.fn(),
+      removeServer: jest.fn(),
+    }));
+
+    const result = getSupportedClients();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Claude Desktop');
+  });
+
+  it('should return empty array when no clients are supported', () => {
+    MockedCursorMCPClient.mockImplementation(() => ({
+      name: 'Cursor',
+      isClientSupported: jest.fn().mockResolvedValue(false),
+      getConfigPath: jest.fn(),
+      isServerInstalled: jest.fn(),
+      addServer: jest.fn(),
+      removeServer: jest.fn(),
+    }));
+
+    MockedClaudeMCPClient.mockImplementation(() => ({
+      name: 'Claude Desktop',
+      isClientSupported: jest.fn().mockResolvedValue(false),
+      getConfigPath: jest.fn(),
+      isServerInstalled: jest.fn(),
+      addServer: jest.fn(),
+      removeServer: jest.fn(),
+    }));
+
+    const result = getSupportedClients();
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/steps/add-mcp-server-to-clients/__tests__/index.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/index.test.ts
@@ -35,15 +35,15 @@ describe('getSupportedClients', () => {
     }));
   });
 
-  it('should return all clients when both are supported', () => {
-    const result = getSupportedClients();
+  it('should return all clients when both are supported', async () => {
+    const result = await getSupportedClients();
 
     expect(result).toHaveLength(2);
     expect(MockedCursorMCPClient).toHaveBeenCalledTimes(1);
     expect(MockedClaudeMCPClient).toHaveBeenCalledTimes(1);
   });
 
-  it('should return only supported clients when some are not supported', () => {
+  it('should return only supported clients when some are not supported', async () => {
     MockedCursorMCPClient.mockImplementation(() => ({
       name: 'Cursor',
       isClientSupported: jest.fn().mockResolvedValue(false),
@@ -53,13 +53,13 @@ describe('getSupportedClients', () => {
       removeServer: jest.fn(),
     }));
 
-    const result = getSupportedClients();
+    const result = await getSupportedClients();
 
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('Claude Desktop');
   });
 
-  it('should return empty array when no clients are supported', () => {
+  it('should return empty array when no clients are supported', async () => {
     MockedCursorMCPClient.mockImplementation(() => ({
       name: 'Cursor',
       isClientSupported: jest.fn().mockResolvedValue(false),
@@ -78,7 +78,7 @@ describe('getSupportedClients', () => {
       removeServer: jest.fn(),
     }));
 
-    const result = getSupportedClients();
+    const result = await getSupportedClients();
 
     expect(result).toHaveLength(0);
   });

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -13,10 +13,11 @@ import { ClaudeMCPClient } from './clients/claude';
 import { getPersonalApiKey } from '../../mcp';
 import type { CloudRegion } from '../../utils/types';
 
-export const getSupportedClients = (): MCPClient[] => {
-  return [new CursorMCPClient(), new ClaudeMCPClient()].filter((client) =>
-    client.isClientSupported(),
-  );
+export const getSupportedClients = async (): Promise<MCPClient[]> => {
+  const clients = [new CursorMCPClient(), new ClaudeMCPClient()];
+  const supportPromises = clients.map((client) => client.isClientSupported());
+  const supportedResults = await Promise.all(supportPromises);
+  return clients.filter((_, index) => supportedResults[index]);
 };
 
 export const addMCPServerToClientsStep = async ({
@@ -57,7 +58,7 @@ export const addMCPServerToClientsStep = async ({
     return [];
   }
 
-  const clients = getSupportedClients();
+  const clients = await getSupportedClients();
 
   const installedClients = await getInstalledClients();
 
@@ -182,7 +183,7 @@ export const removeMCPServerFromClientsStep = async ({
 };
 
 export const getInstalledClients = async (): Promise<MCPClient[]> => {
-  const clients = getSupportedClients();
+  const clients = await getSupportedClients();
 
   const installedClients: MCPClient[] = [];
 


### PR DESCRIPTION
Resolves #64 

The methods `isClientSupported` and `getConfigPath` in `DefaultMCPClient` look like they don't need to be `async`, but I chose to leave them as they are not to make big changes.