### PR TITLE
fix: package not installed tracked twice

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -391,7 +391,6 @@ export async function ensurePackageIsInstalled(
     analytics.setTag(`${packageName.toLowerCase()}-installed`, installed);
 
     if (!installed) {
-      analytics.setTag(`${packageName.toLowerCase()}-installed`, false);
       const continueWithoutPackage = await abortIfCancelled(
         clack.confirm({
           message: `${packageName} does not seem to be installed. Do you still want to continue?`,


### PR DESCRIPTION
`analytics.setTag(`${packageName.toLowerCase()}-installed`, installed);` already tracks that the package was not installed, making it unnecessary for it to be called again in the `!installed` branch