### PR TITLE
fix: Prevent uploading newline env values

### DIFF
--- a/src/steps/upload-environment-variables/providers/__tests__/vercel.test.ts
+++ b/src/steps/upload-environment-variables/providers/__tests__/vercel.test.ts
@@ -111,7 +111,11 @@ describe('VercelEnvironmentProvider', () => {
       }),
     });
 
-    await provider.uploadEnvironmentVariable('TEST_KEY', 'valuewithnewlines\n', 'production');
+    await provider.uploadEnvironmentVariable(
+      'TEST_KEY',
+      'valuewithnewlines\n',
+      'production',
+    );
 
     // Verify newlines were removed and value was trimmed
     expect(stdinMock.write).toHaveBeenCalledWith('valuewithnewlines');

--- a/src/steps/upload-environment-variables/providers/vercel.ts
+++ b/src/steps/upload-environment-variables/providers/vercel.ts
@@ -7,6 +7,11 @@ import clack from '../../../utils/clack';
 import chalk from 'chalk';
 import { analytics } from '../../../utils/analytics';
 
+function sanitizeEnvValue(value: string): string {
+  // Remove all newlines and trim whitespace
+  return value.replace(/\n/g, '').trim();
+}
+
 export class VercelEnvironmentProvider extends EnvironmentProvider {
   name = 'Vercel';
   environments = ['production', 'preview', 'development'];
@@ -93,7 +98,7 @@ export class VercelEnvironmentProvider extends EnvironmentProvider {
         stderr += data.toString();
       });
 
-      proc.stdin.write(value);
+      proc.stdin.write(sanitizeEnvValue(value));
       proc.stdin.end();
 
       proc.on('close', (code) => {


### PR DESCRIPTION
womp womp:

https://posthog.com/questions/vercel-request-401

On uploading values to Vercel, remove any stray newlines that got sucked in as part of a value.