### PR TITLE
fix: remove pr comment at end of workflow

### DIFF
--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -67,7 +67,6 @@ export const getOutroMessage = ({
     uploadedEnvVars.length === 0
       ? `Upload your Project API key to your hosting provider`
       : '',
-    `Create a PR for your changes`,
   ].filter(Boolean);
 
   return `


### PR DESCRIPTION
We don't need this here - we are not doing a PR automatically anymore.