### PR TITLE
fix: always ask for dirty repo

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -133,13 +133,11 @@ ${uncommittedOrUntrackedFiles.join('\n')}
 
 The wizard will create and update files.`,
       );
-      const continueWithDirtyRepo = options.default
-        ? true
-        : await abortIfCancelled(
-            clack.confirm({
-              message: 'Do you want to continue anyway?',
-            }),
-          );
+      const continueWithDirtyRepo = await abortIfCancelled(
+        clack.confirm({
+          message: 'Do you want to continue anyway?',
+        }),
+      );
 
       analytics.setTag('continue-with-dirty-repo', continueWithDirtyRepo);
 


### PR DESCRIPTION
We shouldn't default this option, as it can mess up someones existing work on a branch.

Give them the chance to exit.