### PR TITLE
fix: don't import e2e tests in prod

### DIFF
--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -5,8 +5,6 @@ import type { AIModel, CloudRegion } from './types';
 import { getCloudUrlFromRegion } from './urls';
 import { analytics } from './analytics';
 import { AxiosError } from 'axios';
-import { fixtureTracker } from '../../e2e-tests/mocks/fixture-tracker';
-import { shouldRecord } from '../../e2e-tests/mocks/handlers';
 
 export interface QueryOptions<S> {
   message: string;
@@ -36,7 +34,7 @@ export const query = async <S>({
       {
         headers: {
           'X-PostHog-Wizard-Hash': wizardHash,
-          ...(shouldRecord
+          ...(process.env.RECORD_FIXTURES === 'true'
             ? { 'X-PostHog-Wizard-Fixture-Generation': true }
             : {}),
         },
@@ -65,6 +63,10 @@ export const query = async <S>({
   }
 
   if (process.env.NODE_ENV === 'test') {
+    const { fixtureTracker } = await import(
+      '../../e2e-tests/mocks/fixture-tracker.js'
+    );
+
     const requestBody = JSON.stringify({
       message,
       model,


### PR DESCRIPTION
Makes it so we don't import e2e tests that aren't bundled into the npm package, which caused the package crash