### PR TITLE
feat: prevent users from running wizard in non tty env

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -4,6 +4,7 @@ import { red } from './src/utils/logging';
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import chalk from 'chalk';
 
 const NODE_VERSION_RANGE = '>=18.17.0';
 
@@ -20,8 +21,24 @@ import { runMCPInstall, runMCPRemove } from './src/mcp';
 import type { CloudRegion, WizardOptions } from './src/utils/types';
 import { runWizard } from './src/run';
 import { runEventSetupWizard } from './src/nextjs/event-setup';
-import { readEnvironment } from './src/utils/environment';
+import {
+  readEnvironment,
+  isNonInteractiveEnvironment,
+} from './src/utils/environment';
 import path from 'path';
+import clack from './src/utils/clack';
+
+// Check for non-interactive environment before proceeding
+if (isNonInteractiveEnvironment()) {
+  clack.intro(chalk.inverse(`PostHog Wizard`));
+
+  clack.log.error(
+    'This installer requires an interactive terminal (TTY) to run.\n' +
+      'It appears you are running in a non-interactive environment.\n' +
+      'Please run the wizard in an interactive terminal.',
+  );
+  process.exit(1);
+}
 
 if (process.env.NODE_ENV === 'test') {
   void (async () => {

--- a/bin.ts
+++ b/bin.ts
@@ -28,7 +28,6 @@ import {
 import path from 'path';
 import clack from './src/utils/clack';
 
-// Check for non-interactive environment before proceeding
 if (isNonInteractiveEnvironment()) {
   clack.intro(chalk.inverse(`PostHog Wizard`));
 

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -5,7 +5,7 @@ import fg from 'fast-glob';
 import { IS_DEV } from '../lib/constants';
 
 export function isNonInteractiveEnvironment(): boolean {
-  if (IS_DEV || process.env.NODE_ENV === 'test') {
+  if (IS_DEV) {
     return false;
   }
 

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -2,6 +2,19 @@ import readEnv from 'read-env';
 import { getPackageDotJson } from './clack-utils';
 import type { WizardOptions } from './types';
 import fg from 'fast-glob';
+import { IS_DEV } from '../lib/constants';
+
+export function isNonInteractiveEnvironment(): boolean {
+  if (IS_DEV || process.env.NODE_ENV === 'test') {
+    return false;
+  }
+
+  if (!process.stdout.isTTY || !process.stderr.isTTY) {
+    return true;
+  }
+
+  return false;
+}
 
 export function readEnvironment(): Record<string, unknown> {
   const result = readEnv('POSTHOG_WIZARD');


### PR DESCRIPTION
We don't support running the Wizard in a non-interactive environment, so disable it for that scenario