### PR TITLE
feat: add support for claude code as an MCP client

### DIFF
--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -36,7 +36,7 @@ export abstract class DefaultMCPClient extends MCPClient {
   }
 
   async addServer(apiKey: string): Promise<{ success: boolean }> {
-    return this._addServerType(apiKey, 'streamable-http');
+    return this._addServerType(apiKey, 'sse');
   }
 
   async _addServerType(

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
@@ -326,7 +326,7 @@ describe('ClaudeMCPClient', () => {
 
       expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
         mockApiKey,
-        'streamable-http',
+        'sse',
       );
     });
   });

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -1,0 +1,66 @@
+import { DefaultMCPClient } from '../MCPClient';
+import { DefaultMCPClientConfig, getDefaultServerConfig } from '../defaults';
+import { z } from 'zod';
+import { execSync } from 'child_process';
+
+export const ClaudeCodeMCPConfig = DefaultMCPClientConfig;
+
+export type ClaudeCodeMCPConfig = z.infer<typeof DefaultMCPClientConfig>;
+
+export class ClaudeCodeMCPClient extends DefaultMCPClient {
+  name = 'Claude Code';
+
+  constructor() {
+    super();
+  }
+
+  isClientSupported(): Promise<boolean> {
+    try {
+      execSync('claude --version', { stdio: 'ignore' });
+      return Promise.resolve(true);
+    } catch {
+      return Promise.resolve(false);
+    }
+  }
+
+  isServerInstalled(): Promise<boolean> {
+    try {
+      // check if posthog in output
+      const output = execSync('claude mcp list', {
+        stdio: 'pipe',
+      });
+
+      if (output.toString().includes('posthog')) {
+        return Promise.resolve(true);
+      }
+    } catch {
+      //
+    }
+
+    return Promise.resolve(false);
+  }
+
+  getConfigPath(): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+  addServer(apiKey: string): Promise<{ success: boolean }> {
+    const config = getDefaultServerConfig(apiKey, 'sse');
+
+    const command = `claude mcp add-json posthog -s user '${JSON.stringify(
+      config,
+    )}'`;
+
+    execSync(command);
+
+    return Promise.resolve({ success: true });
+  }
+
+  removeServer(): Promise<{ success: boolean }> {
+    const command = `claude mcp remove --scope user posthog`;
+
+    execSync(command);
+
+    return Promise.resolve({ success: true });
+  }
+}

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -12,9 +12,14 @@ import { CursorMCPClient } from './clients/cursor';
 import { ClaudeMCPClient } from './clients/claude';
 import { getPersonalApiKey } from '../../mcp';
 import type { CloudRegion } from '../../utils/types';
+import { ClaudeCodeMCPClient } from './clients/claude-code';
 
 export const getSupportedClients = async (): Promise<MCPClient[]> => {
-  const allClients = [new CursorMCPClient(), new ClaudeMCPClient()];
+  const allClients = [
+    new CursorMCPClient(),
+    new ClaudeMCPClient(),
+    new ClaudeCodeMCPClient(),
+  ];
   const supportedClients: MCPClient[] = [];
 
   for (const client of allClients) {


### PR DESCRIPTION
Add Claude Code as an MCP client for the mcp add / remove commands.

Tested it locally. It is requiring the /sse endpoint to get working for me.