### PR TITLE
fix: vercel env var provider lower case error

### DIFF
--- a/src/steps/upload-environment-variables/providers/vercel.ts
+++ b/src/steps/upload-environment-variables/providers/vercel.ts
@@ -62,7 +62,9 @@ export class VercelEnvironmentProvider extends EnvironmentProvider {
       },
     });
 
-    const output = (result.stdout + result.stderr).toLowerCase();
+    const output = (
+      String(result.stdout) + String(result.stderr)
+    ).toLowerCase();
 
     if (
       output.includes('log in to vercel') ||


### PR DESCRIPTION
This was sometimes showing toLowerCase() is not a function