### PR TITLE
feat: add vscode mcp client

### DIFF
--- a/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
@@ -1,0 +1,71 @@
+import z from 'zod';
+import * as path from 'path';
+import * as os from 'os';
+import { DefaultMCPClient } from '../MCPClient';
+
+export const VisualStudioCodeMCPConfig = z
+  .object({
+    servers: z.record(
+      z.string(),
+      z.object({
+        command: z.string().optional(),
+        args: z.array(z.string()).optional(),
+        env: z.record(z.string(), z.string()).optional(),
+      }),
+    ),
+  })
+  .passthrough();
+
+export type VisualStudioCodeMCPConfig = z.infer<
+  typeof VisualStudioCodeMCPConfig
+>;
+
+export class VisualStudioCodeClient extends DefaultMCPClient {
+  name = 'Visual Studio Code';
+
+  getServerPropertyName(): string {
+    return 'servers';
+  }
+
+  async isClientSupported(): Promise<boolean> {
+    return Promise.resolve(
+      process.platform === 'darwin' ||
+        process.platform === 'win32' ||
+        process.platform === 'linux',
+    );
+  }
+
+  async getConfigPath(): Promise<string> {
+    const homeDir = os.homedir();
+    const isWindows = process.platform === 'win32';
+    const isMac = process.platform === 'darwin';
+    const isLinux = process.platform === 'linux';
+
+    if (isMac) {
+      return Promise.resolve(
+        path.join(
+          homeDir,
+          'Library',
+          'Application Support',
+          'Code',
+          'User',
+          'mcp.json',
+        ),
+      );
+    }
+
+    if (isWindows) {
+      return Promise.resolve(
+        path.join(process.env.APPDATA || '', 'Code', 'User', 'mcp.json'),
+      );
+    }
+
+    if (isLinux) {
+      return Promise.resolve(
+        path.join(homeDir, '.config', 'Code', 'User', 'mcp.json'),
+      );
+    }
+
+    throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -10,12 +10,14 @@ import { ClaudeMCPClient } from './clients/claude';
 import { getPersonalApiKey } from '../../mcp';
 import type { CloudRegion } from '../../utils/types';
 import { ClaudeCodeMCPClient } from './clients/claude-code';
+import { VisualStudioCodeClient } from './clients/visual-studio-code';
 
 export const getSupportedClients = async (): Promise<MCPClient[]> => {
   const allClients = [
     new CursorMCPClient(),
     new ClaudeMCPClient(),
     new ClaudeCodeMCPClient(),
+    new VisualStudioCodeClient(),
   ];
   const supportedClients: MCPClient[] = [];
 
@@ -146,7 +148,6 @@ export const removeMCPServerFromClientsStep = async ({
   integration?: Integration;
 }): Promise<string[]> => {
   const installedClients = await getInstalledClients();
-
   if (installedClients.length === 0) {
     analytics.capture('wizard interaction', {
       action: 'no mcp servers to remove',
@@ -198,7 +199,6 @@ export const removeMCPServerFromClientsStep = async ({
 
 export const getInstalledClients = async (): Promise<MCPClient[]> => {
   const clients = await getSupportedClients();
-
   const installedClients: MCPClient[] = [];
 
   for (const client of clients) {


### PR DESCRIPTION
VS code uses `servers` instead of `mcpServers` as their primary key in their MCP config format so we also needed some adjustments for that