### PR TITLE
feat: add zed mcp client

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "fast-glob": "^3.3.3",
     "glob": "9.3.5",
     "inquirer": "^6.2.0",
+    "jsonc-parser": "^3.3.1",
     "lodash": "^4.17.21",
     "magicast": "^0.2.10",
     "opn": "^5.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       inquirer:
         specifier: ^6.2.0
         version: 6.5.2
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1912,6 +1915,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4880,6 +4886,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   keyv@4.5.4:
     dependencies:

--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -37,7 +37,7 @@ export abstract class DefaultMCPClient extends MCPClient {
       }
 
       const configContent = await fs.promises.readFile(configPath, 'utf8');
-      const config = jsonc.parse(configContent);
+      const config = jsonc.parse(configContent) as Record<string, any>;
       const serverPropertyName = this.getServerPropertyName();
       return (
         serverPropertyName in config && 'posthog' in config[serverPropertyName]
@@ -72,10 +72,11 @@ export abstract class DefaultMCPClient extends MCPClient {
 
       const baseConfig = getDefaultServerConfig(apiKey, type);
       const newServerConfig = this.customizeServerConfig(baseConfig);
-      if (!existingConfig[serverPropertyName]) {
-        existingConfig[serverPropertyName] = {};
+      const typedConfig = existingConfig as Record<string, any>;
+      if (!typedConfig[serverPropertyName]) {
+        typedConfig[serverPropertyName] = {};
       }
-      existingConfig[serverPropertyName].posthog = newServerConfig;
+      typedConfig[serverPropertyName].posthog = newServerConfig;
 
       const edits = jsonc.modify(
         configContent,
@@ -108,7 +109,7 @@ export abstract class DefaultMCPClient extends MCPClient {
       }
 
       const configContent = await fs.promises.readFile(configPath, 'utf8');
-      const config = jsonc.parse(configContent);
+      const config = jsonc.parse(configContent) as Record<string, any>;
       const serverPropertyName = this.getServerPropertyName();
 
       if (

--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -24,8 +24,8 @@ export abstract class DefaultMCPClient extends MCPClient {
     return 'mcpServers';
   }
 
-  customizeServerConfig(baseConfig: any): any {
-    return baseConfig;
+  getServerConfig(apiKey: string, type: 'sse' | 'streamable-http') {
+    return getDefaultServerConfig(apiKey, type);
   }
 
   async isServerInstalled(): Promise<boolean> {
@@ -70,8 +70,7 @@ export abstract class DefaultMCPClient extends MCPClient {
         existingConfig = jsonc.parse(configContent) || {};
       }
 
-      const baseConfig = getDefaultServerConfig(apiKey, type);
-      const newServerConfig = this.customizeServerConfig(baseConfig);
+      const newServerConfig = this.getServerConfig(apiKey, type);
       const typedConfig = existingConfig as Record<string, any>;
       if (!typedConfig[serverPropertyName]) {
         typedConfig[serverPropertyName] = {};

--- a/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
@@ -1,0 +1,71 @@
+import z from 'zod';
+import * as path from 'path';
+import * as os from 'os';
+import { DefaultMCPClient } from '../MCPClient';
+
+export const VisualStudioCodeMCPConfig = z
+  .object({
+    servers: z.record(
+      z.string(),
+      z.object({
+        command: z.string().optional(),
+        args: z.array(z.string()).optional(),
+        env: z.record(z.string(), z.string()).optional(),
+      }),
+    ),
+  })
+  .passthrough();
+
+export type VisualStudioCodeMCPConfig = z.infer<
+  typeof VisualStudioCodeMCPConfig
+>;
+
+export class VisualStudioCodeClient extends DefaultMCPClient {
+  name = 'Visual Studio Code';
+
+  getServerPropertyName(): string {
+    return 'servers';
+  }
+
+  async isClientSupported(): Promise<boolean> {
+    return Promise.resolve(
+      process.platform === 'darwin' ||
+        process.platform === 'win32' ||
+        process.platform === 'linux',
+    );
+  }
+
+  async getConfigPath(): Promise<string> {
+    const homeDir = os.homedir();
+    const isWindows = process.platform === 'win32';
+    const isMac = process.platform === 'darwin';
+    const isLinux = process.platform === 'linux';
+
+    if (isMac) {
+      return Promise.resolve(
+        path.join(
+          homeDir,
+          'Library',
+          'Application Support',
+          'Code',
+          'User',
+          'mcp.json',
+        ),
+      );
+    }
+
+    if (isWindows) {
+      return Promise.resolve(
+        path.join(process.env.APPDATA || '', 'Code', 'User', 'mcp.json'),
+      );
+    }
+
+    if (isLinux) {
+      return Promise.resolve(
+        path.join(homeDir, '.config', 'Code', 'User', 'mcp.json'),
+      );
+    }
+
+    throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -2,6 +2,7 @@ import z from 'zod';
 import * as path from 'path';
 import * as os from 'os';
 import { DefaultMCPClient } from '../MCPClient';
+import { getDefaultServerConfig } from '../defaults';
 
 export const ZedMCPConfig = z
   .object({
@@ -60,7 +61,8 @@ export class ZedClient extends DefaultMCPClient {
     throw new Error(`Unsupported platform: ${process.platform}`);
   }
 
-  customizeServerConfig(baseConfig: any): any {
+  getServerConfig(apiKey: string, type: 'sse' | 'streamable-http') {
+    const baseConfig = getDefaultServerConfig(apiKey, type);
     return {
       enabled: true,
       source: 'custom',

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -1,0 +1,70 @@
+import z from 'zod';
+import * as path from 'path';
+import * as os from 'os';
+import { DefaultMCPClient } from '../MCPClient';
+
+export const ZedMCPConfig = z
+  .object({
+    context_servers: z.record(
+      z.string(),
+      z.object({
+        enabled: z.boolean().optional(),
+        source: z.string().optional(),
+        command: z.string().optional(),
+        args: z.array(z.string()).optional(),
+        env: z.record(z.string(), z.string()).optional(),
+      }),
+    ),
+  })
+  .passthrough();
+
+export type ZedMCPConfig = z.infer<typeof ZedMCPConfig>;
+
+export class ZedClient extends DefaultMCPClient {
+  name = 'Zed';
+
+  getServerPropertyName(): string {
+    return 'context_servers';
+  }
+
+  async isClientSupported(): Promise<boolean> {
+    return Promise.resolve(
+      process.platform === 'darwin' || process.platform === 'linux',
+    );
+  }
+
+  async getConfigPath(): Promise<string> {
+    const homeDir = os.homedir();
+    const isMac = process.platform === 'darwin';
+    const isLinux = process.platform === 'linux';
+
+    if (isMac) {
+      return Promise.resolve(
+        path.join(homeDir, '.config', 'zed', 'settings.json'),
+      );
+    }
+
+    if (isLinux) {
+      // https://zed.dev/docs/configuring-zed#settings-files
+      const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+      if (xdgConfigHome) {
+        return Promise.resolve(
+          path.join(xdgConfigHome, 'zed', 'settings.json'),
+        );
+      }
+      return Promise.resolve(
+        path.join(homeDir, '.config', 'zed', 'settings.json'),
+      );
+    }
+
+    throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+
+  customizeServerConfig(baseConfig: any): any {
+    return {
+      enabled: true,
+      source: 'custom',
+      ...baseConfig,
+    };
+  }
+}

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -10,12 +10,14 @@ import { ClaudeMCPClient } from './clients/claude';
 import { getPersonalApiKey } from '../../mcp';
 import type { CloudRegion } from '../../utils/types';
 import { ClaudeCodeMCPClient } from './clients/claude-code';
+import { VisualStudioCodeClient } from './clients/visual-studio-code';
 
 export const getSupportedClients = async (): Promise<MCPClient[]> => {
   const allClients = [
     new CursorMCPClient(),
     new ClaudeMCPClient(),
     new ClaudeCodeMCPClient(),
+    new VisualStudioCodeClient(),
   ];
   const supportedClients: MCPClient[] = [];
 
@@ -146,7 +148,6 @@ export const removeMCPServerFromClientsStep = async ({
   integration?: Integration;
 }): Promise<string[]> => {
   const installedClients = await getInstalledClients();
-
   if (installedClients.length === 0) {
     analytics.capture('wizard interaction', {
       action: 'no mcp servers to remove',
@@ -198,7 +199,6 @@ export const removeMCPServerFromClientsStep = async ({
 
 export const getInstalledClients = async (): Promise<MCPClient[]> => {
   const clients = await getSupportedClients();
-
   const installedClients: MCPClient[] = [];
 
   for (const client of clients) {

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -11,6 +11,7 @@ import { getPersonalApiKey } from '../../mcp';
 import type { CloudRegion } from '../../utils/types';
 import { ClaudeCodeMCPClient } from './clients/claude-code';
 import { VisualStudioCodeClient } from './clients/visual-studio-code';
+import { ZedClient } from './clients/zed';
 
 export const getSupportedClients = async (): Promise<MCPClient[]> => {
   const allClients = [
@@ -18,6 +19,7 @@ export const getSupportedClients = async (): Promise<MCPClient[]> => {
     new ClaudeMCPClient(),
     new ClaudeCodeMCPClient(),
     new VisualStudioCodeClient(),
+    new ZedClient(),
   ];
   const supportedClients: MCPClient[] = [];
 


### PR DESCRIPTION
gotta plug my favourite code editor in here too

ALSO adds `jsonc` parsing instead of `json` parsing because vscode and zed supports the `jsonc` spec which causes `json.parse` to fail when parsing comments. `jsonc` comes with some nice benefits like being able to edit specific properties as well.