### PR TITLE
fix: better input check in abortIfCancelled

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -70,8 +70,13 @@ export async function abortIfCancelled<T>(
   integration?: Integration,
 ): Promise<Exclude<T, symbol>> {
   await analytics.shutdown('cancelled');
+  const resolvedInput = await input;
 
-  if (clack.isCancel(await input)) {
+  if (
+    clack.isCancel(resolvedInput) ||
+    (typeof resolvedInput === 'symbol' &&
+      resolvedInput.description === 'clack:cancel')
+  ) {
     const docsUrl = integration
       ? INTEGRATION_CONFIG[integration].docsUrl
       : 'https://posthog.com/docs';


### PR DESCRIPTION
Fixed abortIfCancelled so it detects cancel symbols from Promises. The issue was that `clack.isCancel` checks symbol identity, but the Promise was resolving to a different symbol with the same description.