### PR TITLE
feat: allow feature selection during MCP setup

### DIFF
--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -8,7 +8,10 @@ export abstract class MCPClient {
   abstract getConfigPath(): Promise<string>;
   abstract getServerPropertyName(): string;
   abstract isServerInstalled(): Promise<boolean>;
-  abstract addServer(apiKey: string): Promise<{ success: boolean }>;
+  abstract addServer(
+    apiKey: string,
+    selectedFeatures?: string[],
+  ): Promise<{ success: boolean }>;
   abstract removeServer(): Promise<{ success: boolean }>;
   abstract isClientSupported(): Promise<boolean>;
 }
@@ -24,8 +27,12 @@ export abstract class DefaultMCPClient extends MCPClient {
     return 'mcpServers';
   }
 
-  getServerConfig(apiKey: string, type: 'sse' | 'streamable-http') {
-    return getDefaultServerConfig(apiKey, type);
+  getServerConfig(
+    apiKey: string,
+    type: 'sse' | 'streamable-http',
+    selectedFeatures?: string[],
+  ) {
+    return getDefaultServerConfig(apiKey, type, selectedFeatures);
   }
 
   async isServerInstalled(): Promise<boolean> {
@@ -47,13 +54,17 @@ export abstract class DefaultMCPClient extends MCPClient {
     }
   }
 
-  async addServer(apiKey: string): Promise<{ success: boolean }> {
-    return this._addServerType(apiKey, 'sse');
+  async addServer(
+    apiKey: string,
+    selectedFeatures?: string[],
+  ): Promise<{ success: boolean }> {
+    return this._addServerType(apiKey, 'sse', selectedFeatures);
   }
 
   async _addServerType(
     apiKey: string,
     type: 'sse' | 'streamable-http',
+    selectedFeatures?: string[],
   ): Promise<{ success: boolean }> {
     try {
       const configPath = await this.getConfigPath();
@@ -70,7 +81,11 @@ export abstract class DefaultMCPClient extends MCPClient {
         existingConfig = jsonc.parse(configContent) || {};
       }
 
-      const newServerConfig = this.getServerConfig(apiKey, type);
+      const newServerConfig = this.getServerConfig(
+        apiKey,
+        type,
+        selectedFeatures,
+      );
       const typedConfig = existingConfig as Record<string, any>;
       if (!typedConfig[serverPropertyName]) {
         typedConfig[serverPropertyName] = {};

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
@@ -327,6 +327,7 @@ describe('ClaudeMCPClient', () => {
       expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
         mockApiKey,
         'sse',
+        undefined,
       );
     });
   });

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -45,8 +45,11 @@ export class ClaudeCodeMCPClient extends DefaultMCPClient {
     throw new Error('Not implemented');
   }
 
-  addServer(apiKey: string): Promise<{ success: boolean }> {
-    const config = getDefaultServerConfig(apiKey, 'sse');
+  addServer(
+    apiKey: string,
+    selectedFeatures?: string[],
+  ): Promise<{ success: boolean }> {
+    const config = getDefaultServerConfig(apiKey, 'sse', selectedFeatures);
 
     const command = `claude mcp add-json posthog -s user '${JSON.stringify(
       config,

--- a/src/steps/add-mcp-server-to-clients/clients/cursor.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/cursor.ts
@@ -25,7 +25,10 @@ export class CursorMCPClient extends DefaultMCPClient {
     return Promise.resolve(path.join(os.homedir(), '.cursor', 'mcp.json'));
   }
 
-  async addServer(apiKey: string): Promise<{ success: boolean }> {
-    return this._addServerType(apiKey, 'sse');
+  async addServer(
+    apiKey: string,
+    selectedFeatures?: string[],
+  ): Promise<{ success: boolean }> {
+    return this._addServerType(apiKey, 'sse', selectedFeatures);
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -61,8 +61,12 @@ export class ZedClient extends DefaultMCPClient {
     throw new Error(`Unsupported platform: ${process.platform}`);
   }
 
-  getServerConfig(apiKey: string, type: 'sse' | 'streamable-http') {
-    const baseConfig = getDefaultServerConfig(apiKey, type);
+  getServerConfig(
+    apiKey: string,
+    type: 'sse' | 'streamable-http',
+    selectedFeatures?: string[],
+  ) {
+    const baseConfig = getDefaultServerConfig(apiKey, type, selectedFeatures);
     return {
       enabled: true,
       source: 'custom',

--- a/src/steps/add-mcp-server-to-clients/defaults.ts
+++ b/src/steps/add-mcp-server-to-clients/defaults.ts
@@ -13,21 +13,85 @@ export const DefaultMCPClientConfig = z
   })
   .passthrough();
 
+export const AVAILABLE_FEATURES = {
+  'Data & Analytics': [
+    {
+      value: 'dashboards',
+      label: 'Dashboards',
+      hint: 'Dashboard creation and management',
+    },
+    {
+      value: 'insights',
+      label: 'Insights',
+      hint: 'Analytics insights and SQL queries',
+    },
+    {
+      value: 'experiments',
+      label: 'Experiments',
+      hint: 'A/B testing experiments',
+    },
+    {
+      value: 'llm-analytics',
+      label: 'LLM Analytics',
+      hint: 'LLM usage and cost tracking',
+    },
+  ],
+  'Development Tools': [
+    {
+      value: 'error-tracking',
+      label: 'Error Tracking',
+      hint: 'Error monitoring and debugging',
+    },
+    { value: 'flags', label: 'Feature Flags', hint: 'Feature flag management' },
+  ],
+  'Platform & Management': [
+    {
+      value: 'workspace',
+      label: 'Workspace',
+      hint: 'Organization and project management',
+    },
+    {
+      value: 'docs',
+      label: 'Documentation',
+      hint: 'PostHog documentation search',
+    },
+  ],
+};
+
+export const ALL_FEATURE_VALUES = Object.values(AVAILABLE_FEATURES)
+  .flat()
+  .map((feature) => feature.value);
+
 type MCPServerType = 'sse' | 'streamable-http';
 
 export const getDefaultServerConfig = (
   apiKey: string,
   type: MCPServerType,
-) => ({
-  command: 'npx',
-  args: [
-    '-y',
-    'mcp-remote@latest',
-    `https://mcp.posthog.com/${type === 'sse' ? 'sse' : 'mcp'}`,
-    '--header',
-    `Authorization:\${POSTHOG_AUTH_HEADER}`,
-  ],
-  env: {
-    POSTHOG_AUTH_HEADER: `Bearer ${apiKey}`,
-  },
-});
+  selectedFeatures?: string[],
+) => {
+  const baseUrl = `https://mcp.posthog.com/${type === 'sse' ? 'sse' : 'mcp'}`;
+
+  const isAllFeaturesSelected =
+    selectedFeatures &&
+    selectedFeatures.length === ALL_FEATURE_VALUES.length &&
+    ALL_FEATURE_VALUES.every((feature) => selectedFeatures.includes(feature));
+
+  const urlWithFeatures =
+    selectedFeatures && selectedFeatures.length > 0 && !isAllFeaturesSelected
+      ? `${baseUrl}?features=${selectedFeatures.join(',')}`
+      : baseUrl;
+
+  return {
+    command: 'npx',
+    args: [
+      '-y',
+      'mcp-remote@latest',
+      urlWithFeatures,
+      '--header',
+      `Authorization:\${POSTHOG_AUTH_HEADER}`,
+    ],
+    env: {
+      POSTHOG_AUTH_HEADER: `Bearer ${apiKey}`,
+    },
+  };
+};


### PR DESCRIPTION
Requires https://github.com/PostHog/mcp/pull/118 to be merged first

Allows tool selection while running `wizard mcp add`. If all tools are selected, query param is omitted.

<img width="964" height="297" alt="image" src="https://github.com/user-attachments/assets/95d9f656-035d-449b-8808-025c5fde2c23" />
<img width="1007" height="264" alt="image" src="https://github.com/user-attachments/assets/d2836eb8-d6fd-4f45-a838-f4671c8ad5e1" />
