### PR TITLE
feat(mcp): local mcp server management

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -154,12 +154,23 @@ yargs(hideBin(process.argv))
         'add',
         'Install PostHog MCP server to supported clients',
         (yargs) => {
-          return yargs.options({});
+          return yargs.options({
+            local: {
+              default: false,
+              describe:
+                'Add local development MCP server (http://localhost:8787)',
+              type: 'boolean',
+            },
+          });
         },
         (argv) => {
           const options = { ...argv };
           void runMCPInstall(
-            options as unknown as { signup: boolean; region?: CloudRegion },
+            options as unknown as {
+              signup: boolean;
+              region?: CloudRegion;
+              local?: boolean;
+            },
           );
         },
       )
@@ -167,10 +178,18 @@ yargs(hideBin(process.argv))
         'remove',
         'Remove PostHog MCP server from supported clients',
         (yargs) => {
-          return yargs.options({});
+          return yargs.options({
+            local: {
+              default: false,
+              describe:
+                'Remove local development MCP server (http://localhost:8787)',
+              type: 'boolean',
+            },
+          });
         },
-        () => {
-          void runMCPRemove();
+        (argv) => {
+          const options = { ...argv };
+          void runMCPRemove(options as { local?: boolean });
         },
       )
       .demandCommand(1, 'You must specify a subcommand (add or remove)')

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,12 +13,18 @@ import { sleep } from './lib/helper-functions';
 export const runMCPInstall = async (options: {
   signup: boolean;
   region?: CloudRegion;
+  local?: boolean;
 }) => {
-  clack.intro(chalk.bgGreenBright('Installing the PostHog MCP server'));
+  clack.intro(
+    chalk.bgGreenBright(
+      `Installing the PostHog MCP server ${options.local && '(local)'}`,
+    ),
+  );
 
   await addMCPServerToClientsStep({
     cloudRegion: options.region,
     askPermission: false,
+    local: options.local,
   });
 
   clack.log.message(
@@ -36,9 +42,11 @@ export const runMCPInstall = async (options: {
 ${chalk.blueBright(`https://posthog.com/docs/model-context-protocol`)}`);
 };
 
-export const runMCPRemove = async () => {
+export const runMCPRemove = async (options?: { local?: boolean }) => {
   clack.intro(chalk.bgRed('Removing the PostHog MCP server'));
-  const results = await removeMCPServerFromClientsStep({});
+  const results = await removeMCPServerFromClientsStep({
+    local: options?.local,
+  });
 
   if (results.length === 0) {
     clack.outro(`No PostHog MCP servers found to remove.`);

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
@@ -328,6 +328,7 @@ describe('ClaudeMCPClient', () => {
         mockApiKey,
         'sse',
         undefined,
+        undefined,
       );
     });
   });

--- a/src/steps/add-mcp-server-to-clients/clients/cursor.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/cursor.ts
@@ -28,7 +28,8 @@ export class CursorMCPClient extends DefaultMCPClient {
   async addServer(
     apiKey: string,
     selectedFeatures?: string[],
+    local?: boolean,
   ): Promise<{ success: boolean }> {
-    return this._addServerType(apiKey, 'sse', selectedFeatures);
+    return this._addServerType(apiKey, 'sse', selectedFeatures, local);
   }
 }

--- a/src/steps/add-mcp-server-to-clients/defaults.ts
+++ b/src/steps/add-mcp-server-to-clients/defaults.ts
@@ -68,8 +68,10 @@ export const getDefaultServerConfig = (
   apiKey: string,
   type: MCPServerType,
   selectedFeatures?: string[],
+  local?: boolean,
 ) => {
-  const baseUrl = `https://mcp.posthog.com/${type === 'sse' ? 'sse' : 'mcp'}`;
+  const host = local ? 'localhost:8787' : 'mcp.posthog.com';
+  const baseUrl = `${host}/${type === 'sse' ? 'sse' : 'mcp'}`;
 
   const isAllFeaturesSelected =
     selectedFeatures &&


### PR DESCRIPTION
Closes #150 , I got really tired of adding/removing the localhost MCP server manually. Can be managed by passing `--local` to the `wizard mcp add` and `wizard mcp remove` command.