### PR TITLE
chore: remove unused PAT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-package-version:
     name: Check package version and detect an update
@@ -35,7 +38,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
       - name: Set up Node 18
         uses: actions/setup-node@v4


### PR DESCRIPTION
This Action's only interaction with the GitHub API is to checkout the repo, so the default `GITHUB_TOKEN` is sufficient.