### PR TITLE
chore: add introspection scope to oauth flow

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -589,7 +589,7 @@ async function askForWizardLogin(options: {
 }): Promise<ProjectData> {
   const tokenResponse = await performOAuthFlow({
     cloudRegion: options.cloudRegion,
-    scopes: ['user:read', 'project:read'],
+    scopes: ['user:read', 'project:read', 'introspection'],
     signup: options.signup,
   });
 


### PR DESCRIPTION
This adds the introspection scope to the oauth flow, which we use in the MCP server.

Wait on https://github.com/PostHog/posthog/pull/41440 before merging.