### PR TITLE
feat: use trusted publishing for the npm package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -56,5 +57,3 @@ jobs:
         
       - name: Publish the package in the npm registry
         run: pnpm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This will use trusted publishing, we've now removed the NPM_TOKEN completely.