### PR TITLE
feat: update mcp installations

### DIFF
--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import * as jsonc from 'jsonc-parser';
 import { getDefaultServerConfig } from './defaults';
 
+export type MCPServerConfig = Record<string, unknown>;
+
 export abstract class MCPClient {
   name: string;
   abstract getConfigPath(): Promise<string>;
@@ -33,7 +35,7 @@ export abstract class DefaultMCPClient extends MCPClient {
     type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
-  ) {
+  ): MCPServerConfig {
     return getDefaultServerConfig(apiKey, type, selectedFeatures, local);
   }
 

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -1,5 +1,5 @@
 import { DefaultMCPClient } from '../MCPClient';
-import { DefaultMCPClientConfig } from '../defaults';
+import { buildMCPUrl, DefaultMCPClientConfig } from '../defaults';
 import { z } from 'zod';
 import { execSync } from 'child_process';
 import { analytics } from '../../../utils/analytics';
@@ -120,14 +120,10 @@ export class ClaudeCodeMCPClient extends DefaultMCPClient {
       return Promise.resolve({ success: false });
     }
 
-    // Build Claude Code-specific config
-    // Based on getDefaultServerConfig() but with fixes for Claude Code bugs
-    const config = this.buildClaudeCodeConfig(apiKey, selectedFeatures, local);
     const serverName = local ? 'posthog-local' : 'posthog';
+    const url = buildMCPUrl('streamable-http', selectedFeatures, local);
 
-    const command = `${claudeBinary} mcp add-json ${serverName} -s user '${JSON.stringify(
-      config,
-    )}'`;
+    const command = `${claudeBinary} mcp add --transport http ${serverName} ${url} --header "Authorization: Bearer ${apiKey}" -s user`;
 
     try {
       execSync(command);
@@ -143,61 +139,6 @@ export class ClaudeCodeMCPClient extends DefaultMCPClient {
     }
 
     return Promise.resolve({ success: true });
-  }
-
-  private buildClaudeCodeConfig(
-    apiKey: string,
-    selectedFeatures?: string[],
-    local?: boolean,
-  ) {
-    // Replicate getDefaultServerConfig() logic but with Claude Code fixes:
-    // 1. Add https:// protocol (mcp-remote requires valid URLs)
-    // 2. Embed token directly in Authorization header (env var expansion broken)
-    //
-    // Claude Code bugs:
-    // - https://github.com/anthropics/claude-code/issues/6204
-    // - https://github.com/anthropics/claude-code/issues/9427
-    // - https://github.com/anthropics/claude-code/issues/10955
-
-    const protocol = local ? 'http://' : 'https://';
-    const host = local ? 'localhost:8787' : 'mcp.posthog.com';
-    const baseUrl = `${protocol}${host}/sse`;
-
-    const ALL_FEATURE_VALUES = [
-      'dashboards',
-      'insights',
-      'experiments',
-      'llm-analytics',
-      'error-tracking',
-      'flags',
-      'workspace',
-      'docs',
-    ];
-
-    const isAllFeaturesSelected =
-      selectedFeatures &&
-      selectedFeatures.length === ALL_FEATURE_VALUES.length &&
-      ALL_FEATURE_VALUES.every((feature) => selectedFeatures.includes(feature));
-
-    const urlWithFeatures =
-      selectedFeatures && selectedFeatures.length > 0 && !isAllFeaturesSelected
-        ? `${baseUrl}?features=${selectedFeatures.join(',')}`
-        : baseUrl;
-
-    return {
-      command: 'npx',
-      args: [
-        '-y',
-        'mcp-remote@latest',
-        urlWithFeatures,
-        '--header',
-        `Authorization:Bearer ${apiKey}`, // Embed token directly (not ${VAR})
-      ],
-      // Keep env block for backward compatibility if bugs get fixed
-      env: {
-        POSTHOG_AUTH_HEADER: `Bearer ${apiKey}`,
-      },
-    };
   }
 
   removeServer(local?: boolean): Promise<{ success: boolean }> {

--- a/src/steps/add-mcp-server-to-clients/clients/cursor.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/cursor.ts
@@ -1,7 +1,7 @@
-import { DefaultMCPClient } from '../MCPClient';
+import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
 import * as path from 'path';
 import * as os from 'os';
-import { DefaultMCPClientConfig } from '../defaults';
+import { DefaultMCPClientConfig, getNativeHTTPServerConfig } from '../defaults';
 import { z } from 'zod';
 
 export const CursorMCPConfig = DefaultMCPClientConfig;
@@ -25,11 +25,25 @@ export class CursorMCPClient extends DefaultMCPClient {
     return Promise.resolve(path.join(os.homedir(), '.cursor', 'mcp.json'));
   }
 
+  getServerConfig(
+    apiKey: string,
+    type: 'sse' | 'streamable-http',
+    selectedFeatures?: string[],
+    local?: boolean,
+  ): MCPServerConfig {
+    return getNativeHTTPServerConfig(apiKey, type, selectedFeatures, local);
+  }
+
   async addServer(
     apiKey: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<{ success: boolean }> {
-    return this._addServerType(apiKey, 'sse', selectedFeatures, local);
+    return this._addServerType(
+      apiKey,
+      'streamable-http',
+      selectedFeatures,
+      local,
+    );
   }
 }


### PR DESCRIPTION
A lot of clients now support specifying headers so we don't need to use `mcp-remote`

This updates the ones that do to fix that.