### PR TITLE
Proposal: exclude .env files from agent Read access

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -985,7 +985,7 @@ export async function askForAIConsent(
         : await abortIfCancelled(
             clack.select({
               message:
-                'This setup wizard uses AI, are you happy to continue? ✨',
+                'This wizard uses AI to set up PostHog. Project files (excluding .env) will be processed through PostHog\'s LLM gateway. Continue? ✨',
               options: [
                 {
                   label: 'Yes',


### PR DESCRIPTION
Addresses #244

## Summary
- Exclude `.env*` files from the agent's Read tool access to prevent credentials from transiting the LLM gateway
- Update consent prompt to mention that project files are processed through PostHog's gateway

## Changes

**`src/lib/agent-interface.ts`** — Added `.env*` file check to `wizardCanUseTool()` before the existing non-Bash tool passthrough. When the agent attempts to Read a file whose basename matches `.env` or `.env.*`, the request is denied with a clear message. This runs before the `toolName !== 'Bash'` early return so it catches Read requests specifically.

**`src/utils/clack-utils.ts`** — Updated the AI consent message from:
> "This setup wizard uses AI, are you happy to continue? ✨"

to:
> "This wizard uses AI to set up PostHog. Project files (excluding .env) will be processed through PostHog's LLM gateway. Continue? ✨"

## Test plan
- [ ] Verify agent cannot read `.env`, `.env.local`, `.env.production` etc.
- [ ] Verify environment variable writing still works (uses direct fs via `add-or-update-environment-variables.ts`, not the agent)
- [ ] Verify updated consent prompt displays correctly
- [ ] Verify other Read operations (non-.env files) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)