### PR TITLE
fix: Explicitly disallow reading .env file contents, add local-only .env write tool

### DIFF
--- a/src/angular/angular-wizard-agent.ts
+++ b/src/angular/angular-wizard-agent.ts
@@ -1,0 +1,82 @@
+/* Angular wizard using posthog-agent with PostHog MCP */
+import type { WizardOptions } from '../utils/types';
+import type { FrameworkConfig } from '../lib/framework-config';
+import { Integration } from '../lib/constants';
+import {
+  getPackageVersion,
+  hasPackageInstalled,
+  type PackageDotJson,
+} from '../utils/package-json';
+import { getPackageDotJson, tryGetPackageJson } from '../utils/clack-utils';
+import { getAngularVersionBucket } from './utils';
+
+type AngularContext = Record<string, unknown>;
+
+export const ANGULAR_AGENT_CONFIG: FrameworkConfig<AngularContext> = {
+  metadata: {
+    name: 'Angular',
+    integration: Integration.angular,
+    docsUrl: 'https://posthog.com/docs/libraries/angular',
+  },
+
+  detection: {
+    packageName: '@angular/core',
+    packageDisplayName: 'Angular',
+    getVersion: (packageJson: unknown) =>
+      getPackageVersion('@angular/core', packageJson as PackageDotJson),
+    getVersionBucket: getAngularVersionBucket,
+    minimumVersion: '19.0.0',
+    getInstalledVersion: async (options: WizardOptions) => {
+      const packageJson = await getPackageDotJson(options);
+      return getPackageVersion('@angular/core', packageJson);
+    },
+    detect: async (options) => {
+      const packageJson = await tryGetPackageJson(options);
+      return packageJson
+        ? hasPackageInstalled('@angular/core', packageJson)
+        : false;
+    },
+  },
+
+  environment: {
+    uploadToHosting: false,
+    getEnvVars: (apiKey: string, host: string) => ({
+      NG_APP_POSTHOG_KEY: apiKey,
+      NG_APP_POSTHOG_HOST: host,
+    }),
+  },
+
+  analytics: {
+    getTags: () => ({}),
+  },
+
+  prompts: {
+    projectTypeDetection:
+      'This is an Angular project. Look for package.json, angular.json, and lockfiles (package-lock.json, yarn.lock, pnpm-lock.yaml) to confirm.',
+    packageInstallation:
+      'Look for lockfiles to determine the package manager (npm, yarn, pnpm). Do not manually edit package.json.',
+    getAdditionalContextLines: () => {
+      const frameworkId = 'angular';
+
+      return [
+        `Framework docs ID: ${frameworkId} (use posthog://docs/frameworks/${frameworkId} for documentation)`,
+        'Angular uses dependency injection for services. PostHog should be initialized as a service.',
+        'For standalone components, ensure PostHog is properly provided in the application config.',
+      ];
+    },
+  },
+
+  ui: {
+    successMessage: 'PostHog integration complete',
+    estimatedDurationMinutes: 8,
+    getOutroChanges: () => [
+      `Analyzed your Angular project structure`,
+      `Created and configured PostHog service`,
+      `Integrated PostHog into your application`,
+    ],
+    getOutroNextSteps: () => [
+      'Start your development server with `ng serve` to see PostHog in action',
+      'Visit your PostHog dashboard to see incoming events',
+    ],
+  },
+};

--- a/src/angular/utils.ts
+++ b/src/angular/utils.ts
@@ -1,0 +1,6 @@
+import { createVersionBucket } from '../utils/semver';
+
+/**
+ * Get Angular version bucket for analytics
+ */
+export const getAngularVersionBucket = createVersionBucket();

--- a/src/astro/astro-wizard-agent.ts
+++ b/src/astro/astro-wizard-agent.ts
@@ -1,0 +1,151 @@
+/* Astro wizard using posthog-agent with PostHog MCP */
+import type { WizardOptions } from '../utils/types';
+import type { FrameworkConfig } from '../lib/framework-config';
+import { Integration } from '../lib/constants';
+import {
+  getPackageVersion,
+  hasPackageInstalled,
+  type PackageDotJson,
+} from '../utils/package-json';
+import { getPackageDotJson, tryGetPackageJson } from '../utils/clack-utils';
+import {
+  getAstroRenderingMode,
+  getAstroVersionBucket,
+  getAstroRenderingModeName,
+  AstroRenderingMode,
+} from './utils';
+
+type AstroContext = {
+  renderingMode?: AstroRenderingMode;
+};
+
+export const ASTRO_AGENT_CONFIG: FrameworkConfig<AstroContext> = {
+  metadata: {
+    name: 'Astro',
+    integration: Integration.astro,
+    docsUrl: 'https://posthog.com/docs/libraries/astro',
+    gatherContext: async (options: WizardOptions) => {
+      const renderingMode = await getAstroRenderingMode(options);
+      return { renderingMode };
+    },
+  },
+
+  detection: {
+    packageName: 'astro',
+    packageDisplayName: 'Astro',
+    getVersion: (packageJson: unknown) =>
+      getPackageVersion('astro', packageJson as PackageDotJson),
+    getVersionBucket: getAstroVersionBucket,
+    minimumVersion: '4.0.0',
+    getInstalledVersion: async (options: WizardOptions) => {
+      const packageJson = await getPackageDotJson(options);
+      return getPackageVersion('astro', packageJson);
+    },
+    detect: async (options) => {
+      const packageJson = await tryGetPackageJson(options);
+      return packageJson ? hasPackageInstalled('astro', packageJson) : false;
+    },
+  },
+
+  environment: {
+    uploadToHosting: true,
+    getEnvVars: (apiKey: string, host: string) => ({
+      PUBLIC_POSTHOG_KEY: apiKey,
+      PUBLIC_POSTHOG_HOST: host,
+    }),
+  },
+
+  analytics: {
+    getTags: (context) => ({
+      'rendering-mode': context.renderingMode ?? 'static',
+    }),
+  },
+
+  prompts: {
+    projectTypeDetection:
+      'This is a JavaScript/TypeScript project. Look for package.json and lockfiles (package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb) to confirm.',
+    packageInstallation:
+      'Look for lockfiles to determine the package manager (npm, yarn, pnpm, bun). Do not manually edit package.json.',
+    getAdditionalContextLines: (context) => {
+      const modeName = getAstroRenderingModeName(
+        context.renderingMode ?? AstroRenderingMode.STATIC,
+      );
+
+      // Map rendering mode to framework ID for MCP docs resource
+      const frameworkIdMap: Record<AstroRenderingMode, string> = {
+        [AstroRenderingMode.STATIC]: 'astro-static',
+        [AstroRenderingMode.VIEW_TRANSITIONS]: 'astro-view-transitions',
+        [AstroRenderingMode.SSR]: 'astro-ssr',
+        [AstroRenderingMode.HYBRID]: 'astro-hybrid',
+      };
+
+      const frameworkId =
+        frameworkIdMap[context.renderingMode ?? AstroRenderingMode.STATIC];
+
+      const lines = [
+        `Rendering mode: ${modeName}`,
+        `Framework docs ID: ${frameworkId} (use posthog://docs/frameworks/${frameworkId} for documentation)`,
+      ];
+
+      // Add mode-specific guidance
+      if (context.renderingMode === AstroRenderingMode.VIEW_TRANSITIONS) {
+        lines.push(
+          'IMPORTANT: Use window.__posthog_initialized guard to prevent re-initialization during soft navigation',
+        );
+        lines.push(
+          "IMPORTANT: Set capture_pageview: 'history_change' for automatic pageview tracking",
+        );
+      }
+
+      if (
+        context.renderingMode === AstroRenderingMode.SSR ||
+        context.renderingMode === AstroRenderingMode.HYBRID
+      ) {
+        lines.push(
+          'IMPORTANT: Use posthog-node for server-side tracking in API routes',
+        );
+        lines.push(
+          'IMPORTANT: Create a singleton pattern for the posthog-node client',
+        );
+      }
+
+      return lines;
+    },
+  },
+
+  ui: {
+    successMessage: 'PostHog integration complete',
+    estimatedDurationMinutes: 6,
+    getOutroChanges: (context) => {
+      const modeName = getAstroRenderingModeName(
+        context.renderingMode ?? AstroRenderingMode.STATIC,
+      );
+      const changes = [
+        `Analyzed your Astro project structure (${modeName})`,
+        `Created PostHog component with is:inline script`,
+        `Integrated PostHog into your layout`,
+      ];
+
+      if (
+        context.renderingMode === AstroRenderingMode.SSR ||
+        context.renderingMode === AstroRenderingMode.HYBRID
+      ) {
+        changes.push(`Set up posthog-node for server-side tracking`);
+      }
+
+      if (context.renderingMode === AstroRenderingMode.VIEW_TRANSITIONS) {
+        changes.push(
+          `Added initialization guard for view transitions compatibility`,
+        );
+      }
+
+      return changes;
+    },
+    getOutroNextSteps: () => {
+      return [
+        'Start your development server to see PostHog in action',
+        'Visit your PostHog dashboard to see incoming events',
+      ];
+    },
+  },
+};

--- a/src/astro/utils.ts
+++ b/src/astro/utils.ts
@@ -1,0 +1,179 @@
+import fg from 'fast-glob';
+import fs from 'fs/promises';
+import path from 'path';
+import { abortIfCancelled } from '../utils/clack-utils';
+import clack from '../utils/clack';
+import type { WizardOptions } from '../utils/types';
+import { Integration } from '../lib/constants';
+import { createVersionBucket } from '../utils/semver';
+
+export const getAstroVersionBucket = createVersionBucket();
+
+export enum AstroRenderingMode {
+  STATIC = 'static',
+  SSR = 'ssr',
+  HYBRID = 'hybrid',
+  VIEW_TRANSITIONS = 'view-transitions',
+}
+
+export const IGNORE_PATTERNS = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/.astro/**',
+];
+
+/**
+ * Detect the Astro rendering mode by analyzing:
+ * 1. astro.config.* for output mode
+ * 2. Package.json for adapters
+ * 3. Source files for view transitions usage
+ */
+export async function getAstroRenderingMode({
+  installDir,
+}: Pick<WizardOptions, 'installDir'>): Promise<AstroRenderingMode> {
+  // Check for astro config file
+  const configMatches = await fg('astro.config.@(mjs|ts|js)', {
+    dot: true,
+    cwd: installDir,
+    ignore: IGNORE_PATTERNS,
+  });
+
+  let hasAdapter = false;
+  let outputMode: string | null = null;
+  let usesViewTransitions = false;
+
+  // Check package.json for adapters
+  try {
+    const packageJsonPath = path.join(installDir, 'package.json');
+    const packageJsonContent = await fs.readFile(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent);
+    const allDeps = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    };
+
+    // Check for Astro adapters (node, vercel, netlify, cloudflare, etc.)
+    hasAdapter = Object.keys(allDeps).some(
+      (dep) =>
+        dep.startsWith('@astrojs/') &&
+        (dep.includes('node') ||
+          dep.includes('vercel') ||
+          dep.includes('netlify') ||
+          dep.includes('cloudflare') ||
+          dep.includes('deno')),
+    );
+  } catch {
+    // package.json not found or invalid
+  }
+
+  // Parse astro config for output mode
+  if (configMatches.length > 0) {
+    try {
+      const configPath = path.join(installDir, configMatches[0]);
+      const configContent = await fs.readFile(configPath, 'utf-8');
+
+      // Simple regex to detect output mode
+      const outputMatch = configContent.match(/output:\s*['"](\w+)['"]/);
+      if (outputMatch) {
+        outputMode = outputMatch[1];
+      }
+    } catch {
+      // Config file not readable
+    }
+  }
+
+  // Check for view transitions usage
+  const viewTransitionMatches = await fg('**/*.@(astro|ts|tsx|js|jsx)', {
+    dot: true,
+    cwd: installDir,
+    ignore: IGNORE_PATTERNS,
+  });
+
+  for (const file of viewTransitionMatches.slice(0, 20)) {
+    // Check first 20 files
+    try {
+      const filePath = path.join(installDir, file);
+      const content = await fs.readFile(filePath, 'utf-8');
+      if (
+        content.includes('ClientRouter') ||
+        content.includes('ViewTransitions') ||
+        content.includes('astro:transitions')
+      ) {
+        usesViewTransitions = true;
+        break;
+      }
+    } catch {
+      // File not readable
+    }
+  }
+
+  // Determine rendering mode based on findings
+  if (usesViewTransitions) {
+    clack.log.info(`Detected Astro with View Transitions (ClientRouter) 🔄`);
+    return AstroRenderingMode.VIEW_TRANSITIONS;
+  }
+
+  if (outputMode === 'server' && hasAdapter) {
+    clack.log.info(`Detected Astro SSR mode 🖥️`);
+    return AstroRenderingMode.SSR;
+  }
+
+  // In Astro 5, 'static' is the default and supports per-page SSR opt-in when an adapter is present
+  // This is the "hybrid" pattern even if output mode isn't explicitly set
+  if (hasAdapter) {
+    clack.log.info(`Detected Astro hybrid mode 🔀`);
+    return AstroRenderingMode.HYBRID;
+  }
+
+  if (!hasAdapter) {
+    clack.log.info(`Detected Astro static mode 📄`);
+    return AstroRenderingMode.STATIC;
+  }
+
+  // If detection is ambiguous, ask the user
+  const result: AstroRenderingMode = await abortIfCancelled(
+    clack.select({
+      message: 'What rendering mode is your Astro project using?',
+      options: [
+        {
+          label: getAstroRenderingModeName(AstroRenderingMode.STATIC),
+          value: AstroRenderingMode.STATIC,
+          hint: 'Pre-rendered static HTML (default)',
+        },
+        {
+          label: getAstroRenderingModeName(AstroRenderingMode.VIEW_TRANSITIONS),
+          value: AstroRenderingMode.VIEW_TRANSITIONS,
+          hint: 'Static with ClientRouter for SPA-like navigation',
+        },
+        {
+          label: getAstroRenderingModeName(AstroRenderingMode.HYBRID),
+          value: AstroRenderingMode.HYBRID,
+          hint: 'Mostly static with some SSR pages',
+        },
+        {
+          label: getAstroRenderingModeName(AstroRenderingMode.SSR),
+          value: AstroRenderingMode.SSR,
+          hint: 'Full server-side rendering',
+        },
+      ],
+    }),
+    Integration.astro,
+  );
+
+  return result;
+}
+
+export const getAstroRenderingModeName = (mode: AstroRenderingMode): string => {
+  switch (mode) {
+    case AstroRenderingMode.STATIC:
+      return 'Static (SSG)';
+    case AstroRenderingMode.VIEW_TRANSITIONS:
+      return 'View Transitions';
+    case AstroRenderingMode.SSR:
+      return 'Server (SSR)';
+    case AstroRenderingMode.HYBRID:
+      return 'Hybrid';
+    default:
+      return 'Static';
+  }
+};

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,8 @@ export enum Integration {
   reactRouter = 'react-router',
   tanstackStart = 'tanstack-start',
   tanstackRouter = 'tanstack-router',
+  angular = 'angular',
+  astro = 'astro',
   django = 'django',
   flask = 'flask',
   fastapi = 'fastapi',

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -6,6 +6,8 @@ import { VUE_AGENT_CONFIG } from '../vue/vue-wizard-agent';
 import { REACT_ROUTER_AGENT_CONFIG } from '../react-router/react-router-wizard-agent';
 import { TANSTACK_ROUTER_AGENT_CONFIG } from '../tanstack-router/tanstack-router-wizard-agent';
 import { TANSTACK_START_AGENT_CONFIG } from '../tanstack-start/tanstack-start-wizard-agent';
+import { ANGULAR_AGENT_CONFIG } from '../angular/angular-wizard-agent';
+import { ASTRO_AGENT_CONFIG } from '../astro/astro-wizard-agent';
 import { DJANGO_AGENT_CONFIG } from '../django/django-wizard-agent';
 import { FLASK_AGENT_CONFIG } from '../flask/flask-wizard-agent';
 import { FASTAPI_AGENT_CONFIG } from '../fastapi/fastapi-wizard-agent';
@@ -21,6 +23,8 @@ export const FRAMEWORK_REGISTRY: Record<Integration, FrameworkConfig> = {
   [Integration.tanstackStart]: TANSTACK_START_AGENT_CONFIG,
   [Integration.reactRouter]: REACT_ROUTER_AGENT_CONFIG,
   [Integration.tanstackRouter]: TANSTACK_ROUTER_AGENT_CONFIG,
+  [Integration.angular]: ANGULAR_AGENT_CONFIG,
+  [Integration.astro]: ASTRO_AGENT_CONFIG,
   [Integration.django]: DJANGO_AGENT_CONFIG,
   [Integration.flask]: FLASK_AGENT_CONFIG,
   [Integration.fastapi]: FASTAPI_AGENT_CONFIG,


### PR DESCRIPTION
Adds a new tool that can check for the _presence_ of keys, but not read their values, and also write new key/value pairs and ensure the .env file is properly git ignored.

Meanwhile:

- Read/Write/Edit: Deny when file_path basename starts with .env                                                                           
- Grep: Deny when path directly targets a .env* file (broad directory searches are safe — ripgrep skips dotfiles by default)               
 - Arbitrary bash commands: Already covered by positive allowlist (only specific commands allowed)