### PR TITLE
fix: don't show the entire conversation in error message

### DIFF
--- a/src/lib/agent-interface.ts
+++ b/src/lib/agent-interface.ts
@@ -626,16 +626,22 @@ export async function runAgent(
     }
 
     // Check for API errors (rate limits, etc.)
+    // Extract just the API error line(s), not the entire output
+    const apiErrorMatch = outputText.match(/API Error: [^\n]+/g);
+    const apiErrorMessage = apiErrorMatch
+      ? apiErrorMatch.join('\n')
+      : 'Unknown API error';
+
     if (outputText.includes('API Error: 429')) {
       logToFile('Agent error: RATE_LIMIT');
       spinner.stop('Rate limit exceeded');
-      return { error: AgentErrorType.RATE_LIMIT, message: outputText };
+      return { error: AgentErrorType.RATE_LIMIT, message: apiErrorMessage };
     }
 
     if (outputText.includes('API Error:')) {
       logToFile('Agent error: API_ERROR');
       spinner.stop('API error occurred');
-      return { error: AgentErrorType.API_ERROR, message: outputText };
+      return { error: AgentErrorType.API_ERROR, message: apiErrorMessage };
     }
 
     return completeWithSuccess();


### PR DESCRIPTION
Users are seeing the entire conversation history with successful wizard runs because of API errors. https://posthoghelp.zendesk.com/agent/tickets/50556 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52397)

Limit the error message to the line where the API error message appears. 

