### PR TITLE
fix: add react-native-svg peer dependency instruction for React Native wizard

### DIFF
--- a/src/react-native/react-native-wizard-agent.ts
+++ b/src/react-native/react-native-wizard-agent.ts
@@ -76,6 +76,7 @@ export const REACT_NATIVE_AGENT_CONFIG: FrameworkConfig<ReactNativeContext> = {
       const lines = [
         `Framework docs ID: ${frameworkId} (use posthog://docs/frameworks/${frameworkId} for documentation)`,
         `Variant: ${isExpo ? 'Expo' : 'React Native'}`,
+        'react-native-svg is a required peer dependency of posthog-react-native (used by the surveys feature) and must be installed alongside it.',
       ];
 
       if (isExpo) {


### PR DESCRIPTION
Hey, PostHog team! 👋

I really enjoyed using the wizard; it truly feels magical when it configures everything on its own. However, in my expo project, one small detail was missing for everything to actually work after running a single wizard command. I decided to fix it myself as a thank you and submit a PR. I checked this change on my project, and everything worked!

I also thought about adding a condition and adding this line to prompt only for those package managers where there is no peer dependency installation, but I didn't see the benefit in terms of context savings, etc. But I'm curious to hear what you think!

Here is the description of the problem:

`react-native-svg` is a required (non-optional) peer dependency of `posthog-react-native`, used by the surveys feature. Projects with `legacy-peer-deps=true` in `.npmrc` or using package managers that don’t auto-install peer deps (yarn, pnpm) silently skip it, causing a build failure:

```
Unable to resolve "react-native-svg" from "node_modules/posthog-react-native/dist/surveys/icons.js"
```

This adds an instruction to the React Native wizard agent context so the AI agent explicitly installs `react-native-svg` alongside the SDK

<img width="440" height="956" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-02-21 at 09 05 31" src="https://github.com/user-attachments/assets/2df8a9c8-3d59-4a5f-86e8-faed9877614f" />
