### PR TITLE
feat: pass project id

### DIFF
--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -142,10 +142,11 @@ export async function runAgentWizard(
   });
 
   // Get PostHog credentials
-  const { projectApiKey, host, accessToken } = await getOrAskForProjectData({
-    ...options,
-    cloudRegion,
-  });
+  const { projectApiKey, host, accessToken, projectId } =
+    await getOrAskForProjectData({
+      ...options,
+      cloudRegion,
+    });
 
   // Gather framework-specific context (e.g., Next.js router, React Native platform)
   const frameworkContext = config.metadata.gatherContext
@@ -166,6 +167,7 @@ export async function runAgentWizard(
       typescript: typeScriptDetected,
       projectApiKey,
       host,
+      projectId,
     },
     frameworkContext,
   );
@@ -362,6 +364,7 @@ function buildIntegrationPrompt(
     typescript: boolean;
     projectApiKey: string;
     host: string;
+    projectId: number;
   },
   frameworkContext: Record<string, unknown>,
 ): string {
@@ -379,6 +382,7 @@ function buildIntegrationPrompt(
   } project.
 
 Project context:
+- PostHog Project ID: ${context.projectId}
 - Framework: ${config.metadata.name} ${context.frameworkVersion}
 - TypeScript: ${context.typescript ? 'Yes' : 'No'}
 - PostHog API Key: ${context.projectApiKey}


### PR DESCRIPTION
<img width="448" height="253" alt="Screenshot 2026-02-24 at 11 09 19 AM" src="https://github.com/user-attachments/assets/243513c7-2798-4de1-95d1-d31e7afa6a19" />

Pass project ID into context. This will help the Wizard waste less time on multi-project organizations when using MCP calls