### PR TITLE
chore: Better error handling for project id mismatch

### DIFF
--- a/src/utils/clack-utils.ts
+++ b/src/utils/clack-utils.ts
@@ -688,7 +688,7 @@ async function fetchProjectDataWithApiKey(
     };
   } catch (error) {
     throw new Error(
-      `Failed to fetch project data for project ${projectId} (resolved from your user's last selected project in the PostHog app). This can happen if your API key is scoped to a different project or organization.\n\nTry passing --project-id explicitly.`,
+      `Failed to fetch project data for project ${projectId} (resolved from your user's last selected project in the PostHog app). This can happen if your API key is scoped to a different project or organization.\n\nTry passing --project-id or setting the POSTHOG_WIZARD_PROJECT_ID environment variable explicitly.`,
       { cause: error },
     );
   }


### PR DESCRIPTION
<img width="495" height="306" alt="Screenshot 2026-02-24 at 3 59 17 PM" src="https://github.com/user-attachments/assets/a8ce4b3f-6de0-4a6f-8067-ef61b2d42c32" />

PostHog tracks what you last opened project ID is and if we don't explicitly pass in a project ID, it'll try to access that specific project.

What does this mean?

1. you run the wizard
2. The API key is for project 1
3. Your last logged in project was project 2 on app.posthog.com
4. Wizard runs will fail

This reminds you to try explicitly passing in the project ID, which solves this issue.

Solves a DX paper cut for me