### PR TITLE
fix: include dist/package.json in published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "files": [
     "dist/bin.*",
     "dist/src",
+    "dist/package.json",
     "package.json",
     "README.md"
   ],


### PR DESCRIPTION
`dist/package.json` is missing from the files array in `package.json`, so it doesn't ship to npm and npx

from this: https://github.com/PostHog/wizard/commit/edae68f 