### PR TITLE
chore: add slack notification for GH issues

### DIFF
--- a/.github/workflows/gh-issue-notify.yml
+++ b/.github/workflows/gh-issue-notify.yml
@@ -53,6 +53,6 @@ jobs:
         if: steps.check.outputs.notify == 'true'
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_CHANNEL_WIZARD }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_WIZARD_CHANNEL }}
           webhook-type: incoming-webhook
           payload: ${{ steps.check.outputs.payload }}


### PR DESCRIPTION
workflow to automate Slack nots for GitHub issues, filters out "Integration autonomy" project items

> do not merge yet, waiting for the webhook secret to be added to org