### PR TITLE
fix: unblock signup when GitHub Releases is down

### DIFF
--- a/src/ui/tui/screens/health/HealthCheckScreen.test.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.test.tsx
@@ -1,0 +1,30 @@
+import { canContinueBlockingOutage } from './outage-behavior.js';
+
+describe('canContinueBlockingOutage', () => {
+  it('allows continuing when GitHub Releases is healthy', () => {
+    expect(
+      canContinueBlockingOutage({
+        isGithubReleasesDown: false,
+        signup: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks non-signup runs when GitHub Releases is down', () => {
+    expect(
+      canContinueBlockingOutage({
+        isGithubReleasesDown: true,
+        signup: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows signup runs to continue when GitHub Releases is down', () => {
+    expect(
+      canContinueBlockingOutage({
+        isGithubReleasesDown: true,
+        signup: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -22,6 +22,7 @@ import { ServiceHealthStatus } from '../../../../lib/health-checks/types.js';
 import { wizardAbort } from '../../../../utils/wizard-abort.js';
 import { fetchSkillMenu, downloadSkill } from '../../../../lib/wizard-tools.js';
 import { REMOTE_SKILLS_BASE_URL } from '../../../../lib/constants.js';
+import { canContinueBlockingOutage } from './outage-behavior.js';
 
 interface HealthCheckScreenProps {
   store: WizardStore;
@@ -92,6 +93,10 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
   if (blockingKeys.length === 0) return null;
 
   const isGithubReleasesDown = blockingKeys.includes('githubReleases');
+  const canContinue = canContinueBlockingOutage({
+    isGithubReleasesDown,
+    signup: store.session.signup,
+  });
   const canDownloadSkills =
     result.health.githubReleases.status === ServiceHealthStatus.Healthy;
   const integration = store.session.integration;
@@ -100,7 +105,9 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
 
   const docsUrl = store.session.frameworkConfig?.metadata.docsUrl;
   const description = isGithubReleasesDown
-    ? "The Wizard can't download necessary skills from GitHub Releases right now."
+    ? store.session.signup
+      ? "PostHog account creation can continue, but the Wizard can't download necessary skills from GitHub Releases right now."
+      : "The Wizard can't download necessary skills from GitHub Releases right now."
     : 'The Wizard may not work reliably while services are affected.';
 
   const handleDownloadAndExit = async () => {
@@ -138,7 +145,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
       title={title}
       width={72}
       footer={
-        isGithubReleasesDown ? (
+        !canContinue ? (
           <ConfirmationInput
             message=""
             confirmLabel=""

--- a/src/ui/tui/screens/health/outage-behavior.ts
+++ b/src/ui/tui/screens/health/outage-behavior.ts
@@ -1,0 +1,9 @@
+export function canContinueBlockingOutage({
+  isGithubReleasesDown,
+  signup,
+}: {
+  isGithubReleasesDown: boolean;
+  signup: boolean;
+}): boolean {
+  return signup || !isGithubReleasesDown;
+}


### PR DESCRIPTION
## What changed

A `--signup` run now continues past the blocking outage screen when GitHub Releases is down.

The health check warning still appears. A signup run now also offers a `Continue anyway` action, instead of only an exit.

## Why

The published wizard blocks before account provisioning when GitHub Releases is unavailable. The provisioning flow does not use GitHub Releases. It calls PostHog's signup and provisioning APIs only.

The new-account flow therefore failed before it reached `provisionNewAccount`, because of a service that flow does not use.

## Impact

A new user can create a PostHog account during an outage that affects skill downloads.

An external outage can still affect the later integration step. It no longer blocks account creation.

## Root cause

`HealthCheckScreen` held a special case for a `githubReleases` outage, and that case removed the `Continue` action. The case also applied to a signup run, so the wizard exited before auth and provisioning.

## Validation

I added a unit test for the outage decision helper. It covers three cases:

- A normal run continues when GitHub Releases is healthy.
- A normal run blocks when GitHub Releases is down.
- A signup run continues when GitHub Releases is down.

I ran `jest src/ui/tui/screens/health/HealthCheckScreen.test.tsx --runInBand`.

## Notes

A larger follow-up could group the readiness checks by phase, so signup blocks only on the services it uses.

Skills invoked: `/unambiguous-agent-text`.
