### PR TITLE
feat: open PostHog dashboard after signup

### DIFF
--- a/src/lib/agent/agent-runner.ts
+++ b/src/lib/agent/agent-runner.ts
@@ -55,6 +55,7 @@ import type { WizardOptions } from '../../utils/types';
 
 import type { WorkflowConfig } from '../workflows/workflow-step';
 import { assemblePrompt, type PromptContext } from './agent-prompt';
+import { requestDeepLink } from '../../utils/provisioning';
 
 export type { PromptContext };
 
@@ -434,9 +435,13 @@ export async function runWorkflow(
       cloudRegion,
     );
   } else {
-    const continueUrl = session.signup
-      ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
-      : undefined;
+    let continueUrl: string | undefined;
+    if (session.signup) {
+      const deepLink = await requestDeepLink(accessToken, host);
+      continueUrl =
+        deepLink ??
+        `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`;
+    }
 
     session.outroData = {
       kind: OutroKind.Success,
@@ -448,6 +453,15 @@ export async function runWorkflow(
   }
 
   getUI().outro(config.successMessage);
+
+  if (session.signup && session.outroData?.continueUrl) {
+    try {
+      const opn = (await import('opn')).default;
+      await opn(session.outroData.continueUrl, { wait: false });
+    } catch {
+      // Browser open failed - URL is still shown in the outro screen
+    }
+  }
 
   // 12. Analytics shutdown
   await analytics.shutdown('success');

--- a/src/lib/agent/agent-runner.ts
+++ b/src/lib/agent/agent-runner.ts
@@ -56,6 +56,7 @@ import type { WizardOptions } from '../../utils/types';
 import type { WorkflowConfig } from '../workflows/workflow-step';
 import { assemblePrompt, type PromptContext } from './agent-prompt';
 import { requestDeepLink } from '../../utils/provisioning';
+import opn from 'opn';
 
 export type { PromptContext };
 
@@ -454,13 +455,14 @@ export async function runWorkflow(
 
   getUI().outro(config.successMessage);
 
-  if (session.signup && session.outroData?.continueUrl) {
-    try {
-      const opn = (await import('opn')).default;
-      await opn(session.outroData.continueUrl, { wait: false });
-    } catch {
-      // Browser open failed - URL is still shown in the outro screen
-    }
+  if (
+    session.signup &&
+    session.outroData?.continueUrl &&
+    process.env.NODE_ENV !== 'test'
+  ) {
+    opn(session.outroData.continueUrl, { wait: false }).catch(() => {
+      // opn throws in environments without a browser
+    });
   }
 
   // 12. Analytics shutdown

--- a/src/lib/agent/agent-runner.ts
+++ b/src/lib/agent/agent-runner.ts
@@ -55,8 +55,6 @@ import type { WizardOptions } from '../../utils/types';
 
 import type { WorkflowConfig } from '../workflows/workflow-step';
 import { assemblePrompt, type PromptContext } from './agent-prompt';
-import { requestDeepLink } from '../../utils/provisioning';
-import opn from 'opn';
 
 export type { PromptContext };
 
@@ -436,13 +434,9 @@ export async function runWorkflow(
       cloudRegion,
     );
   } else {
-    let continueUrl: string | undefined;
-    if (session.signup) {
-      const deepLink = await requestDeepLink(accessToken, host);
-      continueUrl =
-        deepLink ??
-        `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`;
-    }
+    const continueUrl = session.signup
+      ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
+      : undefined;
 
     session.outroData = {
       kind: OutroKind.Success,
@@ -454,16 +448,6 @@ export async function runWorkflow(
   }
 
   getUI().outro(config.successMessage);
-
-  if (
-    session.signup &&
-    session.outroData?.continueUrl &&
-    process.env.NODE_ENV !== 'test'
-  ) {
-    opn(session.outroData.continueUrl, { wait: false }).catch(() => {
-      // opn throws in environments without a browser
-    });
-  }
 
   // 12. Analytics shutdown
   await analytics.shutdown('success');

--- a/src/lib/workflows/posthog-integration/index.ts
+++ b/src/lib/workflows/posthog-integration/index.ts
@@ -1,3 +1,4 @@
+import opn from 'opn';
 import type { WorkflowConfig } from '../workflow-step.js';
 import type { WorkflowRun } from '../../agent/agent-runner.js';
 import type { WizardSession } from '../../wizard-session.js';
@@ -15,7 +16,23 @@ import { analytics } from '../../../utils/analytics.js';
 import { WIZARD_INTERACTION_EVENT_NAME } from '../../constants.js';
 import { getUI } from '../../../ui/index.js';
 import { getCloudUrlFromRegion } from '../../../utils/urls.js';
+import { requestDeepLink } from '../../../utils/provisioning.js';
+import type { CloudRegion } from '../../../utils/types.js';
 import { POSTHOG_INTEGRATION_WORKFLOW } from './steps.js';
+
+const DASHBOARD_DEEP_LINK_KEY = 'dashboardDeepLink';
+
+function resolveContinueUrl(
+  sess: WizardSession,
+  cloudRegion: CloudRegion | undefined,
+  deepLink: unknown,
+): string | undefined {
+  if (!sess.signup) return undefined;
+  if (typeof deepLink === 'string' && deepLink) return deepLink;
+  if (cloudRegion)
+    return `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`;
+  return undefined;
+}
 
 export const SETUP_REPORT_FILE = 'posthog-setup-report.md';
 export const EVENT_PLAN_FILE = '.posthog-events.json';
@@ -165,6 +182,21 @@ Important: Use the detect_package_manager tool (from the wizard-tools MCP server
             });
           }
         }
+
+        if (sess.signup) {
+          const deepLink = await requestDeepLink(
+            credentials.accessToken,
+            credentials.host,
+          );
+          if (deepLink) {
+            sess.frameworkContext[DASHBOARD_DEEP_LINK_KEY] = deepLink;
+            if (process.env.NODE_ENV !== 'test') {
+              opn(deepLink, { wait: false }).catch(() => {
+                // opn throws in environments without a browser
+              });
+            }
+          }
+        }
       },
 
       buildOutroData: (sess, credentials, cloudRegion) => {
@@ -172,10 +204,8 @@ Important: Use the detect_package_manager tool (from the wizard-tools MCP server
           credentials.projectApiKey,
           credentials.host,
         );
-        const continueUrl =
-          sess.signup && cloudRegion
-            ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
-            : undefined;
+        const deepLink = sess.frameworkContext[DASHBOARD_DEEP_LINK_KEY];
+        const continueUrl = resolveContinueUrl(sess, cloudRegion, deepLink);
 
         const changes = [
           ...config.ui.getOutroChanges(frameworkContext),

--- a/src/utils/provisioning.ts
+++ b/src/utils/provisioning.ts
@@ -216,3 +216,42 @@ export async function provisionNewAccount(
     accountId: tokenData.account?.id ?? '',
   };
 }
+
+/**
+ * Request a one-time deep link URL that logs the user into PostHog
+ * and redirects to their project dashboard.
+ */
+export async function requestDeepLink(
+  accessToken: string,
+  host: string,
+): Promise<string | null> {
+  try {
+    const baseUrl = host
+      .replace('us.i.posthog.com', 'us.posthog.com')
+      .replace('eu.i.posthog.com', 'eu.posthog.com');
+
+    const res = await axios.post(
+      `${baseUrl}/api/agentic/provisioning/deep_links`,
+      { purpose: 'dashboard' },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+          'API-Version': API_VERSION,
+          'User-Agent': WIZARD_USER_AGENT,
+        },
+        timeout: 10_000,
+      },
+    );
+
+    const url = res.data?.url;
+    if (typeof url === 'string') {
+      logToFile(`[provisioning] deep link created: ${url}`);
+      return url;
+    }
+    return null;
+  } catch {
+    logToFile('[provisioning] deep link request failed, skipping');
+    return null;
+  }
+}


### PR DESCRIPTION
## Problem

After the wizard creates a new PostHog account via provisioning, the user has no way to get to their dashboard without manually navigating to posthog.com and resetting their password. The outro screen shows a static URL but doesn't open it.

## Changes

- Added `requestDeepLink()` to `provisioning.ts` - calls `POST /api/agentic/provisioning/deep_links` to get a one-time login URL
- After signup, the wizard requests a deep link and auto-opens the user's browser to their PostHog project dashboard, already logged in
- Falls back to the static `/products?source=wizard` URL if the deep link request fails
- The deep link URL is also shown in the outro screen so the user can click it manually

The deep link infrastructure already exists on the PostHog server side (used by Stripe). The token is one-time use, expires in 10 minutes.

## How did you test this code?

- All 6 provisioning tests pass
- Build + smoke test pass
- Lint clean (0 errors, only pre-existing warnings)
- Deep link API tested manually against US prod via curl (confirmed it returns valid URLs)

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code.