### PR TITLE
fix: add urls to open source repos

### DIFF
--- a/src/ui/tui/screens/AgentSkillIntroScreen.tsx
+++ b/src/ui/tui/screens/AgentSkillIntroScreen.tsx
@@ -60,6 +60,12 @@ export const AgentSkillIntroScreen = ({
   if (showingMoreInfo) {
     body = (
       <Box flexDirection="column" width={56}>
+        <Box flexDirection="column" marginBottom={1}>
+          <Text>
+            The wizard is an agent that executes PostHog tasks. Its code is open
+            source: <Text color="cyan">https://github.com/PostHog/wizard</Text>
+          </Text>
+        </Box>
         <Text>
           Skill:{' '}
           <Text italic color="cyan">
@@ -119,6 +125,7 @@ export const AgentSkillIntroScreen = ({
   return (
     <IntroScreenLayout
       installDir={session.installDir}
+      showSubtitle={!showingMoreInfo}
       body={body}
       showDetection={isMainMenu}
       workflowLabel={session.workflowLabel}

--- a/src/ui/tui/screens/IntroScreenLayout.tsx
+++ b/src/ui/tui/screens/IntroScreenLayout.tsx
@@ -28,6 +28,9 @@ interface IntroScreenLayoutProps {
   /** Title text after the colored blocks, e.g. "PostHog Wizard 🦔" */
   title?: string;
 
+  /** Show the subtitle copy ("We'll use AI…" / ".env*…"). Default true. */
+  showSubtitle?: boolean;
+
   /** Free-form content below the title (copy, spinners, pickers, notices) */
   body?: ReactNode;
 
@@ -67,6 +70,7 @@ const WizardTitle = ({ title }: { title: string }) => (
 export const IntroScreenLayout = ({
   installDir,
   title = 'PostHog Wizard 🦔',
+  showSubtitle = true,
   body,
   showDetection = true,
   detectionRows,
@@ -113,14 +117,16 @@ export const IntroScreenLayout = ({
         <Box flexDirection="column" alignItems="center">
           <WizardTitle title={title} />
 
-          <Box flexDirection="column" alignItems="center" marginTop={1}>
-            <Text dimColor>
-              We'll use AI to analyze your project and complete work.
-            </Text>
-            <Text dimColor>
-              .env* file contents will not leave your machine.
-            </Text>
-          </Box>
+          {showSubtitle && (
+            <Box flexDirection="column" alignItems="center" marginTop={1}>
+              <Text dimColor>
+                We'll use AI to analyze your project and complete work.
+              </Text>
+              <Text dimColor>
+                .env* file contents will not leave your machine.
+              </Text>
+            </Box>
+          )}
 
           {body && (
             <Box flexDirection="column" alignItems="center" marginTop={1}>

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -15,6 +15,7 @@ import type { WizardStore } from '../store.js';
 import { Integration } from '../../../lib/constants.js';
 import { PickerMenu, LoadingBox } from '../primitives/index.js';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
+import { CONTEXT_MILL_URL } from '../../../lib/constants.js';
 
 /** Framework picker shown when auto-detection fails. */
 const FrameworkPicker = ({
@@ -117,7 +118,10 @@ export const PostHogIntegrationIntroScreen = ({
   } else if (showingMoreInfo) {
     body = (
       <Box flexDirection="column" width={56}>
-        <Text>The wizard is an agent that executes PostHog tasks.</Text>
+        <Text>
+          The wizard is an agent that executes PostHog tasks. Its code is open
+          source: <Text color="cyan">https://github.com/PostHog/wizard</Text>
+        </Text>
         <Box flexDirection="column" marginTop={1}>
           <Text>
             The{' '}
@@ -133,6 +137,12 @@ export const PostHogIntegrationIntroScreen = ({
           <Text>{`\u2022`} Web Analytics</Text>
           <Text>{`\u2022`} Session Replay</Text>
           <Text>{`\u2022`} Error Tracking</Text>
+        </Box>
+        <Box flexDirection="column" marginTop={1}>
+          <Text>
+            If you prefer your own AI setup, download the skill:{' '}
+            <Text color="cyan">{CONTEXT_MILL_URL}/releases</Text>
+          </Text>
         </Box>
       </Box>
     );
@@ -237,6 +247,7 @@ export const PostHogIntegrationIntroScreen = ({
     <IntroScreenLayout
       installDir={session.installDir}
       title={title}
+      showSubtitle={!showingMoreInfo}
       body={body}
       showDetection={showContinue}
       detectionRows={detectionRows}

--- a/src/ui/tui/screens/RevenueIntroScreen.tsx
+++ b/src/ui/tui/screens/RevenueIntroScreen.tsx
@@ -65,7 +65,10 @@ export const RevenueIntroScreen = ({ store }: RevenueIntroScreenProps) => {
 
   const body = showingMoreInfo ? (
     <Box flexDirection="column" width={56}>
-      <Text>The wizard is an agent that executes PostHog tasks.</Text>
+      <Text>
+        The wizard is an agent that executes PostHog tasks. Its code is open
+        source: <Text color="cyan">https://github.com/PostHog/wizard</Text>.
+      </Text>
       <Box flexDirection="column" marginTop={1}>
         <Text>
           The{' '}
@@ -138,6 +141,7 @@ export const RevenueIntroScreen = ({ store }: RevenueIntroScreenProps) => {
   return (
     <IntroScreenLayout
       installDir={session.installDir}
+      showSubtitle={!showingMoreInfo}
       body={body}
       showDetection={!showingMoreInfo}
       detectionRows={detectionRows}


### PR DESCRIPTION
## Problem

- Adding copy in `More info` screens that link to the open source repos

<img width="586" height="390" alt="image" src="https://github.com/user-attachments/assets/4c39cab1-c131-49c9-be44-f511873fe038" />

