### PR TITLE
fix: Remove hacky desktop connection, stand alone mcp install

### DIFF
--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -5,7 +5,6 @@ import { analytics } from '../../utils/analytics';
 import { getUI } from '../../ui';
 import { MCPClient } from './MCPClient';
 import { CursorMCPClient } from './clients/cursor';
-import { ClaudeMCPClient } from './clients/claude';
 import { ClaudeCodeMCPClient } from './clients/claude-code';
 import { VisualStudioCodeClient } from './clients/visual-studio-code';
 import { ZedClient } from './clients/zed';
@@ -16,7 +15,6 @@ import { debug } from '../../utils/debug';
 export const getSupportedClients = async (): Promise<MCPClient[]> => {
   const allClients = [
     new CursorMCPClient(),
-    new ClaudeMCPClient(),
     new ClaudeCodeMCPClient(),
     new VisualStudioCodeClient(),
     new ZedClient(),

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -65,14 +65,13 @@ export function createScreens(
 
     // Standalone MCP flows
     [Screen.McpAdd]: (
-      <McpScreen store={store} installer={services.mcpInstaller} standalone />
+      <McpScreen store={store} installer={services.mcpInstaller} />
     ),
     [Screen.McpRemove]: (
       <McpScreen
         store={store}
         installer={services.mcpInstaller}
         mode="remove"
-        standalone
       />
     ),
   };

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -33,8 +33,6 @@ interface McpScreenProps {
   store: WizardStore;
   installer: McpInstaller;
   mode?: McpMode;
-  /** When true, exit the process after completion instead of routing to outro. */
-  standalone?: boolean;
 }
 
 enum Phase {
@@ -51,19 +49,14 @@ const markDone = (
   store: WizardStore,
   outcome: McpOutcome,
   clients: string[] = [],
-  standalone = false,
 ) => {
   store.setMcpComplete(outcome, clients);
-  if (standalone) {
-    process.exit(0);
-  }
 };
 
 export const McpScreen = ({
   store,
   installer,
   mode = 'install',
-  standalone = false,
 }: McpScreenProps) => {
   useSyncExternalStore(
     (cb) => store.subscribe(cb),
@@ -87,20 +80,14 @@ export const McpScreen = ({
         const detected = await installer.detectClients();
         if (detected.length === 0) {
           setPhase(Phase.None);
-          setTimeout(
-            () => markDone(store, McpOutcome.NoClients, [], standalone),
-            1500,
-          );
+          setTimeout(() => markDone(store, McpOutcome.NoClients), 1500);
         } else {
           setClients(detected);
           setPhase(Phase.Ask);
         }
       } catch {
         setPhase(Phase.None);
-        setTimeout(
-          () => markDone(store, McpOutcome.Failed, [], standalone),
-          1500,
-        );
+        setTimeout(() => markDone(store, McpOutcome.Failed), 1500);
       }
     })();
   }, [installer]); // eslint-disable-line
@@ -126,7 +113,7 @@ export const McpScreen = ({
   };
 
   const handleSkip = () => {
-    markDone(store, McpOutcome.Skipped, [], standalone);
+    markDone(store, McpOutcome.Skipped);
   };
 
   const doInstall = async (names: string[], features?: string[]) => {
@@ -141,7 +128,7 @@ export const McpScreen = ({
     setPhase(Phase.Done);
     const outcome =
       result.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
-    setTimeout(() => markDone(store, outcome, result, standalone), 2000);
+    setTimeout(() => markDone(store, outcome, result), 2000);
   };
 
   const doRemove = async () => {
@@ -156,7 +143,7 @@ export const McpScreen = ({
     setPhase(Phase.Done);
     const outcome =
       result.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
-    setTimeout(() => markDone(store, outcome, result, standalone), 2000);
+    setTimeout(() => markDone(store, outcome, result), 2000);
   };
 
   return (


### PR DESCRIPTION
## Problem

I broke standalone mcp install with earlier refactor

Claude Desktop's wizard install is very flaky. You should now use the connector through the official marketplace. MCP-remote is buggy yet we cannot use http. [See this post](https://www.reddit.com/r/ClaudeAI/comments/1qvs2kd/connecting_claude_desktop_to_a_remote_mcp_server/)

## Changes

Fixes standalone mcp install, removes claude code. Will update docs separately

Related docs
https://github.com/PostHog/posthog.com/compare/update-claude-desktop?expand=1

## Test plan

<!-- How was this tested? Steps to verify, commands run, or "covered by CI". -->

<!-- ## LLM context -->

<!-- If an LLM agent co-authored this PR, uncomment and leave relevant context about the session or tools used. -->
