### PR TITLE
fix: send correct client_id for regional provisioning

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -88,6 +88,8 @@ export const POSTHOG_US_CLIENT_ID = 'c4Rdw8DIxgtQfA80IiSnGKlNX8QN00cFWF00QQhM';
 export const POSTHOG_EU_CLIENT_ID = 'bx2C5sZRN03TkdjraCcetvQFPGH6N2Y9vRLkcKEy';
 export const POSTHOG_DEV_CLIENT_ID = 'DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ';
 export const POSTHOG_PROXY_CLIENT_ID = POSTHOG_US_CLIENT_ID;
+export const POSTHOG_US_PROVISIONING_APP_ID = '019a0c79-b69d-0000-f31b-b41345208c9d';
+export const POSTHOG_EU_PROVISIONING_APP_ID = '019a12d0-6edd-0000-0458-86616af3a3db';
 export const DUMMY_PROJECT_API_KEY = '_YOUR_POSTHOG_PROJECT_TOKEN_';
 
 // ── Wizard run / variants ───────────────────────────────────────────

--- a/src/utils/provisioning.ts
+++ b/src/utils/provisioning.ts
@@ -12,14 +12,17 @@ import axios from 'axios';
 import { z } from 'zod';
 import {
   IS_DEV,
-  POSTHOG_DEV_CLIENT_ID,
-  POSTHOG_US_CLIENT_ID,
+  POSTHOG_EU_PROVISIONING_APP_ID,
+  POSTHOG_US_PROVISIONING_APP_ID,
   WIZARD_USER_AGENT,
 } from '../lib/constants';
 import { logToFile } from './debug';
 import { analytics } from './analytics';
 
-const WIZARD_CLIENT_ID = IS_DEV ? POSTHOG_DEV_CLIENT_ID : POSTHOG_US_CLIENT_ID;
+const PROVISIONING_APP_IDS: Record<string, string> = {
+  US: POSTHOG_US_PROVISIONING_APP_ID,
+  EU: POSTHOG_EU_PROVISIONING_APP_ID,
+};
 const API_VERSION = '0.1d';
 
 const PROVISIONING_BASE_URL = IS_DEV
@@ -114,7 +117,7 @@ export async function provisionNewAccount(
       id: crypto.randomUUID(),
       email,
       name,
-      client_id: WIZARD_CLIENT_ID,
+      client_id: PROVISIONING_APP_IDS[region] ?? PROVISIONING_APP_IDS['US'],
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
       configuration: {


### PR DESCRIPTION
## Problem

Provisioning requests were 401'ing because the wizard was sending the wrong value as `client_id`.

The server's PKCE partner lookup runs `OAuthApplication.objects.get(client_id=...)` against the **`client_id` column** — not the row's primary key (`id`). An earlier commit on this branch introduced two new constants (`POSTHOG_US_PROVISIONING_APP_ID`, `POSTHOG_EU_PROVISIONING_APP_ID`) holding the OAuthApplication **primary key UUIDs**, and sent those as `client_id`. The lookup never matched → `_identify_partner` returned None → the view's "no partner identified" branch returned 401 "Authentication required".

The existing `POSTHOG_US_CLIENT_ID` / `POSTHOG_EU_CLIENT_ID` constants already hold the correct `client_id` column values for the wizard's OAuthApplication records. We just need to send those, with region routing.

## Changes

- Drop the PK-UUID constants (`POSTHOG_US_PROVISIONING_APP_ID`, `POSTHOG_EU_PROVISIONING_APP_ID`).
- Send `POSTHOG_US_CLIENT_ID` / `POSTHOG_EU_CLIENT_ID` (already in `constants.ts`) based on the requested region.
- Preserve `IS_DEV` → `POSTHOG_DEV_CLIENT_ID` for local dev.

Implementation is a single `getWizardClientIdForRegion(region)` helper so the call site stays clean.

## How did you test this code?

- Verified request body now carries the correct `client_id` via axios request interceptor:
  ```json
  { "client_id": "c4Rdw8DIxgtQfA80IiSnGKlNX8QN00cFWF00QQhM", ... }
  ```
- Ran `npx @posthog/wizard provision --email matt+...@posthog.com --json` against `us.posthog.com`: returns full `ProvisioningResult` JSON (projectApiKey, personalApiKey, host, projectId).
- EU is blocked on a separate server-side config: the EU `OAuthApplication` row needs `provisioning_active=True` flipped in the admin (same thing that was blocking US before — just hasn't been done for EU yet).
- Unit tests: `npx jest src/utils/__tests__/provisioning.test.ts` passes (16/16).

## Publish to changelog?

no