### PR TITLE
fix: add --email CLI flag for signup provisioning

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -120,6 +120,11 @@ const cli = yargs(hideBin(process.argv))
         'PostHog project ID to use (optional; when not set, uses default from API key or OAuth)\nenv: POSTHOG_WIZARD_PROJECT_ID',
       type: 'string',
     },
+    email: {
+      describe:
+        'Email address for signup (used with --signup)\nenv: POSTHOG_WIZARD_EMAIL',
+      type: 'string',
+    },
   })
   .command(
     ['$0'],


### PR DESCRIPTION
## Problem

`npx @posthog/wizard --signup --email user@example.com` silently ignores the email flag and fails with "Email is required." The session builder supports `email` and the provisioning code reads it, but `bin.ts` never declared `email` as a yargs option. Yargs drops unknown flags silently.

## Changes

Add `email` to the global yargs options in `bin.ts`.

One-line fix.