### PR TITLE
feat: headless provision subcommand + --ci --signup for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,30 @@ npx @posthog/wizard revenue
 Requires PostHog and Stripe SDKs already installed. Supports `--ci` with the
 same flags as the main wizard.
 
+## Headless Provisioning
+
+Create a new PostHog account from a non-interactive environment (agents, CI,
+scripts). No TTY, no browser, no framework detection — just the 3-call PKCE
+signup flow with a structured result:
+
+```bash
+# Human-readable (when stdout is a TTY)
+npx @posthog/wizard provision --email user@example.com --region us
+
+# Machine-readable — auto when stdout is piped, or force with --json
+npx @posthog/wizard provision --email user@example.com --region eu --json
+```
+
+Success prints the full `ProvisioningResult` (`projectApiKey`, `host`,
+`projectId`, `accountId`, `accessToken`, `refreshToken`, and
+`personalApiKey` if present). Failure exits 1; in `--json` mode the error
+is emitted to stderr as `{"error":"...","code":"..."}`, with `code` set to
+`email_exists` when the address is already registered.
+
+> ⚠️ **The JSON result contains live credentials.** Pipe it into a secrets
+> store — do not let it be captured by shared CI logs. Mask the step output
+> or redirect stdout to a file your job then reads and discards.
+
 # Options
 
 The following CLI arguments are available:

--- a/README.md
+++ b/README.md
@@ -44,11 +44,27 @@ npx @posthog/wizard revenue
 Requires PostHog and Stripe SDKs already installed. Supports `--ci` with the
 same flags as the main wizard.
 
-## Headless Provisioning
+## Headless signup + install (agents / CI)
 
-Create a new PostHog account from a non-interactive environment (agents, CI,
-scripts). No TTY, no browser, no framework detection — just the 3-call PKCE
-signup flow with a structured result:
+For a fully non-interactive first-run (no existing PostHog account, no TTY,
+no browser), combine `--ci --signup --email`. The wizard provisions a new
+account, uses the returned personal API key to run the normal CI install,
+and wires PostHog into the project at `--install-dir`:
+
+```bash
+npx @posthog/wizard --ci --signup \
+  --email you@example.com \
+  --install-dir .
+```
+
+Optional flags: `--name "Your Name"`, `--region eu` (default `us`),
+`--integration nextjs` (else auto-detected).
+
+### Provision only
+
+If you just want credentials — for tests, pre-flight checks, or wiring up
+PostHog yourself — use the `provision` subcommand, which emits a structured
+`ProvisioningResult` and does nothing else:
 
 ```bash
 # Human-readable (when stdout is a TTY)
@@ -64,9 +80,9 @@ Success prints the full `ProvisioningResult` (`projectApiKey`, `host`,
 is emitted to stderr as `{"error":"...","code":"..."}`, with `code` set to
 `email_exists` when the address is already registered.
 
-> ⚠️ **The JSON result contains live credentials.** Pipe it into a secrets
-> store — do not let it be captured by shared CI logs. Mask the step output
-> or redirect stdout to a file your job then reads and discards.
+> ⚠️ **Output contains live credentials.** Pipe it into a secrets store —
+> do not let it be captured by shared CI logs. Mask the step output or
+> redirect stdout to a file your job reads and discards.
 
 # Options
 

--- a/bin.ts
+++ b/bin.ts
@@ -438,35 +438,68 @@ cli.command(
           choices: ['us', 'eu'] as const,
           default: 'us',
         },
+        name: {
+          describe: 'Name for the new account',
+          type: 'string' as const,
+          default: '',
+        },
+        json: {
+          describe:
+            'Emit JSON result to stdout (defaults to true when stdout is not a TTY)',
+          type: 'boolean' as const,
+        },
       })
+      .example('wizard provision --email matt+test@posthog.com --region us', '')
       .example(
-        'wizard provision --email matt+test@posthog.com --region us',
+        'wizard provision --email user@example.com --region eu --json',
         '',
       );
   },
   (argv) => {
-    setUI(new LoggingUI());
-    const email = argv.email as string;
-    const region = (argv.region as string).toUpperCase() as 'US' | 'EU';
+    const email = argv.email;
+    const region = argv.region.toUpperCase() as 'US' | 'EU';
+    const name = argv.name ?? '';
+    const jsonMode =
+      argv.json === undefined ? !process.stdout.isTTY : argv.json;
+
+    if (!jsonMode) {
+      setUI(new LoggingUI());
+    }
 
     void (async () => {
       try {
         const { provisionNewAccount } = await import(
           './src/utils/provisioning.js'
         );
-        getUI().log.info(`Provisioning account for ${email} in ${region}...`);
-        const result = await provisionNewAccount(email, '', region);
-        getUI().log.success('Account provisioned successfully:');
-        getUI().log.info(`  API Key:    ${result.projectApiKey}`);
-        getUI().log.info(`  Host:       ${result.host}`);
-        getUI().log.info(`  Project ID: ${result.projectId}`);
-        if (result.personalApiKey) {
-          getUI().log.info(`  Personal API Key: ${result.personalApiKey}`);
+        if (!jsonMode) {
+          getUI().log.info(`Provisioning account for ${email} in ${region}...`);
+        }
+        const result = await provisionNewAccount(email, name, region);
+        if (jsonMode) {
+          process.stdout.write(`${JSON.stringify(result)}\n`);
+        } else {
+          getUI().log.success('Account provisioned successfully:');
+          getUI().log.info(`  API Key:       ${result.projectApiKey}`);
+          getUI().log.info(`  Host:          ${result.host}`);
+          getUI().log.info(`  Project ID:    ${result.projectId}`);
+          getUI().log.info(`  Account ID:    ${result.accountId}`);
+          getUI().log.info(`  Access Token:  ${result.accessToken}`);
+          getUI().log.info(`  Refresh Token: ${result.refreshToken}`);
+          if (result.personalApiKey) {
+            getUI().log.info(`  Personal API Key: ${result.personalApiKey}`);
+          }
         }
         process.exit(0);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        getUI().log.error(`Provisioning failed: ${msg}`);
+        const code = msg.includes('already associated')
+          ? 'email_exists'
+          : 'provisioning_failed';
+        if (jsonMode) {
+          process.stderr.write(`${JSON.stringify({ error: msg, code })}\n`);
+        } else {
+          getUI().log.error(`Provisioning failed: ${msg}`);
+        }
         process.exit(1);
       }
     })();

--- a/bin.ts
+++ b/bin.ts
@@ -185,11 +185,6 @@ const cli = yargs(hideBin(process.argv))
             'Run a specific context-mill skill by ID\nenv: POSTHOG_WIZARD_SKILL',
           type: 'string',
         },
-        email: {
-          describe:
-            'Email for account creation with --ci --signup\nenv: POSTHOG_WIZARD_EMAIL',
-          type: 'string',
-        },
         name: {
           describe:
             'Name for account creation with --ci --signup\nenv: POSTHOG_WIZARD_NAME',

--- a/bin.ts
+++ b/bin.ts
@@ -179,6 +179,16 @@ const cli = yargs(hideBin(process.argv))
             'Run a specific context-mill skill by ID\nenv: POSTHOG_WIZARD_SKILL',
           type: 'string',
         },
+        email: {
+          describe:
+            'Email for account creation with --ci --signup\nenv: POSTHOG_WIZARD_EMAIL',
+          type: 'string',
+        },
+        name: {
+          describe:
+            'Name for account creation with --ci --signup\nenv: POSTHOG_WIZARD_NAME',
+          type: 'string',
+        },
       });
     },
     (argv) => {
@@ -187,15 +197,6 @@ const cli = yargs(hideBin(process.argv))
       // CI mode validation and TTY check
       if (options.ci) {
         if (!options.region) options.region = 'us';
-        if (!options.apiKey) {
-          setUI(new LoggingUI());
-          getUI().intro('PostHog Wizard');
-          getUI().log.error(
-            'CI mode requires --api-key (personal API key phx_xxx)',
-          );
-          process.exit(1);
-          return;
-        }
         if (!options.installDir) {
           setUI(new LoggingUI());
           getUI().intro('PostHog Wizard');
@@ -205,7 +206,72 @@ const cli = yargs(hideBin(process.argv))
           process.exit(1);
           return;
         }
+        if (!options.apiKey && !options.signup) {
+          setUI(new LoggingUI());
+          getUI().intro('PostHog Wizard');
+          getUI().log.error(
+            'CI mode requires --api-key (personal API key phx_xxx). ' +
+              'To create a new account instead, use --signup --email you@example.com.',
+          );
+          process.exit(1);
+          return;
+        }
+        if (!options.apiKey && options.signup && !options.email) {
+          setUI(new LoggingUI());
+          getUI().intro('PostHog Wizard');
+          getUI().log.error(
+            'CI --signup requires --email to create a new account.',
+          );
+          process.exit(1);
+          return;
+        }
         void (async () => {
+          // If --signup but no existing key, provision a new account first and
+          // use its personal API key for the rest of the CI install.
+          if (!options.apiKey && options.signup) {
+            setUI(new LoggingUI());
+            getUI().intro('PostHog Wizard');
+            try {
+              const { provisionNewAccount } = await import(
+                './src/utils/provisioning.js'
+              );
+              const signupRegion = (options.region as string).toUpperCase() as
+                | 'US'
+                | 'EU';
+              getUI().log.info(
+                `Provisioning new PostHog account for ${String(
+                  options.email,
+                )} in ${signupRegion}...`,
+              );
+              const result = await provisionNewAccount(
+                options.email as string,
+                options.name ?? '',
+                signupRegion,
+              );
+              if (!result.personalApiKey) {
+                getUI().log.error(
+                  'Provisioning succeeded but no personal API key was returned — cannot continue install.',
+                );
+                process.exit(1);
+                return;
+              }
+              getUI().log.success('Account ready.');
+              getUI().log.info(`  Project API Key:  ${result.projectApiKey}`);
+              getUI().log.info(`  Personal API Key: ${result.personalApiKey}`);
+              getUI().log.info(`  Host:             ${result.host}`);
+              options.apiKey = result.personalApiKey;
+              if (options.projectId == null) {
+                options.projectId = result.projectId;
+              }
+            } catch (error) {
+              const msg =
+                error instanceof Error ? error.message : String(error);
+              getUI().log.error(`Provisioning failed: ${msg}`);
+              process.exit(1);
+              return;
+            }
+          }
+
           const { posthogIntegrationConfig } = await import(
             './src/lib/workflows/posthog-integration/index.js'
           );

--- a/bin.ts
+++ b/bin.ts
@@ -422,6 +422,57 @@ const cli = yargs(hideBin(process.argv))
       .help();
   });
 
+cli.command(
+  'provision',
+  'Create a new PostHog account (headless, no TUI)',
+  (yargs) => {
+    return yargs
+      .options({
+        email: {
+          describe: 'Email address for the new account',
+          type: 'string' as const,
+          demandOption: true,
+        },
+        region: {
+          describe: 'Cloud region (us or eu)',
+          choices: ['us', 'eu'] as const,
+          default: 'us',
+        },
+      })
+      .example(
+        'wizard provision --email matt+test@posthog.com --region us',
+        '',
+      );
+  },
+  (argv) => {
+    setUI(new LoggingUI());
+    const email = argv.email as string;
+    const region = (argv.region as string).toUpperCase() as 'US' | 'EU';
+
+    void (async () => {
+      try {
+        const { provisionNewAccount } = await import(
+          './src/utils/provisioning.js'
+        );
+        getUI().log.info(`Provisioning account for ${email} in ${region}...`);
+        const result = await provisionNewAccount(email, '', region);
+        getUI().log.success('Account provisioned successfully:');
+        getUI().log.info(`  API Key:    ${result.projectApiKey}`);
+        getUI().log.info(`  Host:       ${result.host}`);
+        getUI().log.info(`  Project ID: ${result.projectId}`);
+        if (result.personalApiKey) {
+          getUI().log.info(`  Personal API Key: ${result.personalApiKey}`);
+        }
+        process.exit(0);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        getUI().log.error(`Provisioning failed: ${msg}`);
+        process.exit(1);
+      }
+    })();
+  },
+);
+
 // ── Skill-based workflow subcommands (derived from registry) ─────────
 for (const wfConfig of getSubcommandWorkflows()) {
   cli.command(

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,10 +1,16 @@
 // Mock functions must be defined before imports (jest hoists jest.mock calls;
 // variables starting with "mock" are allowed in the factory scope).
-const mockBuildSession = jest.fn((args: Record<string, unknown>) => args);
+// NOTE: variable names must be unique across test files because .test.ts
+// files without top-level imports/exports share a single TS project scope.
+const mockBuildSessionCli = jest.fn((args: Record<string, unknown>) => args);
+const mockProvisionNewAccountCli = jest.fn();
 
 jest.mock('semver', () => ({ satisfies: () => true }));
 jest.mock('../lib/wizard-session', () => ({
-  buildSession: mockBuildSession,
+  buildSession: mockBuildSessionCli,
+}));
+jest.mock('../utils/provisioning', () => ({
+  provisionNewAccount: mockProvisionNewAccountCli,
 }));
 jest.mock('../ui/tui/start-tui', () => ({
   startTUI: () => ({
@@ -106,8 +112,8 @@ describe('CLI argument parsing', () => {
    * buildSession is the common interception point for both CI and non-CI paths.
    */
   function getLastBuildSessionArgs() {
-    expect(mockBuildSession).toHaveBeenCalled();
-    const calls = mockBuildSession.mock.calls;
+    expect(mockBuildSessionCli).toHaveBeenCalled();
+    const calls = mockBuildSessionCli.mock.calls;
     return calls[calls.length - 1][0];
   }
 
@@ -118,17 +124,17 @@ describe('CLI argument parsing', () => {
   describe('--default flag', () => {
     test('accepted when not specified', async () => {
       await runCLI([]);
-      expect(mockBuildSession).toHaveBeenCalled();
+      expect(mockBuildSessionCli).toHaveBeenCalled();
     });
 
     test('accepted with --no-default', async () => {
       await runCLI(['--no-default']);
-      expect(mockBuildSession).toHaveBeenCalled();
+      expect(mockBuildSessionCli).toHaveBeenCalled();
     });
 
     test('accepted when explicitly set to true', async () => {
       await runCLI(['--default']);
-      expect(mockBuildSession).toHaveBeenCalled();
+      expect(mockBuildSessionCli).toHaveBeenCalled();
     });
   });
 
@@ -137,7 +143,7 @@ describe('CLI argument parsing', () => {
       'accepts "%s" as a valid region',
       async (region) => {
         await runCLI(['--region', region]);
-        expect(mockBuildSession).toHaveBeenCalled();
+        expect(mockBuildSessionCli).toHaveBeenCalled();
       },
     );
   });
@@ -148,7 +154,7 @@ describe('CLI argument parsing', () => {
 
       await runCLI([]);
 
-      expect(mockBuildSession).toHaveBeenCalled();
+      expect(mockBuildSessionCli).toHaveBeenCalled();
     });
 
     test('respects POSTHOG_WIZARD_DEFAULT', async () => {
@@ -156,7 +162,7 @@ describe('CLI argument parsing', () => {
 
       await runCLI([]);
 
-      expect(mockBuildSession).toHaveBeenCalled();
+      expect(mockBuildSessionCli).toHaveBeenCalled();
     });
 
     test('CLI args override environment variables', async () => {
@@ -165,7 +171,7 @@ describe('CLI argument parsing', () => {
 
       await runCLI(['--region', 'eu', '--default']);
 
-      expect(mockBuildSession).toHaveBeenCalled();
+      expect(mockBuildSessionCli).toHaveBeenCalled();
     });
   });
 
@@ -299,6 +305,123 @@ describe('CLI argument parsing', () => {
 
       const args = getLastBuildSessionArgs();
       expect(args.apiKey).toBe('phx_cli_key');
+    });
+  });
+
+  describe('--ci --signup flow', () => {
+    // Exits inside the async provisioning IIFE become unhandled rejections if
+    // process.exit throws. Override to a silent no-op for this block — the
+    // handler's exit calls are always terminal, so "continuing" past them is
+    // harmless and lets us assert on both the exit code and mock state.
+    beforeEach(() => {
+      process.exit = jest.fn() as unknown as typeof process.exit;
+    });
+
+    const successResult = {
+      projectApiKey: 'phc_new',
+      host: 'https://us.posthog.com',
+      projectId: 'proj_42',
+      accountId: 'acc_1',
+      accessToken: 'at',
+      refreshToken: 'rt',
+      personalApiKey: 'phx_from_signup',
+    };
+
+    async function runCISignup(extra: string[] = []) {
+      await runCLI([
+        '--ci',
+        '--signup',
+        '--email',
+        'new@example.com',
+        '--install-dir',
+        '/tmp/test',
+        ...extra,
+      ]);
+      // Let the async provisioning IIFE + runWizardCI's own IIFE settle
+      for (let i = 0; i < 5; i++) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    }
+
+    test('requires --email when --ci --signup is set', async () => {
+      await runCLI(['--ci', '--signup', '--install-dir', '/tmp/test']);
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(mockProvisionNewAccountCli).not.toHaveBeenCalled();
+    });
+
+    test('rejects --ci without --api-key and without --signup', async () => {
+      await runCLI(['--ci', '--install-dir', '/tmp/test']);
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(mockProvisionNewAccountCli).not.toHaveBeenCalled();
+    });
+
+    test('provisions a new account and feeds personalApiKey into the CI flow', async () => {
+      mockProvisionNewAccountCli.mockResolvedValue(successResult);
+      await runCISignup();
+      expect(mockProvisionNewAccountCli).toHaveBeenCalledWith(
+        'new@example.com',
+        '',
+        'US',
+      );
+      const args = getLastBuildSessionArgs();
+      expect(args.apiKey).toBe('phx_from_signup');
+    });
+
+    test('forwards --name to provisionNewAccount', async () => {
+      mockProvisionNewAccountCli.mockResolvedValue(successResult);
+      await runCISignup(['--name', 'Test User']);
+      expect(mockProvisionNewAccountCli).toHaveBeenCalledWith(
+        'new@example.com',
+        'Test User',
+        'US',
+      );
+    });
+
+    test('uppercases --region before provisioning', async () => {
+      mockProvisionNewAccountCli.mockResolvedValue(successResult);
+      await runCISignup(['--region', 'eu']);
+      expect(mockProvisionNewAccountCli).toHaveBeenCalledWith(
+        'new@example.com',
+        '',
+        'EU',
+      );
+    });
+
+    test('exits non-zero when provisioning rejects', async () => {
+      mockProvisionNewAccountCli.mockRejectedValue(new Error('network fail'));
+      await runCISignup();
+      expect(mockProvisionNewAccountCli).toHaveBeenCalled();
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(mockBuildSessionCli).not.toHaveBeenCalled();
+    });
+
+    test('exits non-zero when provisioning returns no personal API key', async () => {
+      mockProvisionNewAccountCli.mockResolvedValue({
+        ...successResult,
+        personalApiKey: undefined,
+      });
+      await runCISignup();
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(mockBuildSessionCli).not.toHaveBeenCalled();
+    });
+
+    test('existing --api-key takes precedence over --signup', async () => {
+      await runCLI([
+        '--ci',
+        '--signup',
+        '--email',
+        'new@example.com',
+        '--api-key',
+        'phx_existing',
+        '--install-dir',
+        '/tmp/test',
+      ]);
+      for (let i = 0; i < 3; i++) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      expect(mockProvisionNewAccountCli).not.toHaveBeenCalled();
+      const args = getLastBuildSessionArgs();
+      expect(args.apiKey).toBe('phx_existing');
     });
   });
 });

--- a/src/__tests__/provision-cli.test.ts
+++ b/src/__tests__/provision-cli.test.ts
@@ -1,0 +1,233 @@
+// Mock functions must be defined before imports (jest hoists jest.mock calls;
+// variables starting with "mock" are allowed in the factory scope).
+const mockProvisionNewAccount = jest.fn();
+
+jest.mock('semver', () => ({ satisfies: () => true }));
+jest.mock('../utils/provisioning', () => ({
+  provisionNewAccount: mockProvisionNewAccount,
+}));
+// Same supporting mocks as src/__tests__/cli.test.ts — bin.ts imports these
+// at module load regardless of which subcommand yargs dispatches.
+jest.mock('../lib/wizard-session', () => ({
+  buildSession: jest.fn((args: Record<string, unknown>) => args),
+}));
+jest.mock('../ui/tui/start-tui', () => ({
+  startTUI: () => ({
+    unmount: jest.fn(),
+    store: {
+      session: {},
+      runReadyHooks: jest.fn().mockResolvedValue(undefined),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      getGate: jest.fn().mockReturnValue(new Promise(() => {})),
+      subscribe: jest.fn(),
+      onEnterScreen: jest.fn(),
+    },
+  }),
+}));
+jest.mock('../lib/workflows/posthog-integration/index', () => ({
+  posthogIntegrationConfig: {
+    flowKey: 'posthog-integration',
+    steps: [],
+    run: null,
+  },
+}));
+jest.mock('../utils/environment', () => ({
+  isNonInteractiveEnvironment: () => false,
+  readEnvironment: () => ({}),
+}));
+jest.mock('../utils/env-api-key', () => ({
+  readApiKeyFromEnv: () => undefined,
+}));
+jest.mock('../utils/debug', () => ({
+  configureLogFileFromEnvironment: jest.fn(),
+  logToFile: jest.fn(),
+}));
+jest.mock('../lib/registry', () => ({ FRAMEWORK_REGISTRY: {} }));
+jest.mock('../lib/detection/index', () => ({
+  detectFramework: jest.fn().mockResolvedValue(null),
+  gatherFrameworkContext: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../utils/analytics', () => ({
+  analytics: { setTag: jest.fn() },
+}));
+jest.mock('../utils/wizard-abort', () => ({ wizardAbort: jest.fn() }));
+jest.mock('../lib/agent/agent-runner', () => ({
+  runAgent: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('wizard provision subcommand', () => {
+  const originalArgv = process.argv;
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalExit = process.exit;
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalIsTTY = process.stdout.isTTY;
+
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+  let consoleLogSpy: jest.SpyInstance;
+
+  const successResult = {
+    projectApiKey: 'phc_test',
+    host: 'https://us.posthog.com',
+    projectId: 'proj_1',
+    accountId: 'acc_1',
+    accessToken: 'access_token',
+    refreshToken: 'refresh_token',
+    personalApiKey: 'phx_test',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stdoutChunks = [];
+    stderrChunks = [];
+
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: unknown) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {
+      // suppress LoggingUI output during tests
+    });
+
+    // process.exit is always the final call in each branch of the provision
+    // handler, so a silent no-op is enough. Throwing here would escape the
+    // void async IIFE and become an unhandled rejection.
+    process.exit = jest.fn() as unknown as typeof process.exit;
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exit = originalExit;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    consoleLogSpy.mockRestore();
+    jest.resetModules();
+  });
+
+  function setTTY(isTTY: boolean) {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: isTTY,
+      configurable: true,
+    });
+  }
+
+  async function runCLI(args: string[]) {
+    process.argv = ['node', 'bin.ts', 'provision', ...args];
+    try {
+      jest.isolateModules(() => {
+        require('../../bin.ts');
+      });
+    } catch {
+      // process.exit mock throws to halt handler execution
+    }
+    // Dynamic import + async handler need several microtask flushes
+    for (let i = 0; i < 10; i++) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  }
+
+  test('exits non-zero without calling the API when --email is missing', async () => {
+    setTTY(true);
+    await runCLI([]);
+    expect(mockProvisionNewAccount).not.toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  test('uppercases --region before calling provisionNewAccount', async () => {
+    setTTY(true);
+    mockProvisionNewAccount.mockResolvedValue(successResult);
+    await runCLI(['--email', 'user@example.com', '--region', 'eu']);
+    expect(mockProvisionNewAccount).toHaveBeenCalledWith(
+      'user@example.com',
+      '',
+      'EU',
+    );
+  });
+
+  test('forwards --name to provisionNewAccount', async () => {
+    setTTY(true);
+    mockProvisionNewAccount.mockResolvedValue(successResult);
+    await runCLI([
+      '--email',
+      'user@example.com',
+      '--name',
+      'Test User',
+      '--region',
+      'us',
+    ]);
+    expect(mockProvisionNewAccount).toHaveBeenCalledWith(
+      'user@example.com',
+      'Test User',
+      'US',
+    );
+  });
+
+  test('--json emits a single JSON object of the full ProvisioningResult', async () => {
+    setTTY(true);
+    mockProvisionNewAccount.mockResolvedValue(successResult);
+    await runCLI(['--email', 'user@example.com', '--json']);
+    const out = stdoutChunks.join('').trim();
+    expect(JSON.parse(out)).toEqual(successResult);
+    // Human log lines should not also appear on stdout
+    expect(stdoutChunks.join('')).not.toContain('API Key:');
+  });
+
+  test('auto-enables JSON output when stdout is not a TTY', async () => {
+    setTTY(false);
+    mockProvisionNewAccount.mockResolvedValue(successResult);
+    await runCLI(['--email', 'user@example.com']);
+    const out = stdoutChunks.join('').trim();
+    expect(JSON.parse(out)).toEqual(successResult);
+  });
+
+  test('uses human-readable output when TTY and --json not set', async () => {
+    setTTY(true);
+    mockProvisionNewAccount.mockResolvedValue(successResult);
+    await runCLI(['--email', 'user@example.com']);
+    expect(stdoutChunks.join('')).toBe('');
+    // LoggingUI writes via console.log
+    const consoleOutput = consoleLogSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join('\n');
+    expect(consoleOutput).toContain('API Key:');
+    expect(consoleOutput).toContain(successResult.projectApiKey);
+  });
+
+  test('emits email_exists code when email is already associated', async () => {
+    setTTY(false);
+    mockProvisionNewAccount.mockRejectedValue(
+      new Error(
+        'This email is already associated with a PostHog account. Please use the login flow instead.',
+      ),
+    );
+    await runCLI(['--email', 'user@example.com']);
+    const err = stderrChunks.join('').trim();
+    const parsed = JSON.parse(err) as { error: string; code: string };
+    expect(parsed.code).toBe('email_exists');
+    expect(parsed.error).toContain('already associated');
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  test('uses provisioning_failed code for other errors', async () => {
+    setTTY(false);
+    mockProvisionNewAccount.mockRejectedValue(new Error('network unreachable'));
+    await runCLI(['--email', 'user@example.com']);
+    const parsed = JSON.parse(stderrChunks.join('').trim()) as {
+      error: string;
+      code: string;
+    };
+    expect(parsed.code).toBe('provisioning_failed');
+    expect(parsed.error).toBe('network unreachable');
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/__tests__/provision-cli.test.ts
+++ b/src/__tests__/provision-cli.test.ts
@@ -1,10 +1,12 @@
 // Mock functions must be defined before imports (jest hoists jest.mock calls;
 // variables starting with "mock" are allowed in the factory scope).
-const mockProvisionNewAccount = jest.fn();
+// Name-scoped to this file because .test.ts files share TS project scope when
+// they have no top-level imports/exports.
+const mockProvisionNewAccountSubcmd = jest.fn();
 
 jest.mock('semver', () => ({ satisfies: () => true }));
 jest.mock('../utils/provisioning', () => ({
-  provisionNewAccount: mockProvisionNewAccount,
+  provisionNewAccount: mockProvisionNewAccountSubcmd,
 }));
 // Same supporting mocks as src/__tests__/cli.test.ts — bin.ts imports these
 // at module load regardless of which subcommand yargs dispatches.
@@ -139,15 +141,15 @@ describe('wizard provision subcommand', () => {
   test('exits non-zero without calling the API when --email is missing', async () => {
     setTTY(true);
     await runCLI([]);
-    expect(mockProvisionNewAccount).not.toHaveBeenCalled();
+    expect(mockProvisionNewAccountSubcmd).not.toHaveBeenCalled();
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   test('uppercases --region before calling provisionNewAccount', async () => {
     setTTY(true);
-    mockProvisionNewAccount.mockResolvedValue(successResult);
+    mockProvisionNewAccountSubcmd.mockResolvedValue(successResult);
     await runCLI(['--email', 'user@example.com', '--region', 'eu']);
-    expect(mockProvisionNewAccount).toHaveBeenCalledWith(
+    expect(mockProvisionNewAccountSubcmd).toHaveBeenCalledWith(
       'user@example.com',
       '',
       'EU',
@@ -156,7 +158,7 @@ describe('wizard provision subcommand', () => {
 
   test('forwards --name to provisionNewAccount', async () => {
     setTTY(true);
-    mockProvisionNewAccount.mockResolvedValue(successResult);
+    mockProvisionNewAccountSubcmd.mockResolvedValue(successResult);
     await runCLI([
       '--email',
       'user@example.com',
@@ -165,7 +167,7 @@ describe('wizard provision subcommand', () => {
       '--region',
       'us',
     ]);
-    expect(mockProvisionNewAccount).toHaveBeenCalledWith(
+    expect(mockProvisionNewAccountSubcmd).toHaveBeenCalledWith(
       'user@example.com',
       'Test User',
       'US',
@@ -174,7 +176,7 @@ describe('wizard provision subcommand', () => {
 
   test('--json emits a single JSON object of the full ProvisioningResult', async () => {
     setTTY(true);
-    mockProvisionNewAccount.mockResolvedValue(successResult);
+    mockProvisionNewAccountSubcmd.mockResolvedValue(successResult);
     await runCLI(['--email', 'user@example.com', '--json']);
     const out = stdoutChunks.join('').trim();
     expect(JSON.parse(out)).toEqual(successResult);
@@ -184,7 +186,7 @@ describe('wizard provision subcommand', () => {
 
   test('auto-enables JSON output when stdout is not a TTY', async () => {
     setTTY(false);
-    mockProvisionNewAccount.mockResolvedValue(successResult);
+    mockProvisionNewAccountSubcmd.mockResolvedValue(successResult);
     await runCLI(['--email', 'user@example.com']);
     const out = stdoutChunks.join('').trim();
     expect(JSON.parse(out)).toEqual(successResult);
@@ -192,7 +194,7 @@ describe('wizard provision subcommand', () => {
 
   test('uses human-readable output when TTY and --json not set', async () => {
     setTTY(true);
-    mockProvisionNewAccount.mockResolvedValue(successResult);
+    mockProvisionNewAccountSubcmd.mockResolvedValue(successResult);
     await runCLI(['--email', 'user@example.com']);
     expect(stdoutChunks.join('')).toBe('');
     // LoggingUI writes via console.log
@@ -205,7 +207,7 @@ describe('wizard provision subcommand', () => {
 
   test('emits email_exists code when email is already associated', async () => {
     setTTY(false);
-    mockProvisionNewAccount.mockRejectedValue(
+    mockProvisionNewAccountSubcmd.mockRejectedValue(
       new Error(
         'This email is already associated with a PostHog account. Please use the login flow instead.',
       ),
@@ -220,7 +222,9 @@ describe('wizard provision subcommand', () => {
 
   test('uses provisioning_failed code for other errors', async () => {
     setTTY(false);
-    mockProvisionNewAccount.mockRejectedValue(new Error('network unreachable'));
+    mockProvisionNewAccountSubcmd.mockRejectedValue(
+      new Error('network unreachable'),
+    );
     await runCLI(['--email', 'user@example.com']);
     const parsed = JSON.parse(stderrChunks.join('').trim()) as {
       error: string;


### PR DESCRIPTION
## Problem

The wizard has no headless signup path. The interactive `$0` flow requires a TTY + browser, and `--ci` requires a personal API key the caller already has. Neither works for a cold-start agent that needs to bootstrap PostHog into a project in one shot.

## Changes

Two layered entry points:

**1. `wizard provision` subcommand** — a primitive that calls `provisionNewAccount()` directly and emits the structured `ProvisioningResult` on stdout. No TUI, no framework detection, no browser. For tests, pre-flight checks, or callers that want credentials without the install.

```bash
# Human-readable when stdout is a TTY
npx @posthog/wizard provision --email user@example.com --region us

# Machine-readable JSON when piped, or force with --json
npx @posthog/wizard provision --email user@example.com --region us --json
# → {"projectApiKey":"phc_...","host":"https://us.posthog.com","projectId":"...","accountId":"...","accessToken":"...","refreshToken":"...","personalApiKey":"phx_..."}
```

Failure exits 1; in `--json` mode errors surface on stderr as `{"error":"...","code":"..."}` with a stable `email_exists` code for the already-registered case.

**2. `wizard --ci --signup --email you@example.com --install-dir .`** — the end-to-end flow. The `$0` CI branch provisions a new account via `provisionNewAccount`, sets `options.apiKey = result.personalApiKey`, then falls through to the existing `runWizardCI` install. `--api-key` takes precedence if both are supplied.

Also adds `--email` and `--name` options (scoped to `$0`, not global — global placement broke the existing `cli.test.ts` mocking setup via a yargs parse-order quirk).

## Test plan

- **New**: `src/__tests__/provision-cli.test.ts` — 8 tests covering the subcommand (required --email, region uppercasing, --name forwarding, JSON shape, auto-JSON for non-TTY, human-readable mode, email_exists error code, provisioning_failed error code).
- **Extended**: `src/__tests__/cli.test.ts` — new `--ci --signup flow` describe block with 7 tests (missing --email, missing key + no signup, success path sets apiKey, --name forwarding, region uppercasing, provisioning rejection, --api-key precedence).
- Full suite: 81/81 passing, lint clean (0 errors).
- Manual against `us.posthog.com`: both `provision --json` and `--ci --signup` produce valid credentials and the latter reaches the install flow.

Dependency note: `--ci --signup` needs the server-side provisioned PAT to have working scopes. Tracked in PostHog/posthog#56029 — the wizard side works as soon as that PR merges (without it, the install reaches `detectRegionFromToken` and fails because the PAT has no scopes).

<!-- ## LLM context -->
Authored with Claude Opus 4.7 (1M context). Tests passed locally and I verified the real-API flow against us.posthog.com; I'm an agent and did not run the full CI locally.