### PR TITLE
fix: use of temp folders for windows

### DIFF
--- a/src/lib/middleware/config.ts
+++ b/src/lib/middleware/config.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import { logToFile } from '../../utils/debug';
 import { AgentSignals } from '../agent/agent-interface';
 import { runtimeEnv } from '@env';
+import { WIZARD_BENCHMARK_FILE, WIZARD_LOG_FILE } from '../../utils/paths';
 
 export interface BenchmarkConfig {
   /** Enable/disable individual metric plugins */
@@ -41,9 +42,9 @@ const DEFAULT_CONFIG: BenchmarkConfig = {
     jsonWriter: true,
   },
   output: {
-    benchmarkPath: '/tmp/posthog-wizard-benchmark.json',
+    benchmarkPath: WIZARD_BENCHMARK_FILE,
     benchmarkEnabled: true,
-    logPath: '/tmp/posthog-wizard.log',
+    logPath: WIZARD_LOG_FILE,
     logEnabled: true,
     suppressWizardLogs: false,
   },

--- a/src/lib/task-stream/destinations/file.ts
+++ b/src/lib/task-stream/destinations/file.ts
@@ -4,8 +4,7 @@ import type {
   TaskStreamUpdate,
   StreamEvent,
 } from '../types';
-
-const TASK_STREAM_LOG = '/tmp/posthog-task-stream.log';
+import { WIZARD_TASK_STREAM_LOG } from '../../../utils/paths';
 
 export class FileDestination implements TaskStreamDestination {
   readonly name = 'file';
@@ -13,7 +12,7 @@ export class FileDestination implements TaskStreamDestination {
   send(event: StreamEvent, payload: TaskStreamUpdate): Promise<void> {
     try {
       appendFileSync(
-        TASK_STREAM_LOG,
+        WIZARD_TASK_STREAM_LOG,
         `[${event}] ${JSON.stringify(payload, null, 2)}\n`,
       );
     } catch {

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -12,6 +12,7 @@ import fs from 'fs';
 import { execFileSync } from 'child_process';
 import { z } from 'zod';
 import { logToFile } from '../utils/debug';
+import { skillTmpPath } from '../utils/paths';
 import type { PackageManagerDetector } from './detection/package-manager';
 
 // ---------------------------------------------------------------------------
@@ -81,7 +82,7 @@ export function downloadSkill(
   const skillDir = skillsRoot
     ? path.join(installDir, skillsRoot, skillEntry.id)
     : path.join(installDir, '.claude', 'skills', skillEntry.id);
-  const tmpFile = `/tmp/posthog-skill-${skillEntry.id}.zip`;
+  const tmpFile = skillTmpPath(skillEntry.id);
 
   try {
     fs.mkdirSync(skillDir, { recursive: true });

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -105,7 +105,7 @@ export function formatScanReport(): string | null {
   return lines.join('\n');
 }
 
-const YARA_REPORT_PATH = '/tmp/posthog-wizard-yara-report.json';
+import { WIZARD_YARA_REPORT_FILE } from '../utils/paths';
 
 /** Write the scan report to a JSON file. Returns the file path, or null if no scans occurred. */
 export function writeScanReport(): string | null {
@@ -121,12 +121,12 @@ export function writeScanReport(): string | null {
   };
 
   try {
-    fs.writeFileSync(YARA_REPORT_PATH, JSON.stringify(report, null, 2));
+    fs.writeFileSync(WIZARD_YARA_REPORT_FILE, JSON.stringify(report, null, 2));
   } catch (err) {
     logToFile('[YARA] Failed to write scan report:', err);
     return null;
   }
-  return YARA_REPORT_PATH;
+  return WIZARD_YARA_REPORT_FILE;
 }
 
 // ─── Hook Timeouts (ms) ─────────────────────────────────────────

--- a/src/ui/tui/playground/demos/RunScreenDemo.tsx
+++ b/src/ui/tui/playground/demos/RunScreenDemo.tsx
@@ -18,6 +18,7 @@ import {
 import type { ProgressItem } from '../../primitives/index.js';
 import { LearnCard } from '../../components/LearnCard.js';
 import { TipsCard } from '../../components/TipsCard.js';
+import { WIZARD_LOG_FILE } from '../../../../utils/paths.js';
 
 const MOCK_TASKS = [
   {
@@ -192,7 +193,7 @@ export const RunScreenDemo = ({ store }: RunScreenDemoProps) => {
     {
       id: 'logs',
       label: 'Tail logs',
-      component: <LogViewer filePath="/tmp/posthog-wizard.log" />,
+      component: <LogViewer filePath={WIZARD_LOG_FILE} />,
     },
     {
       id: 'hn',

--- a/src/ui/tui/screens/RunScreen.tsx
+++ b/src/ui/tui/screens/RunScreen.tsx
@@ -26,7 +26,7 @@ import { LearnCard } from '../components/LearnCard.js';
 import { TipsCard } from '../components/TipsCard.js';
 import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
 
-const LOG_FILE = '/tmp/posthog-wizard.log';
+import { WIZARD_LOG_FILE } from '../../../utils/paths.js';
 
 interface RunScreenProps {
   store: WizardStore;
@@ -98,7 +98,7 @@ export const RunScreen = ({ store }: RunScreenProps) => {
     {
       id: 'logs',
       label: 'Tail logs',
-      component: <LogViewer filePath={LOG_FILE} />,
+      component: <LogViewer filePath={WIZARD_LOG_FILE} />,
     },
     {
       id: 'hn',

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -3,9 +3,10 @@ import path from 'path';
 import { prepareMessage } from './logging';
 import { getUI } from '../ui';
 import { runtimeEnv } from '@env';
+import { WIZARD_LOG_FILE } from './paths';
 
 let debugEnabled = false;
-let logFilePath = '/tmp/posthog-wizard.log';
+let logFilePath = WIZARD_LOG_FILE;
 let logEnabled = true;
 
 export function getLogFilePath(): string {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,8 +1,8 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-// use tmpdir for windows compatibility!
-const TMP = tmpdir();
+// /tmp is stable and discoverable on macOS/Linux; Windows needs os.tmpdir()
+const TMP = process.platform === 'win32' ? tmpdir() : '/tmp';
 
 export const WIZARD_LOG_FILE = join(TMP, 'posthog-wizard.log');
 export const WIZARD_BENCHMARK_FILE = join(TMP, 'posthog-wizard-benchmark.json');

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,18 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// use tmpdir for windows compatibility!
+const TMP = tmpdir();
+
+export const WIZARD_LOG_FILE = join(TMP, 'posthog-wizard.log');
+export const WIZARD_BENCHMARK_FILE = join(TMP, 'posthog-wizard-benchmark.json');
+export const WIZARD_YARA_REPORT_FILE = join(
+  TMP,
+  'posthog-wizard-yara-report.json',
+);
+export const WIZARD_TASK_STREAM_LOG = join(TMP, 'posthog-task-stream.log');
+
+/** Temp path for a skill download zip. */
+export function skillTmpPath(skillId: string): string {
+  return join(TMP, `posthog-skill-${skillId}.zip`);
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -70,7 +70,7 @@ export type WizardOptions = {
   /**
    * Whether to run in benchmark mode with per-phase token tracking.
    * When enabled, the wizard runs each workflow phase as a separate agent call
-   * and writes detailed usage data to /tmp/posthog-wizard-benchmark.json.
+   * and writes detailed usage data to posthog-wizard-benchmark.json in the OS temp dir.
    */
   benchmark: boolean;
 


### PR DESCRIPTION
## Problem

`/tmp/` doesn't exist on windows which causes all kinds of issues.

## Changes

Uses `import { tmpdir } from 'node:os';`  to figure out a tmp path that is valid.

## Test plan

Do a few runs to see if all the logging we need and the unzipping of files still work :)