### PR TITLE
fix: outro/exit clash

### DIFF
--- a/src/ui/tui/flows.ts
+++ b/src/ui/tui/flows.ts
@@ -90,7 +90,6 @@ export const FLOWS: Record<Flow, FlowEntry[]> = {
       screen: Screen.McpAdd,
       isComplete: (s) => s.mcpComplete,
     },
-    { screen: Screen.Outro },
     { screen: Screen.Exit },
   ],
 
@@ -99,7 +98,6 @@ export const FLOWS: Record<Flow, FlowEntry[]> = {
       screen: Screen.McpRemove,
       isComplete: (s) => s.mcpComplete,
     },
-    { screen: Screen.Outro },
     { screen: Screen.Exit },
   ],
 };


### PR DESCRIPTION
## Problem

mcp add was getting stuck on "finishing up" after installs succeeded. the install worked, but the process didn't exit

## Changes

removed `Screen.Outro` from `Flow.McpAdd` and `Flow.McpRemove` in favor of `Screen.Exit` from #407 

## Test plan

- reproduced the hang locally in tmux, cmux, and mac terminal
- ran `pnpm try mcp add` in tmux, cmux, and mac terminal after the fix - clean exit back to shell
- `pnpm test` passes 
