### PR TITLE
fix: prevent intro screen squish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ plugins
 .vercel
 .claude/settings.json
 .claude/settings.local.json
+.claude/worktrees/
 
 e2e-tests/fixtures/.tracking/*
 

--- a/src/ui/tui/screens/AgentSkillIntroScreen.tsx
+++ b/src/ui/tui/screens/AgentSkillIntroScreen.tsx
@@ -59,7 +59,7 @@ export const AgentSkillIntroScreen = ({
 
   if (showingMoreInfo) {
     body = (
-      <Box flexDirection="column" width={56}>
+      <Box flexDirection="column" width={56} flexShrink={0}>
         <Box flexDirection="column" marginBottom={1}>
           <Text>
             The wizard is an agent that executes PostHog tasks. Its code is open

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -117,7 +117,7 @@ export const PostHogIntegrationIntroScreen = ({
     );
   } else if (showingMoreInfo) {
     body = (
-      <Box flexDirection="column" width={56}>
+      <Box flexDirection="column" width={56} flexShrink={0}>
         <Text>
           The wizard is an agent that executes PostHog tasks. Its code is open
           source: <Text color="cyan">https://github.com/PostHog/wizard</Text>

--- a/src/ui/tui/screens/RevenueIntroScreen.tsx
+++ b/src/ui/tui/screens/RevenueIntroScreen.tsx
@@ -64,7 +64,7 @@ export const RevenueIntroScreen = ({ store }: RevenueIntroScreenProps) => {
   // ── Body ────────────────────────────────────────────────────────────
 
   const body = showingMoreInfo ? (
-    <Box flexDirection="column" width={56}>
+    <Box flexDirection="column" width={56} flexShrink={0}>
       <Text>
         The wizard is an agent that executes PostHog tasks. Its code is open
         source: <Text color="cyan">https://github.com/PostHog/wizard</Text>.


### PR DESCRIPTION
## Problem

on default sized mac terminals the bullet list on the intro screen rendered with text squished onto the same line: PA and WA. resizing the terminal fixed this but it looks wonky at first

body box is set to `width={56}` but on first render Ink was compressing. noticed a few other screens with the same pattern

## Changes

added `flexShrink={0}` to the body box on all the affected intro screens to tell Ink to respect the declared width and not squeeze on first paint

also added claude worktrees to gitignore so sandbox folders stop getting picked up lol

before

https://github.com/user-attachments/assets/50abb5ff-e109-4a65-b336-135e39047b56

after

https://github.com/user-attachments/assets/b2dca6ee-4a2c-454a-8afb-037420e669b9

## Test plan

- pnpm try in native mac terminal, _not_ cursor terminal to replicate and verify
