### PR TITLE
feat: detect LLM usage in Python

### DIFF
--- a/src/lib/detection/__tests__/features.test.ts
+++ b/src/lib/detection/__tests__/features.test.ts
@@ -22,6 +22,10 @@ function writePackageJson(
   );
 }
 
+function writeFile(dir: string, name: string, content: string): void {
+  fs.writeFileSync(path.join(dir, name), content);
+}
+
 describe('discoverFeatures', () => {
   let tmpDir: string;
 
@@ -30,7 +34,7 @@ describe('discoverFeatures', () => {
   });
   afterEach(() => cleanup(tmpDir));
 
-  it('returns empty when no package.json exists', () => {
+  it('returns empty when no manifest exists', () => {
     expect(discoverFeatures(tmpDir)).toEqual([]);
   });
 
@@ -51,5 +55,108 @@ describe('discoverFeatures', () => {
   it('handles malformed package.json gracefully', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), 'not valid json');
     expect(discoverFeatures(tmpDir)).toEqual([]);
+  });
+
+  describe('Python dependency manifests', () => {
+    it('detects LLM from requirements.txt', () => {
+      writeFile(
+        tmpDir,
+        'requirements.txt',
+        ['# top comment', '-r other.txt', 'openai==1.50.0', 'flask>=3.0'].join(
+          '\n',
+        ),
+      );
+      expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.LLM]);
+    });
+
+    it('handles requirements.txt extras and version operators', () => {
+      writeFile(
+        tmpDir,
+        'requirements.txt',
+        'anthropic[bedrock] >= 0.30.0; python_version >= "3.10"',
+      );
+      expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.LLM]);
+    });
+
+    it('detects LLM from PEP 621 pyproject.toml dependencies', () => {
+      writeFile(
+        tmpDir,
+        'pyproject.toml',
+        [
+          '[project]',
+          'name = "demo"',
+          'dependencies = [',
+          '  "fastapi>=0.110",',
+          '  "anthropic>=0.30",',
+          ']',
+        ].join('\n'),
+      );
+      expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.LLM]);
+    });
+
+    it('detects LLM from Poetry pyproject.toml dependencies and ignores python pin', () => {
+      writeFile(
+        tmpDir,
+        'pyproject.toml',
+        [
+          '[tool.poetry.dependencies]',
+          'python = "^3.11"',
+          'langchain = "^0.1.0"',
+          '',
+          '[tool.poetry.group.dev.dependencies]',
+          'pytest = "*"',
+        ].join('\n'),
+      );
+      expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.LLM]);
+    });
+
+    it('detects LLM from legacy Poetry dev-dependencies section', () => {
+      writeFile(
+        tmpDir,
+        'pyproject.toml',
+        [
+          '[tool.poetry.dev-dependencies]',
+          'litellm = "^1.0"',
+          'pytest = "*"',
+        ].join('\n'),
+      );
+      expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.LLM]);
+    });
+
+    it('detects LLM from Pipfile [packages] and normalizes underscores', () => {
+      writeFile(
+        tmpDir,
+        'Pipfile',
+        [
+          '[packages]',
+          'flask = "*"',
+          'llama_index = "*"',
+          '',
+          '[dev-packages]',
+          'pytest = "*"',
+        ].join('\n'),
+      );
+      expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.LLM]);
+    });
+
+    it('returns empty for Python projects with no LLM deps', () => {
+      writeFile(
+        tmpDir,
+        'requirements.txt',
+        ['flask==3.0', 'sqlalchemy==2.0'].join('\n'),
+      );
+      writeFile(
+        tmpDir,
+        'pyproject.toml',
+        ['[project]', 'dependencies = ["fastapi"]'].join('\n'),
+      );
+      expect(discoverFeatures(tmpDir)).toEqual([]);
+    });
+
+    it('does not double-emit LLM when both Node and Python manifests have LLM deps', () => {
+      writePackageJson(tmpDir, { openai: '4.0.0' });
+      writeFile(tmpDir, 'requirements.txt', 'anthropic==0.30.0');
+      expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.LLM]);
+    });
   });
 });

--- a/src/lib/detection/features.ts
+++ b/src/lib/detection/features.ts
@@ -27,38 +27,155 @@ const LLM_PACKAGES = [
   'portkey-ai',
 ];
 
-/**
- * Scan `package.json` at `installDir` for dependencies that indicate
- * additional PostHog features (Stripe revenue analytics, LLM observability, etc.)
- *
- * Returns an array of discovered features, or empty if nothing found
- * or no package.json exists.
- */
+// PyPI normalizes `_` to `-` and is case-insensitive; compare via normalizePyName.
+const PYTHON_LLM_PACKAGES = [
+  'openai',
+  'anthropic',
+  'langchain',
+  'langchain-openai',
+  'langchain-anthropic',
+  'langchain-google-genai',
+  'langgraph',
+  'litellm',
+  'llama-index',
+  'pydantic-ai',
+  'crewai',
+  'instructor',
+  'dspy-ai',
+  'mistralai',
+  'cohere',
+  'google-generativeai',
+  'google-genai',
+  'portkey-ai',
+];
+
 export function discoverFeatures(installDir: string): DiscoveredFeature[] {
   const features: DiscoveredFeature[] = [];
+  discoverNodeFeatures(installDir, features);
+  discoverPythonFeatures(installDir, features);
+  return features;
+}
 
+function discoverNodeFeatures(
+  installDir: string,
+  features: DiscoveredFeature[],
+): void {
+  const text = safeRead(installDir, 'package.json');
+  if (!text) return;
+
+  let pkg: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
   try {
-    const pkg = JSON.parse(
-      readFileSync(join(installDir, 'package.json'), 'utf-8'),
-    ) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-    const depNames = Object.keys({
-      ...pkg.dependencies,
-      ...pkg.devDependencies,
-    });
-
-    if (depNames.some((d) => STRIPE_PACKAGES.includes(d))) {
-      features.push(DiscoveredFeature.Stripe);
-    }
-
-    if (depNames.some((d) => LLM_PACKAGES.includes(d))) {
-      features.push(DiscoveredFeature.LLM);
-    }
+    pkg = JSON.parse(text);
   } catch {
-    // No package.json or parse error — skip feature discovery
+    return;
   }
 
-  return features;
+  const depNames = Object.keys({
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+  });
+
+  if (depNames.some((d) => STRIPE_PACKAGES.includes(d))) {
+    features.push(DiscoveredFeature.Stripe);
+  }
+  if (depNames.some((d) => LLM_PACKAGES.includes(d))) {
+    features.push(DiscoveredFeature.LLM);
+  }
+}
+
+function discoverPythonFeatures(
+  installDir: string,
+  features: DiscoveredFeature[],
+): void {
+  if (features.includes(DiscoveredFeature.LLM)) return;
+
+  const deps: string[] = [];
+
+  const req = safeRead(installDir, 'requirements.txt');
+  if (req) deps.push(...parseRequirementsTxt(req));
+
+  const pyproj = safeRead(installDir, 'pyproject.toml');
+  if (pyproj) deps.push(...parsePyprojectToml(pyproj));
+
+  const pipfile = safeRead(installDir, 'Pipfile');
+  if (pipfile) deps.push(...parsePipfile(pipfile));
+
+  if (deps.some((d) => PYTHON_LLM_PACKAGES.includes(d))) {
+    features.push(DiscoveredFeature.LLM);
+  }
+}
+
+function safeRead(installDir: string, file: string): string | null {
+  try {
+    return readFileSync(join(installDir, file), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function normalizePyName(name: string): string {
+  return name.toLowerCase().replace(/_/g, '-');
+}
+
+export function parseRequirementsTxt(content: string): string[] {
+  return content
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#') && !l.startsWith('-'))
+    .map((l) => l.replace(/\[[^\]]*\]/, ''))
+    .map((l) => l.split(/[<>=!~;\s]/)[0])
+    .filter(Boolean)
+    .map(normalizePyName);
+}
+
+// Pragmatic, not a full TOML parser — only the dep shapes we care about.
+export function parsePyprojectToml(content: string): string[] {
+  const deps: string[] = [];
+
+  for (const m of content.matchAll(/dependencies\s*=\s*\[([^\]]*)\]/g)) {
+    for (const s of m[1].matchAll(/["']([^"']+)["']/g)) {
+      const raw = s[1].replace(/\[[^\]]*\]/, '');
+      const name = raw.split(/[<>=!~;\s]/)[0];
+      if (name) deps.push(normalizePyName(name));
+    }
+  }
+
+  const poetryRe =
+    /\[tool\.poetry\.(?:dev-dependencies|dependencies|group\.[^.\]]+\.dependencies)\]([\s\S]*?)(?=\n\[|$)/g;
+  for (const m of content.matchAll(poetryRe)) {
+    deps.push(...extractTomlSectionKeys(m[1], { skip: ['python'] }));
+  }
+
+  return deps;
+}
+
+export function parsePipfile(content: string): string[] {
+  const deps: string[] = [];
+  const re = /\[(packages|dev-packages)\]([\s\S]*?)(?=\n\[|$)/g;
+  for (const m of content.matchAll(re)) {
+    deps.push(...extractTomlSectionKeys(m[2]));
+  }
+  return deps;
+}
+
+function extractTomlSectionKeys(
+  body: string,
+  opts: { skip?: string[] } = {},
+): string[] {
+  const skip = new Set(opts.skip ?? []);
+  const out: string[] = [];
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue;
+    const name = trimmed.slice(0, eq).trim();
+    if (!/^[a-zA-Z0-9._-]+$/.test(name)) continue;
+    if (skip.has(name.toLowerCase())) continue;
+    out.push(normalizePyName(name));
+  }
+  return out;
 }

--- a/src/lib/detection/features.ts
+++ b/src/lib/detection/features.ts
@@ -60,28 +60,28 @@ function discoverNodeFeatures(
   installDir: string,
   features: DiscoveredFeature[],
 ): void {
-  const text = safeRead(installDir, 'package.json');
-  if (!text) return;
+  const packageJsonText = safeRead(installDir, 'package.json');
+  if (!packageJsonText) return;
 
-  let pkg: {
+  let packageJson: {
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
   };
   try {
-    pkg = JSON.parse(text);
+    packageJson = JSON.parse(packageJsonText);
   } catch {
     return;
   }
 
   const depNames = Object.keys({
-    ...pkg.dependencies,
-    ...pkg.devDependencies,
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
   });
 
-  if (depNames.some((d) => STRIPE_PACKAGES.includes(d))) {
+  if (depNames.some((depName) => STRIPE_PACKAGES.includes(depName))) {
     features.push(DiscoveredFeature.Stripe);
   }
-  if (depNames.some((d) => LLM_PACKAGES.includes(d))) {
+  if (depNames.some((depName) => LLM_PACKAGES.includes(depName))) {
     features.push(DiscoveredFeature.LLM);
   }
 }
@@ -92,18 +92,18 @@ function discoverPythonFeatures(
 ): void {
   if (features.includes(DiscoveredFeature.LLM)) return;
 
-  const deps: string[] = [];
+  const depNames: string[] = [];
 
-  const req = safeRead(installDir, 'requirements.txt');
-  if (req) deps.push(...parseRequirementsTxt(req));
+  const requirementsTxt = safeRead(installDir, 'requirements.txt');
+  if (requirementsTxt) depNames.push(...parseRequirementsTxt(requirementsTxt));
 
-  const pyproj = safeRead(installDir, 'pyproject.toml');
-  if (pyproj) deps.push(...parsePyprojectToml(pyproj));
+  const pyprojectToml = safeRead(installDir, 'pyproject.toml');
+  if (pyprojectToml) depNames.push(...parsePyprojectToml(pyprojectToml));
 
   const pipfile = safeRead(installDir, 'Pipfile');
-  if (pipfile) deps.push(...parsePipfile(pipfile));
+  if (pipfile) depNames.push(...parsePipfile(pipfile));
 
-  if (deps.some((d) => PYTHON_LLM_PACKAGES.includes(d))) {
+  if (depNames.some((depName) => PYTHON_LLM_PACKAGES.includes(depName))) {
     features.push(DiscoveredFeature.LLM);
   }
 }
@@ -123,59 +123,64 @@ function normalizePyName(name: string): string {
 export function parseRequirementsTxt(content: string): string[] {
   return content
     .split('\n')
-    .map((l) => l.trim())
-    .filter((l) => l && !l.startsWith('#') && !l.startsWith('-'))
-    .map((l) => l.replace(/\[[^\]]*\]/, ''))
-    .map((l) => l.split(/[<>=!~;\s]/)[0])
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#') && !line.startsWith('-'))
+    .map((line) => line.replace(/\[[^\]]*\]/, ''))
+    .map((line) => line.split(/[<>=!~;\s]/)[0])
     .filter(Boolean)
     .map(normalizePyName);
 }
 
 // Pragmatic, not a full TOML parser — only the dep shapes we care about.
 export function parsePyprojectToml(content: string): string[] {
-  const deps: string[] = [];
+  const depNames: string[] = [];
 
-  for (const m of content.matchAll(/dependencies\s*=\s*\[([^\]]*)\]/g)) {
-    for (const s of m[1].matchAll(/["']([^"']+)["']/g)) {
-      const raw = s[1].replace(/\[[^\]]*\]/, '');
-      const name = raw.split(/[<>=!~;\s]/)[0];
-      if (name) deps.push(normalizePyName(name));
+  for (const arrayMatch of content.matchAll(
+    /dependencies\s*=\s*\[([^\]]*)\]/g,
+  )) {
+    const arrayBody = arrayMatch[1];
+    for (const quotedMatch of arrayBody.matchAll(/["']([^"']+)["']/g)) {
+      const depSpec = quotedMatch[1];
+      const name = depSpec.replace(/\[[^\]]*\]/, '').split(/[<>=!~;\s]/)[0];
+      if (name) depNames.push(normalizePyName(name));
     }
   }
 
-  const poetryRe =
+  const poetrySectionRe =
     /\[tool\.poetry\.(?:dev-dependencies|dependencies|group\.[^.\]]+\.dependencies)\]([\s\S]*?)(?=\n\[|$)/g;
-  for (const m of content.matchAll(poetryRe)) {
-    deps.push(...extractTomlSectionKeys(m[1], { skip: ['python'] }));
+  for (const sectionMatch of content.matchAll(poetrySectionRe)) {
+    const sectionBody = sectionMatch[1];
+    depNames.push(...extractTomlSectionKeys(sectionBody, { skip: ['python'] }));
   }
 
-  return deps;
+  return depNames;
 }
 
 export function parsePipfile(content: string): string[] {
-  const deps: string[] = [];
-  const re = /\[(packages|dev-packages)\]([\s\S]*?)(?=\n\[|$)/g;
-  for (const m of content.matchAll(re)) {
-    deps.push(...extractTomlSectionKeys(m[2]));
+  const depNames: string[] = [];
+  const sectionRe = /\[(packages|dev-packages)\]([\s\S]*?)(?=\n\[|$)/g;
+  for (const sectionMatch of content.matchAll(sectionRe)) {
+    const sectionBody = sectionMatch[2];
+    depNames.push(...extractTomlSectionKeys(sectionBody));
   }
-  return deps;
+  return depNames;
 }
 
 function extractTomlSectionKeys(
-  body: string,
+  sectionBody: string,
   opts: { skip?: string[] } = {},
 ): string[] {
-  const skip = new Set(opts.skip ?? []);
-  const out: string[] = [];
-  for (const line of body.split('\n')) {
+  const skipNames = new Set(opts.skip ?? []);
+  const depNames: string[] = [];
+  for (const line of sectionBody.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
-    const eq = trimmed.indexOf('=');
-    if (eq <= 0) continue;
-    const name = trimmed.slice(0, eq).trim();
+    const equalsIndex = trimmed.indexOf('=');
+    if (equalsIndex <= 0) continue;
+    const name = trimmed.slice(0, equalsIndex).trim();
     if (!/^[a-zA-Z0-9._-]+$/.test(name)) continue;
-    if (skip.has(name.toLowerCase())) continue;
-    out.push(normalizePyName(name));
+    if (skipNames.has(name.toLowerCase())) continue;
+    depNames.push(normalizePyName(name));
   }
-  return out;
+  return depNames;
 }


### PR DESCRIPTION
## Problem

Currently we don't detect LLM features in Python; JS only. The underlying skill in context-mill tags Python and looks like there's already support there. 

## Changes

- parse Python dependency manifests
- added package list for Python LLM packages
- normalized PyPI naming to be idiomatic

## Test plan

- added unit tests
- ran a live e2e on a local fastapi project. it loaded the fastapi project and showed a "LLM features detected" step
<img width="896" height="411" alt="Screenshot 2026-04-27 at 2 18 36 PM" src="https://github.com/user-attachments/assets/393885f3-2386-4d2e-96a6-a6f59d4ceedb" />
