### PR TITLE
fix(mcp): add command ignoring --region flag

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -365,6 +365,7 @@ const cli = yargs(hideBin(process.argv))
                 localMcp: options.local,
                 mcpFeatures,
                 apiKey,
+                region: options.region as 'us' | 'eu' | undefined,
               });
               tui.store.session = session;
             } catch {
@@ -377,6 +378,7 @@ const cli = yargs(hideBin(process.argv))
                 local: options.local,
                 features: mcpFeatures,
                 apiKey,
+                cloudRegion: options.region as 'us' | 'eu' | undefined,
               });
             }
           })();

--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as jsonc from 'jsonc-parser';
 import { getDefaultServerConfig } from './defaults';
+import type { CloudRegion } from '../../utils/types';
 
 export type MCPServerConfig = Record<string, unknown>;
 
@@ -14,6 +15,7 @@ export abstract class MCPClient {
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): Promise<{ success: boolean }>;
   abstract removeServer(local?: boolean): Promise<{ success: boolean }>;
   abstract isClientSupported(): Promise<boolean>;
@@ -35,8 +37,15 @@ export abstract class DefaultMCPClient extends MCPClient {
     type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): MCPServerConfig {
-    return getDefaultServerConfig(apiKey, type, selectedFeatures, local);
+    return getDefaultServerConfig(
+      apiKey,
+      type,
+      selectedFeatures,
+      local,
+      region,
+    );
   }
 
   async isServerInstalled(local?: boolean): Promise<boolean> {
@@ -64,8 +73,9 @@ export abstract class DefaultMCPClient extends MCPClient {
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): Promise<{ success: boolean }> {
-    return this._addServerType(apiKey, 'sse', selectedFeatures, local);
+    return this._addServerType(apiKey, 'sse', selectedFeatures, local, region);
   }
 
   async _addServerType(
@@ -73,6 +83,7 @@ export abstract class DefaultMCPClient extends MCPClient {
     type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): Promise<{ success: boolean }> {
     try {
       const configPath = await this.getConfigPath();
@@ -94,6 +105,7 @@ export abstract class DefaultMCPClient extends MCPClient {
         type,
         selectedFeatures,
         local,
+        region,
       );
       const typedConfig = existingConfig as Record<string, any>;
       if (!typedConfig[serverPropertyName]) {

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
@@ -329,6 +329,7 @@ describe('ClaudeMCPClient', () => {
         'sse',
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -340,6 +341,7 @@ describe('ClaudeMCPClient', () => {
       expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
         undefined,
         'sse',
+        undefined,
         undefined,
         undefined,
       );

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -1,5 +1,6 @@
 import { DefaultMCPClient } from '../MCPClient';
 import { buildMCPUrl, DefaultMCPClientConfig } from '../defaults';
+import type { CloudRegion } from '../../../utils/types';
 import { z } from 'zod';
 import { execSync } from 'child_process';
 import { analytics } from '../../../utils/analytics';
@@ -114,6 +115,7 @@ export class ClaudeCodeMCPClient extends DefaultMCPClient {
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): Promise<{ success: boolean }> {
     const claudeBinary = this.findClaudeBinary();
     if (!claudeBinary) {
@@ -121,7 +123,7 @@ export class ClaudeCodeMCPClient extends DefaultMCPClient {
     }
 
     const serverName = local ? 'posthog-local' : 'posthog';
-    const url = buildMCPUrl('streamable-http', selectedFeatures, local);
+    const url = buildMCPUrl('streamable-http', selectedFeatures, local, region);
 
     // OAuth mode: no auth header
     const authArgs = apiKey ? `--header "Authorization: Bearer ${apiKey}"` : '';

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -3,6 +3,7 @@ import { execSync, spawnSync } from 'node:child_process';
 
 import { DefaultMCPClient } from '../MCPClient';
 import { buildMCPUrl, DefaultMCPClientConfig } from '../defaults';
+import type { CloudRegion } from '../../../utils/types';
 
 import { analytics } from '../../../utils/analytics';
 
@@ -60,9 +61,10 @@ export class CodexMCPClient extends DefaultMCPClient {
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): Promise<{ success: boolean }> {
     const serverName = local ? 'posthog-local' : 'posthog';
-    const url = buildMCPUrl('streamable-http', selectedFeatures, local);
+    const url = buildMCPUrl('streamable-http', selectedFeatures, local, region);
 
     const args = ['mcp', 'add', serverName, '--url', url];
 

--- a/src/steps/add-mcp-server-to-clients/clients/cursor.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/cursor.ts
@@ -1,4 +1,5 @@
 import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
+import type { CloudRegion } from '../../../utils/types';
 import * as path from 'path';
 import * as os from 'os';
 import { DefaultMCPClientConfig, getNativeHTTPServerConfig } from '../defaults';
@@ -30,20 +31,29 @@ export class CursorMCPClient extends DefaultMCPClient {
     type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): MCPServerConfig {
-    return getNativeHTTPServerConfig(apiKey, type, selectedFeatures, local);
+    return getNativeHTTPServerConfig(
+      apiKey,
+      type,
+      selectedFeatures,
+      local,
+      region,
+    );
   }
 
   async addServer(
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): Promise<{ success: boolean }> {
     return this._addServerType(
       apiKey,
       'streamable-http',
       selectedFeatures,
       local,
+      region,
     );
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
 import { buildMCPUrl } from '../defaults';
+import type { CloudRegion } from '../../../utils/types';
 import { runtimeEnv } from '@env';
 
 export const VisualStudioCodeMCPConfig = z
@@ -83,10 +84,11 @@ export class VisualStudioCodeClient extends DefaultMCPClient {
     type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): MCPServerConfig {
     return {
       type: 'http',
-      url: buildMCPUrl(type, selectedFeatures, local),
+      url: buildMCPUrl(type, selectedFeatures, local, region),
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },
@@ -97,12 +99,14 @@ export class VisualStudioCodeClient extends DefaultMCPClient {
     apiKey: string,
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): Promise<{ success: boolean }> {
     return this._addServerType(
       apiKey,
       'streamable-http',
       selectedFeatures,
       local,
+      region,
     );
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
 import { buildMCPUrl } from '../defaults';
+import type { CloudRegion } from '../../../utils/types';
 import { runtimeEnv } from '@env';
 
 export const ZedMCPConfig = z
@@ -74,10 +75,11 @@ export class ZedClient extends DefaultMCPClient {
     type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): MCPServerConfig {
     return {
       enabled: true,
-      url: buildMCPUrl(type, selectedFeatures, local),
+      url: buildMCPUrl(type, selectedFeatures, local, region),
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },
@@ -88,12 +90,14 @@ export class ZedClient extends DefaultMCPClient {
     apiKey: string,
     selectedFeatures?: string[],
     local?: boolean,
+    region?: CloudRegion,
   ): Promise<{ success: boolean }> {
     return this._addServerType(
       apiKey,
       'streamable-http',
       selectedFeatures,
       local,
+      region,
     );
   }
 }

--- a/src/steps/add-mcp-server-to-clients/defaults.ts
+++ b/src/steps/add-mcp-server-to-clients/defaults.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+import type { CloudRegion } from '../../utils/types';
 
 export const DefaultMCPClientConfig = z
   .object({
@@ -219,8 +220,13 @@ export const buildMCPUrl = (
   type: MCPServerType,
   selectedFeatures?: string[],
   local?: boolean,
+  region?: CloudRegion,
 ) => {
-  const host = local ? 'http://localhost:8787' : 'https://mcp.posthog.com';
+  const host = local
+    ? 'http://localhost:8787'
+    : region === 'eu'
+    ? 'https://mcp-eu.posthog.com'
+    : 'https://mcp.posthog.com';
   const baseUrl = `${host}/${type === 'sse' ? 'sse' : 'mcp'}`;
 
   const isAllFeaturesSelected =
@@ -247,9 +253,10 @@ export const getNativeHTTPServerConfig = (
   type: MCPServerType,
   selectedFeatures?: string[],
   local?: boolean,
+  region?: CloudRegion,
 ) => {
   const config: Record<string, unknown> = {
-    url: buildMCPUrl(type, selectedFeatures, local),
+    url: buildMCPUrl(type, selectedFeatures, local, region),
   };
 
   // Only add auth header if API key is provided (not OAuth mode)
@@ -267,8 +274,9 @@ export const getDefaultServerConfig = (
   type: MCPServerType,
   selectedFeatures?: string[],
   local?: boolean,
+  region?: CloudRegion,
 ) => {
-  const urlWithFeatures = buildMCPUrl(type, selectedFeatures, local);
+  const urlWithFeatures = buildMCPUrl(type, selectedFeatures, local, region);
 
   // OAuth mode: no auth header, let MCP handle OAuth
   if (!apiKey) {

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -47,7 +47,7 @@ export const addMCPServerToClientsStep = async ({
   integration,
   local = false,
   ci = false,
-  cloudRegion: _cloudRegion,
+  cloudRegion,
   features,
   apiKey,
 }: {
@@ -82,6 +82,7 @@ export const addMCPServerToClientsStep = async ({
       apiKey,
       features ?? [...ALL_FEATURE_VALUES],
       local,
+      cloudRegion,
     );
   });
 
@@ -147,9 +148,10 @@ export const addMCPServer = async (
   personalApiKey?: string,
   selectedFeatures?: string[],
   local?: boolean,
+  region?: CloudRegion,
 ): Promise<void> => {
   for (const client of clients) {
-    await client.addServer(personalApiKey, selectedFeatures, local);
+    await client.addServer(personalApiKey, selectedFeatures, local, region);
   }
 };
 

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -120,7 +120,12 @@ export const McpScreen = ({
     setPhase(Phase.Working);
     let result: string[] = [];
     try {
-      result = await installer.install(names, features, store.session.apiKey);
+      result = await installer.install(
+        names,
+        features,
+        store.session.apiKey,
+        store.session.region,
+      );
       setResultClients(result);
     } catch {
       setResultClients([]);

--- a/src/ui/tui/services/mcp-installer.ts
+++ b/src/ui/tui/services/mcp-installer.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../steps/add-mcp-server-to-clients/index.js';
 import { ALL_FEATURE_VALUES } from '../../../steps/add-mcp-server-to-clients/defaults.js';
 import { logToFile } from '../../../utils/debug.js';
+import type { CloudRegion } from '../../../utils/types.js';
 
 export interface McpClientInfo {
   name: string;
@@ -26,6 +27,7 @@ export interface McpInstaller {
     clientNames: string[],
     features?: string[],
     apiKey?: string,
+    region?: CloudRegion,
   ): Promise<string[]>;
 
   /** Remove the PostHog MCP server from all installed clients. Returns names of removed clients. */
@@ -50,6 +52,7 @@ export function createMcpInstaller(): McpInstaller {
       clientNames: string[],
       features?: string[],
       apiKey?: string,
+      region?: CloudRegion,
     ): Promise<string[]> {
       const resolvedFeatures = features ?? [...ALL_FEATURE_VALUES];
       const toInstall = cachedClients
@@ -73,6 +76,7 @@ export function createMcpInstaller(): McpInstaller {
             apiKey,
             resolvedFeatures,
             false,
+            region,
           );
           if (result?.success) {
             installed.push(client.name as string);


### PR DESCRIPTION
## Summary

  - Fix `mcp add` command ignoring `--region` flag — EU users were always pointed to `mcp.posthog.com` instead of `mcp-eu.posthog.com`
  - Thread `region` parameter through the entire MCP client chain: `buildMCPUrl()` → `MCPClient` base → all 5 client implementations (Cursor, Claude Code, VS Code, Zed, Codex) → installer service → TUI screen → CLI handler

  ## Test plan

  - [x] All existing tests pass (updated assertions for new `region` parameter)
  - [x] `npx posthog-wizard mcp add --region eu` produces configs with `mcp-eu.posthog.com`
  - [x] `npx posthog-wizard mcp add --region us` (or no flag) produces configs with `mcp.posthog.com`
  - [x] `npx posthog-wizard mcp add --local` still uses `localhost:8787` regardless of region