### PR TITLE
fix(mcp): drop /sse transport, always install /mcp

### DIFF
--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -32,11 +32,10 @@ export abstract class DefaultMCPClient extends MCPClient {
 
   getServerConfig(
     apiKey: string | undefined,
-    type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
-    return getDefaultServerConfig(apiKey, type, selectedFeatures, local);
+    return getDefaultServerConfig(apiKey, selectedFeatures, local);
   }
 
   async isServerInstalled(local?: boolean): Promise<boolean> {
@@ -65,15 +64,6 @@ export abstract class DefaultMCPClient extends MCPClient {
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<{ success: boolean }> {
-    return this._addServerType(apiKey, 'sse', selectedFeatures, local);
-  }
-
-  async _addServerType(
-    apiKey: string | undefined,
-    type: 'sse' | 'streamable-http',
-    selectedFeatures?: string[],
-    local?: boolean,
-  ): Promise<{ success: boolean }> {
     try {
       const configPath = await this.getConfigPath();
       const configDir = path.dirname(configPath);
@@ -91,7 +81,6 @@ export abstract class DefaultMCPClient extends MCPClient {
 
       const newServerConfig = this.getServerConfig(
         apiKey,
-        type,
         selectedFeatures,
         local,
       );

--- a/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
@@ -6,43 +6,33 @@ import {
 
 describe('defaults', () => {
   describe('buildMCPUrl', () => {
-    it('should build base URL for streamable-http type', () => {
-      const url = buildMCPUrl('streamable-http');
+    it('should build base URL', () => {
+      const url = buildMCPUrl();
       expect(url).toBe('https://mcp.posthog.com/mcp');
     });
 
-    it('should build base URL for sse type', () => {
-      const url = buildMCPUrl('sse');
-      expect(url).toBe('https://mcp.posthog.com/sse');
-    });
-
     it('should use localhost for local mode', () => {
-      const url = buildMCPUrl('streamable-http', undefined, true);
+      const url = buildMCPUrl(undefined, true);
       expect(url).toBe('http://localhost:8787/mcp');
     });
 
     it('should add features param when not all features selected', () => {
-      const url = buildMCPUrl('streamable-http', ['dashboards', 'insights']);
+      const url = buildMCPUrl(['dashboards', 'insights']);
       expect(url).toBe(
         'https://mcp.posthog.com/mcp?features=dashboards,insights',
       );
-    });
-
-    it('should not add region param in local mode', () => {
-      const url = buildMCPUrl('streamable-http', undefined, true);
-      expect(url).toBe('http://localhost:8787/mcp');
     });
   });
 
   describe('getDefaultServerConfig', () => {
     it('should return config with auth header when API key provided', () => {
-      const config = getDefaultServerConfig('phx_test123', 'sse');
+      const config = getDefaultServerConfig('phx_test123');
       expect(config).toEqual({
         command: 'npx',
         args: [
           '-y',
           'mcp-remote@latest',
-          'https://mcp.posthog.com/sse',
+          'https://mcp.posthog.com/mcp',
           '--header',
           'Authorization:${POSTHOG_AUTH_HEADER}',
         ],
@@ -53,10 +43,10 @@ describe('defaults', () => {
     });
 
     it('should return config without auth header for OAuth mode (no API key)', () => {
-      const config = getDefaultServerConfig(undefined, 'sse');
+      const config = getDefaultServerConfig(undefined);
       expect(config).toEqual({
         command: 'npx',
-        args: ['-y', 'mcp-remote@latest', 'https://mcp.posthog.com/sse'],
+        args: ['-y', 'mcp-remote@latest', 'https://mcp.posthog.com/mcp'],
       });
       expect(config).not.toHaveProperty('env');
     });
@@ -64,10 +54,7 @@ describe('defaults', () => {
 
   describe('getNativeHTTPServerConfig', () => {
     it('should return config with headers when API key provided', () => {
-      const config = getNativeHTTPServerConfig(
-        'phx_test123',
-        'streamable-http',
-      );
+      const config = getNativeHTTPServerConfig('phx_test123');
       expect(config).toEqual({
         url: 'https://mcp.posthog.com/mcp',
         headers: {
@@ -77,7 +64,7 @@ describe('defaults', () => {
     });
 
     it('should return config without headers for OAuth mode (no API key)', () => {
-      const config = getNativeHTTPServerConfig(undefined, 'streamable-http');
+      const config = getNativeHTTPServerConfig(undefined);
       expect(config).toEqual({
         url: 'https://mcp.posthog.com/mcp',
       });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
@@ -326,7 +326,6 @@ describe('ClaudeMCPClient', () => {
 
       expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
         mockApiKey,
-        'sse',
         undefined,
         undefined,
       );
@@ -339,7 +338,6 @@ describe('ClaudeMCPClient', () => {
 
       expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
         undefined,
-        'sse',
         undefined,
         undefined,
       );

--- a/src/steps/add-mcp-server-to-clients/clients/cursor.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/cursor.ts
@@ -27,23 +27,9 @@ export class CursorMCPClient extends DefaultMCPClient {
 
   getServerConfig(
     apiKey: string | undefined,
-    type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
-    return getNativeHTTPServerConfig(apiKey, type, selectedFeatures, local);
-  }
-
-  async addServer(
-    apiKey?: string,
-    selectedFeatures?: string[],
-    local?: boolean,
-  ): Promise<{ success: boolean }> {
-    return this._addServerType(
-      apiKey,
-      'streamable-http',
-      selectedFeatures,
-      local,
-    );
+    return getNativeHTTPServerConfig(apiKey, selectedFeatures, local);
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
@@ -80,29 +80,15 @@ export class VisualStudioCodeClient extends DefaultMCPClient {
 
   getServerConfig(
     apiKey: string,
-    type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       type: 'http',
-      url: buildMCPUrl(type, selectedFeatures, local),
+      url: buildMCPUrl(selectedFeatures, local),
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },
     };
-  }
-
-  async addServer(
-    apiKey: string,
-    selectedFeatures?: string[],
-    local?: boolean,
-  ): Promise<{ success: boolean }> {
-    return this._addServerType(
-      apiKey,
-      'streamable-http',
-      selectedFeatures,
-      local,
-    );
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import * as path from 'path';
 import * as os from 'os';
 import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
-import { buildMCPUrl } from '../defaults';
+import { getNativeHTTPServerConfig } from '../defaults';
 import { runtimeEnv } from '@env';
 
 export const VisualStudioCodeMCPConfig = z
@@ -79,16 +79,13 @@ export class VisualStudioCodeClient extends DefaultMCPClient {
   }
 
   getServerConfig(
-    apiKey: string,
+    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       type: 'http',
-      url: buildMCPUrl(selectedFeatures, local),
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+      ...getNativeHTTPServerConfig(apiKey, selectedFeatures, local),
     };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -71,29 +71,15 @@ export class ZedClient extends DefaultMCPClient {
 
   getServerConfig(
     apiKey: string,
-    type: 'sse' | 'streamable-http',
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       enabled: true,
-      url: buildMCPUrl(type, selectedFeatures, local),
+      url: buildMCPUrl(selectedFeatures, local),
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },
     };
-  }
-
-  async addServer(
-    apiKey: string,
-    selectedFeatures?: string[],
-    local?: boolean,
-  ): Promise<{ success: boolean }> {
-    return this._addServerType(
-      apiKey,
-      'streamable-http',
-      selectedFeatures,
-      local,
-    );
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import * as path from 'path';
 import * as os from 'os';
 import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
-import { buildMCPUrl } from '../defaults';
+import { getNativeHTTPServerConfig } from '../defaults';
 import { runtimeEnv } from '@env';
 
 export const ZedMCPConfig = z
@@ -70,16 +70,13 @@ export class ZedClient extends DefaultMCPClient {
   }
 
   getServerConfig(
-    apiKey: string,
+    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       enabled: true,
-      url: buildMCPUrl(selectedFeatures, local),
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+      ...getNativeHTTPServerConfig(apiKey, selectedFeatures, local),
     };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/defaults.ts
+++ b/src/steps/add-mcp-server-to-clients/defaults.ts
@@ -213,15 +213,9 @@ export const ALL_FEATURE_VALUES = Object.values(AVAILABLE_FEATURES)
   .flat()
   .map((feature) => feature.value);
 
-type MCPServerType = 'sse' | 'streamable-http';
-
-export const buildMCPUrl = (
-  type: MCPServerType,
-  selectedFeatures?: string[],
-  local?: boolean,
-) => {
+export const buildMCPUrl = (selectedFeatures?: string[], local?: boolean) => {
   const host = local ? 'http://localhost:8787' : 'https://mcp.posthog.com';
-  const baseUrl = `${host}/${type === 'sse' ? 'sse' : 'mcp'}`;
+  const baseUrl = `${host}/mcp`;
 
   const isAllFeaturesSelected =
     selectedFeatures &&
@@ -244,12 +238,11 @@ export const buildMCPUrl = (
 
 export const getNativeHTTPServerConfig = (
   apiKey: string | undefined,
-  type: MCPServerType,
   selectedFeatures?: string[],
   local?: boolean,
 ) => {
   const config: Record<string, unknown> = {
-    url: buildMCPUrl(type, selectedFeatures, local),
+    url: buildMCPUrl(selectedFeatures, local),
   };
 
   // Only add auth header if API key is provided (not OAuth mode)
@@ -264,11 +257,10 @@ export const getNativeHTTPServerConfig = (
 
 export const getDefaultServerConfig = (
   apiKey: string | undefined,
-  type: MCPServerType,
   selectedFeatures?: string[],
   local?: boolean,
 ) => {
-  const urlWithFeatures = buildMCPUrl(type, selectedFeatures, local);
+  const urlWithFeatures = buildMCPUrl(selectedFeatures, local);
 
   // OAuth mode: no auth header, let MCP handle OAuth
   if (!apiKey) {


### PR DESCRIPTION
## Summary

- The PostHog MCP server no longer serves `/sse`, so any installation pointing there is broken. Two paths still did: `DefaultMCPClient.addServer` (inherited by Claude Desktop) and a now-stale Codex callsite (Codex itself moved to plugin install, but the `'sse' | 'streamable-http'` abstraction was still threaded through the codebase).
- Removed the transport-type abstraction entirely. `buildMCPUrl`, `getNativeHTTPServerConfig`, and `getDefaultServerConfig` no longer take a `type` arg and always emit `/mcp`. Cursor / VS Code / Zed `addServer` overrides existed solely to pass `'streamable-http'` and are now unnecessary — deleted.
- The lone surviving `'sse'` is the Zod enum at `visual-studio-code.ts:19` that parses VS Code's own `mcp.json` — left untouched so we don't reject existing user configs.

## Test plan

- [x] `pnpm exec jest` — 589 pass (updated `defaults.test.ts` and `claude.test.ts` fixtures to drop the `type` arg).
- [x] `pnpm typecheck` clean within `src/steps/add-mcp-server-to-clients`.
- [ ] Manual: run wizard with `--local` against Claude Desktop and verify the written config points at `http://localhost:8787/mcp`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*