### PR TITLE
chore: fallback v2

### DIFF
--- a/src/frameworks/javascript-node/javascript-node-wizard-agent.ts
+++ b/src/frameworks/javascript-node/javascript-node-wizard-agent.ts
@@ -1,10 +1,25 @@
 /* Generic Node.js language wizard using posthog-agent with PostHog MCP */
+import type { WizardOptions } from '../../utils/types';
 import type { FrameworkConfig } from '../../lib/framework-config';
 import { Integration } from '../../lib/constants';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { tryGetPackageJson } from '../../utils/setup-utils';
 import { detectNodePackageManagers } from '../../lib/detection/package-manager';
+import { detectAllPackageManagers } from '../../utils/package-manager';
+import {
+  detectServerFramework,
+  detectEntryPoint,
+  detectProjectType,
+} from './utils';
 
-type JavaScriptNodeContext = Record<string, unknown>;
+type JavaScriptNodeContext = {
+  serverFramework?: string;
+  entryPoint?: string;
+  hasTypeScript?: boolean;
+  packageManagerName?: string;
+  projectType?: string;
+};
 
 export const JAVASCRIPT_NODE_AGENT_CONFIG: FrameworkConfig<JavaScriptNodeContext> =
   {
@@ -13,6 +28,34 @@ export const JAVASCRIPT_NODE_AGENT_CONFIG: FrameworkConfig<JavaScriptNodeContext
       integration: Integration.javascriptNode,
       beta: true,
       docsUrl: 'https://posthog.com/docs/libraries/node',
+      gatherContext: (options: WizardOptions) => {
+        const { installDir } = options;
+        const context: JavaScriptNodeContext = {};
+
+        const detected = detectAllPackageManagers(options);
+        if (detected.length > 0) {
+          context.packageManagerName = detected[0].label;
+        }
+
+        context.hasTypeScript = fs.existsSync(
+          path.join(installDir, 'tsconfig.json'),
+        );
+
+        try {
+          const content = fs.readFileSync(
+            path.join(installDir, 'package.json'),
+            'utf-8',
+          );
+          const pkg = JSON.parse(content) as Record<string, unknown>;
+          context.serverFramework = detectServerFramework(pkg);
+          context.entryPoint = detectEntryPoint(installDir, pkg);
+          context.projectType = detectProjectType(pkg);
+        } catch {
+          // No package.json or parse error
+        }
+
+        return Promise.resolve(context);
+      },
     },
 
     detection: {
@@ -36,29 +79,77 @@ export const JAVASCRIPT_NODE_AGENT_CONFIG: FrameworkConfig<JavaScriptNodeContext
     },
 
     analytics: {
-      getTags: () => ({}),
+      getTags: (context) => {
+        const tags: Record<string, string> = {};
+        if (context.serverFramework) {
+          tags.serverFramework = context.serverFramework;
+        }
+        if (context.projectType) {
+          tags.projectType = context.projectType;
+        }
+        return tags;
+      },
     },
 
     prompts: {
       projectTypeDetection:
-        'This is a server-side Node.js project. Look for package.json and lockfiles to confirm.',
+        'This is a server-side Node.js project. Check the additional context lines below for detected patterns.',
       packageInstallation:
         'Use npm, yarn, pnpm, or bun based on the existing lockfile (package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb). Install posthog-node as a regular dependency.',
-      getAdditionalContextLines: () => [
-        `Framework docs ID: javascript_node (use posthog://docs/frameworks/javascript_node for documentation)`,
-      ],
+      getAdditionalContextLines: (context) => {
+        const lines: string[] = [];
+
+        if (context.serverFramework) {
+          lines.push(
+            `Server framework: ${context.serverFramework} (detected in package.json)`,
+          );
+        }
+
+        if (context.entryPoint) {
+          lines.push(`Entry point: ${context.entryPoint}`);
+        }
+
+        if (context.projectType) {
+          lines.push(`Project type: ${context.projectType}`);
+        } else {
+          lines.push(
+            `Project type: Node.js application (no specific framework detected)`,
+          );
+        }
+
+        lines.push(
+          `Package manager: ${context.packageManagerName ?? 'unknown'}`,
+        );
+        lines.push(`Has TypeScript: ${context.hasTypeScript ? 'yes' : 'no'}`);
+        lines.push(
+          `Framework docs ID: javascript_node (use posthog://docs/frameworks/javascript_node for documentation)`,
+        );
+        lines.push(``);
+        lines.push(
+          `Integration approach: Explore the project's file structure to understand its architecture, then integrate posthog-node in the way that best fits the project's existing patterns. If a server framework was detected above, look at how it handles middleware, routes, and error handling to find the right integration points.`,
+        );
+
+        return lines;
+      },
     },
 
     ui: {
       successMessage: 'PostHog integration complete',
       estimatedDurationMinutes: 5,
-      getOutroChanges: () => [
-        `Analyzed your Node.js project structure`,
-        `Installed the posthog-node package`,
-        `Created PostHog initialization with proper configuration`,
-        `Configured graceful shutdown for event flushing`,
-        `Added example code for events, feature flags, and error capture`,
-      ],
+      getOutroChanges: (context) => {
+        const changes = [`Analyzed your Node.js project structure`];
+        if (context.serverFramework) {
+          changes.push(
+            `Detected ${context.serverFramework} and integrated PostHog accordingly`,
+          );
+        }
+        changes.push(
+          `Installed the posthog-node package`,
+          `Created PostHog initialization with proper configuration`,
+          `Configured graceful shutdown for event flushing`,
+        );
+        return changes;
+      },
       getOutroNextSteps: () => [
         'Use the PostHog client instance for all tracking calls',
         'Call posthog.shutdown() on application exit to flush pending events',

--- a/src/frameworks/javascript-node/utils.ts
+++ b/src/frameworks/javascript-node/utils.ts
@@ -1,0 +1,87 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Server frameworks that don't have dedicated wizard skills.
+ * Package name → display name.
+ */
+const SERVER_FRAMEWORKS: Record<string, string> = {
+  express: 'Express',
+  fastify: 'Fastify',
+  koa: 'Koa',
+  '@hapi/hapi': 'Hapi',
+  '@nestjs/core': 'Nest.js',
+  hono: 'Hono',
+  micro: 'Micro',
+  restify: 'Restify',
+};
+
+const CLI_PACKAGES = [
+  'commander',
+  'yargs',
+  'meow',
+  'oclif',
+  'inquirer',
+  'vorpal',
+];
+const WORKER_PACKAGES = ['bullmq', 'bull', 'bee-queue', 'agenda', 'node-cron'];
+
+function getAllDeps(
+  packageJson: Record<string, unknown>,
+): Record<string, string> {
+  return {
+    ...(packageJson.dependencies as Record<string, string> | undefined),
+    ...(packageJson.devDependencies as Record<string, string> | undefined),
+  };
+}
+
+export function detectServerFramework(
+  packageJson: Record<string, unknown>,
+): string | undefined {
+  const deps = getAllDeps(packageJson);
+  for (const [pkg, name] of Object.entries(SERVER_FRAMEWORKS)) {
+    if (deps[pkg]) return name;
+  }
+  return undefined;
+}
+
+export function detectProjectType(
+  packageJson: Record<string, unknown>,
+): string | undefined {
+  const deps = getAllDeps(packageJson);
+  if (CLI_PACKAGES.some((pkg) => deps[pkg])) return 'CLI tool';
+  if (WORKER_PACKAGES.some((pkg) => deps[pkg]))
+    return 'background worker / job processor';
+  if (Object.keys(SERVER_FRAMEWORKS).some((pkg) => deps[pkg]))
+    return 'API server';
+  return undefined;
+}
+
+export function detectEntryPoint(
+  installDir: string,
+  packageJson: Record<string, unknown>,
+): string | undefined {
+  if (typeof packageJson.main === 'string') return packageJson.main;
+
+  const candidates = [
+    'src/index.ts',
+    'src/index.js',
+    'src/server.ts',
+    'src/server.js',
+    'src/app.ts',
+    'src/app.js',
+    'server.ts',
+    'server.js',
+    'index.ts',
+    'index.js',
+    'app.ts',
+    'app.js',
+    'main.ts',
+    'main.js',
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(installDir, candidate))) return candidate;
+  }
+  return undefined;
+}

--- a/src/frameworks/javascript-web/javascript-web-wizard-agent.ts
+++ b/src/frameworks/javascript-web/javascript-web-wizard-agent.ts
@@ -11,6 +11,8 @@ import {
   detectJsPackageManager,
   detectBundler,
   hasIndexHtml,
+  detectVanillaWeb,
+  hasSrcDirectory,
   type JavaScriptContext,
 } from './utils';
 import { detectNodePackageManagers } from '../../lib/detection/package-manager';
@@ -27,7 +29,16 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
         path.join(options.installDir, 'tsconfig.json'),
       );
       const hasBundler = detectBundler(options);
-      return Promise.resolve({ packageManagerName, hasTypeScript, hasBundler });
+      const vanillaHtml = detectVanillaWeb(options);
+      const hasSrcDir = hasSrcDirectory(options);
+      return Promise.resolve({
+        packageManagerName,
+        hasTypeScript,
+        hasBundler,
+        isVanilla: !!vanillaHtml,
+        htmlEntryPoint: vanillaHtml ?? undefined,
+        hasSrcDir,
+      });
     },
   },
 
@@ -39,8 +50,11 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
     detectPackageManager: detectNodePackageManagers,
     detect: async (options) => {
       const packageJson = await tryGetPackageJson(options);
+
+      // Path 1: Vanilla web project (no package.json at all)
       if (!packageJson) {
-        return false;
+        const vanillaHtml = detectVanillaWeb(options);
+        return !!vanillaHtml;
       }
 
       // Exclude projects with known framework packages
@@ -52,9 +66,8 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
 
       const { installDir } = options;
 
-      // Has (index.html OR has a bundler) AND is a JavaScript project
+      // Path 2: Bundled web project (package.json + lockfile + frontend signal)
       const hasIndexHtmlFlag = hasIndexHtml(options);
-
       const bundler = detectBundler(options);
       const hasBundler = !!bundler;
 
@@ -67,9 +80,6 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
         'deno.lock',
       ].some((lockfile) => fs.existsSync(path.join(installDir, lockfile)));
 
-      // We only treat this as JS Web if there's BOTH:
-      // - a lockfile, and
-      // - at least one frontend signal (index.html or bundler)
       if (hasLockfile && (hasIndexHtmlFlag || hasBundler)) {
         return true;
       }
@@ -95,26 +105,52 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
       if (context.hasBundler) {
         tags.bundler = context.hasBundler;
       }
+      if (context.isVanilla) {
+        tags.projectVariant = 'vanilla';
+      }
       return tags;
     },
   },
 
   prompts: {
     projectTypeDetection:
-      'This is a JavaScript/TypeScript project. Look for package.json and lockfiles (package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb) to confirm.',
+      'This is a client-side web project. It may use a package manager and bundler, or it may be a vanilla HTML/CSS/JS site — check the additional context lines below.',
     packageInstallation:
-      'Look for lockfiles to determine the package manager (npm, yarn, pnpm, bun). Do not manually edit package.json.',
+      'Check the additional context below for whether a package manager is available. If no package manager is detected, use a CDN script tag for posthog-js instead of npm install.',
     getAdditionalContextLines: (context) => {
-      const lines = [
-        `Package manager: ${context.packageManagerName ?? 'unknown'}`,
-        `Has TypeScript: ${context.hasTypeScript ? 'yes' : 'no'}`,
-        `Framework docs ID: js (use posthog://docs/frameworks/js for documentation if available)`,
-        `Project type: Generic JavaScript/TypeScript application (no specific framework detected)`,
-      ];
+      const lines: string[] = [];
 
-      if (context.hasBundler) {
-        lines.unshift(`Bundler: ${context.hasBundler}`);
+      if (context.isVanilla) {
+        lines.push(
+          `Project type: Vanilla web (no package manager — use CDN script tag for posthog-js)`,
+        );
+        if (context.htmlEntryPoint) {
+          lines.push(`HTML entry point: ${context.htmlEntryPoint}`);
+        }
+      } else {
+        lines.push(
+          `Project type: JavaScript/TypeScript web application (no specific framework detected)`,
+        );
+        lines.push(
+          `Package manager: ${context.packageManagerName ?? 'unknown'}`,
+        );
+        if (context.hasBundler) {
+          lines.push(`Bundler: ${context.hasBundler}`);
+        }
+        lines.push(`Has TypeScript: ${context.hasTypeScript ? 'yes' : 'no'}`);
       }
+
+      if (context.hasSrcDir) {
+        lines.push(`Project structure: has src/ directory`);
+      }
+
+      lines.push(
+        `Framework docs ID: js (use posthog://docs/frameworks/js for documentation if available)`,
+      );
+      lines.push(``);
+      lines.push(
+        `Integration approach: No specific framework was detected. Explore the project's file structure to understand its architecture, then integrate posthog-js in the way that best fits the project's existing patterns.`,
+      );
 
       return lines;
     },
@@ -124,6 +160,14 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
     successMessage: 'PostHog integration complete',
     estimatedDurationMinutes: 5,
     getOutroChanges: (context) => {
+      if (context.isVanilla) {
+        return [
+          `Analyzed your vanilla web project structure`,
+          `Added posthog-js via script tag`,
+          `Created PostHog initialization code`,
+          `Configured autocapture, error tracking, and event capture`,
+        ];
+      }
       const packageManagerName =
         context.packageManagerName ?? 'package manager';
       return [

--- a/src/frameworks/javascript-web/utils.ts
+++ b/src/frameworks/javascript-web/utils.ts
@@ -7,6 +7,9 @@ export type JavaScriptContext = {
   packageManagerName?: string;
   hasTypeScript?: boolean;
   hasBundler?: string;
+  isVanilla?: boolean;
+  htmlEntryPoint?: string;
+  hasSrcDir?: boolean;
 };
 
 const INDEX_HTML_MAX_DEPTH = 6;
@@ -65,7 +68,10 @@ export function detectBundler(
       path.join(options.installDir, 'package.json'),
       'utf-8',
     );
-    const pkg = JSON.parse(content);
+    const pkg = JSON.parse(content) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
     const allDeps: Record<string, string> = {
       ...pkg.dependencies,
       ...pkg.devDependencies,
@@ -126,4 +132,50 @@ export function hasIndexHtml(
   }
 
   return search(root, 0);
+}
+
+/**
+ * Detect a vanilla web project (HTML/CSS/JS with no package manager).
+ * Returns the path to the first HTML file found at the root, or undefined.
+ */
+export function detectVanillaWeb(
+  options: Pick<WizardOptions, 'installDir'>,
+): string | undefined {
+  const root = options.installDir;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.toLowerCase().endsWith('.html')) {
+      try {
+        const content = fs.readFileSync(path.join(root, entry.name), 'utf-8');
+        if (/<script/i.test(content)) {
+          return entry.name;
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Check whether the project has a src/ directory.
+ */
+export function hasSrcDirectory(
+  options: Pick<WizardOptions, 'installDir'>,
+): boolean {
+  try {
+    const srcPath = path.join(options.installDir, 'src');
+    return fs.existsSync(srcPath) && fs.statSync(srcPath).isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/src/frameworks/python/python-wizard-agent.ts
+++ b/src/frameworks/python/python-wizard-agent.ts
@@ -17,6 +17,9 @@ import {
 
 type PythonContext = {
   packageManager?: PythonPackageManager;
+  entryPoint?: string;
+  projectLayout?: string;
+  detectedPatterns?: string[];
 };
 
 export const PYTHON_AGENT_CONFIG: FrameworkConfig<PythonContext> = {
@@ -26,8 +29,76 @@ export const PYTHON_AGENT_CONFIG: FrameworkConfig<PythonContext> = {
     beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/python',
     gatherContext: async (options: WizardOptions) => {
+      const { installDir } = options;
       const packageManager = await detectPackageManager(options);
-      return { packageManager };
+      const context: PythonContext = { packageManager };
+
+      // Detect entry point
+      const entryPointCandidates = [
+        'main.py',
+        'app.py',
+        'run.py',
+        'cli.py',
+        'manage.py',
+        'src/main.py',
+        'src/app.py',
+      ];
+      for (const candidate of entryPointCandidates) {
+        if (fs.existsSync(path.join(installDir, candidate))) {
+          context.entryPoint = candidate;
+          break;
+        }
+      }
+
+      // Detect project layout
+      if (fs.existsSync(path.join(installDir, 'src'))) {
+        context.projectLayout = 'src layout';
+      } else if (fs.existsSync(path.join(installDir, 'lib'))) {
+        context.projectLayout = 'lib layout';
+      } else {
+        context.projectLayout = 'flat layout';
+      }
+
+      // Detect patterns from dependencies
+      const depFiles = [
+        'requirements.txt',
+        'pyproject.toml',
+        'Pipfile',
+        'setup.cfg',
+      ];
+      let depContent = '';
+      for (const depFile of depFiles) {
+        try {
+          depContent +=
+            fs.readFileSync(path.join(installDir, depFile), 'utf-8') + '\n';
+        } catch {
+          /* skip */
+        }
+      }
+
+      const patternMarkers: Record<string, string[]> = {
+        CLI: ['click', 'typer', 'argparse'],
+        'background worker': ['celery', 'rq', 'dramatiq'],
+        'database (ORM)': ['sqlalchemy', 'peewee', 'tortoise-orm'],
+        'async web framework': ['aiohttp', 'tornado', 'sanic', 'starlette'],
+        'data/ML': ['pandas', 'numpy', 'scikit'],
+      };
+
+      const patterns = Object.entries(patternMarkers)
+        .filter(([, pkgs]) =>
+          pkgs.some((pkg) => new RegExp(`\\b${pkg}\\b`, 'i').test(depContent)),
+        )
+        .map(([label]) => label);
+
+      if (fs.existsSync(path.join(installDir, 'Dockerfile'))) {
+        patterns.push('containerized');
+      }
+
+      if (patterns.length > 0) {
+        context.detectedPatterns = patterns;
+      }
+
+      return context;
     },
   },
 
@@ -163,17 +234,37 @@ export const PYTHON_AGENT_CONFIG: FrameworkConfig<PythonContext> = {
   prompts: {
     packageInstallation: PYTHON_PACKAGE_INSTALLATION,
     projectTypeDetection:
-      'This is a generic Python project. Look for requirements.txt, pyproject.toml, setup.py, or Pipfile to confirm.',
+      'This is a Python project. Check the additional context lines below for detected patterns and entry points.',
     getAdditionalContextLines: (context) => {
       const packageManagerName = context.packageManager
         ? getPackageManagerName(context.packageManager)
         : 'unknown';
 
-      return [
-        `Package manager: ${packageManagerName}`,
+      const lines: string[] = [];
+
+      lines.push(`Package manager: ${packageManagerName}`);
+
+      if (context.entryPoint) {
+        lines.push(`Entry point: ${context.entryPoint}`);
+      }
+
+      if (context.projectLayout) {
+        lines.push(`Project structure: ${context.projectLayout}`);
+      }
+
+      if (context.detectedPatterns && context.detectedPatterns.length > 0) {
+        lines.push(`Detected patterns: ${context.detectedPatterns.join(', ')}`);
+      }
+
+      lines.push(
         `Framework docs ID: python (use posthog://docs/frameworks/python for documentation)`,
-        `Project type: Generic Python application (CLI, script, worker, data pipeline, etc.)`,
-      ];
+      );
+      lines.push(``);
+      lines.push(
+        `Integration approach: No specific web framework was detected. Explore the project's file structure to understand its architecture, then integrate the PostHog Python SDK in the way that best fits the project's existing patterns. Look for the entry point, request handlers, authentication flows, and error handling to find the right integration points.`,
+      );
+
+      return lines;
     },
   },
 

--- a/src/frameworks/ruby/ruby-wizard-agent.ts
+++ b/src/frameworks/ruby/ruby-wizard-agent.ts
@@ -3,6 +3,8 @@ import type { WizardOptions } from '../../utils/types';
 import type { FrameworkConfig } from '../../lib/framework-config';
 import { bundlerPackageManager } from '../../lib/detection/package-manager';
 import { Integration } from '../../lib/constants';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   getRubyVersion,
   getRubyVersionBucket,
@@ -14,6 +16,8 @@ import {
 
 type RubyContext = {
   packageManager?: RubyPackageManager;
+  entryPoint?: string;
+  detectedPatterns?: string[];
 };
 
 export const RUBY_AGENT_CONFIG: FrameworkConfig<RubyContext> = {
@@ -23,8 +27,59 @@ export const RUBY_AGENT_CONFIG: FrameworkConfig<RubyContext> = {
     beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/ruby',
     gatherContext: (options: WizardOptions) => {
+      const { installDir } = options;
       const packageManager = detectPackageManager(options);
-      return Promise.resolve({ packageManager });
+      const context: RubyContext = { packageManager };
+
+      // Detect entry point
+      const entryPointCandidates = [
+        'app.rb',
+        'main.rb',
+        'run.rb',
+        'lib/main.rb',
+        'bin/main',
+        'exe/main',
+      ];
+      for (const candidate of entryPointCandidates) {
+        if (fs.existsSync(path.join(installDir, candidate))) {
+          context.entryPoint = candidate;
+          break;
+        }
+      }
+
+      // Detect patterns from Gemfile
+      let gemfileContent = '';
+      try {
+        gemfileContent = fs.readFileSync(
+          path.join(installDir, 'Gemfile'),
+          'utf-8',
+        );
+      } catch {
+        /* no Gemfile */
+      }
+
+      const patternMarkers: Record<string, string[]> = {
+        'Sinatra web app': ['sinatra'],
+        'Grape API': ['grape'],
+        'Hanami web app': ['hanami'],
+        'background worker': ['sidekiq', 'resque'],
+        CLI: ['thor', 'gli'],
+        database: ['sequel', 'activerecord'],
+      };
+
+      const patterns = Object.entries(patternMarkers)
+        .filter(([, gems]) =>
+          gems.some((gem) =>
+            new RegExp(`\\b${gem}\\b`, 'i').test(gemfileContent),
+          ),
+        )
+        .map(([label]) => label);
+
+      if (patterns.length > 0) {
+        context.detectedPatterns = patterns;
+      }
+
+      return Promise.resolve(context);
     },
   },
 
@@ -62,7 +117,7 @@ export const RUBY_AGENT_CONFIG: FrameworkConfig<RubyContext> = {
 
   prompts: {
     projectTypeDetection:
-      'This is a Ruby project. Look for Gemfile, *.gemspec, .ruby-version, or *.rb files to confirm.',
+      'This is a Ruby project. Check the additional context lines below for detected patterns and entry points.',
     packageInstallation:
       "Use Bundler if a Gemfile is present (add `gem 'posthog-ruby'` and run `bundle install`). Otherwise use `gem install posthog-ruby`. Do not pin a specific version.",
     getAdditionalContextLines: (context) => {
@@ -70,42 +125,70 @@ export const RUBY_AGENT_CONFIG: FrameworkConfig<RubyContext> = {
         ? getPackageManagerName(context.packageManager)
         : 'unknown';
 
-      const lines = [
-        `Package manager: ${packageManagerName}`,
+      const lines: string[] = [];
+
+      lines.push(`Package manager: ${packageManagerName}`);
+
+      if (context.entryPoint) {
+        lines.push(`Entry point: ${context.entryPoint}`);
+      }
+
+      if (context.detectedPatterns && context.detectedPatterns.length > 0) {
+        lines.push(`Detected patterns: ${context.detectedPatterns.join(', ')}`);
+      }
+
+      lines.push(
         `Framework docs ID: ruby (use posthog://docs/frameworks/ruby for documentation)`,
-        `Project type: Generic Ruby application (CLI, script, gem, worker, etc.)`,
-        ``,
-        `## CRITICAL: Ruby PostHog Best Practices`,
-        ``,
-        `### 1. Gem Name vs Require`,
+      );
+      lines.push(``);
+      lines.push(
+        `Integration approach: Explore the project's file structure to understand its architecture, then integrate posthog-ruby in the way that best fits the project's existing patterns.`,
+      );
+      lines.push(``);
+      lines.push(`## CRITICAL: Ruby PostHog Best Practices`);
+      lines.push(``);
+      lines.push(`### 1. Gem Name vs Require`);
+      lines.push(
         `The gem is named posthog-ruby but you require it as 'posthog':`,
-        `  gem 'posthog-ruby'  # in Gemfile`,
+      );
+      lines.push(`  gem 'posthog-ruby'  # in Gemfile`);
+      lines.push(
         `  require 'posthog'   # in code (NOT require 'posthog-ruby')`,
-        ``,
-        `### 2. Use Instance-Based API (REQUIRED for scripts/CLIs)`,
+      );
+      lines.push(``);
+      lines.push(`### 2. Use Instance-Based API (REQUIRED for scripts/CLIs)`);
+      lines.push(
         `Use PostHog::Client.new for scripts and standalone applications:`,
-        ``,
-        `client = PostHog::Client.new(`,
-        `  api_key: ENV['POSTHOG_PROJECT_TOKEN'],`,
-        `  host: ENV['POSTHOG_HOST'] || 'https://us.i.posthog.com'`,
-        `)`,
-        ``,
-        `### 3. MUST Call shutdown Before Exit`,
+      );
+      lines.push(``);
+      lines.push(`client = PostHog::Client.new(`);
+      lines.push(`  api_key: ENV['POSTHOG_PROJECT_TOKEN'],`);
+      lines.push(`  host: ENV['POSTHOG_HOST'] || 'https://us.i.posthog.com'`);
+      lines.push(`)`);
+      lines.push(``);
+      lines.push(`### 3. MUST Call shutdown Before Exit`);
+      lines.push(
         `In scripts and CLIs, you MUST call client.shutdown or events will be lost:`,
-        ``,
-        `begin`,
+      );
+      lines.push(``);
+      lines.push(`begin`);
+      lines.push(
         `  client.capture(distinct_id: 'user_123', event: 'my_event')`,
-        `ensure`,
-        `  client.shutdown`,
-        `end`,
-        ``,
-        `### 4. capture_exception Takes Positional Args`,
+      );
+      lines.push(`ensure`);
+      lines.push(`  client.shutdown`);
+      lines.push(`end`);
+      lines.push(``);
+      lines.push(`### 4. capture_exception Takes Positional Args`);
+      lines.push(
         `client.capture_exception(exception, distinct_id, additional_properties)`,
-        `Do NOT use keyword arguments for capture_exception.`,
-        ``,
-        `### 5. NEVER Send PII`,
+      );
+      lines.push(`Do NOT use keyword arguments for capture_exception.`);
+      lines.push(``);
+      lines.push(`### 5. NEVER Send PII`);
+      lines.push(
         `Do NOT include emails, names, phone numbers, or user content in event properties.`,
-      ];
+      );
 
       return lines;
     },


### PR DESCRIPTION
our basic language skills are flaky at best - sometimes they work, but they never produce as good of an outcome as the framework-specific skills

the fallback skills are too constrained. strict detection requirements were causing it to do weird things with projects we can't predict the shape of

sister PR: https://github.com/PostHog/context-mill/pull/123

## changes

**Vanilla HTML/CSS/JS:**
- Projects with HTML files but no `package.json` now auto-detect instead of requiring manual selection
- Agent gets told whether it's vanilla (use CDN script tag) or bundled (use npm install)
- HTML entry point is passed to the agent so it knows where to add the snippet

**Node.js:**
- New `utils.ts` with shared detection helpers
- Improved context gathering for plain Node.js projects

**Python:**
- Detects entry point (`main.py`, `app.py`, etc.) and passes it to the agent
- Detects project layout (src layout, lib layout, flat)
- Scans dependencies for patterns (CLI, background worker, database, async framework, data/ML) so the agent understands what kind of Python project it's working with

**Ruby:**
- Improved detection and context gathering for plain Ruby projects

detection order in `constants.ts` is unchanged. frameworks are checked first, fallbacks last

## Testing

A/B tested all four fallback languages across three configurations:
1. **Published** – `npx @posthog/wizard@latest` (current production)
2. **This branch + example apps** – our wizard changes paired with context-mill, example apps still connected
3. **This branch, no example apps** – same wizard changes, but example apps disconnected from fallback skills (docs-only)

Each test ran on minimal, no-framework apps: plain `http.server`, plain `http.createServer`, vanilla HTML, plain WEBrick

### Vanilla HTML/CSS/JS

| | **Published** | **+ example apps** | **Docs-only (no examples)** |
|---|---|---|---|
| Auto-detected? | No — manual selection | Yes | Yes |
| API key | Hardcoded in HTML | Placeholders | Placeholders |
| Events | `signup_clicked` | `signup_clicked` | `signup_clicked` |

### Python

| | **Published** | **+ example apps** | **Docs-only (no examples)** |
|---|---|---|---|
| API key | Env vars via dotenv | Env vars via `os.environ` | Env vars via `os.environ` |
| Events | `signup_form_viewed`, `signup_completed` | `page_viewed`, `user_signed_up` | `signup_form_viewed`, `user_signed_up` |
| User ID | Random UUID | SHA256 hash | SHA256 hash |
| Identify | No | No | Yes — `posthog.set()` |
| Error tracking | Autocapture only | No | `capture_exception` + autocapture |
| Graceful shutdown | Yes (`atexit`) | No | Yes (`atexit`) |

### Node.js

| | **Published** | **+ example apps** | **Docs-only (no examples)** |
|---|---|---|---|
| API key | Env vars (no dotenv) | Env vars via dotenv | Env vars via dotenv |
| Events | `user signed up` (spaces!) | `page_viewed`, `user_signed_up` | `signup_page_viewed`, `user_signed_up` |
| User ID | Raw email | SHA256 hash | `crypto.randomUUID()` |
| Identify | Yes | No | Yes |
| Error tracking | `captureException` | No | `captureException` + autocapture |
| Graceful shutdown | Yes (SIGTERM + SIGINT) | Yes (SIGTERM) | Yes (SIGINT) |

### Ruby

| | **Published** | **+ example apps** | **Docs-only (no examples)** |
|---|---|---|---|
| API key | Env vars via dotenv | Env vars via dotenv | Env vars |
| User ID | IP address! | `SecureRandom.uuid` | `SecureRandom.uuid` |
| Identify | Yes — hardcoded `plan: 'free'` | No | Yes — real properties |
| Error tracking | No | Error tracking | `capture_exception` in rescue blocks |
| Graceful shutdown | Yes | Yes | Yes (`at_exit` + `trap`) |

with example apps connected, the agent was copying patterns from the example but skipping identify, error tracking, and graceful shutdown. it was too constrained. 

without them, the agent leaned on the SDK docs and our `fallback-description.md` guidance – and consistently produced more complete integrations

seems fallback skills just need some docs, general guidance, and some freedom

### The big wins

- **Vanilla auto-detection**: no longer requires manual framework selection
- **API key safety**: no more hardcoded keys in vanilla HTML projects
- **User ID handling**: no more raw emails (Node) or IP addresses (Ruby) as distinct IDs
- **Identify + error tracking**: consistently present across all languages now (previously hit or miss)
- **Event naming**: clean snake_case names, no spaces