### PR TITLE
fix: request llm_gateway:read scope during signup provisioning

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -93,9 +93,19 @@ export const DUMMY_PROJECT_API_KEY = '_YOUR_POSTHOG_PROJECT_TOKEN_';
 
 /**
  * Scopes the wizard requests during the agentic provisioning signup flow.
+ *
+ * Each entry is justified by what the wizard's agent step does after signup:
+ * - user:read         identify the user for analytics + agent context
+ * - project:read      look up the freshly-provisioned project
+ * - llm_gateway:read  authenticate to gateway.{us,eu}.posthog.com/wizard
+ *                     (the agent's LLM calls — without this scope, every
+ *                     agent message returns 401)
+ * - query:read        run HogQL queries when the agent needs data
+ * - dashboard:write   create the onboarding dashboard during setup
+ * - insight:write     create the onboarding insights during setup
+ *
  * Must be a subset of `ALLOWED_PROVISIONING_SCOPES` in
- * `ee/api/agentic_provisioning/views.py` on the backend — `llm_gateway:read`
- * is required for the agent step to call the LLM gateway.
+ * `ee/api/agentic_provisioning/views.py` on the backend.
  */
 export const WIZARD_PROVISIONING_SCOPES = [
   'user:read',
@@ -108,8 +118,10 @@ export const WIZARD_PROVISIONING_SCOPES = [
 
 /**
  * Scopes the wizard requests during the OAuth login flow. Superset of
- * `WIZARD_PROVISIONING_SCOPES` — `introspection` and `health_issue:read` are
- * not in the provisioning allowlist and only apply to the login path.
+ * `WIZARD_PROVISIONING_SCOPES` with two scopes that only apply to the login
+ * path and are not in the provisioning allowlist:
+ * - introspection      lets the wizard introspect its own token
+ * - health_issue:read  used by `wizard doctor`
  */
 export const WIZARD_OAUTH_SCOPES = [
   ...WIZARD_PROVISIONING_SCOPES,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -91,6 +91,32 @@ export const POSTHOG_DEV_CLIENT_ID = 'DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ';
 export const POSTHOG_PROXY_CLIENT_ID = POSTHOG_US_CLIENT_ID;
 export const DUMMY_PROJECT_API_KEY = '_YOUR_POSTHOG_PROJECT_TOKEN_';
 
+/**
+ * Scopes the wizard requests during the agentic provisioning signup flow.
+ * Must be a subset of `ALLOWED_PROVISIONING_SCOPES` in
+ * `ee/api/agentic_provisioning/views.py` on the backend — `llm_gateway:read`
+ * is required for the agent step to call the LLM gateway.
+ */
+export const WIZARD_PROVISIONING_SCOPES = [
+  'user:read',
+  'project:read',
+  'llm_gateway:read',
+  'dashboard:write',
+  'insight:write',
+  'query:read',
+] as const;
+
+/**
+ * Scopes the wizard requests during the OAuth login flow. Superset of
+ * `WIZARD_PROVISIONING_SCOPES` — `introspection` and `health_issue:read` are
+ * not in the provisioning allowlist and only apply to the login path.
+ */
+export const WIZARD_OAUTH_SCOPES = [
+  ...WIZARD_PROVISIONING_SCOPES,
+  'introspection',
+  'health_issue:read',
+] as const;
+
 // ── Wizard run / variants ───────────────────────────────────────────
 
 export const WIZARD_INTERACTION_EVENT_NAME = 'wizard interaction';

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -89,6 +89,9 @@ describe('provisionNewAccount', () => {
       (accountCall[1] as Record<string, unknown>).code_challenge,
     ).toBeTruthy();
     expect((accountCall[1] as Record<string, unknown>).client_id).toBeTruthy();
+    expect((accountCall[1] as Record<string, unknown>).scopes).toEqual(
+      expect.arrayContaining(['llm_gateway:read', 'project:read', 'user:read']),
+    );
 
     // Verify token exchange includes code_verifier
     const tokenCall = mockedAxios.post.mock.calls[1];

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -89,9 +89,14 @@ describe('provisionNewAccount', () => {
       (accountCall[1] as Record<string, unknown>).code_challenge,
     ).toBeTruthy();
     expect((accountCall[1] as Record<string, unknown>).client_id).toBeTruthy();
-    expect((accountCall[1] as Record<string, unknown>).scopes).toEqual(
-      expect.arrayContaining(['llm_gateway:read', 'project:read', 'user:read']),
-    );
+    expect((accountCall[1] as Record<string, unknown>).scopes).toEqual([
+      'user:read',
+      'project:read',
+      'llm_gateway:read',
+      'dashboard:write',
+      'insight:write',
+      'query:read',
+    ]);
 
     // Verify token exchange includes code_verifier
     const tokenCall = mockedAxios.post.mock.calls[1];

--- a/src/utils/provisioning.ts
+++ b/src/utils/provisioning.ts
@@ -14,6 +14,7 @@ import {
   IS_DEV,
   POSTHOG_DEV_CLIENT_ID,
   POSTHOG_US_CLIENT_ID,
+  WIZARD_PROVISIONING_SCOPES,
   WIZARD_USER_AGENT,
 } from '../lib/constants';
 import { logToFile } from './debug';
@@ -117,6 +118,7 @@ export async function provisionNewAccount(
       client_id: WIZARD_CLIENT_ID,
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
+      scopes: WIZARD_PROVISIONING_SCOPES,
       configuration: {
         region,
         ...(opts?.orgName ? { organization_name: opts.orgName } : {}),

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_HOST_URL,
   DUMMY_PROJECT_API_KEY,
   ISSUES_URL,
+  WIZARD_OAUTH_SCOPES,
 } from '../lib/constants';
 import { analytics } from './analytics';
 import { getUI } from '../ui';
@@ -489,16 +490,7 @@ async function askForWizardLogin(options: {
   }
 
   const tokenResponse = await performOAuthFlow({
-    scopes: [
-      'user:read',
-      'project:read',
-      'introspection',
-      'llm_gateway:read',
-      'dashboard:write',
-      'insight:write',
-      'query:read',
-      'health_issue:read',
-    ],
+    scopes: [...WIZARD_OAUTH_SCOPES],
     signup: false,
   });
 


### PR DESCRIPTION
## Problem

The wizard's `--signup` flow exits with a 401 ("Authentication failed") immediately after provisioning succeeds, so nothing is ever written into the user's project. Repro:

```bash
mkdir /tmp/ph-test && cd /tmp/ph-test && npm init -y
npx @posthog/wizard --signup --email someone+test@example.com --region us
```

`/tmp/posthog-wizard.log` shows the chain:

```
[provisioning] starting account creation
[provisioning] account created, exchanging code for tokens
[provisioning] tokens received, provisioning resources
[provisioning] resources provisioned successfully
...
Failed to authenticate. API Error: 401 {"detail":"Authentication required"}
Agent error: 401, showing auth error screen
```

Account + project + PAT are all created server-side, but the agent step that writes the SDK integration immediately bails on the first call to `gateway.us.posthog.com/wizard`.

Root cause: `provisionNewAccount` in `src/utils/provisioning.ts` POSTs to `/api/agentic/provisioning/account_requests` with **no `scopes` field**. The PostHog backend (`ee/api/agentic_provisioning/views.py:315`) defaults to `[]`, `_validate_scopes` short-circuits empty lists as valid, and the issued OAuth token gets minted with zero scopes. The LLM gateway (`services/llm-gateway/src/llm_gateway/auth/authenticators.py:130`) gates on `has_required_scope(scopes, "llm_gateway:read")` — empty scopes → `False` → 401, regardless of which OAuth client minted the token.

The non-signup OAuth path in `setup-utils.ts:491` already requests the right scopes (including `llm_gateway:read`); the signup path was just never updated to match.

## Changes

- Extract two scope constants in `src/lib/constants.ts`:
  - `WIZARD_PROVISIONING_SCOPES` — the 6 scopes the wizard needs that are also in the backend's `ALLOWED_PROVISIONING_SCOPES` allowlist.
  - `WIZARD_OAUTH_SCOPES` — superset that adds `introspection` and `health_issue:read`, which only apply to the OAuth login path (not in the provisioning allowlist).
- Pass `scopes: WIZARD_PROVISIONING_SCOPES` in the `account_requests` body in `provisionNewAccount`.
- Replace the inline scope list in `setup-utils.ts` with the new constant so the two paths can't drift again.
- Test asserts the new scopes field is present on the outgoing request.

The provisioning subset deliberately excludes `introspection` and `health_issue:read` because they are not in `ALLOWED_PROVISIONING_SCOPES` ([posthog/posthog ee/api/agentic_provisioning/views.py:2033-2052](https://github.com/PostHog/posthog/blob/master/ee/api/agentic_provisioning/views.py#L2033-L2052)). If the wizard ever needs them on the signup path, they need to be added to that allowlist first.

## Test plan

- [x] Existing `provisionNewAccount` tests still pass (`pnpm exec jest src/utils/__tests__/provisioning.test.ts`)
- [x] New assertion that `scopes` is the exact `WIZARD_PROVISIONING_SCOPES` array
- [x] `pnpm typecheck`
- [x] `pnpm lint` (no new errors; existing warnings only)
- [x] Manual end-to-end against prod-us with this branch built locally:
  - `node dist/bin.js provision --email <fresh>@gmail.com --region us --json` → fresh account + `pha_...` access token
  - `curl -X POST https://gateway.us.posthog.com/wizard/v1/messages -H "Authorization: Bearer <pha_...>"` → **HTTP 200** with a real Claude response, vs the 401 the same call returns from a token minted on `main`