### PR TITLE
feat: enable AWS Bedrock fallback for wizard agent requests

### DIFF
--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -387,6 +387,7 @@ function buildAgentEnv(
   wizardFlags: Record<string, string>,
 ): string {
   const headers = createCustomHeaders();
+  headers.add('x-posthog-use-bedrock-fallback', 'true');
   for (const [key, value] of Object.entries(wizardMetadata)) {
     headers.add(
       key.startsWith(POSTHOG_PROPERTY_HEADER_PREFIX)

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -380,7 +380,9 @@ export function buildWizardMetadata(
 }
 
 /**
- * Build env for the SDK subprocess: process.env plus ANTHROPIC_CUSTOM_HEADERS from wizard metadata/flags.
+ * Build env for the SDK subprocess: process.env plus ANTHROPIC_CUSTOM_HEADERS, which always
+ * includes `x-posthog-use-bedrock-fallback: true` so the LLM gateway falls back to Bedrock on
+ * Anthropic 5xx, plus any wizard metadata/flags.
  */
 function buildAgentEnv(
   wizardMetadata: Record<string, string>,


### PR DESCRIPTION
## Summary
- Adds the `x-posthog-use-bedrock-fallback: true` header to every wizard agent request via `buildAgentEnv()` in `src/lib/agent/agent-interface.ts`.
- The header is encoded into `ANTHROPIC_CUSTOM_HEADERS` and passed through to the Claude Agent SDK subprocess, so it applies to all inference calls routed through the PostHog LLM gateway (`gateway.us.posthog.com/wizard` / `gateway.eu.posthog.com/wizard`).
- When the gateway sees a 5xx from Anthropic, it now falls back to Bedrock-hosted Anthropic models (Sonnet/Opus/Haiku) automatically — improving wizard uptime during Anthropic incidents without changing the primary provider.

## Why
Recent Anthropic uptime hiccups have caused user-facing failures in the wizard. The LLM gateway already supports a Bedrock fallback path opt-in per-request via this header — wiring it up gives us a free uptime win and lets us dogfood the fallback.

## Test plan
- [ ] `pnpm typecheck` passes locally
- [ ] Manual: run the wizard and confirm requests still succeed under normal conditions
- [ ] Manual (optional): force an Anthropic 5xx via gateway and confirm Bedrock serves the response

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*