### PR TITLE
fix: claude desktop in the `mcp add` dialog

### DIFF
--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -5,6 +5,7 @@ import { analytics } from '../../utils/analytics';
 import { getUI } from '../../ui';
 import { MCPClient } from './MCPClient';
 import { CursorMCPClient } from './clients/cursor';
+import { ClaudeMCPClient } from './clients/claude';
 import { ClaudeCodeMCPClient } from './clients/claude-code';
 import { VisualStudioCodeClient } from './clients/visual-studio-code';
 import { ZedClient } from './clients/zed';
@@ -16,6 +17,7 @@ import { isPluginCapable, PluginCapable } from './plugin-client';
 export const getSupportedClients = async (): Promise<MCPClient[]> => {
   const allClients = [
     new ClaudeCodeMCPClient(),
+    new ClaudeMCPClient(),
     new CodexMCPClient(),
     new CursorMCPClient(),
     new VisualStudioCodeClient(),


### PR DESCRIPTION
## Problem

Installation for Claude Desktop is implemented, but the dialog doesn't have an option to select it.

## Changes

Added the option to the dialog.

## Test plan

Verified locally