### PR TITLE
fix: drop ungrantable `introspection` scope from OAuth authorize URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ When creating your personal API key, ensure it has the following scopes enabled:
 
 - `user:read` - Required to fetch user information
 - `project:read` - Required to fetch project details and API token
-- `introspection` - Required for API introspection
 - `llm_gateway:read` - Required for LLM gateway access
 - `dashboard:write` - Required to create dashboards
 - `insight:write` - Required to create insights

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -120,14 +120,12 @@ export const WIZARD_PROVISIONING_SCOPES = [
  * Scopes the wizard requests during the OAuth login flow. Superset of
  * `WIZARD_PROVISIONING_SCOPES` with scopes that only apply to the login
  * path and are not in the provisioning allowlist:
- * - introspection         lets the wizard introspect its own token
  * - health_issue:read     used by `wizard doctor`
  * - wizard_session:read   list / retrieve / stream sessions
  * - wizard_session:write  stream run state to /api/projects/{id}/wizard/sessions/
  */
 export const WIZARD_OAUTH_SCOPES = [
   ...WIZARD_PROVISIONING_SCOPES,
-  'introspection',
   'health_issue:read',
   'wizard_session:read',
   'wizard_session:write',


### PR DESCRIPTION
## Summary

Closes #433

- Drops the `introspection` entry from the OAuth `scopes` array in `src/utils/setup-utils.ts` (around line 495). It is not present in `posthog/scopes.py` (the canonical scope list), is not grantable, and the authorization server currently rejects the authorize request as `invalid_scope`.
- Removes the matching bullet from the README's "Required API Key Scopes" list so users don't try to enable a scope that doesn't exist.

Token introspection continues to work without it as a granted scope: introspection is an endpoint per [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662), authenticated via the bearer token, not a scope that needs to be requested at authorize time.

## Test plan

- [ ] `pnpm build` (passes locally; smoke test green)
- [ ] Run the wizard's OAuth flow end-to-end and confirm the authorize step no longer returns `invalid_scope`
- [ ] Verify token introspection (e.g. via `/oauth/introspect`) still succeeds for a token issued with the trimmed scope set

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
