### PR TITLE
feat: error tracking source maps

### DIFF
--- a/.claude/skills/wizard-development/SKILL.md
+++ b/.claude/skills/wizard-development/SKILL.md
@@ -69,7 +69,7 @@ Three prevention layers:
 
 - **L0 — Commandments** (`commandments.ts`): Terse rules in the system prompt. Keep these short. If a rule needs a paragraph of explanation, it belongs in a skill reference file, not in the per-turn system prompt.
 
-- **L1 — canUseTool allowlist** (`agent-interface.ts`): Blocks dangerous bash commands before execution. The `wizard-tools` MCP fences `.env` files so the agent never sees secret values.
+- **L1 — canUseTool allowlist** (`agent-interface.ts`): Blocks dangerous bash commands before execution. The `wizard-tools` MCP fences `.env` files so the agent can't read them directly. Secrets the user supplies are handled separately by the **session secret vault** (`secret-vault.ts`): `wizard_ask` and `set_env_values` exchange the raw value for an opaque `secret:<uuid>` ref, so a user's API key reaches the `.env` file without ever entering the LLM conversation. See [ARCHITECTURE.md](references/ARCHITECTURE.md#secret-vault-keeping-values-out-of-the-model).
 
 - **L2 — warlock scanner** (rules live in [warlock](https://github.com/PostHog/warlock); wizard wires hooks in `yara-hooks.ts`): Real YARA-X rules running as pre/post tool-use hooks. Catches PII in capture calls, hardcoded keys, prompt injection, secret exfiltration, supply chain attacks, destructive operations. The scanner is engine-only — it returns matches with category/severity/action metadata; the wizard decides how to respond. Critical violations terminate the session. **Fails closed** — scanner error means block, not pass. (Note: the wizard still ships a legacy hand-rolled regex scanner at `src/lib/yara-scanner.ts` during the warlock migration. New rules go in warlock; the in-repo scanner is being retired.)
 
@@ -122,7 +122,7 @@ When you're adding something that doesn't have a precedent in the codebase, ask 
 
 ### Patterns for common extension types
 
-**New agent tool (in-process MCP):** Add it to `wizard-tools.ts` alongside `check_env_keys`, `set_env_values`, etc. The tool runs locally — secret values never leave the machine. Register the tool name in `WIZARD_TOOL_NAMES` so the SDK allowlist includes it. Follow the existing tool pattern: zod schema, path-traversal protection, logging.
+**New agent tool (in-process MCP):** Add it to `wizard-tools.ts` alongside `check_env_keys`, `set_env_values`, etc. The tool runs locally — secret values never leave the machine. Register the tool name in `WIZARD_TOOL_NAMES` so the SDK allowlist includes it. Follow the existing tool pattern: zod schema, path-traversal protection, logging. If the tool handles a user secret, route it through the secret vault (`secret-vault.ts`) — return a `secret:<uuid>` ref, not the value, and resolve it host-side at the point of use — so the secret stays out of the LLM conversation.
 
 **New security rule:** Contribute the rule to [warlock](https://github.com/PostHog/warlock), not to the wizard. Warlock is the YARA-X engine that backs the wizard's security scanning; it's an append-only sibling repo with its own contribution process. Add a `.yar` file under `src/scanner/rules/` with a meta block (description, severity, category, scan_context, action) and a test under `src/scanner/__tests__/rules/`. The wizard's hooks in `yara-hooks.ts` automatically pick up new rules when it bumps its warlock dependency — wizard-side changes are unnecessary unless the response to a new category needs different handling. Filter consumed matches by `category` and `severity` (the append-only API contract), not by individual rule names.
 

--- a/.claude/skills/wizard-development/references/ARCHITECTURE.md
+++ b/.claude/skills/wizard-development/references/ARCHITECTURE.md
@@ -104,6 +104,28 @@ The sandbox (filesystem + network scoping) is configured once in the SDK `query(
 
 Commandments (L0) are in the system prompt and operate at the model's judgment layer — no code enforcement. They're the first line, not the last.
 
+## Secret vault: keeping values out of the model
+
+The layers above stop the agent from _misusing_ tools. A separate boundary stops secret _values_ from ever reaching the model in the first place: the session-scoped secret vault in `src/lib/secret-vault.ts`.
+
+```
+wizard_ask (sensitive: true)
+    ↓  user types secret in the TUI
+vault.put(value) → "secret:<uuid>"     ← raw value stays host-side
+    ↓
+agent receives { secretRef } — never the string
+    ↓  agent passes the ref to the next tool
+set_env_values({ KEY: { secretRef } })
+    ↓
+vault.get(ref) → value, written to .env  ← resolved at the last moment
+    ↓
+result returned to agent (no value)
+```
+
+The vault is a plain in-memory `Map` created once per `createWizardToolsServer()` call — one per wizard run, no persistence, no cross-session sharing. A ref minted in one run can't be resolved in another. `list()` exposes metadata (label, source, timestamp) but never values. The two ends of the pipe both live in `wizard-tools.ts`: `wizard_ask` mints refs for answers flagged `sensitive: true` (text questions only), and `set_env_values` accepts `{ secretRef }` in place of a literal and resolves it before writing.
+
+The point of the boundary: the model orchestrates a secret's journey from the user's keyboard to a `.env` file without the value entering the LLM conversation, the transcript, or the logs. When you add a tool that touches a user secret, route it through the vault — return refs, resolve them host-side — rather than passing the value back to the agent.
+
 ## Screen resolution flow
 
 ```
@@ -148,7 +170,7 @@ The agent has access to two MCP servers:
 
 - **posthog-wizard** — remote, HTTP-based. The PostHog MCP server at `mcp.posthog.com/mcp` (or `mcp-eu.posthog.com/mcp`). Provides query tools for PostHog data, dashboard creation, etc. Authenticated via Bearer token. Tool schemas are deferred (`ENABLE_TOOL_SEARCH: 'auto:0'`) to avoid bloating the system prompt. It's almost never the right move to add tools here, unless a server-side component is the only path forward.
 
-- **wizard-tools** — local, in-process. Created by `createWizardToolsServer()` in `wizard-tools.ts`. Provides `check_env_keys`, `set_env_values`, `detect_package_manager`, `load_skill_menu`, `install_skill`. Runs in the wizard process — secret values never leave the machine.
+- **wizard-tools** — local, in-process. Created by `createWizardToolsServer()` in `wizard-tools.ts`. Provides `check_env_keys`, `set_env_values`, `detect_package_manager`, `load_skill_menu`, `install_skill`, `wizard_ask`. Runs in the wizard process — secret values never leave the machine, and the secret vault (see [Secret vault](#secret-vault-keeping-values-out-of-the-model)) keeps them out of the model context entirely.
 
 Frameworks can add additional MCP servers via `FrameworkConfig.metadata.additionalMcpServers` (e.g. SvelteKit adds the official Svelte MCP at `https://mcp.svelte.dev/mcp`).
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,32 @@ This also allows us to pick up the bill on behalf of our customers.
 When we make improvements to this process, these are available instantly to all
 users of the wizard, no training delays or other ambiguity.
 
+## Keep secrets out of the LLM
+
+The wizard somtimes needs to move a secret. The agent
+orchestrates that journey, but the raw value should _never_ enter the LLM
+conversation, where it would be sent to the model provider, written to
+transcripts, and captured in logs.
+
+`src/lib/secret-vault.ts` is a small, reusable pattern for exactly this. It's a
+session-scoped, in-memory vault: a tool that handles a secret calls `put()` to
+store the raw value and hands the agent an opaque `secret:<uuid>` reference
+instead. The agent passes that ref between tools as if it were the value; the
+host resolves it back to the real secret only at the last moment, inside the
+process, when it writes the file.
+
+Two tools in `src/lib/wizard-tools.ts` form the ends of that pipe:
+
+- `wizard_ask` with `sensitive: true` vaults the user's typed answer and returns
+  `{ secretRef: "secret:..." }` to the agent rather than the string.
+- `set_env_values` accepts `{ secretRef }` in place of a literal value and
+  resolves it against the vault before writing — the value lands in the `.env`
+  file but is never returned to the model.
+
+The vault has no persistence and is dropped at the end of the run; refs minted
+in one session can't be resolved in another. The net effect: the model gets to
+drive the work end to end, but the only thing it ever sees is an opaque handle.
+
 ## Build system
 
 Built with [tsdown](https://tsdown.dev/) (Rolldown). `pnpm build` bundles `bin.ts` into ESM chunks in `dist/`, inlining all local source and keeping npm dependencies external.

--- a/src/lib/__tests__/secret-vault.test.ts
+++ b/src/lib/__tests__/secret-vault.test.ts
@@ -1,0 +1,74 @@
+import { createSecretVault, isSecretRef } from '../secret-vault';
+
+describe('createSecretVault', () => {
+  it('stores a value and returns a ref', () => {
+    const vault = createSecretVault();
+    const ref = vault.put('phx_super_secret', {
+      label: 'PostHog key',
+      source: 'test',
+    });
+
+    expect(isSecretRef(ref)).toBe(true);
+    expect(ref).toMatch(/^secret:[0-9a-f-]{36}$/);
+    expect(vault.has(ref)).toBe(true);
+    expect(vault.get(ref)).toBe('phx_super_secret');
+  });
+
+  it('mints a fresh ref per put even for the same value', () => {
+    const vault = createSecretVault();
+    const a = vault.put('same-value', { label: 'A', source: 'test' });
+    const b = vault.put('same-value', { label: 'B', source: 'test' });
+
+    expect(a).not.toBe(b);
+    expect(vault.get(a)).toBe('same-value');
+    expect(vault.get(b)).toBe('same-value');
+  });
+
+  it('returns undefined for unknown refs', () => {
+    const vault = createSecretVault();
+    expect(vault.get('secret:does-not-exist')).toBeUndefined();
+    expect(vault.has('secret:does-not-exist')).toBe(false);
+  });
+
+  it('list() returns metadata only, never values', () => {
+    const vault = createSecretVault();
+    vault.put('value-1', { label: 'one', source: 'src-a' });
+    vault.put('value-2', { label: 'two', source: 'src-b' });
+
+    const metas = vault.list();
+    expect(metas).toHaveLength(2);
+    expect(metas.map((m) => m.label).sort()).toEqual(['one', 'two']);
+    expect(metas.map((m) => m.source).sort()).toEqual(['src-a', 'src-b']);
+    // Ensure no `value` key bled into the metadata
+    for (const m of metas) {
+      expect(m).not.toHaveProperty('value');
+    }
+  });
+
+  it('clear() drops every secret', () => {
+    const vault = createSecretVault();
+    const ref = vault.put('gone', { label: 'temp', source: 'test' });
+    vault.clear();
+    expect(vault.has(ref)).toBe(false);
+    expect(vault.get(ref)).toBeUndefined();
+    expect(vault.list()).toEqual([]);
+  });
+
+  it('isolates vault instances from each other', () => {
+    const a = createSecretVault();
+    const b = createSecretVault();
+    const ref = a.put('only-in-a', { label: 'a-only', source: 'test' });
+
+    expect(a.has(ref)).toBe(true);
+    expect(b.has(ref)).toBe(false);
+  });
+
+  it('isSecretRef recognises refs and rejects garbage', () => {
+    expect(isSecretRef('secret:abc')).toBe(true);
+    expect(isSecretRef('not a ref')).toBe(false);
+    expect(isSecretRef('')).toBe(false);
+    expect(isSecretRef(null)).toBe(false);
+    expect(isSecretRef(undefined)).toBe(false);
+    expect(isSecretRef({ secretRef: 'secret:abc' })).toBe(false);
+  });
+});

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -65,7 +65,13 @@ export const DEFAULT_WIZARD_READINESS_CONFIG: WizardReadinessConfig = {
     'mcp',
     'githubReleases',
   ],
-  degradedBlocksRun: ['anthropic'],
+  // TEMP — LOCAL ONLY, DO NOT COMMIT. status.claude.com is reporting a
+  // "minor" degradation, which (via degradedBlocksRun: ['anthropic']) would
+  // hard-block the wizard before OAuth and hang the auth screen at
+  // "Waiting for authentication...". Emptied so we can keep testing; a real
+  // major/critical Anthropic outage still blocks via downBlocksRun above.
+  // Revert to ['anthropic'] once Claude status is back to operational.
+  degradedBlocksRun: [],
 };
 
 /**

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -65,13 +65,7 @@ export const DEFAULT_WIZARD_READINESS_CONFIG: WizardReadinessConfig = {
     'mcp',
     'githubReleases',
   ],
-  // TEMP — LOCAL ONLY, DO NOT COMMIT. status.claude.com is reporting a
-  // "minor" degradation, which (via degradedBlocksRun: ['anthropic']) would
-  // hard-block the wizard before OAuth and hang the auth screen at
-  // "Waiting for authentication...". Emptied so we can keep testing; a real
-  // major/critical Anthropic outage still blocks via downBlocksRun above.
-  // Revert to ['anthropic'] once Claude status is back to operational.
-  degradedBlocksRun: [],
+  degradedBlocksRun: ['anthropic'],
 };
 
 /**

--- a/src/lib/programs/__tests__/source-maps-detect.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect.test.ts
@@ -1,0 +1,199 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  detectSourceMapsPrerequisites,
+  SOURCE_MAPS_CONTEXT_KEYS,
+} from '@lib/programs/error-tracking-upload-source-maps/index';
+import { buildSession } from '@lib/wizard-session';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'source-maps-detect-'));
+}
+
+function cleanup(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writePackageJson(
+  dir: string,
+  deps: Record<string, string> = {},
+  devDeps: Record<string, string> = {},
+): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({
+      dependencies: deps,
+      ...(Object.keys(devDeps).length > 0 ? { devDependencies: devDeps } : {}),
+    }),
+  );
+}
+
+describe('detectSourceMapsPrerequisites', () => {
+  let tmpDir: string;
+  let ctx: Record<string, unknown>;
+  let setCtx: jest.Mock;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    ctx = {};
+    setCtx = jest.fn((key: string, value: unknown) => {
+      ctx[key] = value;
+    });
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  it('errors when install directory is missing', () => {
+    const session = buildSession({ installDir: '/nonexistent/path' });
+    detectSourceMapsPrerequisites(session, setCtx);
+
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toEqual(
+      expect.objectContaining({ kind: 'bad-directory', reason: 'missing' }),
+    );
+  });
+
+  it('errors when install directory is not a directory', () => {
+    const filePath = path.join(tmpDir, 'not-a-dir');
+    fs.writeFileSync(filePath, '');
+
+    const session = buildSession({ installDir: filePath });
+    detectSourceMapsPrerequisites(session, setCtx);
+
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toEqual(
+      expect.objectContaining({ kind: 'bad-directory', reason: 'not-dir' }),
+    );
+  });
+
+  it('errors when no project files are found', () => {
+    const session = buildSession({ installDir: tmpDir });
+    detectSourceMapsPrerequisites(session, setCtx);
+
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toEqual({
+      kind: 'no-project-files',
+    });
+  });
+
+  it('errors with unsupported-platform when files exist but stack is unknown', () => {
+    fs.writeFileSync(path.join(tmpDir, 'README.md'), 'hello');
+
+    const session = buildSession({ installDir: tmpDir });
+    detectSourceMapsPrerequisites(session, setCtx);
+
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toEqual({
+      kind: 'unsupported-platform',
+      detected: 'unknown',
+    });
+  });
+
+  it.each([
+    ['react-native', { 'react-native': '0.74.0' }],
+    ['flutter', {}],
+    ['ios', {}],
+    ['android', {}],
+  ] as const)(
+    'errors with unsupported-platform for native stack %s',
+    (variant, deps) => {
+      if (variant === 'flutter') {
+        fs.writeFileSync(path.join(tmpDir, 'pubspec.yaml'), 'name: myapp\n');
+      } else if (variant === 'ios') {
+        fs.mkdirSync(path.join(tmpDir, 'MyApp.xcodeproj'));
+      } else if (variant === 'android') {
+        fs.writeFileSync(path.join(tmpDir, 'build.gradle'), '');
+      } else {
+        writePackageJson(tmpDir, deps);
+      }
+
+      const session = buildSession({ installDir: tmpDir });
+      detectSourceMapsPrerequisites(session, setCtx);
+
+      expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toEqual({
+        kind: 'unsupported-platform',
+        detected: variant,
+      });
+    },
+  );
+
+  it('errors when PostHog SDK is missing for a supported JS stack', () => {
+    writePackageJson(tmpDir, { next: '14.0.0' });
+
+    const session = buildSession({ installDir: tmpDir });
+    detectSourceMapsPrerequisites(session, setCtx);
+
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toEqual({
+      kind: 'no-posthog-sdk',
+      platform: 'nextjs',
+    });
+  });
+
+  it.each([
+    ['nextjs', { next: '14.0.0' }, 'Next.js'],
+    ['vite', { vite: '5.0.0' }, 'Vite'],
+    ['webpack', { webpack: '5.0.0' }, 'Webpack'],
+    ['rollup', { rollup: '4.0.0' }, 'Rollup'],
+    ['react', { react: '18.0.0' }, 'React'],
+    ['angular', { '@angular/core': '17.0.0' }, 'Angular'],
+    ['nuxt', { nuxt: '3.0.0' }, 'Nuxt'],
+    ['node', { 'posthog-node': '4.0.0' }, 'Node.js'],
+    ['web', {}, 'Web (JavaScript)'],
+  ] as const)(
+    'detects %s when PostHog SDK is present',
+    (variant, deps, displayName) => {
+      writePackageJson(tmpDir, { 'posthog-js': '1.0.0', ...deps });
+
+      const session = buildSession({ installDir: tmpDir });
+      detectSourceMapsPrerequisites(session, setCtx);
+
+      expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toBeUndefined();
+      expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.skillVariant]).toBe(variant);
+      expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.displayName]).toBe(displayName);
+      expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.packagePaths]).toEqual([
+        'package.json',
+      ]);
+    },
+  );
+
+  it('prefers framework-specific variants over bundlers', () => {
+    writePackageJson(tmpDir, {
+      'posthog-js': '1.0.0',
+      next: '14.0.0',
+      vite: '5.0.0',
+    });
+
+    const session = buildSession({ installDir: tmpDir });
+    detectSourceMapsPrerequisites(session, setCtx);
+
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.skillVariant]).toBe('nextjs');
+  });
+
+  it('aggregates dependencies across monorepo packages', () => {
+    writePackageJson(tmpDir, { 'posthog-js': '1.0.0' });
+
+    const appDir = path.join(tmpDir, 'apps', 'web');
+    writePackageJson(appDir, { next: '14.0.0' });
+
+    const session = buildSession({ installDir: tmpDir });
+    detectSourceMapsPrerequisites(session, setCtx);
+
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toBeUndefined();
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.skillVariant]).toBe('nextjs');
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.packagePaths]).toEqual(
+      expect.arrayContaining([
+        'package.json',
+        path.join('apps', 'web', 'package.json'),
+      ]),
+    );
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.packagePaths]).toHaveLength(2);
+  });
+
+  it('detects PostHog SDK from devDependencies', () => {
+    writePackageJson(tmpDir, { next: '14.0.0' }, { 'posthog-js': '1.0.0' });
+
+    const session = buildSession({ installDir: tmpDir });
+    detectSourceMapsPrerequisites(session, setCtx);
+
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.detectError]).toBeUndefined();
+    expect(ctx[SOURCE_MAPS_CONTEXT_KEYS.skillVariant]).toBe('nextjs');
+  });
+});

--- a/src/lib/programs/error-tracking-upload-source-maps/content/index.tsx
+++ b/src/lib/programs/error-tracking-upload-source-maps/content/index.tsx
@@ -15,8 +15,29 @@ import { Text } from 'ink';
 import { Colors } from '@ui/tui/styles';
 import type { WizardStore } from '@ui/tui/store';
 import { TextRevealMode } from '@ui/tui/primitives/TextBlock';
-import type { ContentBlock } from '@ui/tui/primitives/content-types';
+import {
+  isClearBlock,
+  type ContentBlock,
+} from '@ui/tui/primitives/content-types';
 import { StatusPeekTrigger } from '@ui/tui/components/StatusPeekTrigger';
+
+/**
+ * Per-slide dwell multiplier. Each block stays on screen for `pause * SLIDE_PACE`
+ * ms after it finishes animating, before the deck advances. Bump this single
+ * knob to give every slide more reading time. Clear (page-break) blocks are
+ * left untouched so the blank gap between slides stays snappy.
+ */
+const SLIDE_PACE = 1.5;
+
+const withPace = (block: ContentBlock): ContentBlock => {
+  if (typeof block === 'string' || isClearBlock(block) || block.pause == null) {
+    return block;
+  }
+  return { ...block, pause: Math.round(block.pause * SLIDE_PACE) };
+};
+
+/** Apply the dwell multiplier to every block in a deck. */
+const pace = (blocks: ContentBlock[]): ContentBlock[] => blocks.map(withPace);
 
 /** A minified production stack trace — the problem source maps solve. */
 const MINIFIED_TRACE: ContentBlock = {
@@ -79,105 +100,164 @@ const CHUNK_ID_LINK: ContentBlock = {
   ],
 };
 
-export const getContentBlocks = (store?: WizardStore): ContentBlock[] => [
-  {
-    content: 'Welcome.',
-    pause: 3000,
-    mode: TextRevealMode.Typewriter,
-    animationInterval: 160,
-  },
-
-  {
-    content: "I'm wiring PostHog Error Tracking into your build.",
-    pause: 5000,
-  },
-
-  { type: 'clear', pause: 1500 },
-
-  {
-    content: 'When you ship to production, your code gets minified.',
-    pause: 5000,
-  },
-  {
-    content: 'Thousands of readable lines collapse into one dense bundle.',
-    pause: 5000,
-  },
-  {
-    content: 'So a thrown error gives you a stack trace like this:',
-    pause: 2000,
-  },
-
-  MINIFIED_TRACE,
-
-  { content: 'Just offsets into a file no human can read.', pause: 5000 },
-
-  { type: 'clear', pause: 1500 },
-
-  { content: 'Source maps are the key.', pause: 3500 },
-  {
-    content:
-      'They map every position in that bundle back to your original source — the real file, line, and function.',
-    pause: 6000,
-  },
-  {
-    content:
-      "Right now I'm hooking source-map generation and upload into your build, tied to each release you ship.",
-    pause: 6000,
-  },
-
-  { type: 'clear', pause: 1500 },
-
-  {
-    content: 'But how does PostHog know which map belongs to which build?',
-    pause: 4500,
-  },
-  {
-    content: 'During the build, it injects a unique chunk ID into each bundle:',
-    pause: 2500,
-  },
-
-  CHUNK_ID_LINK,
-
-  {
-    content:
-      'The matching source map is stamped with that same ID before it ships to PostHog.',
-    pause: 6000,
-  },
-  {
-    content:
-      'When an error comes in, PostHog reads the chunk ID off the bundle, finds the map with the exact same ID, and uses it to map each frame back to your source — even for a release you shipped weeks ago.',
-    pause: 8000,
-  },
-
-  { type: 'clear', pause: 1500 },
-
-  { content: 'So that same error becomes:', pause: 2000 },
-
-  RESOLVED_TRACE,
-
-  { content: 'Readable stack traces, straight from production.', pause: 5000 },
-  {
-    content: 'You debug a live error like it happened on your own machine.',
-    pause: 6000,
-  },
-
-  { type: 'clear', pause: 1500 },
-
-  {
-    pause: 5000,
-    persist: true,
-    content: <StatusPeekTrigger store={store} />,
-  },
-  {
-    pause: 90000,
-    content: (
-      <Text>
-        Press{' '}
-        <Text color={Colors.accent} bold>
-          S
-        </Text>{' '}
-        to follow along — or sit tight, I'll let you know when it's done.
+/** Many similar exceptions collapse into a single issue. */
+const GROUPING: ContentBlock = {
+  type: 'lines',
+  interval: 450,
+  pause: 7000,
+  lines: [
+    <Text dimColor>{'exception ─┐'}</Text>,
+    <Text>
+      <Text dimColor>{'exception ─┼──→ '}</Text>
+      <Text color={Colors.accent} bold>
+        1 issue
       </Text>
-    ),
-  },
-];
+    </Text>,
+    <Text dimColor>{'exception ─┘'}</Text>,
+  ],
+};
+
+export const getContentBlocks = (store?: WizardStore): ContentBlock[] =>
+  pace([
+    {
+      content: 'Welcome.',
+      pause: 3000,
+      mode: TextRevealMode.Typewriter,
+      animationInterval: 160,
+    },
+
+    {
+      content: "I'm wiring PostHog Error Tracking into your build.",
+      pause: 5000,
+    },
+
+    { type: 'clear', pause: 1500 },
+
+    {
+      content: 'When you ship to production, your code gets minified.',
+      pause: 5000,
+    },
+    {
+      content: 'Thousands of readable lines collapse into one dense bundle.',
+      pause: 5000,
+    },
+    {
+      content: 'So a thrown error gives you a stack trace like this:',
+      pause: 2000,
+    },
+
+    MINIFIED_TRACE,
+
+    { content: 'Just offsets into a file no human can read.', pause: 5000 },
+
+    { type: 'clear', pause: 1500 },
+
+    { content: 'Source maps are the key.', pause: 3500 },
+    {
+      content:
+        'They map every position in that bundle back to your original source — the real file, line, and function.',
+      pause: 6000,
+    },
+    {
+      content:
+        "Right now I'm hooking source-map generation and upload into your build, tied to each release you ship.",
+      pause: 6000,
+    },
+
+    { type: 'clear', pause: 1500 },
+
+    {
+      content: 'But how does PostHog know which map belongs to which build?',
+      pause: 4500,
+    },
+    {
+      content:
+        'During the build, it injects a unique chunk ID into each bundle:',
+      pause: 2500,
+    },
+
+    CHUNK_ID_LINK,
+
+    {
+      content:
+        'The matching source map is stamped with that same ID before it ships to PostHog.',
+      pause: 6000,
+    },
+    {
+      content:
+        'When an error comes in, PostHog reads the chunk ID off the bundle, finds the map with the exact same ID, and uses it to map each frame back to your source — even for a release you shipped weeks ago.',
+      pause: 8000,
+    },
+
+    { type: 'clear', pause: 1500 },
+
+    { content: 'So that same error becomes:', pause: 2000 },
+
+    RESOLVED_TRACE,
+
+    {
+      content: 'Readable stack traces, straight from production.',
+      pause: 5000,
+    },
+    {
+      content: 'You debug a live error like it happened on your own machine.',
+      pause: 6000,
+    },
+
+    { type: 'clear', pause: 1500 },
+
+    { content: 'Zooming out — this is how Error Tracking works.', pause: 4000 },
+    {
+      content: 'Every error your app throws is captured as an exception.',
+      pause: 5000,
+    },
+    {
+      content: 'PostHog groups similar exceptions into a single issue:',
+      pause: 2500,
+    },
+
+    GROUPING,
+
+    {
+      content:
+        'So a bug that fires ten thousand times is one issue to triage — not ten thousand alerts.',
+      pause: 6500,
+    },
+
+    { type: 'clear', pause: 1500 },
+
+    {
+      content: 'And this is where source maps earn their keep again.',
+      pause: 4500,
+    },
+    {
+      content:
+        'Grouping reads the stack trace. Minified frames all look alike — so unrelated crashes get merged, and one real bug scatters across many issues.',
+      pause: 8000,
+    },
+    {
+      content:
+        'With source maps, PostHog groups on your real frames — so each distinct bug lands as one clean issue.',
+      pause: 7000,
+    },
+
+    { type: 'clear', pause: 1500 },
+
+    {
+      pause: 5000,
+      persist: true,
+      content: <StatusPeekTrigger store={store} />,
+    },
+    {
+      pause: 90000,
+      content: (
+        <Text>
+          Press{' '}
+          <Text color={Colors.accent} bold>
+            S
+          </Text>{' '}
+          to follow along — or sit tight, I'll let you know when it's done.
+        </Text>
+      ),
+    },
+  ]);

--- a/src/lib/programs/error-tracking-upload-source-maps/content/index.tsx
+++ b/src/lib/programs/error-tracking-upload-source-maps/content/index.tsx
@@ -1,7 +1,183 @@
 /**
- * Source-maps learn-deck. Delegates to the generic skill deck — the
- * workflow doesn't yet have content unique enough to justify a
- * dedicated script.
+ * Source-maps learn-deck — the narrative played in the run screen's left
+ * pane (LearnCard) while the agent wires source-map upload into the build.
+ *
+ * It educates the user on what source maps are and why uploading them
+ * matters, built around a before/after stack-trace contrast: a minified
+ * production trace nobody can read, then the same trace resolved back to
+ * real source. Program-owned; wired onto the program's getContentBlocks.
+ *
+ * Lines stay narrow (~36 cols) because this renders in the left half of a
+ * split pane — see LearnCard's paneWidth math.
  */
 
-export { getContentBlocks } from '../../agent-skill/content/index.js';
+import { Text } from 'ink';
+import { Colors } from '@ui/tui/styles';
+import type { WizardStore } from '@ui/tui/store';
+import { TextRevealMode } from '@ui/tui/primitives/TextBlock';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
+import { StatusPeekTrigger } from '@ui/tui/components/StatusPeekTrigger';
+
+/** A minified production stack trace — the problem source maps solve. */
+const MINIFIED_TRACE: ContentBlock = {
+  type: 'lines',
+  interval: 400,
+  pause: 7000,
+  lines: [
+    <Text color={Colors.error}>{'✘ TypeError: cart is undefined'}</Text>,
+    <Text dimColor>{'    at t.min.js:1:48213'}</Text>,
+    <Text dimColor>{'    at t.min.js:1:9402'}</Text>,
+    <Text dimColor>{'    at t.min.js:1:71150'}</Text>,
+  ],
+};
+
+/** The same trace, resolved through uploaded source maps. */
+const RESOLVED_TRACE: ContentBlock = {
+  type: 'lines',
+  interval: 400,
+  pause: 8000,
+  lines: [
+    <Text color={Colors.success}>{'✔ TypeError: cart is undefined'}</Text>,
+    <Text>
+      <Text dimColor>{'    at '}</Text>
+      <Text color="cyan">Cart.tsx:42</Text>
+      <Text dimColor>{'  loadCart'}</Text>
+    </Text>,
+    <Text>
+      <Text dimColor>{'    at '}</Text>
+      <Text color="cyan">App.tsx:88</Text>
+      <Text dimColor>{'   render'}</Text>
+    </Text>,
+    <Text>
+      <Text dimColor>{'    at '}</Text>
+      <Text color="cyan">index.tsx:5</Text>
+      <Text dimColor>{'  main'}</Text>
+    </Text>,
+  ],
+};
+
+/**
+ * How a bundle is tied to its map: PostHog injects a chunk-ID marker into the
+ * built JS and stamps the matching source map with the same ID.
+ */
+const CHUNK_ID_LINK: ContentBlock = {
+  type: 'lines',
+  interval: 450,
+  pause: 7500,
+  lines: [
+    <Text dimColor>app.min.js</Text>,
+    <Text dimColor>{'  …minified code…'}</Text>,
+    <Text>
+      <Text color="cyan">{'  //# chunkId=a1b2c3d4'}</Text>
+      <Text dimColor>{'  ← injected'}</Text>
+    </Text>,
+    <Text dimColor>{'        ↕  matched by id'}</Text>,
+    <Text>
+      <Text dimColor>app.min.js.map</Text>
+      <Text dimColor>{'  ← uploaded'}</Text>
+    </Text>,
+  ],
+};
+
+export const getContentBlocks = (store?: WizardStore): ContentBlock[] => [
+  {
+    content: 'Welcome.',
+    pause: 3000,
+    mode: TextRevealMode.Typewriter,
+    animationInterval: 160,
+  },
+
+  {
+    content: "I'm wiring PostHog Error Tracking into your build.",
+    pause: 5000,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  {
+    content: 'When you ship to production, your code gets minified.',
+    pause: 5000,
+  },
+  {
+    content: 'Thousands of readable lines collapse into one dense bundle.',
+    pause: 5000,
+  },
+  {
+    content: 'So a thrown error gives you a stack trace like this:',
+    pause: 2000,
+  },
+
+  MINIFIED_TRACE,
+
+  { content: 'Just offsets into a file no human can read.', pause: 5000 },
+
+  { type: 'clear', pause: 1500 },
+
+  { content: 'Source maps are the key.', pause: 3500 },
+  {
+    content:
+      'They map every position in that bundle back to your original source — the real file, line, and function.',
+    pause: 6000,
+  },
+  {
+    content:
+      "Right now I'm hooking source-map generation and upload into your build, tied to each release you ship.",
+    pause: 6000,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  {
+    content: 'But how does PostHog know which map belongs to which build?',
+    pause: 4500,
+  },
+  {
+    content: 'During the build, it injects a unique chunk ID into each bundle:',
+    pause: 2500,
+  },
+
+  CHUNK_ID_LINK,
+
+  {
+    content:
+      'The matching source map is stamped with that same ID before it ships to PostHog.',
+    pause: 6000,
+  },
+  {
+    content:
+      'When an error comes in, PostHog reads the chunk ID off the bundle, finds the map with the exact same ID, and uses it to map each frame back to your source — even for a release you shipped weeks ago.',
+    pause: 8000,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  { content: 'So that same error becomes:', pause: 2000 },
+
+  RESOLVED_TRACE,
+
+  { content: 'Readable stack traces, straight from production.', pause: 5000 },
+  {
+    content: 'You debug a live error like it happened on your own machine.',
+    pause: 6000,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  {
+    pause: 5000,
+    persist: true,
+    content: <StatusPeekTrigger store={store} />,
+  },
+  {
+    pause: 90000,
+    content: (
+      <Text>
+        Press{' '}
+        <Text color={Colors.accent} bold>
+          S
+        </Text>{' '}
+        to follow along — or sit tight, I'll let you know when it's done.
+      </Text>
+    ),
+  },
+];

--- a/src/lib/programs/error-tracking-upload-source-maps/content/index.tsx
+++ b/src/lib/programs/error-tracking-upload-source-maps/content/index.tsx
@@ -1,0 +1,7 @@
+/**
+ * Source-maps learn-deck. Delegates to the generic skill deck — the
+ * workflow doesn't yet have content unique enough to justify a
+ * dedicated script.
+ */
+
+export { getContentBlocks } from '../../agent-skill/content/index.js';

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -1,0 +1,312 @@
+/**
+ * Source maps upload prerequisite detection.
+ *
+ * Scans the project for signals that identify the platform and build system,
+ * then maps to one of the context-mill `error-tracking-upload-source-maps-*`
+ * skill variants. Results are written to frameworkContext for the intro
+ * screen to render and for the agent prompt to consume.
+ */
+
+import type { Dirent } from 'fs';
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { IGNORED_DIRS } from '@utils/file-utils';
+import type { WizardSession } from '@lib/wizard-session';
+import type { AbortCase } from '@lib/agent/agent-runner';
+
+/**
+ * Skill variants published under the `error-tracking-upload-source-maps`
+ * category in context-mill. The agent loads
+ * `error-tracking-upload-source-maps-<variant>`.
+ */
+export type SkillVariant =
+  | 'web'
+  | 'nextjs'
+  | 'node'
+  | 'react'
+  | 'angular'
+  | 'nuxt'
+  | 'react-native'
+  | 'android'
+  | 'flutter'
+  | 'ios'
+  | 'vite'
+  | 'webpack'
+  | 'rollup';
+
+const DISPLAY_NAME: Record<SkillVariant, string> = {
+  web: 'Web (JavaScript)',
+  nextjs: 'Next.js',
+  node: 'Node.js',
+  react: 'React',
+  angular: 'Angular',
+  nuxt: 'Nuxt',
+  'react-native': 'React Native',
+  android: 'Android',
+  flutter: 'Flutter',
+  ios: 'iOS',
+  vite: 'Vite',
+  webpack: 'Webpack',
+  rollup: 'Rollup',
+};
+
+const POSTHOG_SDKS = [
+  'posthog-js',
+  'posthog-node',
+  'posthog-react-native',
+  'posthog-android',
+  'posthog-ios',
+];
+
+/**
+ * Structured detection errors. The screen renders each kind into JSX
+ * with proper formatting — keeps error data separate from presentation.
+ */
+export type SourceMapsDetectError =
+  | {
+      kind: 'bad-directory';
+      path: string;
+      reason: 'missing' | 'not-dir' | 'unreadable';
+    }
+  | { kind: 'no-project-files' }
+  | { kind: 'unsupported-platform'; detected: string }
+  | { kind: 'no-posthog-sdk'; platform: SkillVariant };
+
+/** `[ABORT] <reason>` cases the source maps skill can emit. */
+export const SOURCE_MAPS_ABORT_CASES: AbortCase[] = [
+  {
+    match: /^no posthog sdk detected$/i,
+    message: 'No PostHog SDK detected',
+    body:
+      'The agent could not find a PostHog SDK in your project. ' +
+      'Source map upload requires the SDK to already be installed so it can ' +
+      'report errors. Run `npx @posthog/wizard` first to install the SDK.',
+    docsUrl: 'https://posthog.com/docs/error-tracking',
+  },
+  {
+    match: /^build command not found$/i,
+    message: 'Build command not found',
+    body:
+      'The agent could not identify how to build your project. Source map ' +
+      'upload runs as part of the production build. Add a build script to ' +
+      'your project and run this wizard again.',
+    docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
+  },
+];
+
+// ── File / dependency probes ─────────────────────────────────────────
+
+interface ProjectSignals {
+  packageJsons: Array<{ path: string; deps: Set<string> }>;
+  hasXcodeProject: boolean;
+  hasPodfile: boolean;
+  hasSwiftPackage: boolean;
+  hasGradle: boolean;
+  hasPubspec: boolean;
+  scannedFileCount: number;
+}
+
+function collectSignals(installDir: string, maxDepth = 3): ProjectSignals {
+  const signals: ProjectSignals = {
+    packageJsons: [],
+    hasXcodeProject: false,
+    hasPodfile: false,
+    hasSwiftPackage: false,
+    hasGradle: false,
+    hasPubspec: false,
+    scannedFileCount: 0,
+  };
+
+  function scan(dir: string, depth: number): void {
+    if (depth > maxDepth) return;
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') && entry.name !== '.') continue;
+      if (IGNORED_DIRS.has(entry.name)) continue;
+
+      const fullPath = join(dir, entry.name);
+
+      if (entry.isFile()) {
+        signals.scannedFileCount += 1;
+        if (entry.name === 'package.json') {
+          try {
+            const pkg = JSON.parse(readFileSync(fullPath, 'utf-8')) as {
+              dependencies?: Record<string, string>;
+              devDependencies?: Record<string, string>;
+            };
+            const deps = new Set([
+              ...Object.keys(pkg.dependencies ?? {}),
+              ...Object.keys(pkg.devDependencies ?? {}),
+            ]);
+            signals.packageJsons.push({
+              path: relative(installDir, fullPath) || 'package.json',
+              deps,
+            });
+          } catch {
+            // skip malformed package.json
+          }
+        } else if (entry.name === 'Podfile') {
+          signals.hasPodfile = true;
+        } else if (entry.name === 'Package.swift') {
+          signals.hasSwiftPackage = true;
+        } else if (entry.name === 'pubspec.yaml') {
+          signals.hasPubspec = true;
+        } else if (
+          entry.name === 'build.gradle' ||
+          entry.name === 'build.gradle.kts' ||
+          entry.name === 'settings.gradle' ||
+          entry.name === 'settings.gradle.kts'
+        ) {
+          signals.hasGradle = true;
+        }
+      } else if (entry.isDirectory()) {
+        if (entry.name.endsWith('.xcodeproj')) {
+          signals.hasXcodeProject = true;
+        } else {
+          scan(fullPath, depth + 1);
+        }
+      }
+    }
+  }
+
+  scan(installDir, 0);
+  return signals;
+}
+
+// ── Skill selection ──────────────────────────────────────────────────
+
+function pickJsVariant(deps: Set<string>): SkillVariant {
+  // Opinionated full-stack frameworks first — they own their build pipeline
+  // and have dedicated skill variants, so bundler detection underneath
+  // them is irrelevant.
+  if (deps.has('react-native')) return 'react-native';
+  if (deps.has('nuxt')) return 'nuxt';
+  if (deps.has('next')) return 'nextjs';
+  if (deps.has('@angular/core')) return 'angular';
+  // Bundlers next — prefer these over the bare `react` variant because
+  // their skills are simpler (one bundler-plugin config) than wiring
+  // posthog-cli into an arbitrary React setup.
+  if (deps.has('vite')) return 'vite';
+  if (deps.has('webpack')) return 'webpack';
+  if (deps.has('rollup')) return 'rollup';
+  // Plain React with no recognised bundler.
+  if (deps.has('react')) return 'react';
+  // Server-only Node project
+  if (deps.has('posthog-node')) return 'node';
+  // Fallback: generic web
+  return 'web';
+}
+
+function selectVariant(signals: ProjectSignals): SkillVariant | null {
+  // Mobile / native first — they don't coexist with JS bundlers in the
+  // detection signals we look at.
+  if (signals.hasPubspec) return 'flutter';
+  if (signals.hasXcodeProject || signals.hasPodfile || signals.hasSwiftPackage)
+    return 'ios';
+  if (signals.hasGradle) return 'android';
+
+  if (signals.packageJsons.length > 0) {
+    // Union all deps across package.json files (covers monorepos)
+    const allDeps = new Set<string>();
+    for (const pkg of signals.packageJsons) {
+      for (const dep of pkg.deps) allDeps.add(dep);
+    }
+    return pickJsVariant(allDeps);
+  }
+
+  return null;
+}
+
+function hasPostHogSdk(signals: ProjectSignals): boolean {
+  for (const pkg of signals.packageJsons) {
+    for (const sdk of POSTHOG_SDKS) {
+      if (pkg.deps.has(sdk)) return true;
+    }
+  }
+  // For native platforms the PostHog SDK lives outside package.json and
+  // is detected by the agent during the skill run. Assume present here.
+  return (
+    signals.hasXcodeProject ||
+    signals.hasPodfile ||
+    signals.hasSwiftPackage ||
+    signals.hasGradle ||
+    signals.hasPubspec
+  );
+}
+
+// ── Entry point ──────────────────────────────────────────────────────
+
+export const SOURCE_MAPS_CONTEXT_KEYS = {
+  skillVariant: 'sourceMapsSkillVariant',
+  displayName: 'sourceMapsDisplayName',
+  packagePaths: 'sourceMapsPackagePaths',
+  detectError: 'detectError',
+} as const;
+
+/**
+ * Scan `session.installDir` for platform / build-system signals. Writes
+ * detection results into frameworkContext via the callback — either the
+ * picked skill variant + display name, or a `SourceMapsDetectError`.
+ *
+ * The skill install happens later in the agent run, not here. This step
+ * only picks which variant the prompt should ask the agent to load.
+ */
+export function detectSourceMapsPrerequisites(
+  session: WizardSession,
+  setFrameworkContext: (key: string, value: unknown) => void,
+): void {
+  const fail = (error: SourceMapsDetectError) =>
+    setFrameworkContext(SOURCE_MAPS_CONTEXT_KEYS.detectError, error);
+
+  const installDir = session.installDir;
+
+  if (!existsSync(installDir)) {
+    fail({ kind: 'bad-directory', path: installDir, reason: 'missing' });
+    return;
+  }
+  try {
+    if (!statSync(installDir).isDirectory()) {
+      fail({ kind: 'bad-directory', path: installDir, reason: 'not-dir' });
+      return;
+    }
+  } catch {
+    fail({ kind: 'bad-directory', path: installDir, reason: 'unreadable' });
+    return;
+  }
+
+  const signals = collectSignals(installDir);
+  const variant = selectVariant(signals);
+
+  if (!variant) {
+    if (signals.scannedFileCount === 0) {
+      fail({ kind: 'no-project-files' });
+    } else {
+      fail({ kind: 'unsupported-platform', detected: 'unknown' });
+    }
+    return;
+  }
+
+  if (!hasPostHogSdk(signals)) {
+    fail({ kind: 'no-posthog-sdk', platform: variant });
+    return;
+  }
+
+  setFrameworkContext(SOURCE_MAPS_CONTEXT_KEYS.skillVariant, variant);
+  setFrameworkContext(
+    SOURCE_MAPS_CONTEXT_KEYS.displayName,
+    DISPLAY_NAME[variant],
+  );
+  setFrameworkContext(
+    SOURCE_MAPS_CONTEXT_KEYS.packagePaths,
+    signals.packageJsons.map((p) => p.path),
+  );
+}
+
+export { DISPLAY_NAME as VARIANT_DISPLAY_NAME };

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -284,6 +284,16 @@ export function detectSourceMapsPrerequisites(
   const signals = collectSignals(installDir);
   const variant = selectVariant(signals);
 
+  // This program currently targets JS-like stacks only. Avoid selecting native
+  // platforms until dedicated skill variants are available.
+  if (
+    variant &&
+    ['react-native', 'flutter', 'ios', 'android'].includes(variant)
+  ) {
+    fail({ kind: 'unsupported-platform', detected: variant });
+    return;
+  }
+
   if (!variant) {
     if (signals.scannedFileCount === 0) {
       fail({ kind: 'no-project-files' });

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -1,0 +1,337 @@
+import type { ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramRun } from '@lib/agent/agent-runner';
+import type { WizardSession } from '@lib/wizard-session';
+import { OutroKind } from '@lib/wizard-session';
+import { AgentSignals } from '@lib/agent/agent-interface';
+import { ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM } from './steps.js';
+import {
+  SOURCE_MAPS_ABORT_CASES,
+  SOURCE_MAPS_CONTEXT_KEYS,
+  type SkillVariant,
+} from './detect.js';
+import { getContentBlocks } from './content/index.js';
+
+const REPORT_FILE = 'posthog-source-maps-report.md';
+const DOCS_URL = 'https://posthog.com/docs/error-tracking/upload-source-maps';
+
+export const errorTrackingUploadSourceMapsConfig: ProgramConfig = {
+  command: 'upload-sourcemaps',
+  description: 'Upload source maps to PostHog Error Tracking',
+  id: 'error-tracking-upload-source-maps',
+  steps: ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM,
+  reportFile: REPORT_FILE,
+  getContentBlocks,
+  requires: ['posthog-integration'],
+
+  run: (session: WizardSession): Promise<ProgramRun> => {
+    const variant = session.frameworkContext[
+      SOURCE_MAPS_CONTEXT_KEYS.skillVariant
+    ] as SkillVariant | undefined;
+    const displayName = session.frameworkContext[
+      SOURCE_MAPS_CONTEXT_KEYS.displayName
+    ] as string | undefined;
+
+    const skillId = variant
+      ? `error-tracking-upload-source-maps-${variant}`
+      : undefined;
+
+    return Promise.resolve({
+      integrationLabel: 'error-tracking-upload-source-maps',
+      // Skill is installed by the agent (after the API-key choice is made)
+      // rather than pre-installed by the runner, so leave skillId unset.
+      successMessage: 'Source maps wired up!',
+      reportFile: REPORT_FILE,
+      docsUrl: DOCS_URL,
+      spinnerMessage: 'Wiring up source maps...',
+      estimatedDurationMinutes: 3,
+      abortCases: SOURCE_MAPS_ABORT_CASES,
+
+      customPrompt: (ctx) => {
+        if (!skillId || !variant) {
+          // Detection failed but the user got past the intro somehow.
+          // Tell the agent to abort with a structured signal so the runner
+          // renders a friendly outro.
+          return `Detection did not pick a source maps skill variant for this project.
+Emit: ${AgentSignals.ABORT} unsupported-platform
+Then halt.`;
+        }
+
+        const settingsUrl = `${ctx.host.replace(/\/$/, '')}/project/${
+          ctx.projectId
+        }/settings/user-api-keys`;
+
+        return `You are wiring up PostHog Error Tracking source map upload for this ${
+          displayName ?? variant
+        } project.
+
+Project context:
+- PostHog Project ID: ${ctx.projectId}
+- PostHog Host: ${ctx.host}
+- Detected platform: ${displayName ?? variant}
+- Skill to use: ${skillId}
+- Personal API keys settings page: ${settingsUrl}
+
+Follow these steps IN ORDER. Do not skip or reorder.
+
+STEP 1 — Obtain a personal API key from the user.
+   Source maps upload requires a personal API key the user creates in their
+   PostHog settings. The wizard cannot mint keys and you must never attempt
+   to do so via the PostHog API or any other tool. The user supplies the
+   key; you only receive it as a vaulted secret reference (so the raw
+   value never enters this conversation).
+
+   Call the wizard_ask MCP tool with exactly one sensitive question that
+   both explains where to get the key and accepts it:
+     {
+       id: "api-key",
+       prompt: "Paste your PostHog personal API key below.\\n\\nDon't have one yet? Create one here:\\n${settingsUrl}\\n\\nWhen creating the key, choose the 'Source map upload' preset, then come back and paste it here.",
+       kind: "text",
+       sensitive: true
+     }
+   Keep the \\n line breaks in the prompt exactly as written — the TUI
+   renders them as separate lines (Ink's <Text> respects \\n).
+   The answer comes back as { secretRef: "secret:..." } — never the raw
+   string. Remember this secretRef for STEP 5.
+
+   If wizard_ask is unavailable (CI / non-interactive), emit
+   ${AgentSignals.ABORT} requires-interactive-mode and halt.
+
+STEP 2 — Install the skill.
+   Call install_skill (wizard-tools MCP server) with skillId "${skillId}".
+   Do NOT run shell commands to install skills.
+   If install fails, emit ${
+     AgentSignals.ERROR_RESOURCE_MISSING
+   } skill ${skillId} could not be installed.
+
+STEP 3 — Load and follow the skill.
+   Read the installed skill's SKILL.md and reference files. Make all
+   bundler / build-config changes the skill instructs. Do not invent steps
+   that are not in the skill — the skill is the source of truth for this
+   platform.
+
+STEP 4 — Make the credentials readable at build time.
+   The skill's "Making credentials available at build time" section is the
+   source of truth for HOW .env is loaded for the detected platform — read
+   it and follow it. The wizard-specific rules layered on top:
+
+   - If a loader is needed and the project doesn't already load .env,
+     install \`dotenv\` SILENTLY — do NOT ask the user, do NOT call
+     wizard_ask. Run detect_package_manager first, add \`dotenv\` as a
+     devDependency in the background, and require/import it at the top of
+     the relevant config file (\`require('dotenv').config()\`, or
+     \`import 'dotenv/config'\` for ESM). Keep it to one line plus the
+     dependency.
+   - If source map upload runs as a separate \`posthog-cli\` step (a
+     separate child process — see the skill), pass \`--env-file <path>\` to
+     that command so the CLI reads the .env file directly (e.g.
+     \`posthog-cli --env-file .env sourcemap upload ...\`). Do NOT ask the
+     user to log in. Write all the POSTHOG_CLI_* vars to .env in STEP 5 as
+     normal.
+   - If the detected platform already loads .env, skip this step entirely.
+
+STEP 5 — Seed the personal API key into the environment.
+   Use the wizard-tools MCP server.
+   - Reuse the env file the project already uses — do NOT create a new one.
+     If the project already has an env file (the skill's "Picking the
+     correct env file" section is the source of truth for which), write to
+     that same file. The prerequisite PostHog integration step has usually
+     already written POSTHOG_* vars to one — seed your keys alongside them
+     rather than introducing a second file (e.g. don't add .env.local when
+     a .env already exists).
+   - First call check_env_keys on that file to see which keys exist (it
+     returns present/absent, never values — don't read the file directly).
+   - Then call set_env_values to write the key. Pass the secretRef from
+     STEP 1 as the value object, not a literal string:
+       values: {
+         "POSTHOG_CLI_API_KEY": { secretRef: "<the ref from STEP 1>" },
+         "POSTHOG_CLI_PROJECT_ID": "${ctx.projectId}",
+         "POSTHOG_CLI_HOST": "${ctx.host}"
+       }
+     The variable names depend on which CLI/plugin the skill uses — follow
+     the skill's reference. Common conventions:
+       - posthog-cli direct upload → POSTHOG_CLI_API_KEY, POSTHOG_CLI_PROJECT_ID, POSTHOG_CLI_HOST
+       - bundler plugin variants  → POSTHOG_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_HOST
+     You do not need to know the key value to write it — the wizard resolves
+     the ref locally before writing the file.
+
+STEP 6 — Identify the build command.
+   Inspect the project to find the production build command — you'll need
+   it for the summary and (if the user opts in) for the test affordance
+   step. Look at:
+     - package.json scripts ("build", "build:prod", etc.)
+     - gradle wrapper / xcodebuild scheme / Makefile target as appropriate
+   Do NOT run the build yourself. The wizard does not run builds — the
+   user runs their own build after this workflow finishes.
+   If you cannot identify a build command, emit
+   ${AgentSignals.ABORT} build command not found.
+
+STEP 7 — Offer to test the local setup.
+   Call wizard_ask:
+     {
+       id: "test-affordance",
+       prompt: "Want me to help you test your local setup? I'll add a temporary test button (or route) to your app so you can confirm errors show up in Error Tracking with readable stack traces after your next build. I'll remove it once you've confirmed it works.",
+       kind: "single",
+       options: [
+         { label: "Yes, help me test it", value: "yes" },
+         { label: "No, I'll test on my own later",  value: "no"  }
+       ]
+     }
+
+   If "no", skip to STEP 8.
+
+   If "yes":
+
+   a) Pick a platform-appropriate affordance for the detected variant
+      (${displayName ?? variant}). Use distinctive, easy-to-find copy on
+      the trigger (button label, route path) so the user can find the
+      resulting event in the Error Tracking UI.
+
+      The handler MUST call the PostHog SDK's exception-capture method
+      directly — do NOT throw. Throwing creates a visible error overlay
+      (in dev mode) and depends on the SDK's global error handler being
+      wired correctly; calling captureException directly is deterministic
+      and works the same across all platforms.
+
+      Pass an Error (or platform-equivalent throwable) as the single
+      argument. Do NOT pass a custom message string, do NOT pass extra
+      properties, options, or a second argument. The stack trace on the
+      Error is what gets source-map resolved. Common shapes:
+        - posthog-js / posthog-node / posthog-react-native:
+            posthog.captureException(new Error("PostHog source maps test"))
+        - posthog-android (Kotlin):
+            PostHog.capture("$exception") per the skill's reference
+        - posthog-ios (Swift): posthog.capture(...) per the skill's
+            reference
+        - posthog-flutter:
+            Posthog().captureException(Exception("PostHog source maps test"))
+
+      Affordance placement by variant:
+        - Browser / SPA / SSR (web, nextjs, react, nuxt, angular, vite,
+          webpack, rollup): add a clearly-labeled button on the most
+          obvious entry page (home / index / root layout) — e.g. "Test
+          PostHog Error Tracking" — whose onClick calls
+          posthog.captureException(new Error("PostHog source maps test")).
+        - Node.js: add a temporary HTTP route (e.g.
+          \`GET /__posthog-test-error\`) on the project's existing server
+          whose handler calls
+          posthog.captureException(new Error("PostHog source maps test"))
+          and returns 200. If there is no HTTP layer, add the capture call
+          to the project's existing entry/main script (the file behind
+          package.json "main"/"bin" or the "start"/"dev" script, e.g.
+          src/index.ts) rather than creating a new file — read it, add the
+          single captureException call where it already initialises the
+          PostHog client, and revert it in step (d). Only create a new
+          throwaway script if the project has no suitable existing entry
+          file. Tell the user the exact command / URL to hit.
+        - React Native: add a visible Button on the main screen whose
+          onPress calls
+          posthog.captureException(new Error("PostHog source maps test")).
+        - Android: add a Button on the launcher Activity whose onClick
+          calls the PostHog SDK's exception capture method with a
+          \`Throwable\`.
+        - iOS: add a UIButton on the root view controller whose action
+          calls the SDK's exception capture method with an \`NSError\`.
+        - Flutter: add an ElevatedButton on the home widget whose
+          onPressed calls Posthog().captureException(...).
+
+   b) Before editing any file, READ it and note the exact contents you
+      will restore in step (d). Keep the change minimal — one button / one
+      route, no extra helpers, no new imports beyond the strict minimum.
+
+   c) Pause for the user to test. Call wizard_ask with the build command
+      you identified in STEP 6 baked into the prompt — the user must run
+      the build themselves to upload source maps and surface the test
+      affordance.
+
+      IMPORTANT: separate each numbered step with \\n\\n in the prompt
+      string so the TUI renders them as distinct lines instead of a wall
+      of text. Ink's <Text> respects \\n as a line break:
+        {
+          id: "test-done",
+          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test button.\\n\\n2) Start / open the app, click the test button (or hit the test route).\\n\\n3) Open Error Tracking in PostHog (${ctx.host.replace(
+            /\/$/,
+            '',
+          )}/project/${
+          ctx.projectId
+        }/error_tracking) and confirm the test error appears with a source-resolved stack trace pointing at real source files (not minified bundle paths).\\n\\nWhen you're done, select Continue and I'll revert the test code.",
+          kind: "single",
+          options: [{ label: "Continue (revert test code)", value: "continue" }]
+        }
+
+   d) Revert. Restore every file you touched in step (a) to the exact
+      contents you captured in step (b). Re-read each file afterwards to
+      confirm no remnants are left (stray imports, leftover handlers,
+      orphan comments). Do not leave the test affordance in place under
+      any circumstances — even if the user reports the test "didn't work",
+      revert first and surface the failure in STEP 8 instead.
+
+STEP 8 — Summarise and hand off.
+   Tell the user clearly:
+   - Which files you edited (paths only).
+   - Which env-var KEY names you set in .env (never values).
+   - Whether a test affordance was added and reverted (if STEP 7 ran).
+   - The exact build command they need to run themselves to upload source
+     maps — the wizard does not run builds. Examples by platform:
+       npm run build / pnpm build / yarn build (JS)
+       ./gradlew assembleRelease (Android)
+       xcodebuild ... (iOS)
+       flutter build apk / flutter build ios (Flutter)
+   - Where to confirm the upload landed:
+     ${ctx.host.replace(/\/$/, '')}/project/${
+          ctx.projectId
+        }/error_tracking/configuration
+     under "Symbol sets". A new symbol set should appear after the build
+     completes.
+
+Important:
+- Use detect_package_manager (wizard-tools MCP server) before running any
+  npm/pnpm/yarn install commands.
+- Always install packages in the background. Don't await completion.
+- You must read a file immediately before writing it, even if you have
+  already read it.
+- You will never see the raw personal API key. Always pass secretRef
+  objects to set_env_values. Never attempt to mint a key for the user —
+  always direct them to the settings page.
+`;
+      },
+
+      postRun: (sess) => {
+        // Stash a hint for the outro about what variant we shipped.
+        if (variant) {
+          sess.frameworkContext['sourceMapsCompletedVariant'] = variant;
+        }
+        return Promise.resolve();
+      },
+
+      buildOutroData: (sess) => {
+        const completed = sess.frameworkContext[
+          'sourceMapsCompletedVariant'
+        ] as SkillVariant | undefined;
+        const changes = [
+          completed
+            ? `Configured source map upload for ${displayName ?? completed}`
+            : '',
+          'Added PostHog credentials to .env',
+        ].filter(Boolean);
+
+        return {
+          kind: OutroKind.Success as const,
+          message: 'Source maps wired up!',
+          reportFile: REPORT_FILE,
+          changes,
+          docsUrl: DOCS_URL,
+        };
+      },
+    });
+  },
+};
+
+export { ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM } from './steps.js';
+export {
+  detectSourceMapsPrerequisites,
+  SOURCE_MAPS_ABORT_CASES,
+  SOURCE_MAPS_CONTEXT_KEYS,
+  VARIANT_DISPLAY_NAME,
+  type SkillVariant,
+  type SourceMapsDetectError,
+} from './detect.js';

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -71,122 +71,88 @@ Project context:
 - Skill to use: ${skillId}
 - Personal API keys settings page: ${settingsUrl}
 
+The skill you install in STEP 2 is the source of truth for the HOW of every
+step: its "## Steps" section has an overview, tips and per-technology
+examples for each named step, and its reference files carry the exact
+per-framework API. The STEPS below give the order, the conditionals, and the
+wizard-specific mechanics (which MCP tool to call, signals to emit) — read
+the matching skill step (named in parentheses) before doing the work, and do
+not invent steps the skill doesn't describe.
+
 Follow these steps IN ORDER. Do not skip or reorder.
 
-STEP 1 — Obtain a personal API key from the user.
-   Source maps upload requires a personal API key the user creates in their
-   PostHog settings. The wizard cannot mint keys and you must never attempt
-   to do so via the PostHog API or any other tool. The user supplies the
-   key; you only receive it as a vaulted secret reference (so the raw
-   value never enters this conversation).
+Before doing any work, create your FULL task list in a single TaskCreate
+call so the user can follow your progress in the TUI. Use exactly these
+tasks, in this order — do not collapse, rename, or omit any of them:
+  1. Get personal API key
+  2. Install source maps skill
+  3. Apply build-config changes (per skill)
+  4. Make credentials readable at build time
+  5. Write keys to .env
+  6. Identify build & run commands
+  7. Test the local setup
+  8. Summarise & hand off
+Drive the list with TaskUpdate — mark a task in_progress when you start it
+and completed when done. ALWAYS keep task 7 ("Test the local setup") in the
+list even if the user declines testing in STEP 7: mark it completed rather
+than deleting it, so the user can see testing was offered.
 
-   Call the wizard_ask MCP tool with exactly one sensitive question that
-   both explains where to get the key and accepts it:
+STEP 1 — Get a personal API key from the user. (skill: "Get a personal API key")
+   The wizard cannot mint keys — never call the PostHog API or any tool to
+   create one. Ask the user with the wizard_ask MCP tool; you receive the
+   answer as a vaulted secretRef (never the raw value), which you reuse in
+   STEP 5:
      {
        id: "api-key",
        prompt: "Paste your PostHog personal API key below.\\n\\nDon't have one yet? Create one here:\\n${settingsUrl}\\n\\nWhen creating the key, choose the 'Source map upload' preset, then come back and paste it here.",
        kind: "text",
        sensitive: true
      }
-   Keep the \\n line breaks in the prompt exactly as written — the TUI
-   renders them as separate lines (Ink's <Text> respects \\n).
-   The answer comes back as { secretRef: "secret:..." } — never the raw
-   string. Remember this secretRef for STEP 5.
-
+   Keep the \\n line breaks exactly as written — Ink's <Text> renders them
+   as separate lines. The answer is { secretRef: "secret:..." }.
    If wizard_ask is unavailable (CI / non-interactive), emit
    ${AgentSignals.ABORT} requires-interactive-mode and halt.
 
 STEP 2 — Install the skill.
    Call install_skill (wizard-tools MCP server) with skillId "${skillId}".
-   Do NOT run shell commands to install skills.
+   Do NOT run shell commands to install skills. Then read the installed
+   SKILL.md and its reference files — they drive STEPS 3-8.
    If install fails, emit ${
      AgentSignals.ERROR_RESOURCE_MISSING
    } skill ${skillId} could not be installed.
 
-STEP 3 — Load and follow the skill.
-   Read the installed skill's SKILL.md and reference files. Make all
-   bundler / build-config changes the skill instructs. Do not invent steps
-   that are not in the skill — the skill is the source of truth for this
-   platform.
+STEP 3 — Apply build-config changes. (skill: "Apply build-config changes")
+   Make the bundler / build-config changes the skill's step instructs. The
+   skill and its reference are the source of truth for this platform.
 
-STEP 4 — Make the credentials readable at build time.
-   The skill's "Making credentials available at build time" section is the
-   source of truth for HOW .env is loaded for the detected platform — read
-   it and follow it. The wizard-specific rules layered on top:
+STEP 4 — Make the credentials readable at build time. (skill: "Make credentials available at build time")
+   Follow the skill's step. Wizard-specific: if it calls for a loader (e.g.
+   \`dotenv\`), install it SILENTLY — do NOT ask the user or call wizard_ask.
+   Skip this step entirely if the platform already auto-loads .env.
 
-   - If a loader is needed and the project doesn't already load .env,
-     install \`dotenv\` SILENTLY — do NOT ask the user, do NOT call
-     wizard_ask. Run detect_package_manager first, add \`dotenv\` as a
-     devDependency in the background, and require/import it at the top of
-     the relevant config file (\`require('dotenv').config()\`, or
-     \`import 'dotenv/config'\` for ESM). Keep it to one line plus the
-     dependency.
-   - If source map upload runs as a separate \`posthog-cli\` step (a
-     separate child process — see the skill), pass \`--env-file <path>\` to
-     that command so the CLI reads the .env file directly (e.g.
-     \`posthog-cli --env-file .env sourcemap upload ...\`). Do NOT ask the
-     user to log in. Write all the POSTHOG_CLI_* vars to .env in STEP 5 as
-     normal.
-   - If the detected platform already loads .env, skip this step entirely.
-
-STEP 5 — Seed the personal API key into the environment.
-   Use the wizard-tools MCP server.
-   - Reuse the env file the project already uses — do NOT create a new one.
-     If the project already has an env file (the skill's "Picking the
-     correct env file" section is the source of truth for which), write to
-     that same file. The prerequisite PostHog integration step has usually
-     already written POSTHOG_* vars to one — seed your keys alongside them
-     rather than introducing a second file (e.g. don't add .env.local when
-     a .env already exists).
-   - First call check_env_keys on that file to see which keys exist (it
-     returns present/absent, never values — don't read the file directly).
-   - Then call set_env_values to write the key. Pass the secretRef from
-     STEP 1 as the value object, not a literal string:
+STEP 5 — Write the credentials to the env file. (skill: "Write credentials to the env file")
+   Use the wizard-tools MCP server. Reuse the env file the skill tells you to
+   pick — the prerequisite PostHog integration usually already wrote
+   POSTHOG_* vars to one, so seed your keys alongside them.
+   - First call check_env_keys on that file (returns present/absent, never
+     values — don't read the file directly).
+   - Then call set_env_values, passing the STEP 1 secretRef as a value
+     object, not a literal string:
        values: {
          "POSTHOG_CLI_API_KEY": { secretRef: "<the ref from STEP 1>" },
          "POSTHOG_CLI_PROJECT_ID": "${ctx.projectId}",
          "POSTHOG_CLI_HOST": "${ctx.host}"
        }
-     The variable names depend on which CLI/plugin the skill uses — follow
-     the skill's reference. Common conventions:
-       - posthog-cli direct upload → POSTHOG_CLI_API_KEY, POSTHOG_CLI_PROJECT_ID, POSTHOG_CLI_HOST
-       - bundler plugin variants  → POSTHOG_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_HOST
-     You do not need to know the key value to write it — the wizard resolves
-     the ref locally before writing the file.
+   Variable names follow the skill's per-uploader conventions. The wizard
+   resolves the ref locally before writing, so you never see the key value.
 
-STEP 6 — Identify the build AND run commands.
-   Inspect the project to find two commands — you'll need both for the
-   summary and (if the user opts in) for the test affordance step:
+STEP 6 — Identify the build AND run commands. (skill: "Identify the build and run commands")
+   Per the skill, resolve the production BUILD command and the RUN command
+   for THIS project (use detect_package_manager for the package manager). Do
+   NOT run either yourself — the user runs them. If you cannot identify a
+   build command, emit ${AgentSignals.ABORT} build command not found.
 
-   a) The production BUILD command (uploads source maps). Look at:
-     - package.json scripts ("build", "build:prod", etc.)
-     - gradle wrapper / xcodebuild scheme / Makefile target as appropriate
-
-   b) The RUN command that launches the built app so the user can actually
-      click the test button / hit the test route. Resolve the EXACT command
-      for THIS project — never leave it as a generic "start the app". Look at:
-     - package.json scripts: prefer the one that serves the production
-       build (e.g. "start", "preview", "serve") over the dev script when a
-       build artifact is involved. For frameworks: Next.js → \`next start\`
-       (usually \`npm run start\` after \`next build\`); Vite → \`npm run
-       preview\`; plain Node → the "start" script or \`node <built entry>\`
-       (e.g. \`node dist/index.js\` — read package.json "main"/"bin" and the
-       build output dir to name the real file).
-     - Node services with the test route: give the full command to start
-       the server PLUS the exact URL/route to hit (e.g. \`node dist/server.js\`
-       then \`curl http://localhost:3000/__posthog-test-error\`).
-     - Mobile/native (Android/iOS/Flutter/React Native): give the run
-       command the platform uses to launch on a device/simulator (e.g.
-       \`npx react-native run-ios\`, \`flutter run\`, run from Android
-       Studio / Xcode) rather than a web "start".
-
-   Resolve concrete commands from the project's actual scripts/config —
-   substitute the right package manager (from detect_package_manager). Do
-   NOT run the build or the app yourself; the user runs them.
-   If you cannot identify a build command, emit
-   ${AgentSignals.ABORT} build command not found.
-
-STEP 7 — Offer to test the local setup.
+STEP 7 — Offer to test the local setup. (skill: "Test the local setup")
    Call wizard_ask:
      {
        id: "test-affordance",
@@ -200,79 +166,16 @@ STEP 7 — Offer to test the local setup.
 
    If "no", skip to STEP 8.
 
-   If "yes":
-
-   a) Pick a platform-appropriate affordance for the detected variant
-      (${displayName ?? variant}). Use distinctive, easy-to-find copy on
-      the trigger (button label, route path) so the user can find the
-      resulting event in the Error Tracking UI.
-
-      The handler MUST call the PostHog SDK's exception-capture method
-      directly — do NOT throw. Throwing creates a visible error overlay
-      (in dev mode) and depends on the SDK's global error handler being
-      wired correctly; calling captureException directly is deterministic
-      and works the same across all platforms.
-
-      Pass an Error (or platform-equivalent throwable) as the single
-      argument. Do NOT pass a custom message string, do NOT pass extra
-      properties, options, or a second argument. The stack trace on the
-      Error is what gets source-map resolved. Common shapes:
-        - posthog-js / posthog-node / posthog-react-native:
-            posthog.captureException(new Error("PostHog source maps test"))
-        - posthog-android (Kotlin):
-            PostHog.capture("$exception") per the skill's reference
-        - posthog-ios (Swift): posthog.capture(...) per the skill's
-            reference
-        - posthog-flutter:
-            Posthog().captureException(Exception("PostHog source maps test"))
-
-      Affordance placement by variant:
-        - Browser / SPA / SSR (web, nextjs, react, nuxt, angular, vite,
-          webpack, rollup): add a clearly-labeled button on the most
-          obvious entry page (home / index / root layout) — e.g. "Test
-          PostHog Error Tracking" — whose onClick calls
-          posthog.captureException(new Error("PostHog source maps test")).
-        - Node.js: add a temporary HTTP route (e.g.
-          \`GET /__posthog-test-error\`) on the project's existing server
-          whose handler calls
-          posthog.captureException(new Error("PostHog source maps test"))
-          and returns 200. If there is no HTTP layer, add the capture call
-          to the project's existing entry/main script (the file behind
-          package.json "main"/"bin" or the "start"/"dev" script, e.g.
-          src/index.ts) rather than creating a new file — read it, add the
-          single captureException call where it already initialises the
-          PostHog client, and revert it in step (d). Only create a new
-          throwaway script if the project has no suitable existing entry
-          file. Tell the user the exact command / URL to hit.
-        - React Native: add a visible Button on the main screen whose
-          onPress calls
-          posthog.captureException(new Error("PostHog source maps test")).
-        - Android: add a Button on the launcher Activity whose onClick
-          calls the PostHog SDK's exception capture method with a
-          \`Throwable\`.
-        - iOS: add a UIButton on the root view controller whose action
-          calls the SDK's exception capture method with an \`NSError\`.
-        - Flutter: add an ElevatedButton on the home widget whose
-          onPressed calls Posthog().captureException(...).
-
-   b) Before editing any file, READ it and note the exact contents you
-      will restore in step (d). Keep the change minimal — one button / one
-      route, no extra helpers, no new imports beyond the strict minimum.
-
-   c) Pause for the user to test. Call wizard_ask with BOTH the build
-      command and the run command you identified in STEP 6 baked into the
-      prompt as literal, copy-pasteable commands — the user must run the
-      build themselves to upload source maps and surface the test
-      affordance, then run the app to trigger it. Never write a generic
-      "start / open the app"; always substitute the exact run command (and
-      the exact button label or route) for THIS project.
-
-      IMPORTANT: separate each numbered step with \\n\\n in the prompt
-      string so the TUI renders them as distinct lines instead of a wall
-      of text. Ink's <Text> respects \\n as a line break:
+   If "yes", follow the skill's "Test the local setup" step for the
+   platform-appropriate affordance, the captureException shape, the
+   placement, and the read-before-edit / always-revert rules. Then pause for
+   the user with wizard_ask, baking the EXACT build and run commands from
+   STEP 6 (and the exact button label / route) into the prompt as literal,
+   copy-pasteable steps. Separate each numbered step with \\n\\n so the TUI
+   renders them as distinct lines:
         {
           id: "test-done",
-          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test button.\\n\\n2) Start the app with \`<your detected run command>\`, then click the \\"<your test button label>\\" button (or hit \`<your test route>\`).\\n\\n3) Open Error Tracking in PostHog (${ctx.host.replace(
+          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test affordance.\\n\\n2) Start the app with \`<your detected run command>\`, then click the \\"<your test button label>\\" button (or hit \`<your test route>\`).\\n\\n3) Open Error Tracking in PostHog (${ctx.host.replace(
             /\/$/,
             '',
           )}/project/${
@@ -281,41 +184,15 @@ STEP 7 — Offer to test the local setup.
           kind: "single",
           options: [{ label: "Continue (revert test code)", value: "continue" }]
         }
+   After the user continues, revert the test code per the skill's rules and
+   surface any failure in STEP 8.
 
-   d) Revert. Restore every file you touched in step (a) to the exact
-      contents you captured in step (b). Re-read each file afterwards to
-      confirm no remnants are left (stray imports, leftover handlers,
-      orphan comments). Do not leave the test affordance in place under
-      any circumstances — even if the user reports the test "didn't work",
-      revert first and surface the failure in STEP 8 instead.
-
-STEP 8 — Summarise and hand off.
-   Tell the user clearly:
-   - Which files you edited (paths only).
-   - Which env-var KEY names you set in .env (never values).
-   - Whether a test affordance was added and reverted (if STEP 7 ran).
-   - The exact build command they need to run themselves to upload source
-     maps — the wizard does not run builds. Examples by platform:
-       npm run build / pnpm build / yarn build (JS)
-       ./gradlew assembleRelease (Android)
-       xcodebuild ... (iOS)
-       flutter build apk / flutter build ios (Flutter)
-   - Where to confirm the upload landed:
-     ${ctx.host.replace(/\/$/, '')}/project/${
+STEP 8 — Summarise and hand off. (skill: "Verify and hand off")
+   Follow the skill's "Verify and hand off" step. The Symbol sets page for
+   this project — where the user confirms the upload landed — is:
+   ${ctx.host.replace(/\/$/, '')}/project/${
           ctx.projectId
         }/error_tracking/configuration
-     under "Symbol sets". A new symbol set should appear after the build
-     completes.
-
-Important:
-- Use detect_package_manager (wizard-tools MCP server) before running any
-  npm/pnpm/yarn install commands.
-- Always install packages in the background. Don't await completion.
-- You must read a file immediately before writing it, even if you have
-  already read it.
-- You will never see the raw personal API key. Always pass secretRef
-  objects to set_env_values. Never attempt to mint a key for the user —
-  always direct them to the settings page.
 `;
       },
 

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -2,8 +2,11 @@ import type { ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { WizardSession } from '@lib/wizard-session';
 import { OutroKind } from '@lib/wizard-session';
-import { AgentSignals } from '@lib/agent/agent-interface';
 import { ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM } from './steps.js';
+import {
+  buildSourceMapsUploadPrompt,
+  SOURCE_MAPS_DETECTION_FAILED_PROMPT,
+} from './prompt.js';
 import {
   SOURCE_MAPS_ABORT_CASES,
   SOURCE_MAPS_CONTEXT_KEYS,
@@ -52,143 +55,20 @@ export const errorTrackingUploadSourceMapsConfig: ProgramConfig = {
           // Detection failed but the user got past the intro somehow.
           // Tell the agent to abort with a structured signal so the runner
           // renders a friendly outro.
-          return `Detection did not pick a source maps skill variant for this project.
-Emit: ${AgentSignals.ABORT} unsupported-platform
-Then halt.`;
+          return SOURCE_MAPS_DETECTION_FAILED_PROMPT;
         }
 
         const uiHost = getUiHostFromHost(ctx.host).replace(/\/$/, '');
-        const settingsUrl = `${uiHost}/project/${ctx.projectId}/settings/user-api-keys`;
 
-        return `You are wiring up PostHog Error Tracking source map upload for this ${
-          displayName ?? variant
-        } project.
-
-Project context:
-- PostHog Project ID: ${ctx.projectId}
-- PostHog Host: ${ctx.host}
-- Detected platform: ${displayName ?? variant}
-- Skill to use: ${skillId}
-- Personal API keys settings page: ${settingsUrl}
-
-The skill you install in STEP 2 is the source of truth for the HOW of every
-step: its "## Steps" section has an overview, tips and per-technology
-examples for each named step, and its reference files carry the exact
-per-framework API. The STEPS below give the order, the conditionals, and the
-wizard-specific mechanics (which MCP tool to call, signals to emit) — read
-the matching skill step (named in parentheses) before doing the work, and do
-not invent steps the skill doesn't describe.
-
-Follow these steps IN ORDER. Do not skip or reorder.
-
-Before doing any work, create your FULL task list in a single TaskCreate
-call so the user can follow your progress in the TUI. Use exactly these
-tasks, in this order — do not collapse, rename, or omit any of them:
-  1. Get personal API key
-  2. Install source maps skill
-  3. Apply build-config changes (per skill)
-  4. Make credentials readable at build time
-  5. Write keys to .env
-  6. Identify build & run commands
-  7. Test the local setup
-  8. Summarise & hand off
-Drive the list with TaskUpdate — mark a task in_progress when you start it
-and completed when done. ALWAYS keep task 7 ("Test the local setup") in the
-list even if the user declines testing in STEP 7: mark it completed rather
-than deleting it, so the user can see testing was offered.
-
-STEP 1 — Get a personal API key from the user. (skill: "Get a personal API key")
-   The wizard cannot mint keys — never call the PostHog API or any tool to
-   create one. Ask the user with the wizard_ask MCP tool; you receive the
-   answer as a vaulted secretRef (never the raw value), which you reuse in
-   STEP 5:
-     {
-       id: "api-key",
-       prompt: "Paste your PostHog personal API key below.\\n\\nDon't have one yet? Create one here:\\n${settingsUrl}\\n\\nWhen creating the key, choose the 'Source map upload' preset, then come back and paste it here.",
-       kind: "text",
-       sensitive: true
-     }
-   Keep the \\n line breaks exactly as written — Ink's <Text> renders them
-   as separate lines. The answer is { secretRef: "secret:..." }.
-   If wizard_ask is unavailable (CI / non-interactive), emit
-   ${AgentSignals.ABORT} requires-interactive-mode and halt.
-
-STEP 2 — Install the skill.
-   Call install_skill (wizard-tools MCP server) with skillId "${skillId}".
-   Do NOT run shell commands to install skills. Then read the installed
-   SKILL.md and its reference files — they drive STEPS 3-8.
-   If install fails, emit ${
-     AgentSignals.ERROR_RESOURCE_MISSING
-   } skill ${skillId} could not be installed.
-
-STEP 3 — Apply build-config changes. (skill: "Apply build-config changes")
-   Make the bundler / build-config changes the skill's step instructs. The
-   skill and its reference are the source of truth for this platform.
-
-STEP 4 — Make the credentials readable at build time. (skill: "Make credentials available at build time")
-   Follow the skill's step. Wizard-specific: if it calls for a loader (e.g.
-   \`dotenv\`), install it SILENTLY — do NOT ask the user or call wizard_ask.
-   Skip this step entirely if the platform already auto-loads .env.
-
-STEP 5 — Write the credentials to the env file. (skill: "Write credentials to the env file")
-   Use the wizard-tools MCP server. Reuse the env file the skill tells you to
-   pick — the prerequisite PostHog integration usually already wrote
-   POSTHOG_* vars to one, so seed your keys alongside them.
-   - First call check_env_keys on that file (returns present/absent, never
-     values — don't read the file directly).
-   - Then call set_env_values, passing the STEP 1 secretRef as a value
-     object, not a literal string:
-       values: {
-         "POSTHOG_CLI_API_KEY": { secretRef: "<the ref from STEP 1>" },
-         "POSTHOG_CLI_PROJECT_ID": "${ctx.projectId}",
-         "POSTHOG_CLI_HOST": "${ctx.host}"
-       }
-   Variable names follow the skill's per-uploader conventions. The wizard
-   resolves the ref locally before writing, so you never see the key value.
-
-STEP 6 — Identify the build AND run commands. (skill: "Identify the build and run commands")
-   Per the skill, resolve the production BUILD command and the RUN command
-   for THIS project (use detect_package_manager for the package manager). Do
-   NOT run either yourself — the user runs them. If you cannot identify a
-   build command, emit ${AgentSignals.ABORT} build command not found.
-
-STEP 7 — Offer to test the local setup. (skill: "Test the local setup")
-   Call wizard_ask:
-     {
-       id: "test-affordance",
-       prompt: "Want me to help you test your local setup? I'll add a temporary test button (or route) to your app so you can confirm errors show up in Error Tracking with readable stack traces after your next build. I'll remove it once you've confirmed it works.",
-       kind: "single",
-       options: [
-         { label: "Yes, help me test it", value: "yes" },
-         { label: "No, I'll test on my own later",  value: "no"  }
-       ]
-     }
-
-   If "no", skip to STEP 8.
-
-   If "yes", follow the skill's "Test the local setup" step for the
-   platform-appropriate affordance, the captureException shape, the
-   placement, and the read-before-edit / always-revert rules. Then pause for
-   the user with wizard_ask, baking the EXACT build and run commands from
-   STEP 6 (and the exact button label / route) into the prompt as literal,
-   copy-pasteable steps. Separate each numbered step with \\n\\n so the TUI
-   renders them as distinct lines:
-        {
-          id: "test-done",
-          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test affordance.\\n\\n2) Start the app with \`<your detected run command>\`, then click the \\"<your test button label>\\" button (or hit \`<your test route>\`).\\n\\n3) Open Error Tracking in PostHog (${uiHost}/project/${
-          ctx.projectId
-        }/error_tracking) and confirm the test error appears with a source-resolved stack trace pointing at real source files (not minified bundle paths).\\n\\nWhen you're done, select Continue and I'll revert the test code.",
-          kind: "single",
-          options: [{ label: "Continue (revert test code)", value: "continue" }]
-        }
-   After the user continues, revert the test code per the skill's rules and
-   surface any failure in STEP 8.
-
-STEP 8 — Summarise and hand off. (skill: "Verify and hand off")
-   Follow the skill's "Verify and hand off" step. The Symbol sets page for
-   this project — where the user confirms the upload landed — is:
-   ${uiHost}/project/${ctx.projectId}/error_tracking/configuration
-`;
+        return buildSourceMapsUploadPrompt({
+          displayName,
+          variant,
+          skillId,
+          projectId: ctx.projectId,
+          host: ctx.host,
+          settingsUrl: `${uiHost}/project/${ctx.projectId}/settings/user-api-keys`,
+          uiHost,
+        });
       },
 
       postRun: (sess) => {

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -10,6 +10,7 @@ import {
   type SkillVariant,
 } from './detect.js';
 import { getContentBlocks } from './content/index.js';
+import { getUiHostFromHost } from '@utils/urls';
 
 const REPORT_FILE = 'posthog-source-maps-report.md';
 const DOCS_URL = 'https://posthog.com/docs/error-tracking/upload-source-maps';
@@ -56,9 +57,8 @@ Emit: ${AgentSignals.ABORT} unsupported-platform
 Then halt.`;
         }
 
-        const settingsUrl = `${ctx.host.replace(/\/$/, '')}/project/${
-          ctx.projectId
-        }/settings/user-api-keys`;
+        const uiHost = getUiHostFromHost(ctx.host).replace(/\/$/, '');
+        const settingsUrl = `${uiHost}/project/${ctx.projectId}/settings/user-api-keys`;
 
         return `You are wiring up PostHog Error Tracking source map upload for this ${
           displayName ?? variant
@@ -175,10 +175,7 @@ STEP 7 — Offer to test the local setup. (skill: "Test the local setup")
    renders them as distinct lines:
         {
           id: "test-done",
-          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test affordance.\\n\\n2) Start the app with \`<your detected run command>\`, then click the \\"<your test button label>\\" button (or hit \`<your test route>\`).\\n\\n3) Open Error Tracking in PostHog (${ctx.host.replace(
-            /\/$/,
-            '',
-          )}/project/${
+          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test affordance.\\n\\n2) Start the app with \`<your detected run command>\`, then click the \\"<your test button label>\\" button (or hit \`<your test route>\`).\\n\\n3) Open Error Tracking in PostHog (${uiHost}/project/${
           ctx.projectId
         }/error_tracking) and confirm the test error appears with a source-resolved stack trace pointing at real source files (not minified bundle paths).\\n\\nWhen you're done, select Continue and I'll revert the test code.",
           kind: "single",
@@ -190,9 +187,7 @@ STEP 7 — Offer to test the local setup. (skill: "Test the local setup")
 STEP 8 — Summarise and hand off. (skill: "Verify and hand off")
    Follow the skill's "Verify and hand off" step. The Symbol sets page for
    this project — where the user confirms the upload landed — is:
-   ${ctx.host.replace(/\/$/, '')}/project/${
-          ctx.projectId
-        }/error_tracking/configuration
+   ${uiHost}/project/${ctx.projectId}/error_tracking/configuration
 `;
       },
 

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -154,14 +154,35 @@ STEP 5 — Seed the personal API key into the environment.
      You do not need to know the key value to write it — the wizard resolves
      the ref locally before writing the file.
 
-STEP 6 — Identify the build command.
-   Inspect the project to find the production build command — you'll need
-   it for the summary and (if the user opts in) for the test affordance
-   step. Look at:
+STEP 6 — Identify the build AND run commands.
+   Inspect the project to find two commands — you'll need both for the
+   summary and (if the user opts in) for the test affordance step:
+
+   a) The production BUILD command (uploads source maps). Look at:
      - package.json scripts ("build", "build:prod", etc.)
      - gradle wrapper / xcodebuild scheme / Makefile target as appropriate
-   Do NOT run the build yourself. The wizard does not run builds — the
-   user runs their own build after this workflow finishes.
+
+   b) The RUN command that launches the built app so the user can actually
+      click the test button / hit the test route. Resolve the EXACT command
+      for THIS project — never leave it as a generic "start the app". Look at:
+     - package.json scripts: prefer the one that serves the production
+       build (e.g. "start", "preview", "serve") over the dev script when a
+       build artifact is involved. For frameworks: Next.js → \`next start\`
+       (usually \`npm run start\` after \`next build\`); Vite → \`npm run
+       preview\`; plain Node → the "start" script or \`node <built entry>\`
+       (e.g. \`node dist/index.js\` — read package.json "main"/"bin" and the
+       build output dir to name the real file).
+     - Node services with the test route: give the full command to start
+       the server PLUS the exact URL/route to hit (e.g. \`node dist/server.js\`
+       then \`curl http://localhost:3000/__posthog-test-error\`).
+     - Mobile/native (Android/iOS/Flutter/React Native): give the run
+       command the platform uses to launch on a device/simulator (e.g.
+       \`npx react-native run-ios\`, \`flutter run\`, run from Android
+       Studio / Xcode) rather than a web "start".
+
+   Resolve concrete commands from the project's actual scripts/config —
+   substitute the right package manager (from detect_package_manager). Do
+   NOT run the build or the app yourself; the user runs them.
    If you cannot identify a build command, emit
    ${AgentSignals.ABORT} build command not found.
 
@@ -238,17 +259,20 @@ STEP 7 — Offer to test the local setup.
       will restore in step (d). Keep the change minimal — one button / one
       route, no extra helpers, no new imports beyond the strict minimum.
 
-   c) Pause for the user to test. Call wizard_ask with the build command
-      you identified in STEP 6 baked into the prompt — the user must run
-      the build themselves to upload source maps and surface the test
-      affordance.
+   c) Pause for the user to test. Call wizard_ask with BOTH the build
+      command and the run command you identified in STEP 6 baked into the
+      prompt as literal, copy-pasteable commands — the user must run the
+      build themselves to upload source maps and surface the test
+      affordance, then run the app to trigger it. Never write a generic
+      "start / open the app"; always substitute the exact run command (and
+      the exact button label or route) for THIS project.
 
       IMPORTANT: separate each numbered step with \\n\\n in the prompt
       string so the TUI renders them as distinct lines instead of a wall
       of text. Ink's <Text> respects \\n as a line break:
         {
           id: "test-done",
-          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test button.\\n\\n2) Start / open the app, click the test button (or hit the test route).\\n\\n3) Open Error Tracking in PostHog (${ctx.host.replace(
+          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test button.\\n\\n2) Start the app with \`<your detected run command>\`, then click the \\"<your test button label>\\" button (or hit \`<your test route>\`).\\n\\n3) Open Error Tracking in PostHog (${ctx.host.replace(
             /\/$/,
             '',
           )}/project/${

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -204,22 +204,13 @@ STEP 8 — Summarise and hand off. (skill: "Verify and hand off")
         return Promise.resolve();
       },
 
-      buildOutroData: (sess) => {
-        const completed = sess.frameworkContext[
-          'sourceMapsCompletedVariant'
-        ] as SkillVariant | undefined;
-        const changes = [
-          completed
-            ? `Configured source map upload for ${displayName ?? completed}`
-            : '',
-          'Added PostHog credentials to .env',
-        ].filter(Boolean);
-
+      buildOutroData: () => {
+        // SourceMapsOutroScreen renders static "what we did + how it works"
+        // guidance, so no per-run `changes` list is needed here.
         return {
           kind: OutroKind.Success as const,
           message: 'Source maps wired up!',
           reportFile: REPORT_FILE,
-          changes,
           docsUrl: DOCS_URL,
         };
       },

--- a/src/lib/programs/error-tracking-upload-source-maps/prompt.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/prompt.ts
@@ -1,0 +1,155 @@
+import { AgentSignals } from '@lib/agent/agent-interface';
+import type { SkillVariant } from './detect.js';
+
+export type SourceMapsUploadPromptParams = {
+  displayName: string | undefined;
+  variant: SkillVariant;
+  skillId: string;
+  projectId: number;
+  host: string;
+  settingsUrl: string;
+  uiHost: string;
+};
+
+export const SOURCE_MAPS_DETECTION_FAILED_PROMPT = `Detection did not pick a source maps skill variant for this project.
+Emit: ${AgentSignals.ABORT} unsupported-platform
+Then halt.`;
+
+export function buildSourceMapsUploadPrompt(
+  params: SourceMapsUploadPromptParams,
+): string {
+  const {
+    displayName,
+    variant,
+    skillId,
+    projectId,
+    host,
+    settingsUrl,
+    uiHost,
+  } = params;
+  const platformLabel = displayName ?? variant;
+
+  return `You are wiring up PostHog Error Tracking source map upload for this ${platformLabel} project.
+
+Project context:
+- PostHog Project ID: ${projectId}
+- PostHog Host: ${host}
+- Detected platform: ${platformLabel}
+- Skill to use: ${skillId}
+- Personal API keys settings page: ${settingsUrl}
+
+The skill you install in STEP 2 is the source of truth for the HOW of every
+step: its "## Steps" section has an overview, tips and per-technology
+examples for each named step, and its reference files carry the exact
+per-framework API. The STEPS below give the order, the conditionals, and the
+wizard-specific mechanics (which MCP tool to call, signals to emit) — read
+the matching skill step (named in parentheses) before doing the work, and do
+not invent steps the skill doesn't describe.
+
+Follow these steps IN ORDER. Do not skip or reorder.
+
+Before doing any work, create your FULL task list in a single TaskCreate
+call so the user can follow your progress in the TUI. Use exactly these
+tasks, in this order — do not collapse, rename, or omit any of them:
+  1. Get personal API key
+  2. Install source maps skill
+  3. Apply build-config changes (per skill)
+  4. Make credentials readable at build time
+  5. Write keys to .env
+  6. Identify build & run commands
+  7. Test the local setup
+  8. Summarise & hand off
+Drive the list with TaskUpdate — mark a task in_progress when you start it
+and completed when done. ALWAYS keep task 7 ("Test the local setup") in the
+list even if the user declines testing in STEP 7: mark it completed rather
+than deleting it, so the user can see testing was offered.
+
+STEP 1 — Get a personal API key from the user. (skill: "Get a personal API key")
+   The wizard cannot mint keys — never call the PostHog API or any tool to
+   create one. Ask the user with the wizard_ask MCP tool; you receive the
+   answer as a vaulted secretRef (never the raw value), which you reuse in
+   STEP 5:
+     {
+       id: "api-key",
+       prompt: "Paste your PostHog personal API key below.\\n\\nDon't have one yet? Create one here:\\n${settingsUrl}\\n\\nWhen creating the key, choose the 'Source map upload' preset, then come back and paste it here.",
+       kind: "text",
+       sensitive: true
+     }
+   Keep the \\n line breaks exactly as written — Ink's <Text> renders them
+   as separate lines. The answer is { secretRef: "secret:..." }.
+   If wizard_ask is unavailable (CI / non-interactive), emit
+   ${AgentSignals.ABORT} requires-interactive-mode and halt.
+
+STEP 2 — Install the skill.
+   Call install_skill (wizard-tools MCP server) with skillId "${skillId}".
+   Do NOT run shell commands to install skills. Then read the installed
+   SKILL.md and its reference files — they drive STEPS 3-8.
+   If install fails, emit ${AgentSignals.ERROR_RESOURCE_MISSING} skill ${skillId} could not be installed.
+
+STEP 3 — Apply build-config changes. (skill: "Apply build-config changes")
+   Make the bundler / build-config changes the skill's step instructs. The
+   skill and its reference are the source of truth for this platform.
+
+STEP 4 — Make the credentials readable at build time. (skill: "Make credentials available at build time")
+   Follow the skill's step. Wizard-specific: if it calls for a loader (e.g.
+   \`dotenv\`), install it SILENTLY — do NOT ask the user or call wizard_ask.
+   Skip this step entirely if the platform already auto-loads .env.
+
+STEP 5 — Write the credentials to the env file. (skill: "Write credentials to the env file")
+   Use the wizard-tools MCP server. Reuse the env file the skill tells you to
+   pick — the prerequisite PostHog integration usually already wrote
+   POSTHOG_* vars to one, so seed your keys alongside them.
+   - First call check_env_keys on that file (returns present/absent, never
+     values — don't read the file directly).
+   - Then call set_env_values, passing the STEP 1 secretRef as a value
+     object, not a literal string:
+       values: {
+         "POSTHOG_CLI_API_KEY": { secretRef: "<the ref from STEP 1>" },
+         "POSTHOG_CLI_PROJECT_ID": "${projectId}",
+         "POSTHOG_CLI_HOST": "${host}"
+       }
+   Variable names follow the skill's per-uploader conventions. The wizard
+   resolves the ref locally before writing, so you never see the key value.
+
+STEP 6 — Identify the build AND run commands. (skill: "Identify the build and run commands")
+   Per the skill, resolve the production BUILD command and the RUN command
+   for THIS project (use detect_package_manager for the package manager). Do
+   NOT run either yourself — the user runs them. If you cannot identify a
+   build command, emit ${AgentSignals.ABORT} build command not found.
+
+STEP 7 — Offer to test the local setup. (skill: "Test the local setup")
+   Call wizard_ask:
+     {
+       id: "test-affordance",
+       prompt: "Want me to help you test your local setup? I'll add a temporary test button (or route) to your app so you can confirm errors show up in Error Tracking with readable stack traces after your next build. I'll remove it once you've confirmed it works.",
+       kind: "single",
+       options: [
+         { label: "Yes, help me test it", value: "yes" },
+         { label: "No, I'll test on my own later",  value: "no"  }
+       ]
+     }
+
+   If "no", skip to STEP 8.
+
+   If "yes", follow the skill's "Test the local setup" step for the
+   platform-appropriate affordance, the captureException shape, the
+   placement, and the read-before-edit / always-revert rules. Then pause for
+   the user with wizard_ask, baking the EXACT build and run commands from
+   STEP 6 (and the exact button label / route) into the prompt as literal,
+   copy-pasteable steps. Separate each numbered step with \\n\\n so the TUI
+   renders them as distinct lines:
+        {
+          id: "test-done",
+          prompt: "1) Run \`<your detected build command>\` to upload source maps and build the app with the test affordance.\\n\\n2) Start the app with \`<your detected run command>\`, then click the \\"<your test button label>\\" button (or hit \`<your test route>\`).\\n\\n3) Open Error Tracking in PostHog (${uiHost}/project/${projectId}/error_tracking) and confirm the test error appears with a source-resolved stack trace pointing at real source files (not minified bundle paths).\\n\\nWhen you're done, select Continue and I'll revert the test code.",
+          kind: "single",
+          options: [{ label: "Continue (revert test code)", value: "continue" }]
+        }
+   After the user continues, revert the test code per the skill's rules and
+   surface any failure in STEP 8.
+
+STEP 8 — Summarise and hand off. (skill: "Verify and hand off")
+   Follow the skill's "Verify and hand off" step. The Symbol sets page for
+   this project — where the user confirms the upload landed — is:
+   ${uiHost}/project/${projectId}/error_tracking/configuration
+`;
+}

--- a/src/lib/programs/error-tracking-upload-source-maps/steps.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/steps.ts
@@ -7,8 +7,36 @@
  */
 
 import type { ProgramStep } from '@lib/programs/program-step';
+import type { WizardSession } from '@lib/wizard-session';
 import { RunPhase } from '@lib/wizard-session';
+import {
+  evaluateWizardReadiness,
+  WizardReadiness,
+  SIGNUP_WIZARD_READINESS_CONFIG,
+  getBlockingServiceKeys,
+} from '@lib/health-checks/readiness';
 import { detectSourceMapsPrerequisites } from './detect.js';
+
+function healthCheckReady(session: WizardSession): boolean {
+  if (!session.readinessResult) return false;
+
+  if (session.signup) {
+    const hardBlocking = getBlockingServiceKeys(
+      session.readinessResult.health,
+      SIGNUP_WIZARD_READINESS_CONFIG,
+    );
+    const defaultBlocking = getBlockingServiceKeys(
+      session.readinessResult.health,
+    );
+    if (hardBlocking.length === 0 && defaultBlocking.length === 0) return true;
+    return session.outageDismissed;
+  }
+
+  if (session.readinessResult.decision === WizardReadiness.No) {
+    return session.outageDismissed;
+  }
+  return true;
+}
 
 export const ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM: ProgramStep[] = [
   {
@@ -25,6 +53,25 @@ export const ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM: ProgramStep[] = [
     label: 'Welcome',
     screenId: 'source-maps-intro',
     gate: (session) => session.setupConfirmed,
+  },
+  {
+    id: 'health-check',
+    label: 'Health check',
+    screenId: 'health-check',
+    gate: healthCheckReady,
+    onInit: (ctx) => {
+      evaluateWizardReadiness()
+        .then((readiness) => {
+          ctx.setReadinessResult(readiness);
+        })
+        .catch(() => {
+          ctx.setReadinessResult({
+            decision: WizardReadiness.Yes,
+            health: {} as never,
+            reasons: [],
+          });
+        });
+    },
   },
   {
     id: 'auth',

--- a/src/lib/programs/error-tracking-upload-source-maps/steps.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/steps.ts
@@ -1,0 +1,54 @@
+/**
+ * Error tracking source maps upload program step list.
+ *
+ * Detection runs headless via onReady, then the user sees a custom intro
+ * showing the picked skill variant. Auth → agent run → outro mirrors the
+ * other programs.
+ */
+
+import type { ProgramStep } from '@lib/programs/program-step';
+import { RunPhase } from '@lib/wizard-session';
+import { detectSourceMapsPrerequisites } from './detect.js';
+
+export const ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM: ProgramStep[] = [
+  {
+    id: 'detect',
+    label: 'Detecting platform',
+    // Headless: scans for platform / build-system signals and picks the
+    // matching context-mill skill variant. Writes either the variant or
+    // a detectError to frameworkContext.
+    onReady: (ctx) =>
+      detectSourceMapsPrerequisites(ctx.session, ctx.setFrameworkContext),
+  },
+  {
+    id: 'intro',
+    label: 'Welcome',
+    screenId: 'source-maps-intro',
+    gate: (session) => session.setupConfirmed,
+  },
+  {
+    id: 'auth',
+    label: 'Authentication',
+    screenId: 'auth',
+    isComplete: (session) => session.credentials !== null,
+  },
+  {
+    id: 'run',
+    label: 'Upload source maps',
+    screenId: 'run',
+    isComplete: (session) =>
+      session.runPhase === RunPhase.Completed ||
+      session.runPhase === RunPhase.Error,
+  },
+  {
+    id: 'outro',
+    label: 'Done',
+    screenId: 'outro',
+    isComplete: (session) => session.outroDismissed,
+  },
+  {
+    id: 'skills',
+    label: 'Skills',
+    screenId: 'keep-skills',
+  },
+];

--- a/src/lib/programs/error-tracking-upload-source-maps/steps.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/steps.ts
@@ -43,7 +43,7 @@ export const ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM: ProgramStep[] = [
   {
     id: 'outro',
     label: 'Done',
-    screenId: 'outro',
+    screenId: 'source-maps-outro',
     isComplete: (session) => session.outroDismissed,
   },
   {

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -18,6 +18,7 @@ import { eventsAuditConfig } from './events-audit/index.js';
 import { audit3000Config } from './audit-3000/index.js';
 import { posthogDoctorConfig } from './posthog-doctor/index.js';
 import { migrationConfig } from './migration/index.js';
+import { errorTrackingUploadSourceMapsConfig } from './error-tracking-upload-source-maps/index.js';
 import { AGENT_SKILL_STEPS } from './agent-skill/index.js';
 import { getContentBlocks as agentSkillContentBlocks } from './agent-skill/content/index.js';
 import { mcpAddConfig, mcpRemoveConfig } from './mcp/index.js';
@@ -36,6 +37,7 @@ const agentSkillConfig: ProgramConfig = {
 export const PROGRAM_REGISTRY = [
   posthogIntegrationConfig,
   revenueAnalyticsConfig,
+  errorTrackingUploadSourceMapsConfig,
   auditConfig,
   eventsAuditConfig,
   audit3000Config,
@@ -54,6 +56,7 @@ export const PROGRAM_REGISTRY = [
 export const Program = {
   PostHogIntegration: posthogIntegrationConfig.id,
   RevenueAnalyticsSetup: revenueAnalyticsConfig.id,
+  ErrorTrackingUploadSourceMaps: errorTrackingUploadSourceMapsConfig.id,
   Migration: migrationConfig.id,
   Audit: auditConfig.id,
   EventsAudit: eventsAuditConfig.id,

--- a/src/lib/secret-vault.ts
+++ b/src/lib/secret-vault.ts
@@ -1,0 +1,79 @@
+/**
+ * Session-scoped secret vault.
+ *
+ * Tools that handle sensitive values (personal API keys pasted by the user
+ * or minted by the wizard, OAuth tokens, etc.) store them here and return
+ * an opaque `secret:<uuid>` ref to the agent. The agent passes the ref
+ * around to subsequent tools — `set_env_values` resolves it host-side
+ * before writing — but the raw value never enters the LLM conversation.
+ *
+ * The vault is created once per `createWizardToolsServer` call and lives
+ * for the duration of a single wizard run. There is no persistence and
+ * no cross-session sharing; refs minted in one run cannot be resolved in
+ * another.
+ */
+
+import { randomUUID } from 'crypto';
+
+const REF_PREFIX = 'secret:';
+
+export interface SecretMeta {
+  /** Opaque reference handed to the agent. */
+  ref: string;
+  /** Human-readable label shown to the user (e.g. "Personal API key"). */
+  label: string;
+  /** Where the secret came from (e.g. "wizard_ask"). */
+  source: string;
+  /** ms epoch when the secret was stored. */
+  createdAt: number;
+}
+
+export interface SecretVault {
+  /** Store a value and return its ref. */
+  put(value: string, meta: Omit<SecretMeta, 'ref' | 'createdAt'>): string;
+  /** Resolve a ref to its value, or undefined if unknown. */
+  get(ref: string): string | undefined;
+  /** Whether the vault knows about this ref. */
+  has(ref: string): boolean;
+  /** Metadata for every stored secret (never the values). */
+  list(): SecretMeta[];
+  /** Drop every secret. Call at session teardown. */
+  clear(): void;
+}
+
+/** True when the value looks like a secret ref. Does not assert resolvability. */
+export function isSecretRef(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith(REF_PREFIX);
+}
+
+export function createSecretVault(): SecretVault {
+  const store = new Map<string, { value: string; meta: SecretMeta }>();
+
+  return {
+    put(value, meta) {
+      const ref = `${REF_PREFIX}${randomUUID()}`;
+      store.set(ref, {
+        value,
+        meta: {
+          ref,
+          label: meta.label,
+          source: meta.source,
+          createdAt: Date.now(),
+        },
+      });
+      return ref;
+    },
+    get(ref) {
+      return store.get(ref)?.value;
+    },
+    has(ref) {
+      return store.has(ref);
+    },
+    list() {
+      return [...store.values()].map((s) => s.meta);
+    },
+    clear() {
+      store.clear();
+    },
+  };
+}

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -105,6 +105,14 @@ export interface AskQuestion {
   options?: { label: string; value: string }[];
   /** Defaults to true */
   required?: boolean;
+  /**
+   * Only meaningful for kind='text'. When true, the wizard-tools `wizard_ask`
+   * tool stores the user's answer in the session secret vault and returns
+   * `{ secretRef }` to the agent instead of the plain string — so the value
+   * never enters the LLM conversation. The TUI may also mask input
+   * accordingly. See `secret-vault.ts`.
+   */
+  sensitive?: boolean;
 }
 
 /** Map of question id → answer (string for single/text, string[] for multi). */

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -24,6 +24,7 @@ import {
   type AuditStatus,
 } from './programs/audit/types';
 import type { WizardAskBridge } from './wizard-ask-bridge';
+import { createSecretVault, type SecretVault } from './secret-vault';
 
 // ---------------------------------------------------------------------------
 // SDK dynamic import (ESM module loaded once, cached)
@@ -192,6 +193,15 @@ export interface WizardToolsOptions {
    * of this cap — see {@link ASK_BATCH_THRESHOLD}.
    */
   askMaxQuestions?: number;
+
+  /**
+   * Optional secret vault. When provided, tools that handle sensitive
+   * values (wizard_ask with `sensitive: true`, set_env_values) route
+   * those values through the vault and return opaque refs to the agent
+   * instead of raw strings — so the LLM never sees them. When omitted
+   * (e.g. in unit tests), a fresh vault is created internally.
+   */
+  secretVault?: SecretVault;
 }
 
 /** Default per-run cap on wizard_ask calls when no override is provided. */
@@ -494,6 +504,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
     skillsBaseUrl,
     askBridge,
     askMaxQuestions = DEFAULT_ASK_MAX_QUESTIONS,
+    secretVault = createSecretVault(),
   } = options;
   const sdk = await getSDKModule();
   const { tool, createSdkMcpServer } = sdk;
@@ -553,16 +564,24 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
 
   const setEnvValues = tool(
     'set_env_values',
-    'Create or update environment variable keys in a .env file. Creates the file if it does not exist. Ensures .gitignore coverage.',
+    'Create or update environment variable keys in a .env file. Creates the file if it does not exist. Ensures .gitignore coverage. Each value can be either a literal string or a secret reference of the form `{ "secretRef": "secret:..." }` returned by another tool (e.g. wizard_ask). Secret references are resolved locally — the actual value is written to the file but never returned to the agent.',
     {
       filePath: z
         .string()
         .describe('Path to the .env file, relative to the project root'),
       values: z
-        .record(z.string(), z.string())
-        .describe('Key-value pairs to set'),
+        .record(
+          z.string(),
+          z.union([z.string(), z.object({ secretRef: z.string() })]),
+        )
+        .describe(
+          'Key → (literal string OR { secretRef } pointing to a vaulted secret)',
+        ),
     },
-    (args: { filePath: string; values: Record<string, string> }) => {
+    (args: {
+      filePath: string;
+      values: Record<string, string | { secretRef: string }>;
+    }) => {
       // Block the wrong key name — the correct key is NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN or similar
       const forbidden = Object.keys(args.values).find(
         (k) => k.toUpperCase() === 'POSTHOG_KEY',
@@ -579,17 +598,45 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         };
       }
 
+      // Resolve any secret refs from the vault before writing.
+      const resolvedValues: Record<string, string> = {};
+      const resolvedRefKeys: string[] = [];
+      for (const [key, val] of Object.entries(args.values)) {
+        if (typeof val === 'string') {
+          resolvedValues[key] = val;
+        } else {
+          const secret = secretVault.get(val.secretRef);
+          if (secret === undefined) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Error: secret reference "${val.secretRef}" for key "${key}" is not known to the vault. The ref may have expired, been minted in a different run, or been mistyped.`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          resolvedValues[key] = secret;
+          resolvedRefKeys.push(key);
+        }
+      }
+
       const resolved = resolveEnvPath(workingDirectory, args.filePath);
       logToFile(
-        `set_env_values: ${resolved}, keys: ${Object.keys(args.values).join(
+        `set_env_values: ${resolved}, keys: ${Object.keys(resolvedValues).join(
           ', ',
-        )}`,
+        )}${
+          resolvedRefKeys.length > 0
+            ? ` (secret refs: ${resolvedRefKeys.join(', ')})`
+            : ''
+        }`,
       );
 
       const existing = fs.existsSync(resolved)
         ? fs.readFileSync(resolved, 'utf8')
         : '';
-      const content = mergeEnvValues(existing, args.values);
+      const content = mergeEnvValues(existing, resolvedValues);
 
       // Ensure parent directory exists
       const dir = path.dirname(resolved);
@@ -895,6 +942,12 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
       .optional()
       .describe('Required for kind=single|multi; ignored for kind=text'),
     required: z.boolean().optional().describe('Defaults to true'),
+    sensitive: z
+      .boolean()
+      .optional()
+      .describe(
+        "Only valid for kind='text'. When true, the user's answer is stored in the wizard's secret vault and returned to you as { secretRef: 'secret:...' } instead of the raw string. Use for API keys, tokens, and any other secret the user types in.",
+      ),
   });
 
   const wizardAsk = tool(
@@ -912,6 +965,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         kind: 'single' | 'multi' | 'text';
         options?: { label: string; value: string }[];
         required?: boolean;
+        sensitive?: boolean;
       }>;
     }) => {
       if (!askBridge) {
@@ -956,6 +1010,17 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
             isError: true,
           };
         }
+        if (q.sensitive && q.kind !== 'text') {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: question "${q.id}" sets sensitive=true but kind="${q.kind}". Only kind="text" answers can be vaulted as secrets.`,
+              },
+            ],
+            isError: true,
+          };
+        }
       }
 
       const ids = new Set<string>();
@@ -978,6 +1043,37 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
 
       try {
         const answers = await askBridge.request({ questions: args.questions });
+
+        // For any question marked sensitive, move the raw answer into the
+        // vault and replace it with an opaque ref before returning to the
+        // agent — so the secret never enters the LLM conversation.
+        const sensitiveById = new Map(
+          args.questions
+            .filter((q) => q.sensitive)
+            .map((q) => [q.id, q.prompt]),
+        );
+        const sanitised: Record<
+          string,
+          string | string[] | { secretRef: string }
+        > = {};
+        for (const [id, answer] of Object.entries(answers)) {
+          const label = sensitiveById.get(id);
+          if (
+            label !== undefined &&
+            typeof answer === 'string' &&
+            answer !== '__cancelled__'
+          ) {
+            const ref = secretVault.put(answer, {
+              label,
+              source: 'wizard_ask',
+            });
+            sanitised[id] = { secretRef: ref };
+            logToFile(`wizard_ask: vaulted answer for "${id}" as ${ref}`);
+          } else {
+            sanitised[id] = answer;
+          }
+        }
+
         logToFile(
           `wizard_ask: resolved ${Object.keys(answers).length} answer(s) for ${
             args.questions.length
@@ -987,7 +1083,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify({ answers }, null, 2),
+              text: JSON.stringify({ answers: sanitised }, null, 2),
             },
           ],
         };

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -21,6 +21,7 @@ import { PortConflictScreen } from './screens/PortConflictScreen.js';
 import { PostHogIntegrationIntroScreen } from './screens/PostHogIntegrationIntroScreen.js';
 import { RevenueIntroScreen } from './screens/RevenueIntroScreen.js';
 import { MigrationIntroScreen } from './screens/MigrationIntroScreen.js';
+import { SourceMapsIntroScreen } from './screens/SourceMapsIntroScreen.js';
 import { AgentSkillIntroScreen } from './screens/AgentSkillIntroScreen.js';
 import { AuditIntroScreen } from './screens/audit/AuditIntroScreen.js';
 import { AuditRunScreen } from './screens/audit/AuditRunScreen.js';
@@ -65,6 +66,7 @@ export function createScreens(
     // Wizard flow
     [ScreenId.Intro]: <PostHogIntegrationIntroScreen store={store} />,
     [ScreenId.RevenueIntro]: <RevenueIntroScreen store={store} />,
+    [ScreenId.SourceMapsIntro]: <SourceMapsIntroScreen store={store} />,
     [ScreenId.MigrationIntro]: <MigrationIntroScreen store={store} />,
     [ScreenId.AgentSkillIntro]: <AgentSkillIntroScreen store={store} />,
     [ScreenId.AuditIntro]: <AuditIntroScreen store={store} />,

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -22,6 +22,7 @@ import { PostHogIntegrationIntroScreen } from './screens/PostHogIntegrationIntro
 import { RevenueIntroScreen } from './screens/RevenueIntroScreen.js';
 import { MigrationIntroScreen } from './screens/MigrationIntroScreen.js';
 import { SourceMapsIntroScreen } from './screens/SourceMapsIntroScreen.js';
+import { SourceMapsOutroScreen } from './screens/SourceMapsOutroScreen.js';
 import { AgentSkillIntroScreen } from './screens/AgentSkillIntroScreen.js';
 import { AuditIntroScreen } from './screens/audit/AuditIntroScreen.js';
 import { AuditRunScreen } from './screens/audit/AuditRunScreen.js';
@@ -67,6 +68,7 @@ export function createScreens(
     [ScreenId.Intro]: <PostHogIntegrationIntroScreen store={store} />,
     [ScreenId.RevenueIntro]: <RevenueIntroScreen store={store} />,
     [ScreenId.SourceMapsIntro]: <SourceMapsIntroScreen store={store} />,
+    [ScreenId.SourceMapsOutro]: <SourceMapsOutroScreen store={store} />,
     [ScreenId.MigrationIntro]: <MigrationIntroScreen store={store} />,
     [ScreenId.AgentSkillIntro]: <AgentSkillIntroScreen store={store} />,
     [ScreenId.AuditIntro]: <AuditIntroScreen store={store} />,

--- a/src/ui/tui/screen-sequences.ts
+++ b/src/ui/tui/screen-sequences.ts
@@ -18,6 +18,7 @@ export enum ScreenId {
   Intro = 'intro',
   RevenueIntro = 'revenue-intro',
   SourceMapsIntro = 'source-maps-intro',
+  SourceMapsOutro = 'source-maps-outro',
   MigrationIntro = 'migration-intro',
   AgentSkillIntro = 'agent-skill-intro',
   AuditIntro = 'audit-intro',

--- a/src/ui/tui/screen-sequences.ts
+++ b/src/ui/tui/screen-sequences.ts
@@ -17,6 +17,7 @@ import { createProgramSequence } from '@lib/programs/program-step';
 export enum ScreenId {
   Intro = 'intro',
   RevenueIntro = 'revenue-intro',
+  SourceMapsIntro = 'source-maps-intro',
   MigrationIntro = 'migration-intro',
   AgentSkillIntro = 'agent-skill-intro',
   AuditIntro = 'audit-intro',

--- a/src/ui/tui/screens/SourceMapsIntroScreen.tsx
+++ b/src/ui/tui/screens/SourceMapsIntroScreen.tsx
@@ -1,0 +1,185 @@
+/**
+ * SourceMapsIntroScreen — Welcome screen for the source-maps upload flow.
+ *
+ * Reads detection results from frameworkContext (written by
+ * detectSourceMapsPrerequisites). On success: shows the detected platform.
+ * On failure: shows the structured error with an Exit prompt.
+ */
+
+import { Box, Text } from 'ink';
+import { useSyncExternalStore } from 'react';
+import type { WizardStore } from '../store.js';
+import { PickerMenu } from '../primitives/index.js';
+import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
+import {
+  SOURCE_MAPS_CONTEXT_KEYS,
+  VARIANT_DISPLAY_NAME,
+  type SkillVariant,
+  type SourceMapsDetectError,
+} from '@lib/programs/error-tracking-upload-source-maps/index';
+
+interface SourceMapsIntroScreenProps {
+  store: WizardStore;
+}
+
+export const SourceMapsIntroScreen = ({
+  store,
+}: SourceMapsIntroScreenProps) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  const { session } = store;
+  const detectError = session.frameworkContext[
+    SOURCE_MAPS_CONTEXT_KEYS.detectError
+  ] as SourceMapsDetectError | undefined;
+  const variant = session.frameworkContext[
+    SOURCE_MAPS_CONTEXT_KEYS.skillVariant
+  ] as SkillVariant | undefined;
+  const displayName = session.frameworkContext[
+    SOURCE_MAPS_CONTEXT_KEYS.displayName
+  ] as string | undefined;
+  const packagePaths =
+    (session.frameworkContext[SOURCE_MAPS_CONTEXT_KEYS.packagePaths] as
+      | string[]
+      | undefined) ?? [];
+
+  const detectionRows: DetectionRow[] = [];
+  if (displayName) {
+    detectionRows.push({ label: 'Platform', value: displayName });
+  }
+  if (variant) {
+    detectionRows.push({
+      label: 'Skill',
+      value: `error-tracking-upload-source-maps-${variant}`,
+    });
+  }
+
+  const body = (
+    <>
+      <Box flexDirection="column" alignItems="center">
+        <Text>Upload source maps so error stack traces de-minify.</Text>
+        <Box flexDirection="column" marginTop={1}>
+          <Text>The agent will wire it into your build.</Text>
+        </Box>
+      </Box>
+
+      {packagePaths.length > 1 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>Found {packagePaths.length} package.json files:</Text>
+          {packagePaths.map((p) => (
+            <Text key={p} dimColor>
+              {'  '}
+              {'•'} {p}
+            </Text>
+          ))}
+        </Box>
+      )}
+    </>
+  );
+
+  const errorView = detectError ? (
+    <>
+      <Box flexDirection="column" marginBottom={1}>
+        <Text color="red" bold>
+          {'✘'} Cannot set up source map upload
+        </Text>
+        <Box marginTop={1} flexDirection="column">
+          <DetectErrorBody error={detectError} />
+        </Box>
+      </Box>
+
+      <PickerMenu
+        options={[{ label: 'Exit', value: 'exit' }]}
+        onSelect={() => process.exit(1)}
+      />
+    </>
+  ) : undefined;
+
+  const menuOptions = [
+    { label: 'Continue', value: 'continue' },
+    { label: 'Cancel', value: 'cancel' },
+  ];
+
+  return (
+    <IntroScreenLayout
+      installDir={session.installDir}
+      body={body}
+      showDetection={true}
+      detectionRows={detectionRows}
+      errorView={errorView}
+      programLabel={session.programLabel}
+      skillId={session.skillId}
+      menuOptions={menuOptions}
+      onSelect={(value) => {
+        if (value === 'cancel') {
+          process.exit(0);
+        } else {
+          store.completeSetup();
+        }
+      }}
+    />
+  );
+};
+
+const DetectErrorBody = ({ error }: { error: SourceMapsDetectError }) => {
+  switch (error.kind) {
+    case 'bad-directory': {
+      const reasonText = {
+        missing: 'does not exist',
+        'not-dir': 'is not a directory',
+        unreadable: 'could not be accessed',
+      }[error.reason];
+      return (
+        <>
+          <Text>This path {reasonText}:</Text>
+          <Text dimColor>
+            {'  '}
+            {error.path}
+          </Text>
+        </>
+      );
+    }
+
+    case 'no-project-files':
+      return (
+        <>
+          <Text>No recognizable project files were found.</Text>
+          <Text dimColor>
+            Source map upload needs a package.json, Xcode project, Gradle build,
+            or Flutter pubspec.yaml.
+          </Text>
+          <Text dimColor>Run this command from your project root.</Text>
+        </>
+      );
+
+    case 'unsupported-platform':
+      return (
+        <>
+          <Text>Source map upload isn't supported for this stack yet.</Text>
+          <Text dimColor>
+            Open an issue at https://github.com/PostHog/wizard/issues with
+            details about your build setup — we'd like to add it.
+          </Text>
+        </>
+      );
+
+    case 'no-posthog-sdk': {
+      const platformLabel =
+        VARIANT_DISPLAY_NAME[error.platform] ?? error.platform;
+      return (
+        <>
+          <Text>Detected {platformLabel} but no PostHog SDK is installed.</Text>
+          <Box marginTop={1}>
+            <Text dimColor>
+              Source map upload only resolves stack traces from errors the SDK
+              reports. Run <Text bold>npx @posthog/wizard</Text> first to
+              install the SDK, then run this command again.
+            </Text>
+          </Box>
+        </>
+      );
+    }
+  }
+};

--- a/src/ui/tui/screens/SourceMapsIntroScreen.tsx
+++ b/src/ui/tui/screens/SourceMapsIntroScreen.tsx
@@ -8,8 +8,8 @@
 
 import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { PickerMenu } from '../primitives/index.js';
+import type { WizardStore } from '@ui/tui/store';
+import { PickerMenu } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
 import {
   SOURCE_MAPS_CONTEXT_KEYS,
@@ -59,7 +59,7 @@ export const SourceMapsIntroScreen = ({
   const body = (
     <>
       <Box flexDirection="column" alignItems="center">
-        <Text>Upload source maps so error stack traces de-minify.</Text>
+        <Text>Upload source maps for accurate error stack traces.</Text>
         <Box flexDirection="column" marginTop={1}>
           <Text>The agent will wire it into your build.</Text>
         </Box>

--- a/src/ui/tui/screens/SourceMapsIntroScreen.tsx
+++ b/src/ui/tui/screens/SourceMapsIntroScreen.tsx
@@ -123,6 +123,39 @@ export const SourceMapsIntroScreen = ({
   );
 };
 
+const SOURCE_MAP_DOCS =
+  'https://posthog.com/docs/error-tracking/upload-source-maps';
+const ERROR_TRACKING_INSTALL_DOCS =
+  'https://posthog.com/docs/error-tracking/installation';
+const WIZARD_ISSUES_URL = 'https://github.com/PostHog/wizard/issues';
+
+/**
+ * Platforms PostHog Error Tracking supports with published source-map / symbol
+ * upload docs, but that the wizard can't automate yet. The user (or their own
+ * coding agent) can follow these docs to wire it up by hand. Anything not in
+ * this map falls through to the generic "not supported yet" message — we don't
+ * hardcode the full supported-platform list (it lives in the docs and changes
+ * server-side), we just point there.
+ */
+const NATIVE_PLATFORM_DOCS: Record<string, { label: string; url: string }> = {
+  ios: {
+    label: 'iOS',
+    url: 'https://posthog.com/docs/error-tracking/upload-source-maps/ios',
+  },
+  android: {
+    label: 'Android',
+    url: 'https://posthog.com/docs/error-tracking/upload-mappings/android',
+  },
+  'react-native': {
+    label: 'React Native',
+    url: 'https://posthog.com/docs/error-tracking/upload-source-maps/react-native',
+  },
+  flutter: {
+    label: 'Flutter',
+    url: 'https://posthog.com/docs/error-tracking/upload-source-maps/flutter',
+  },
+};
+
 const DetectErrorBody = ({ error }: { error: SourceMapsDetectError }) => {
   switch (error.kind) {
     case 'bad-directory': {
@@ -151,19 +184,65 @@ const DetectErrorBody = ({ error }: { error: SourceMapsDetectError }) => {
             or Flutter pubspec.yaml.
           </Text>
           <Text dimColor>Run this command from your project root.</Text>
+          <Box marginTop={1} flexDirection="column">
+            <Text dimColor>How source map upload works:</Text>
+            <Text dimColor>
+              {'  '}
+              {SOURCE_MAP_DOCS}
+            </Text>
+          </Box>
         </>
       );
 
-    case 'unsupported-platform':
+    case 'unsupported-platform': {
+      const native = NATIVE_PLATFORM_DOCS[error.detected];
+
+      // Native mobile: PostHog Error Tracking supports it and we have docs —
+      // the wizard just can't automate source-map upload for it yet. Hand the
+      // user a path forward rather than a dead end.
+      if (native) {
+        return (
+          <>
+            <Text>
+              The wizard can't set up source map upload for {native.label} yet.
+            </Text>
+            <Box marginTop={1} flexDirection="column">
+              <Text dimColor>
+                PostHog Error Tracking does support {native.label}. You can set
+                it up yourself by following the docs below — or hand them to
+                your own coding agent to do it for you:
+              </Text>
+              <Box marginTop={1}>
+                <Text dimColor>{native.url}</Text>
+              </Box>
+            </Box>
+          </>
+        );
+      }
+
+      // Everything else (e.g. Rust): source map upload doesn't apply, and the
+      // stack may not be supported by Error Tracking at all. Don't promise docs
+      // that don't exist — point at the supported-platform list instead.
       return (
         <>
           <Text>Source map upload isn't supported for this stack yet.</Text>
-          <Text dimColor>
-            Open an issue at https://github.com/PostHog/wizard/issues with
-            details about your build setup — we'd like to add it.
-          </Text>
+          <Box marginTop={1} flexDirection="column">
+            <Text dimColor>
+              Check which platforms PostHog Error Tracking supports:
+            </Text>
+            <Box marginTop={1}>
+              <Text dimColor>{ERROR_TRACKING_INSTALL_DOCS}</Text>
+            </Box>
+            <Box marginTop={1}>
+              <Text dimColor>
+                If yours isn't listed and you'd like it added, open an issue at{' '}
+                {WIZARD_ISSUES_URL} with details about your build setup.
+              </Text>
+            </Box>
+          </Box>
         </>
       );
+    }
 
     case 'no-posthog-sdk': {
       const platformLabel =
@@ -171,12 +250,21 @@ const DetectErrorBody = ({ error }: { error: SourceMapsDetectError }) => {
       return (
         <>
           <Text>Detected {platformLabel} but no PostHog SDK is installed.</Text>
-          <Box marginTop={1}>
+          <Box marginTop={1} flexDirection="column">
             <Text dimColor>
               Source map upload only resolves stack traces from errors the SDK
               reports. Run <Text bold>npx @posthog/wizard</Text> first to
               install the SDK, then run this command again.
             </Text>
+            <Box marginTop={1} flexDirection="column">
+              <Text dimColor>
+                Set up source map upload for {platformLabel}:
+              </Text>
+              <Text dimColor>
+                {'  '}
+                {SOURCE_MAP_DOCS}
+              </Text>
+            </Box>
           </Box>
         </>
       );

--- a/src/ui/tui/screens/SourceMapsOutroScreen.tsx
+++ b/src/ui/tui/screens/SourceMapsOutroScreen.tsx
@@ -1,0 +1,154 @@
+/**
+ * SourceMapsOutroScreen — post-run summary for the source-maps upload flow.
+ *
+ * Unlike the generic OutroScreen, this spells out the operational facts a user
+ * needs to actually get de-minified stack traces: that packages were installed
+ * and upload credentials written to .env, plus the three gotchas (builds
+ * upload, run the build, mirror the env vars in CI). All static guidance —
+ * driven only by the program's `buildOutroData` (kind / message / report /
+ * docs), no per-run data.
+ */
+
+import { join } from 'node:path';
+import type { ReactNode } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { useSyncExternalStore } from 'react';
+import type { WizardStore } from '@ui/tui/store';
+import { OutroKind } from '@lib/wizard-session';
+import { Colors } from '@ui/tui/styles';
+
+interface SourceMapsOutroScreenProps {
+  store: WizardStore;
+}
+
+export const SourceMapsOutroScreen = ({
+  store,
+}: SourceMapsOutroScreenProps) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  useInput(() => {
+    store.setOutroDismissed();
+  });
+
+  const outroData = store.session.outroData;
+
+  if (!outroData) {
+    return (
+      <Box flexDirection="column" flexGrow={1}>
+        <Text dimColor>Finishing up...</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      {outroData.kind === OutroKind.Success && (
+        <Box flexDirection="column">
+          <Text color={Colors.success} bold>
+            ✔ {outroData.message || 'Source maps wired up!'}
+          </Text>
+
+          <Section title="What the wizard did">
+            <Text>• Installed the packages needed for source map upload.</Text>
+            <Text>
+              • Wrote the PostHog upload credentials to your{' '}
+              <Text bold>.env</Text> file.
+            </Text>
+          </Section>
+
+          <Section title="How uploads work now">
+            <Text>
+              • Every <Text bold>build</Text> now uploads source maps to PostHog
+              automatically — no extra command to remember.
+            </Text>
+            <Text>
+              • Run your app from the <Text bold>built output</Text>. Source
+              maps only resolve for errors thrown by the build that was
+              uploaded.
+            </Text>
+            <Text>
+              • In <Text bold>CI</Text>, make sure the build job exposes the
+              same env vars the wizard added to your <Text bold>.env</Text>.
+            </Text>
+          </Section>
+
+          {outroData.reportFile && (
+            <Box marginTop={1}>
+              <Text>
+                Details in{' '}
+                <Text bold>
+                  {join(store.session.installDir, outroData.reportFile)}
+                </Text>
+              </Text>
+            </Box>
+          )}
+
+          {outroData.docsUrl && (
+            <Box marginTop={1}>
+              <Text>
+                Learn more:{' '}
+                <Text color={Colors.primary}>{outroData.docsUrl}</Text>
+              </Text>
+            </Box>
+          )}
+
+          <Box marginTop={1}>
+            <Text dimColor>
+              Note: This wizard uses an LLM agent to analyze and modify your
+              project. Please review the changes made.
+            </Text>
+          </Box>
+          <Text dimColor>
+            How did this work for you? Drop us a line: wizard@posthog.com
+          </Text>
+        </Box>
+      )}
+
+      {outroData.kind === OutroKind.Error && (
+        <Box flexDirection="column">
+          <Text color={Colors.error} bold>
+            ✘ {outroData.message || 'An error occurred'}
+          </Text>
+          {outroData.body && (
+            <Box marginTop={1}>
+              <Text dimColor>{outroData.body}</Text>
+            </Box>
+          )}
+          {outroData.docsUrl && (
+            <Box marginTop={1}>
+              <Text>
+                Docs: <Text color={Colors.primary}>{outroData.docsUrl}</Text>
+              </Text>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {outroData.kind === OutroKind.Cancel && (
+        <Text color="yellow">■ {outroData.message || 'Cancelled'}</Text>
+      )}
+
+      <Box marginTop={1}>
+        <Text color={Colors.muted}>Press any key to continue</Text>
+      </Box>
+    </Box>
+  );
+};
+
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) => (
+  <Box flexDirection="column" marginTop={1}>
+    <Text color={Colors.primary} bold>
+      {title}:
+    </Text>
+    {children}
+  </Box>
+);


### PR DESCRIPTION
Context mill PR - https://github.com/PostHog/context-mill/pull/162
Workbench PR - https://github.com/PostHog/wizard-workbench/pull/1685

## What it does

It adds pretty good wizard which works for all supported js-like technologies. It one shots the implementation which ends with a fully working demo.

## What it doesn't do
- we are unable to give oauth permissions with `personal_api_key:write` permissions. User has to manually create the key and paste it.
- we are unable to run build command from within wizard. It conflicts with some rust (our ET CLI is rust) stuff and basically sandbox environment blocks us. We have to tell user to run build.
- it doesn't add support for react-native, flutter, ios and android platforms. This is planned!

## Full demo


https://github.com/user-attachments/assets/e0105e97-3dc3-40e7-853c-b8efdafc5df6

Added that outro screen later:
<img width="1777" height="575" alt="image" src="https://github.com/user-attachments/assets/c054007c-9c6a-4f13-9dd5-18a9b7db7fea" />


## Flow

- does the oauth flow,
- creates a todo list
<img width="1832" height="526" alt="image" src="https://github.com/user-attachments/assets/746a17d1-bdf5-4ec1-9ec7-2306cbadef3e" />

- asks for the key and stores it in a secret storage so it doesn't leak to LLM conversation

<img width="1141" height="546" alt="image" src="https://github.com/user-attachments/assets/6924f56a-8dce-4928-8738-5e66b144de65" />

- does all the magic including writing to the `.env` from the secret storage
- asks user if he wants to test it locally

<img width="1157" height="484" alt="image" src="https://github.com/user-attachments/assets/09c771eb-b05f-4a8f-9619-d6c2dd0260ee" />

- if yes, it adds minimal example and explains to user how to run it

<img width="1177" height="706" alt="image" src="https://github.com/user-attachments/assets/8d3c2786-d074-433a-aab3-e9488780af8d" />


## Positive cases

### Node raw

This is a raw version of node without any framework and without any sort of API inside the file. It is just a raw single `index.ts` script. Wizard correctly sets up raw CLI upload, appends to env. Enriches default build command with CLI specific stuff:

```
    "build": "tsc && posthog-cli --env-file .env sourcemap inject --directory ./dist && posthog-cli --env-file .env sourcemap upload --directory ./dist --release-name node-raw",
```
<img width="1225" height="661" alt="image" src="https://github.com/user-attachments/assets/199cd037-6b2c-4c63-a341-0367b34a3271" />

### Node rollup

This ones tricky. I've intentionally left a setup where no `dotenv` is installed and rollup config is unable to access the env file. Workflow correctly recognizes all of that, install dotenv, sets everything up, life is great.

<img width="1307" height="597" alt="image" src="https://github.com/user-attachments/assets/1e241d71-27e6-4869-aa87-5ceb7d1b5d32" />

### Node rollup with typescript plugin

This ones also tricky. We had to adjust the docs because this one requires changes to the `tsconfig.json`

<img width="666" height="436" alt="image" src="https://github.com/user-attachments/assets/2d5ce221-7293-41b3-93aa-e5df759f0865" />

### Nuxt 3.6-

This ones simple. 

<img width="1448" height="743" alt="image" src="https://github.com/user-attachments/assets/13b38712-815a-426f-9e25-6bbf68484696" />


### Nuxt 3.7+

This ones pretty simple and straight forward. No tricks.

<img width="1428" height="842" alt="image" src="https://github.com/user-attachments/assets/f03bd580-54bd-4362-af2a-6f588d8367c9" />

### React vite

Veeeery simple one

<img width="1554" height="741" alt="image" src="https://github.com/user-attachments/assets/43fbf017-dbc6-45cd-a76f-992884a3f1b7" />


## Deny cases

### No posthog installed ✅ 

`next-no-posthog`- doesn't have posthog installed.

<img width="1755" height="480" alt="image" src="https://github.com/user-attachments/assets/8e3f8ee5-a330-4be7-b2be-8550857dd34a" />

### Unsupported technology ✅ 

`rust` - unsupported technology

<img width="1842" height="548" alt="image" src="https://github.com/user-attachments/assets/97c7408b-1d43-4638-b1ec-878d1c865399" />
