### PR TITLE
fix: make refresh token optional for impersonated users

### DIFF
--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -300,12 +300,12 @@ describe('makeMutex', () => {
 describe('WIZARD_TOOL_NAMES', () => {
   it('exposes audit_add_checks so future programs can append checks through the MCP server', () => {
     expect(WIZARD_TOOL_NAMES.auditAddChecks).toBe(
-      'wizard-tools:audit_add_checks',
+      'mcp__wizard-tools__audit_add_checks',
     );
   });
 
   it('exposes wizard_ask so skills can collect structured input from the user', () => {
-    expect(WIZARD_TOOL_NAMES.wizardAsk).toBe('wizard-tools:wizard_ask');
+    expect(WIZARD_TOOL_NAMES.wizardAsk).toBe('mcp__wizard-tools__wizard_ask');
   });
 });
 

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -955,6 +955,13 @@ export async function runAgent(
             prompt:
               'You are a general-purpose subagent for the PostHog wizard. Prefer the authenticated mcp__posthog-wizard__* MCP tools over raw HTTP — they are already authenticated for this project. Only fall back to other transports if no MCP tool covers the operation.',
             mcpServers: inheritedMcpServerNames,
+            // SDK does not propagate the parent's disallowedTools to subagents
+            // (sdk.d.ts: AgentDefinition has its own disallowedTools, and
+            // `tools: undefined` means "inherit all"). Without this, a program
+            // that disallows wizard_ask still leaks it to dispatched subagents.
+            disallowedTools: agentConfig.disallowedTools
+              ? [...agentConfig.disallowedTools]
+              : undefined,
           },
         },
         // Load skills from project's .claude/skills/ directory

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -529,10 +529,27 @@ function matchesAllowedPrefix(command: string): boolean {
 export function wizardCanUseTool(
   toolName: string,
   input: Record<string, unknown>,
-  context: { wizardAskPending?: boolean } = {},
+  context: {
+    wizardAskPending?: boolean;
+    disallowedTools?: readonly string[];
+  } = {},
 ):
   | { behavior: 'allow'; updatedInput: Record<string, unknown> }
   | { behavior: 'deny'; message: string } {
+  // Hard gate on the program's disallow list. The SDK's own disallowedTools
+  // option blocks tools at the parent level, but does NOT reliably propagate
+  // to dispatched subagents (their AgentDefinition has its own field which the
+  // SDK appears to ignore for MCP tools). canUseTool is invoked for every
+  // tool call regardless of which agent layer emitted it, so denying here is
+  // the only certain block.
+  if (context.disallowedTools?.includes(toolName)) {
+    logToFile(`Denying disallowed tool: ${toolName}`);
+    return {
+      behavior: 'deny',
+      message: `Tool ${toolName} is disabled for this program.`,
+    };
+  }
+
   if (
     context.wizardAskPending &&
     (toolName === 'Write' || toolName === 'Edit')
@@ -1053,7 +1070,10 @@ export async function runAgent(
           const result = wizardCanUseTool(
             toolName,
             input as Record<string, unknown>,
-            { wizardAskPending: agentConfig.getPendingQuestion?.() != null },
+            {
+              wizardAskPending: agentConfig.getPendingQuestion?.() != null,
+              disallowedTools: agentConfig.disallowedTools,
+            },
           );
           logToFile('canUseTool result:', result);
           return Promise.resolve(result);

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -46,8 +46,9 @@ export const posthogIntegrationConfig: ProgramConfig = {
   steps: POSTHOG_INTEGRATION_PROGRAM,
   getContentBlocks,
   // Basic integration runs without structured user input; drop wizard_ask
-  // so the model can't pop modal prompts mid-run. (Subagent dispatch is
-  // already gated by not opting into `Agent`.)
+  // so the model can't pop modal prompts mid-run. The runner forwards this
+  // list to the general-purpose subagent as well, so dispatched subagents
+  // can't reach around the parent and ask either.
   disallowedTools: [WIZARD_TOOL_NAMES.wizardAsk],
 
   run: async (session: WizardSession): Promise<ProgramRun> => {

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -1026,16 +1026,20 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
 }
 
 /** Tool names exposed by the wizard-tools server, keyed for selective use. */
+// SDK expects MCP tool names in allowedTools/disallowedTools to be the
+// fully-qualified `mcp__<server>__<tool>` form (sdk.d.ts: "Fully-qualified
+// MCP tool name, e.g. mcp__server__tool_name."). The colon form silently
+// fails to match, which made every program's `disallowedTools` entry a no-op.
 export const WIZARD_TOOL_NAMES = {
-  checkEnvKeys: `${SERVER_NAME}:check_env_keys`,
-  setEnvValues: `${SERVER_NAME}:set_env_values`,
-  detectPackageManager: `${SERVER_NAME}:detect_package_manager`,
-  loadSkillMenu: `${SERVER_NAME}:load_skill_menu`,
-  installSkill: `${SERVER_NAME}:install_skill`,
-  auditSeedChecks: `${SERVER_NAME}:audit_seed_checks`,
-  auditAddChecks: `${SERVER_NAME}:audit_add_checks`,
-  auditResolveChecks: `${SERVER_NAME}:audit_resolve_checks`,
-  wizardAsk: `${SERVER_NAME}:wizard_ask`,
+  checkEnvKeys: `mcp__${SERVER_NAME}__check_env_keys`,
+  setEnvValues: `mcp__${SERVER_NAME}__set_env_values`,
+  detectPackageManager: `mcp__${SERVER_NAME}__detect_package_manager`,
+  loadSkillMenu: `mcp__${SERVER_NAME}__load_skill_menu`,
+  installSkill: `mcp__${SERVER_NAME}__install_skill`,
+  auditSeedChecks: `mcp__${SERVER_NAME}__audit_seed_checks`,
+  auditAddChecks: `mcp__${SERVER_NAME}__audit_add_checks`,
+  auditResolveChecks: `mcp__${SERVER_NAME}__audit_resolve_checks`,
+  wizardAsk: `mcp__${SERVER_NAME}__wizard_ask`,
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -48,7 +48,7 @@ const OAuthTokenResponseSchema = z.object({
   expires_in: z.number(),
   token_type: z.string(),
   scope: z.string(),
-  refresh_token: z.string(),
+  refresh_token: z.string().optional(),
   scoped_teams: z.array(z.number()).optional(),
   scoped_organizations: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
## Problem

- refresh token optional so only access token is required
- fix the disabled tool list to use the right mcp naming convention
