### PR TITLE
chore: migrate cross-boundary relative imports to path aliases

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -3,7 +3,7 @@ import { satisfies } from 'semver';
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { VERSION } from './src/lib/version.js';
+import { VERSION } from '@lib/version';
 
 const WIZARD_VERSION = VERSION;
 
@@ -19,16 +19,16 @@ if (!satisfies(process.version, NODE_VERSION_RANGE)) {
   process.exit(1);
 }
 
-import { isNonInteractiveEnvironment } from './src/utils/environment';
-import { getUI, setUI } from './src/ui';
-import { LoggingUI } from './src/ui/logging-ui';
+import { isNonInteractiveEnvironment } from '@utils/environment';
+import { getUI, setUI } from '@ui';
+import { LoggingUI } from '@ui/logging-ui';
 import {
   getSubcommandPrograms,
   Program,
-} from './src/lib/programs/program-registry';
-import type { ProgramConfig } from './src/lib/programs/program-step';
-import type { WizardSession } from './src/lib/wizard-session';
-import { POSTHOG_DOCS_URL } from './src/lib/constants';
+} from '@lib/programs/program-registry';
+import type { ProgramConfig } from '@lib/programs/program-step';
+import type { WizardSession } from '@lib/wizard-session';
+import { POSTHOG_DOCS_URL } from '@lib/constants';
 import { runtimeEnv } from '@env';
 
 // Test mock server — only loaded when NODE_ENV is 'test'.
@@ -258,7 +258,7 @@ const cli = yargs(hideBin(process.argv))
             getUI().intro('PostHog Wizard');
             try {
               const { provisionNewAccount } = await import(
-                './src/utils/provisioning.js'
+                '@utils/provisioning'
               );
               const signupRegion = (options.region as string).toUpperCase() as
                 | 'US'
@@ -298,14 +298,14 @@ const cli = yargs(hideBin(process.argv))
           }
 
           const { posthogIntegrationConfig } = await import(
-            './src/lib/programs/posthog-integration/index.js'
+            '@lib/programs/posthog-integration/index'
           );
-          const { FRAMEWORK_REGISTRY } = await import('./src/lib/registry.js');
+          const { FRAMEWORK_REGISTRY } = await import('@lib/registry');
           const { detectFramework, gatherFrameworkContext } = await import(
-            './src/lib/detection/index.js'
+            '@lib/detection/index'
           );
-          const { analytics } = await import('./src/utils/analytics.js');
-          const { wizardAbort } = await import('./src/utils/wizard-abort.js');
+          const { analytics } = await import('@utils/analytics');
+          const { wizardAbort } = await import('@utils/wizard-abort');
 
           // preRun: honor --integration, else auto-detect, then gather
           // framework context. Bypasses onReady hooks by design.
@@ -362,7 +362,7 @@ const cli = yargs(hideBin(process.argv))
         // Playground mode: launch the TUI primitives playground
         void (async () => {
           const { startPlayground } = await import(
-            './src/ui/tui/playground/start-playground.js'
+            '@ui/tui/playground/start-playground'
           );
           (startPlayground as (version: string) => void)(WIZARD_VERSION);
         })();
@@ -370,7 +370,7 @@ const cli = yargs(hideBin(process.argv))
         // Run a specific skill by ID
         void (async () => {
           const { createSkillProgram } = await import(
-            './src/lib/programs/agent-skill/index.js'
+            '@lib/programs/agent-skill/index'
           );
           const skillId = options.skill as string;
           const config = createSkillProgram({
@@ -392,7 +392,7 @@ const cli = yargs(hideBin(process.argv))
         // Same codepath as `npx @posthog/wizard integrate`.
         void (async () => {
           const { posthogIntegrationConfig } = await import(
-            './src/lib/programs/posthog-integration/index.js'
+            '@lib/programs/posthog-integration/index'
           );
           runWizard(posthogIntegrationConfig, options);
         })();
@@ -432,15 +432,15 @@ const cli = yargs(hideBin(process.argv))
             .filter(Boolean);
           void (async () => {
             const { readApiKeyFromEnv } = await import(
-              './src/utils/env-api-key.js'
+              '@utils/env-api-key'
             );
             const apiKey =
               (options.apiKey as string | undefined) || readApiKeyFromEnv();
 
             try {
-              const { startTUI } = await import('./src/ui/tui/start-tui.js');
+              const { startTUI } = await import('@ui/tui/start-tui');
               const { buildSession } = await import(
-                './src/lib/wizard-session.js'
+                '@lib/wizard-session'
               );
 
               const tui = startTUI(WIZARD_VERSION, Program.McpAdd);
@@ -455,7 +455,7 @@ const cli = yargs(hideBin(process.argv))
               // TUI unavailable — fallback to logging
               setUI(new LoggingUI());
               const { addMCPServerToClientsStep } = await import(
-                './src/steps/add-mcp-server-to-clients/index.js'
+                '@steps/add-mcp-server-to-clients/index'
               );
               await addMCPServerToClientsStep({
                 local: options.local,
@@ -483,9 +483,9 @@ const cli = yargs(hideBin(process.argv))
           const options = { ...argv };
           void (async () => {
             try {
-              const { startTUI } = await import('./src/ui/tui/start-tui.js');
+              const { startTUI } = await import('@ui/tui/start-tui');
               const { buildSession } = await import(
-                './src/lib/wizard-session.js'
+                '@lib/wizard-session'
               );
 
               const tui = startTUI(WIZARD_VERSION, Program.McpRemove);
@@ -498,7 +498,7 @@ const cli = yargs(hideBin(process.argv))
               // TUI unavailable — fallback to logging
               setUI(new LoggingUI());
               const { removeMCPServerFromClientsStep } = await import(
-                './src/steps/add-mcp-server-to-clients/index.js'
+                '@steps/add-mcp-server-to-clients/index'
               );
               await removeMCPServerFromClientsStep({
                 local: options.local,
@@ -558,7 +558,7 @@ cli.command(
     void (async () => {
       try {
         const { provisionNewAccount } = await import(
-          './src/utils/provisioning.js'
+          '@utils/provisioning'
         );
         if (!jsonMode) {
           getUI().log.info(`Provisioning account for ${email} in ${region}...`);
@@ -638,16 +638,16 @@ function runWizard(
     try {
       const installDir = (options.installDir as string) || process.cwd();
 
-      const { startTUI } = await import('./src/ui/tui/start-tui.js');
-      const { buildSession } = await import('./src/lib/wizard-session.js');
-      const { TaskStreamPush } = await import('./src/lib/task-stream/index.js');
+      const { startTUI } = await import('@ui/tui/start-tui');
+      const { buildSession } = await import('@lib/wizard-session');
+      const { TaskStreamPush } = await import('@lib/task-stream/index');
       const { FileDestination } = await import(
-        './src/lib/task-stream/destinations/file.js'
+        '@lib/task-stream/destinations/file'
       );
       const { PostHogDestination } = await import(
-        './src/lib/task-stream/destinations/posthog.js'
+        '@lib/task-stream/destinations/posthog'
       );
-      const { analytics } = await import('./src/utils/analytics.js');
+      const { analytics } = await import('@utils/analytics');
 
       const tui = startTUI(WIZARD_VERSION, config.id as any);
 
@@ -691,7 +691,7 @@ function runWizard(
 
       if (skipAgent) {
         const { getOrAskForProjectData } = await import(
-          './src/utils/setup-utils.js'
+          '@utils/setup-utils'
         );
         const { projectApiKey, host, accessToken, projectId } =
           await getOrAskForProjectData({
@@ -707,7 +707,7 @@ function runWizard(
           projectId,
         });
       } else {
-        const { runAgent } = await import('./src/lib/agent/agent-runner.js');
+        const { runAgent } = await import('@lib/agent/agent-runner');
         await runAgent(config, tui.store.session);
       }
 
@@ -774,14 +774,14 @@ function runWizardCI(
 
   void (async () => {
     const path = await import('path');
-    const { buildSession } = await import('./src/lib/wizard-session.js');
-    const { readEnvironment } = await import('./src/utils/environment.js');
-    const { readApiKeyFromEnv } = await import('./src/utils/env-api-key.js');
+    const { buildSession } = await import('@lib/wizard-session');
+    const { readEnvironment } = await import('@utils/environment');
+    const { readApiKeyFromEnv } = await import('@utils/env-api-key');
     const { configureLogFileFromEnvironment, logToFile } = await import(
-      './src/utils/debug.js'
+      '@utils/debug'
     );
     const { wizardAbort, WizardError } = await import(
-      './src/utils/wizard-abort.js'
+      '@utils/wizard-abort'
     );
 
     configureLogFileFromEnvironment();
@@ -857,7 +857,7 @@ function runWizardCI(
         }
       }
 
-      const { runAgent } = await import('./src/lib/agent/agent-runner.js');
+      const { runAgent } = await import('@lib/agent/agent-runner');
       await runAgent(config, session);
     } catch (error) {
       const errorMessage =

--- a/package.json
+++ b/package.json
@@ -156,7 +156,9 @@
       "^@env$": "<rootDir>/src/env.ts",
       "^@lib/(.*)$": "<rootDir>/src/lib/$1",
       "^@utils/(.*)$": "<rootDir>/src/utils/$1",
+      "^@ui$": "<rootDir>/src/ui/index.ts",
       "^@ui/(.*)$": "<rootDir>/src/ui/$1",
+      "^@steps$": "<rootDir>/src/steps/index.ts",
       "^@steps/(.*)$": "<rootDir>/src/steps/$1",
       "^@frameworks/(.*)$": "<rootDir>/src/frameworks/$1",
       "^(\\.{1,2}/.*)\\.js$": "$1"

--- a/src/__tests__/package-json.test.ts
+++ b/src/__tests__/package-json.test.ts
@@ -7,7 +7,7 @@ import {
   hasPackageInstalled,
   findInstalledPackageFromList,
   type PackageDotJson,
-} from '../utils/package-json';
+} from '@utils/package-json';
 
 describe('getPackageVersion', () => {
   it('returns version from dependencies', () => {

--- a/src/__tests__/wizard-abort.test.ts
+++ b/src/__tests__/wizard-abort.test.ts
@@ -4,8 +4,8 @@ import {
   WizardError,
   registerCleanup,
   clearCleanup,
-} from '../utils/wizard-abort';
-import { analytics } from '../utils/analytics';
+} from '@utils/wizard-abort';
+import { analytics } from '@utils/analytics';
 
 jest.mock('../utils/analytics');
 jest.mock('../ui', () => ({
@@ -184,7 +184,7 @@ describe('abort() delegates to wizardAbort()', () => {
   });
 
   it('abort() calls wizardAbort with message and exitCode', async () => {
-    const { abort } = await import('../utils/setup-utils.js');
+    const { abort } = await import('@utils/setup-utils');
 
     await expect(abort('Test abort', 3)).rejects.toThrow('process.exit called');
 
@@ -195,7 +195,7 @@ describe('abort() delegates to wizardAbort()', () => {
   });
 
   it('abort() uses defaults when called with no args', async () => {
-    const { abort } = await import('../utils/setup-utils.js');
+    const { abort } = await import('@utils/setup-utils');
 
     await expect(abort()).rejects.toThrow('process.exit called');
 

--- a/src/frameworks/android/android-wizard-agent.ts
+++ b/src/frameworks/android/android-wizard-agent.ts
@@ -1,7 +1,7 @@
 /* Android (Kotlin) wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { Integration } from '@lib/constants';
 import fg from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -10,7 +10,7 @@ import {
   getKotlinVersionBucket,
   getMinSdkVersion,
 } from './utils';
-import { gradlePackageManager } from '../../lib/detection/package-manager';
+import { gradlePackageManager } from '@lib/detection/package-manager';
 
 type AndroidContext = {
   kotlinVersion?: string;

--- a/src/frameworks/android/utils.ts
+++ b/src/frameworks/android/utils.ts
@@ -1,5 +1,5 @@
-import type { WizardOptions } from '../../utils/types';
-import { createVersionBucket } from '../../utils/semver';
+import type { WizardOptions } from '@utils/types';
+import { createVersionBucket } from '@utils/semver';
 import fg from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/src/frameworks/angular/angular-wizard-agent.ts
+++ b/src/frameworks/angular/angular-wizard-agent.ts
@@ -1,15 +1,15 @@
 /* Angular wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
 import { getAngularVersionBucket } from './utils';
 
 type AngularContext = Record<string, unknown>;

--- a/src/frameworks/angular/utils.ts
+++ b/src/frameworks/angular/utils.ts
@@ -1,4 +1,4 @@
-import { createVersionBucket } from '../../utils/semver';
+import { createVersionBucket } from '@utils/semver';
 
 /**
  * Get Angular version bucket for analytics

--- a/src/frameworks/astro/astro-wizard-agent.ts
+++ b/src/frameworks/astro/astro-wizard-agent.ts
@@ -1,16 +1,16 @@
 /* Astro wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import { getUI } from '../../ui';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import { getUI } from '@ui';
 import {
   getAstroRenderingMode,
   getAstroVersionBucket,

--- a/src/frameworks/astro/utils.ts
+++ b/src/frameworks/astro/utils.ts
@@ -1,8 +1,8 @@
 import fg from 'fast-glob';
 import fs from 'fs/promises';
 import path from 'path';
-import type { WizardOptions } from '../../utils/types';
-import { createVersionBucket } from '../../utils/semver';
+import type { WizardOptions } from '@utils/types';
+import { createVersionBucket } from '@utils/semver';
 
 export const getAstroVersionBucket = createVersionBucket();
 

--- a/src/frameworks/django/django-wizard-agent.ts
+++ b/src/frameworks/django/django-wizard-agent.ts
@@ -1,9 +1,9 @@
 /* Django wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { PYTHON_PACKAGE_INSTALLATION } from '../../lib/framework-config';
-import { detectPythonPackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { PYTHON_PACKAGE_INSTALLATION } from '@lib/framework-config';
+import { detectPythonPackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import fg from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/src/frameworks/django/utils.ts
+++ b/src/frameworks/django/utils.ts
@@ -1,7 +1,7 @@
 import fg from 'fast-glob';
-import { getUI } from '../../ui';
-import type { WizardOptions } from '../../utils/types';
-import { createVersionBucket } from '../../utils/semver';
+import { getUI } from '@ui';
+import type { WizardOptions } from '@utils/types';
+import { createVersionBucket } from '@utils/semver';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/src/frameworks/fastapi/fastapi-wizard-agent.ts
+++ b/src/frameworks/fastapi/fastapi-wizard-agent.ts
@@ -1,9 +1,9 @@
 /* FastAPI wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { PYTHON_PACKAGE_INSTALLATION } from '../../lib/framework-config';
-import { detectPythonPackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { PYTHON_PACKAGE_INSTALLATION } from '@lib/framework-config';
+import { detectPythonPackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getFastAPIVersion,
   getFastAPIProjectType,

--- a/src/frameworks/fastapi/utils.ts
+++ b/src/frameworks/fastapi/utils.ts
@@ -1,7 +1,7 @@
 import { major, minVersion } from 'semver';
 import fg from 'fast-glob';
-import { getUI } from '../../ui';
-import type { WizardOptions } from '../../utils/types';
+import { getUI } from '@ui';
+import type { WizardOptions } from '@utils/types';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/src/frameworks/flask/flask-wizard-agent.ts
+++ b/src/frameworks/flask/flask-wizard-agent.ts
@@ -1,9 +1,9 @@
 /* Flask wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { PYTHON_PACKAGE_INSTALLATION } from '../../lib/framework-config';
-import { detectPythonPackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { PYTHON_PACKAGE_INSTALLATION } from '@lib/framework-config';
+import { detectPythonPackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import fg from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/src/frameworks/flask/utils.ts
+++ b/src/frameworks/flask/utils.ts
@@ -1,7 +1,7 @@
 import fg from 'fast-glob';
-import { getUI } from '../../ui';
-import type { WizardOptions } from '../../utils/types';
-import { createVersionBucket } from '../../utils/semver';
+import { getUI } from '@ui';
+import type { WizardOptions } from '@utils/types';
+import { createVersionBucket } from '@utils/semver';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/src/frameworks/javascript-node/javascript-node-wizard-agent.ts
+++ b/src/frameworks/javascript-node/javascript-node-wizard-agent.ts
@@ -1,8 +1,8 @@
 /* Generic Node.js language wizard using posthog-agent with PostHog MCP */
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { Integration } from '../../lib/constants';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { Integration } from '@lib/constants';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
 
 type JavaScriptNodeContext = Record<string, unknown>;
 

--- a/src/frameworks/javascript-web/javascript-web-wizard-agent.ts
+++ b/src/frameworks/javascript-web/javascript-web-wizard-agent.ts
@@ -1,11 +1,11 @@
 /* Generic JavaScript Web (client-side) wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { Integration } from '@lib/constants';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { hasPackageInstalled } from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
+import { hasPackageInstalled } from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
 import {
   FRAMEWORK_PACKAGES,
   detectJsPackageManager,
@@ -13,7 +13,7 @@ import {
   hasIndexHtml,
   type JavaScriptContext,
 } from './utils';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
 
 export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
   metadata: {

--- a/src/frameworks/javascript-web/utils.ts
+++ b/src/frameworks/javascript-web/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { detectAllPackageManagers } from '../../utils/package-manager';
-import type { WizardOptions } from '../../utils/types';
+import { detectAllPackageManagers } from '@utils/package-manager';
+import type { WizardOptions } from '@utils/types';
 
 export type JavaScriptContext = {
   packageManagerName?: string;

--- a/src/frameworks/laravel/laravel-wizard-agent.ts
+++ b/src/frameworks/laravel/laravel-wizard-agent.ts
@@ -1,8 +1,8 @@
 /* Laravel wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { composerPackageManager } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { composerPackageManager } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import fg from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/src/frameworks/laravel/utils.ts
+++ b/src/frameworks/laravel/utils.ts
@@ -1,7 +1,7 @@
 import fg from 'fast-glob';
-import { getUI } from '../../ui';
-import type { WizardOptions } from '../../utils/types';
-import { createVersionBucket } from '../../utils/semver';
+import { getUI } from '@ui';
+import type { WizardOptions } from '@utils/types';
+import { createVersionBucket } from '@utils/semver';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/src/frameworks/nextjs/nextjs-wizard-agent.ts
+++ b/src/frameworks/nextjs/nextjs-wizard-agent.ts
@@ -1,16 +1,16 @@
 /* Simplified Next.js wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import { getUI } from '../../ui';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import { getUI } from '@ui';
 import {
   getNextJsRouter,
   getNextJsVersionBucket,

--- a/src/frameworks/nextjs/utils.ts
+++ b/src/frameworks/nextjs/utils.ts
@@ -1,6 +1,6 @@
 import fg from 'fast-glob';
-import type { WizardOptions } from '../../utils/types';
-import { createVersionBucket } from '../../utils/semver';
+import type { WizardOptions } from '@utils/types';
+import { createVersionBucket } from '@utils/semver';
 
 export const getNextJsVersionBucket = createVersionBucket();
 

--- a/src/frameworks/nuxt/nuxt-wizard-agent.ts
+++ b/src/frameworks/nuxt/nuxt-wizard-agent.ts
@@ -1,16 +1,16 @@
 /* Nuxt wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import { createVersionBucket } from '../../utils/semver';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import { createVersionBucket } from '@utils/semver';
 
 const getNuxtVersionBucket = createVersionBucket();
 

--- a/src/frameworks/python/python-wizard-agent.ts
+++ b/src/frameworks/python/python-wizard-agent.ts
@@ -1,9 +1,9 @@
 /* Generic Python language wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { PYTHON_PACKAGE_INSTALLATION } from '../../lib/framework-config';
-import { detectPythonPackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { PYTHON_PACKAGE_INSTALLATION } from '@lib/framework-config';
+import { detectPythonPackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import fg from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/src/frameworks/python/utils.ts
+++ b/src/frameworks/python/utils.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import type { WizardOptions } from '../../utils/types';
+import type { WizardOptions } from '@utils/types';
 
 export enum PythonPackageManager {
   UV = 'uv',

--- a/src/frameworks/rails/rails-wizard-agent.ts
+++ b/src/frameworks/rails/rails-wizard-agent.ts
@@ -1,8 +1,8 @@
 /* Ruby on Rails wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { bundlerPackageManager } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { bundlerPackageManager } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getRailsVersion,
   getRailsProjectType,

--- a/src/frameworks/rails/utils.ts
+++ b/src/frameworks/rails/utils.ts
@@ -1,7 +1,7 @@
 import fg from 'fast-glob';
-import { getUI } from '../../ui';
-import type { WizardOptions } from '../../utils/types';
-import { createVersionBucket } from '../../utils/semver';
+import { getUI } from '@ui';
+import type { WizardOptions } from '@utils/types';
+import { createVersionBucket } from '@utils/semver';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/src/frameworks/react-native/react-native-wizard-agent.ts
+++ b/src/frameworks/react-native/react-native-wizard-agent.ts
@@ -1,15 +1,15 @@
 /* React Native wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
 import {
   detectReactNativeVariant,
   getReactNativeVariantName,

--- a/src/frameworks/react-native/utils.ts
+++ b/src/frameworks/react-native/utils.ts
@@ -1,8 +1,8 @@
-import { createVersionBucket } from '../../utils/semver';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import { hasPackageInstalled } from '../../utils/package-json';
-import { getUI } from '../../ui';
-import type { WizardOptions } from '../../utils/types';
+import { createVersionBucket } from '@utils/semver';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import { hasPackageInstalled } from '@utils/package-json';
+import { getUI } from '@ui';
+import type { WizardOptions } from '@utils/types';
 
 export const getReactNativeVersionBucket = createVersionBucket();
 

--- a/src/frameworks/react-router/react-router-wizard-agent.ts
+++ b/src/frameworks/react-router/react-router-wizard-agent.ts
@@ -1,16 +1,16 @@
 /* React Router wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import { getUI } from '../../ui';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import { getUI } from '@ui';
 import {
   getReactRouterMode,
   getReactRouterModeName,

--- a/src/frameworks/react-router/utils.ts
+++ b/src/frameworks/react-router/utils.ts
@@ -1,9 +1,9 @@
 import { major } from 'semver';
 import fg from 'fast-glob';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import type { WizardOptions } from '../../utils/types';
-import { getPackageVersion } from '../../utils/package-json';
-import { createVersionBucket } from '../../utils/semver';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import type { WizardOptions } from '@utils/types';
+import { getPackageVersion } from '@utils/package-json';
+import { createVersionBucket } from '@utils/semver';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as semver from 'semver';

--- a/src/frameworks/ruby/ruby-wizard-agent.ts
+++ b/src/frameworks/ruby/ruby-wizard-agent.ts
@@ -1,8 +1,8 @@
 /* Generic Ruby language wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { bundlerPackageManager } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { bundlerPackageManager } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getRubyVersion,
   getRubyVersionBucket,

--- a/src/frameworks/ruby/utils.ts
+++ b/src/frameworks/ruby/utils.ts
@@ -1,6 +1,6 @@
 import fg from 'fast-glob';
-import type { WizardOptions } from '../../utils/types';
-import { createVersionBucket } from '../../utils/semver';
+import type { WizardOptions } from '@utils/types';
+import { createVersionBucket } from '@utils/semver';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/src/frameworks/svelte/svelte-wizard-agent.ts
+++ b/src/frameworks/svelte/svelte-wizard-agent.ts
@@ -1,13 +1,13 @@
 /* SvelteKit wizard using posthog-agent with PostHog MCP */
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
 
 type SvelteKitContext = Record<string, unknown>;
 

--- a/src/frameworks/swift/swift-wizard-agent.ts
+++ b/src/frameworks/swift/swift-wizard-agent.ts
@@ -1,8 +1,8 @@
 /* Swift wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { swiftPackageManager } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { swiftPackageManager } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import fg from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/src/frameworks/swift/utils.ts
+++ b/src/frameworks/swift/utils.ts
@@ -1,4 +1,4 @@
-import type { WizardOptions } from '../../utils/types';
+import type { WizardOptions } from '@utils/types';
 import fg from 'fast-glob';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/src/frameworks/tanstack-router/tanstack-router-wizard-agent.ts
+++ b/src/frameworks/tanstack-router/tanstack-router-wizard-agent.ts
@@ -1,16 +1,16 @@
 /* TanStack Router wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import { getUI } from '../../ui';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import { getUI } from '@ui';
 import {
   getTanStackRouterMode,
   getTanStackRouterModeName,

--- a/src/frameworks/tanstack-router/utils.ts
+++ b/src/frameworks/tanstack-router/utils.ts
@@ -1,7 +1,7 @@
 import fg from 'fast-glob';
-import type { WizardOptions } from '../../utils/types';
-import { hasPackageInstalled } from '../../utils/package-json';
-import { createVersionBucket } from '../../utils/semver';
+import type { WizardOptions } from '@utils/types';
+import { hasPackageInstalled } from '@utils/package-json';
+import { createVersionBucket } from '@utils/semver';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/src/frameworks/tanstack-start/tanstack-start-wizard-agent.ts
+++ b/src/frameworks/tanstack-start/tanstack-start-wizard-agent.ts
@@ -1,15 +1,15 @@
 /* TanStack Start wizard using posthog-agent with PostHog MCP */
-import type { WizardOptions } from '../../utils/types';
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { WizardOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
 import { getTanStackStartVersionBucket } from './utils';
 
 type TanStackStartContext = Record<string, unknown>;

--- a/src/frameworks/tanstack-start/utils.ts
+++ b/src/frameworks/tanstack-start/utils.ts
@@ -1,4 +1,4 @@
-import { createVersionBucket } from '../../utils/semver';
+import { createVersionBucket } from '@utils/semver';
 
 /**
  * Get TanStack Start version bucket for analytics

--- a/src/frameworks/vue/vue-wizard-agent.ts
+++ b/src/frameworks/vue/vue-wizard-agent.ts
@@ -1,15 +1,15 @@
 /* Vue wizard using posthog-agent with PostHog MCP */
-import type { FrameworkConfig } from '../../lib/framework-config';
-import { detectNodePackageManagers } from '../../lib/detection/package-manager';
-import { Integration } from '../../lib/constants';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
 import {
   getPackageVersion,
   getInstalledPackageVersion,
   hasPackageInstalled,
   type PackageDotJson,
-} from '../../utils/package-json';
-import { tryGetPackageJson } from '../../utils/setup-utils';
-import { createVersionBucket } from '../../utils/semver';
+} from '@utils/package-json';
+import { tryGetPackageJson } from '@utils/setup-utils';
+import { createVersionBucket } from '@utils/semver';
 
 const getVueVersionBucket = createVersionBucket();
 

--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -1,10 +1,10 @@
-import { runAgent, createStopHook } from '../agent/agent-interface';
-import type { WizardOptions } from '../../utils/types';
-import type { SpinnerHandle } from '../../ui';
+import { runAgent, createStopHook } from '@lib/agent/agent-interface';
+import type { WizardOptions } from '@utils/types';
+import type { SpinnerHandle } from '@ui';
 import {
   AdditionalFeature,
   ADDITIONAL_FEATURE_PROMPTS,
-} from '../wizard-session';
+} from '@lib/wizard-session';
 
 // Mock dependencies
 jest.mock('../../utils/analytics');

--- a/src/lib/__tests__/agent-runner-ask.test.ts
+++ b/src/lib/__tests__/agent-runner-ask.test.ts
@@ -1,4 +1,4 @@
-import { shouldDisableAsk } from '../agent/agent-runner';
+import { shouldDisableAsk } from '@lib/agent/agent-runner';
 
 describe('shouldDisableAsk', () => {
   it('enables wizard_ask in interactive runs by default', () => {

--- a/src/lib/__tests__/cloudflare-detection.test.ts
+++ b/src/lib/__tests__/cloudflare-detection.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { detectCloudflareTarget } from '../cloudflare-detection';
+import { detectCloudflareTarget } from '@lib/cloudflare-detection';
 
 jest.mock('../../utils/debug');
 

--- a/src/lib/__tests__/wizard-ask-bridge.test.ts
+++ b/src/lib/__tests__/wizard-ask-bridge.test.ts
@@ -1,9 +1,9 @@
 import {
   CANCELLED_SENTINEL,
   createWizardAskBridge,
-} from '../wizard-ask-bridge';
-import { analytics } from '../../utils/analytics';
-import type { AskAnswers, PendingQuestion } from '../wizard-session';
+} from '@lib/wizard-ask-bridge';
+import { analytics } from '@utils/analytics';
+import type { AskAnswers, PendingQuestion } from '@lib/wizard-session';
 
 jest.mock('../../utils/analytics', () => ({
   analytics: {

--- a/src/lib/__tests__/wizard-can-use-tool.test.ts
+++ b/src/lib/__tests__/wizard-can-use-tool.test.ts
@@ -1,4 +1,4 @@
-import { wizardCanUseTool } from '../agent/agent-interface';
+import { wizardCanUseTool } from '@lib/agent/agent-interface';
 
 jest.mock('../../utils/analytics', () => ({
   analytics: {

--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -11,8 +11,8 @@ import {
   mergeEnvValues,
   parseEnvKeys,
   resolveEnvPath,
-} from '../wizard-tools';
-import type { AuditCheck } from '../programs/audit/types';
+} from '@lib/wizard-tools';
+import type { AuditCheck } from '@lib/programs/audit/types';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'wizard-tools-'));

--- a/src/lib/__tests__/yara-hooks.test.ts
+++ b/src/lib/__tests__/yara-hooks.test.ts
@@ -1,7 +1,7 @@
 import {
   createPreToolUseYaraHooks,
   createPostToolUseYaraHooks,
-} from '../yara-hooks';
+} from '@lib/yara-hooks';
 
 // Mock dependencies
 jest.mock('../../utils/debug');

--- a/src/lib/__tests__/yara-scanner.test.ts
+++ b/src/lib/__tests__/yara-scanner.test.ts
@@ -1,5 +1,5 @@
-import { scan, scanSkillDirectory, RULES } from '../yara-scanner';
-import type { ScanResult } from '../yara-scanner';
+import { scan, scanSkillDirectory, RULES } from '@lib/yara-scanner';
+import type { ScanResult } from '@lib/yara-scanner';
 
 type MatchedScanResult = Extract<ScanResult, { matched: true }>;
 

--- a/src/lib/agent/__tests__/agent-prompt.test.ts
+++ b/src/lib/agent/__tests__/agent-prompt.test.ts
@@ -1,5 +1,5 @@
-import { assemblePrompt, type PromptContext } from '../agent-prompt.js';
-import type { ProgramRun } from '../agent-runner.js';
+import { assemblePrompt, type PromptContext } from '@lib/agent/agent-prompt';
+import type { ProgramRun } from '@lib/agent/agent-runner';
 
 function makeRunDef(overrides: Partial<ProgramRun> = {}): ProgramRun {
   return {

--- a/src/lib/agent/__tests__/commandments.test.ts
+++ b/src/lib/agent/__tests__/commandments.test.ts
@@ -1,4 +1,4 @@
-import { getWizardCommandments } from '../commandments';
+import { getWizardCommandments } from '@lib/agent/commandments';
 
 describe('getWizardCommandments', () => {
   // The commandment text is load-bearing — the agent reads these rules as

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -5,41 +5,32 @@
 
 import path from 'path';
 import * as fs from 'fs';
-import { getUI, type SpinnerHandle } from '../../ui';
-import {
-  debug,
-  logToFile,
-  initLogFile,
-  getLogFilePath,
-} from '../../utils/debug';
-import type { WizardOptions } from '../../utils/types';
-import { analytics } from '../../utils/analytics';
+import { getUI, type SpinnerHandle } from '@ui';
+import { debug, logToFile, initLogFile, getLogFilePath } from '@utils/debug';
+import type { WizardOptions } from '@utils/types';
+import { analytics } from '@utils/analytics';
 import {
   WIZARD_REMARK_EVENT_NAME,
   POSTHOG_PROPERTY_HEADER_PREFIX,
   WIZARD_VARIANT_FLAG_KEY,
   WIZARD_VARIANTS,
   WIZARD_USER_AGENT,
-} from '../constants';
+} from '@lib/constants';
 import {
   type AdditionalFeature,
   ADDITIONAL_FEATURE_PROMPTS,
-} from '../wizard-session';
-import {
-  registerCleanup,
-  wizardAbort,
-  WizardError,
-} from '../../utils/wizard-abort';
-import { createCustomHeaders } from '../../utils/custom-headers';
-import { getLlmGatewayUrlFromHost } from '../../utils/urls';
-import { LINTING_TOOLS } from '../safe-tools';
-import { createWizardToolsServer, WIZARD_TOOL_NAMES } from '../wizard-tools';
+} from '@lib/wizard-session';
+import { registerCleanup, wizardAbort, WizardError } from '@utils/wizard-abort';
+import { createCustomHeaders } from '@utils/custom-headers';
+import { getLlmGatewayUrlFromHost } from '@utils/urls';
+import { LINTING_TOOLS } from '@lib/safe-tools';
+import { createWizardToolsServer, WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import {
   createPreToolUseYaraHooks,
   createPostToolUseYaraHooks,
-} from '../yara-hooks';
+} from '@lib/yara-hooks';
 import { getWizardCommandments } from './commandments';
-import type { PackageManagerDetector } from '../detection/package-manager';
+import type { PackageManagerDetector } from '@lib/detection/package-manager';
 
 // Dynamic import cache for ESM module
 let _sdkModule: any = null;
@@ -297,7 +288,7 @@ export type AgentConfig = {
   /** Program identifier — selects the model for that program. */
   integrationLabel?: string;
   /** Bridge that drives the `wizard_ask` overlay. Omit in non-interactive hosts. */
-  askBridge?: import('../wizard-ask-bridge').WizardAskBridge;
+  askBridge?: import('@lib/wizard-ask-bridge').WizardAskBridge;
   /** Per-run cap on `wizard_ask` invocations. Defaults to 10. */
   askMaxQuestions?: number;
   /** Extra tools added on top of BASE_ALLOWED_TOOLS for this run. */
@@ -308,7 +299,9 @@ export type AgentConfig = {
    * Read accessor for the active pending question. Used by canUseTool to
    * block Write/Edit while the overlay is open (defense in depth).
    */
-  getPendingQuestion?: () => import('../wizard-session').PendingQuestion | null;
+  getPendingQuestion?: () =>
+    | import('@lib/wizard-session').PendingQuestion
+    | null;
 };
 
 /**
@@ -393,7 +386,9 @@ type AgentRunConfig = {
    * Read accessor for the active pending question. canUseTool reads this
    * to block Write/Edit while the overlay is open.
    */
-  getPendingQuestion?: () => import('../wizard-session').PendingQuestion | null;
+  getPendingQuestion?: () =>
+    | import('@lib/wizard-session').PendingQuestion
+    | null;
 };
 
 /**
@@ -485,7 +480,7 @@ const SAFE_SCRIPTS = [
 const DANGEROUS_OPERATORS = /[;`$()]/;
 
 // Re-export for backwards compatibility — canonical source is skill-install.ts
-export { isSkillInstallCommand } from '../skill-install';
+export { isSkillInstallCommand } from '@lib/skill-install';
 
 /**
  * Check if command is an allowed package manager command.

--- a/src/lib/agent/agent-runner.ts
+++ b/src/lib/agent/agent-runner.ts
@@ -19,10 +19,10 @@ import {
   type AdditionalFeature,
   type Credentials,
   OutroKind,
-} from '../wizard-session';
-import { getOrAskForProjectData } from '../../utils/setup-utils';
-import { analytics } from '../../utils/analytics';
-import { getUI } from '../../ui';
+} from '@lib/wizard-session';
+import { getOrAskForProjectData } from '@utils/setup-utils';
+import { analytics } from '@utils/analytics';
+import { getUI } from '@ui';
 import {
   initializeAgent,
   runAgent as executeAgent,
@@ -33,31 +33,27 @@ import {
   backupAndFixClaudeSettings,
   restoreClaudeSettings,
 } from './agent-interface';
-import { getCloudUrlFromRegion } from '../../utils/urls';
+import { getCloudUrlFromRegion } from '@utils/urls';
 import {
   evaluateWizardReadiness,
   WizardReadiness,
   SIGNUP_WIZARD_READINESS_CONFIG,
   getBlockingServiceKeys,
   SERVICE_LABELS,
-} from '../health-checks/readiness';
-import { enableDebugLogs, initLogFile, logToFile } from '../../utils/debug';
-import { createBenchmarkPipeline } from '../middleware/benchmark';
-import {
-  wizardAbort,
-  WizardError,
-  registerCleanup,
-} from '../../utils/wizard-abort';
-import { formatScanReport, writeScanReport } from '../yara-hooks';
-import { detectNodePackageManagers } from '../detection/package-manager';
-import type { PackageManagerDetector } from '../detection/package-manager';
-import { getSkillsBaseUrl } from '../constants';
+} from '@lib/health-checks/readiness';
+import { enableDebugLogs, initLogFile, logToFile } from '@utils/debug';
+import { createBenchmarkPipeline } from '@lib/middleware/benchmark';
+import { wizardAbort, WizardError, registerCleanup } from '@utils/wizard-abort';
+import { formatScanReport, writeScanReport } from '@lib/yara-hooks';
+import { detectNodePackageManagers } from '@lib/detection/package-manager';
+import type { PackageManagerDetector } from '@lib/detection/package-manager';
+import { getSkillsBaseUrl } from '@lib/constants';
 import { runtimeEnv } from '@env';
-import { installSkillById, type InstallSkillResult } from '../wizard-tools';
-import { createWizardAskBridge } from '../wizard-ask-bridge';
-import type { WizardOptions } from '../../utils/types';
+import { installSkillById, type InstallSkillResult } from '@lib/wizard-tools';
+import { createWizardAskBridge } from '@lib/wizard-ask-bridge';
+import type { WizardOptions } from '@utils/types';
 
-import type { ProgramConfig } from '../programs/program-step';
+import type { ProgramConfig } from '@lib/programs/program-step';
 import { assemblePrompt, type PromptContext } from './agent-prompt';
 
 export type { PromptContext };
@@ -110,7 +106,7 @@ export interface ProgramRun {
   buildOutroData?: (
     session: WizardSession,
     credentials: Credentials,
-    cloudRegion: import('../../utils/types').CloudRegion | undefined,
+    cloudRegion: import('@utils/types').CloudRegion | undefined,
   ) => WizardSession['outroData'];
   /**
    * Per-run cap on `wizard_ask` invocations. Defaults to 10. The 4th call

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import { z } from 'zod';
-import { analytics } from '../utils/analytics';
+import { analytics } from '@utils/analytics';
 import { WIZARD_USER_AGENT } from './constants';
 
 export const ApiUserSchema = z.object({

--- a/src/lib/cloudflare-detection.ts
+++ b/src/lib/cloudflare-detection.ts
@@ -1,6 +1,6 @@
 import fg from 'fast-glob';
-import { logToFile } from '../utils/debug';
-import { tryGetPackageJson } from '../utils/setup-utils';
+import { logToFile } from '@utils/debug';
+import { tryGetPackageJson } from '@utils/setup-utils';
 
 const CLOUDFLARE_PACKAGES = [
   '@react-router/cloudflare',

--- a/src/lib/detection/__tests__/context.test.ts
+++ b/src/lib/detection/__tests__/context.test.ts
@@ -1,6 +1,9 @@
-import { gatherFrameworkContext, checkFrameworkVersion } from '../context.js';
-import type { FrameworkConfig } from '../../framework-config.js';
-import type { WizardOptions } from '../../../utils/types.js';
+import {
+  gatherFrameworkContext,
+  checkFrameworkVersion,
+} from '@lib/detection/context';
+import type { FrameworkConfig } from '@lib/framework-config';
+import type { WizardOptions } from '@utils/types';
 
 const baseOptions: WizardOptions = {
   installDir: '/test/dir',

--- a/src/lib/detection/__tests__/features.test.ts
+++ b/src/lib/detection/__tests__/features.test.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { discoverFeatures } from '../features.js';
-import { DiscoveredFeature } from '../../wizard-session.js';
+import { discoverFeatures } from '@lib/detection/features';
+import { DiscoveredFeature } from '@lib/wizard-session';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'features-detect-'));

--- a/src/lib/detection/__tests__/package-manager.test.ts
+++ b/src/lib/detection/__tests__/package-manager.test.ts
@@ -7,7 +7,7 @@ import {
   composerPackageManager,
   swiftPackageManager,
   gradlePackageManager,
-} from '../package-manager';
+} from '@lib/detection/package-manager';
 
 jest.mock('../../../utils/debug');
 jest.mock('../../../telemetry', () => ({

--- a/src/lib/detection/context.ts
+++ b/src/lib/detection/context.ts
@@ -7,9 +7,9 @@
  */
 
 import * as semver from 'semver';
-import { DETECTION_TIMEOUT_MS } from '../constants.js';
-import type { FrameworkConfig } from '../framework-config.js';
-import type { WizardOptions } from '../../utils/types.js';
+import { DETECTION_TIMEOUT_MS } from '@lib/constants';
+import type { FrameworkConfig } from '@lib/framework-config';
+import type { WizardOptions } from '@utils/types';
 
 /**
  * Run a framework's `gatherContext()` to collect variant-specific

--- a/src/lib/detection/features.ts
+++ b/src/lib/detection/features.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { DiscoveredFeature } from '../wizard-session.js';
+import { DiscoveredFeature } from '@lib/wizard-session';
 
 const STRIPE_PACKAGES = ['stripe', '@stripe/stripe-js'];
 

--- a/src/lib/detection/framework.ts
+++ b/src/lib/detection/framework.ts
@@ -6,8 +6,8 @@
  * (or undefined). No store mutations, no UI calls.
  */
 
-import { Integration, DETECTION_TIMEOUT_MS } from '../constants.js';
-import { FRAMEWORK_REGISTRY } from '../registry.js';
+import { Integration, DETECTION_TIMEOUT_MS } from '@lib/constants';
+import { FRAMEWORK_REGISTRY } from '@lib/registry';
 
 /**
  * Loop through all registered frameworks and return the first one

--- a/src/lib/detection/package-manager.ts
+++ b/src/lib/detection/package-manager.ts
@@ -10,11 +10,11 @@
 import {
   detectAllPackageManagers,
   type PackageManager,
-} from '../../utils/package-manager';
+} from '@utils/package-manager';
 import {
   detectPackageManager as detectPythonPM,
   PythonPackageManager,
-} from '../../frameworks/python/utils';
+} from '@frameworks/python/utils';
 
 // ---------------------------------------------------------------------------
 // Common types

--- a/src/lib/framework-config.ts
+++ b/src/lib/framework-config.ts
@@ -1,5 +1,5 @@
 import type { Integration } from './constants';
-import type { WizardOptions } from '../utils/types';
+import type { WizardOptions } from '@utils/types';
 import type { PackageManagerDetector } from './detection/package-manager';
 
 /**

--- a/src/lib/health-checks/__tests__/health-checks.test.ts
+++ b/src/lib/health-checks/__tests__/health-checks.test.ts
@@ -33,7 +33,7 @@ import {
   evaluateWizardReadiness,
   ServiceHealthStatus,
   WizardReadiness,
-} from '../index';
+} from '@lib/health-checks/index';
 
 // ---------------------------------------------------------------------------
 // Real-world Statuspage.io v2 response factories

--- a/src/lib/health-checks/endpoints.ts
+++ b/src/lib/health-checks/endpoints.ts
@@ -1,4 +1,4 @@
-import { REMOTE_SKILLS_BASE_URL } from '../constants';
+import { REMOTE_SKILLS_BASE_URL } from '@lib/constants';
 import { ServiceHealthStatus, type BaseHealthResult } from './types';
 
 // ---------------------------------------------------------------------------

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -22,7 +22,7 @@ import {
   checkMcpHealth,
   checkGithubReleasesHealth,
 } from './endpoints';
-import { logToFile } from '../../utils/debug';
+import { logToFile } from '@utils/debug';
 
 // ---------------------------------------------------------------------------
 // Service labels (used in human-readable reason strings)

--- a/src/lib/middleware/benchmark.ts
+++ b/src/lib/middleware/benchmark.ts
@@ -7,15 +7,15 @@
  *   pipeline.finalize(resultMessage, durationMs);
  */
 
-import { getUI, type SpinnerHandle } from '../../ui';
-import { logToFile, getLogFilePath, configureLogFile } from '../../utils/debug';
+import { getUI, type SpinnerHandle } from '@ui';
+import { logToFile, getLogFilePath, configureLogFile } from '@utils/debug';
 import { MiddlewarePipeline } from './pipeline';
 import { PhaseDetector } from './phase-detector';
 import { loadBenchmarkConfig } from './config';
 import { createPluginsFromConfig } from './benchmarks';
 import type { BenchmarkConfig } from './config';
-import type { WizardOptions } from '../../utils/types';
-import { AgentSignals } from '../agent/agent-interface';
+import type { WizardOptions } from '@utils/types';
+import { AgentSignals } from '@lib/agent/agent-interface';
 
 // ── Types ──────────────────────────────────────────────────────────────
 

--- a/src/lib/middleware/benchmarks/cache-tracker.ts
+++ b/src/lib/middleware/benchmarks/cache-tracker.ts
@@ -4,7 +4,11 @@
  * Respects the dedup flag from TurnCounterPlugin.
  */
 
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
 import type { TurnData } from './turn-counter';
 
 /** Matches SDK usage.cache_creation (ephemeral 5m vs 1h for pricing). */

--- a/src/lib/middleware/benchmarks/compaction-tracker.ts
+++ b/src/lib/middleware/benchmarks/compaction-tracker.ts
@@ -5,9 +5,13 @@
  * including pre-compaction token counts per phase.
  */
 
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
-import { logToFile } from '../../../utils/debug';
-import { AgentSignals } from '../../agent/agent-interface';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
+import { logToFile } from '@utils/debug';
+import { AgentSignals } from '@lib/agent/agent-interface';
 
 export interface CompactionData {
   phaseCompactions: number;

--- a/src/lib/middleware/benchmarks/context-size-tracker.ts
+++ b/src/lib/middleware/benchmarks/context-size-tracker.ts
@@ -6,7 +6,11 @@
  * Context tokens in = previous phase's context tokens out.
  */
 
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
 import type { TokenData } from './token-tracker';
 
 export interface ContextSizeData {

--- a/src/lib/middleware/benchmarks/cost-tracker.ts
+++ b/src/lib/middleware/benchmarks/cost-tracker.ts
@@ -1,4 +1,8 @@
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
 import type { TokenData } from './token-tracker';
 import type { CacheData } from './cache-tracker';
 

--- a/src/lib/middleware/benchmarks/duration-tracker.ts
+++ b/src/lib/middleware/benchmarks/duration-tracker.ts
@@ -2,7 +2,11 @@
  * Duration tracking plugin (per-phase and total).
  */
 
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
 
 export interface DurationData {
   phaseSnapshots: Array<{

--- a/src/lib/middleware/benchmarks/index.ts
+++ b/src/lib/middleware/benchmarks/index.ts
@@ -5,8 +5,11 @@
  * from a BenchmarkConfig.
  */
 
-import type { Middleware, MiddlewareFactoryOptions } from '../types';
-import type { BenchmarkConfig } from '../config';
+import type {
+  Middleware,
+  MiddlewareFactoryOptions,
+} from '@lib/middleware/types';
+import type { BenchmarkConfig } from '@lib/middleware/config';
 import { TurnCounterPlugin } from './turn-counter';
 import { TokenTrackerPlugin } from './token-tracker';
 import { CacheTrackerPlugin } from './cache-tracker';

--- a/src/lib/middleware/benchmarks/json-writer.ts
+++ b/src/lib/middleware/benchmarks/json-writer.ts
@@ -6,10 +6,14 @@
  */
 
 import fs from 'fs';
-import { getUI } from '../../../ui';
-import { logToFile } from '../../../utils/debug';
-import { AgentSignals } from '../../agent/agent-interface';
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
+import { getUI } from '@ui';
+import { logToFile } from '@utils/debug';
+import { AgentSignals } from '@lib/agent/agent-interface';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
 import type { TokenData } from './token-tracker';
 import type { CacheData } from './cache-tracker';
 import type { TurnData } from './turn-counter';
@@ -17,7 +21,7 @@ import type { CostData } from './cost-tracker';
 import type { DurationData } from './duration-tracker';
 import type { CompactionData } from './compaction-tracker';
 import type { ContextSizeData } from './context-size-tracker';
-import type { BenchmarkData, StepUsage } from '../benchmark';
+import type { BenchmarkData, StepUsage } from '@lib/middleware/benchmark';
 
 /**
  * Sum token usage across all models from the SDK's modelUsage field.

--- a/src/lib/middleware/benchmarks/summary.ts
+++ b/src/lib/middleware/benchmarks/summary.ts
@@ -1,6 +1,10 @@
-import { getUI, type SpinnerHandle } from '../../../ui';
-import { AgentSignals } from '../../agent/agent-interface';
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
+import { getUI, type SpinnerHandle } from '@ui';
+import { AgentSignals } from '@lib/agent/agent-interface';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
 import type { TokenData } from './token-tracker';
 import type { TurnData } from './turn-counter';
 import type { CostData } from './cost-tracker';

--- a/src/lib/middleware/benchmarks/token-tracker.ts
+++ b/src/lib/middleware/benchmarks/token-tracker.ts
@@ -7,7 +7,11 @@
  * is tracked by CacheTrackerPlugin for reporting and pricing.
  */
 
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
 import type { TurnData } from './turn-counter';
 
 export interface TokenData {

--- a/src/lib/middleware/benchmarks/turn-counter.ts
+++ b/src/lib/middleware/benchmarks/turn-counter.ts
@@ -6,7 +6,11 @@
  * counts + a duplicate flag for downstream plugins.
  */
 
-import type { Middleware, MiddlewareContext, MiddlewareStore } from '../types';
+import type {
+  Middleware,
+  MiddlewareContext,
+  MiddlewareStore,
+} from '@lib/middleware/types';
 
 export interface TurnData {
   /** Whether the current message is a duplicate of the last processed turn */

--- a/src/lib/middleware/config.ts
+++ b/src/lib/middleware/config.ts
@@ -7,10 +7,10 @@
 
 import fs from 'fs';
 import path from 'path';
-import { logToFile } from '../../utils/debug';
-import { AgentSignals } from '../agent/agent-interface';
+import { logToFile } from '@utils/debug';
+import { AgentSignals } from '@lib/agent/agent-interface';
 import { runtimeEnv } from '@env';
-import { WIZARD_BENCHMARK_FILE, WIZARD_LOG_FILE } from '../../utils/paths';
+import { WIZARD_BENCHMARK_FILE, WIZARD_LOG_FILE } from '@utils/paths';
 
 export interface BenchmarkConfig {
   /** Enable/disable individual metric plugins */

--- a/src/lib/middleware/types.ts
+++ b/src/lib/middleware/types.ts
@@ -5,7 +5,7 @@
  * and can publish data to a shared store for downstream middleware to read.
  */
 
-import type { SpinnerHandle } from '../../ui';
+import type { SpinnerHandle } from '@ui';
 
 export type SDKMessage = any;
 

--- a/src/lib/programs/__tests__/agent-skill.test.ts
+++ b/src/lib/programs/__tests__/agent-skill.test.ts
@@ -2,9 +2,9 @@ import {
   createSkillProgram,
   AGENT_SKILL_STEPS,
   type SkillProgramOptions,
-} from '../agent-skill/index.js';
-import type { ProgramRun } from '../../agent/agent-runner.js';
-import { buildSession, RunPhase } from '../../wizard-session.js';
+} from '@lib/programs/agent-skill/index';
+import type { ProgramRun } from '@lib/agent/agent-runner';
+import { buildSession, RunPhase } from '@lib/wizard-session';
 
 const baseOpts: SkillProgramOptions = {
   skillId: 'error-tracking-setup',

--- a/src/lib/programs/__tests__/program-registry.test.ts
+++ b/src/lib/programs/__tests__/program-registry.test.ts
@@ -2,7 +2,7 @@ import {
   PROGRAM_REGISTRY,
   getProgramConfig,
   getSubcommandPrograms,
-} from '../program-registry.js';
+} from '@lib/programs/program-registry';
 
 describe('PROGRAM_REGISTRY', () => {
   it('every entry has unique id, description, and non-empty steps', () => {

--- a/src/lib/programs/__tests__/program-step.test.ts
+++ b/src/lib/programs/__tests__/program-step.test.ts
@@ -1,4 +1,7 @@
-import { createProgramSequence, type ProgramStep } from '../program-step.js';
+import {
+  createProgramSequence,
+  type ProgramStep,
+} from '@lib/programs/program-step';
 
 describe('createProgramSequence', () => {
   it('filters out headless steps and keeps only screen-bearing ones', () => {

--- a/src/lib/programs/__tests__/revenue-analytics-detect.test.ts
+++ b/src/lib/programs/__tests__/revenue-analytics-detect.test.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { detectRevenuePrerequisites } from '../revenue-analytics/index.js';
-import { buildSession } from '../../wizard-session.js';
+import { detectRevenuePrerequisites } from '@lib/programs/revenue-analytics/index';
+import { buildSession } from '@lib/wizard-session';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'rev-detect-'));

--- a/src/lib/programs/agent-skill/content/index.tsx
+++ b/src/lib/programs/agent-skill/content/index.tsx
@@ -5,9 +5,9 @@
  */
 
 import { Text } from 'ink';
-import type { WizardStore } from '../../../../ui/tui/store.js';
-import { TextRevealMode } from '../../../../ui/tui/primitives/TextBlock.js';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
+import type { WizardStore } from '@ui/tui/store';
+import { TextRevealMode } from '@ui/tui/primitives/TextBlock';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 export const getContentBlocks = (store?: WizardStore): ContentBlock[] => {
   const skillId = store?.session.skillId ?? 'unknown';

--- a/src/lib/programs/agent-skill/index.ts
+++ b/src/lib/programs/agent-skill/index.ts
@@ -19,8 +19,8 @@
  *   })
  */
 
-import type { ProgramConfig } from '../program-step.js';
-import type { ProgramRun, AbortCase } from '../../agent/agent-runner.js';
+import type { ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramRun, AbortCase } from '@lib/agent/agent-runner';
 import { AGENT_SKILL_STEPS } from './steps.js';
 import { getContentBlocks } from './content/index.js';
 

--- a/src/lib/programs/agent-skill/steps.ts
+++ b/src/lib/programs/agent-skill/steps.ts
@@ -5,8 +5,8 @@
  * No detection, no setup, no MCP.
  */
 
-import type { ProgramStep } from '../program-step.js';
-import { RunPhase } from '../../wizard-session.js';
+import type { ProgramStep } from '@lib/programs/program-step';
+import { RunPhase } from '@lib/wizard-session';
 
 export const AGENT_SKILL_STEPS: ProgramStep[] = [
   {

--- a/src/lib/programs/audit-3000/index.ts
+++ b/src/lib/programs/audit-3000/index.ts
@@ -1,18 +1,21 @@
 import fs from 'fs';
 import path from 'path';
-import { AGENT_SKILL_STEPS, createSkillProgram } from '../agent-skill/index.js';
-import type { ProgramStep, ProgramConfig } from '../program-step.js';
-import type { ProgramRun } from '../../agent/agent-runner.js';
-import type { WizardSession } from '../../wizard-session.js';
-import { WIZARD_TOOL_NAMES } from '../../wizard-tools.js';
-import { AUDIT_ABORT_CASES } from '../audit/detect.js';
+import {
+  AGENT_SKILL_STEPS,
+  createSkillProgram,
+} from '@lib/programs/agent-skill/index';
+import type { ProgramStep, ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramRun } from '@lib/agent/agent-runner';
+import type { WizardSession } from '@lib/wizard-session';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
+import { AUDIT_ABORT_CASES } from '@lib/programs/audit/detect';
 import {
   AUDIT_CHECKS_FILE,
   AUDIT_CHECKS_KEY,
   type AuditCheck,
-} from '../audit/types.js';
-import { AUDIT_SEED_CHECKS } from '../audit/seed.js';
-import { logToFile } from '../../../utils/debug';
+} from '@lib/programs/audit/types';
+import { AUDIT_SEED_CHECKS } from '@lib/programs/audit/seed';
+import { logToFile } from '@utils/debug';
 
 const AUDIT3000_REPORT_FILE = 'posthog-audit-3000-report.md';
 

--- a/src/lib/programs/audit/detect.ts
+++ b/src/lib/programs/audit/detect.ts
@@ -1,4 +1,4 @@
-import type { AbortCase } from '../../agent/agent-runner.js';
+import type { AbortCase } from '@lib/agent/agent-runner';
 
 /** `[ABORT] <reason>` cases the audit skill can emit. Reason strings are
  *  defined in the skill's `Abort statuses` section. */

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -1,8 +1,11 @@
-import { AGENT_SKILL_STEPS, createSkillProgram } from '../agent-skill/index.js';
-import type { ProgramStep, ProgramConfig } from '../program-step.js';
-import type { ProgramRun } from '../../agent/agent-runner.js';
-import type { WizardSession } from '../../wizard-session.js';
-import { WIZARD_TOOL_NAMES } from '../../wizard-tools.js';
+import {
+  AGENT_SKILL_STEPS,
+  createSkillProgram,
+} from '@lib/programs/agent-skill/index';
+import type { ProgramStep, ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramRun } from '@lib/agent/agent-runner';
+import type { WizardSession } from '@lib/wizard-session';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { AUDIT_ABORT_CASES } from './detect.js';
 import { AUDIT_CHECKS_KEY, AUDIT_REPORT_FILE } from './types.js';
 import { AUDIT_SEED_CHECKS, seedAuditLedger } from './seed.js';

--- a/src/lib/programs/audit/seed.ts
+++ b/src/lib/programs/audit/seed.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { logToFile } from '../../../utils/debug';
+import { logToFile } from '@utils/debug';
 import { AUDIT_CHECKS_FILE, type AuditCheck } from './types.js';
 
 /** The 10 data-integrity checks the audit runs. */

--- a/src/lib/programs/audit/types.ts
+++ b/src/lib/programs/audit/types.ts
@@ -1,4 +1,4 @@
-import type { WizardSession } from '../../wizard-session.js';
+import type { WizardSession } from '@lib/wizard-session';
 
 export type AuditStatus =
   | 'pending'

--- a/src/lib/programs/events-audit/index.ts
+++ b/src/lib/programs/events-audit/index.ts
@@ -1,14 +1,14 @@
-import type { ProgramConfig } from '../program-step.js';
-import type { ProgramRun } from '../../agent/agent-runner.js';
-import type { WizardSession } from '../../wizard-session.js';
-import { OutroKind } from '../../wizard-session.js';
-import { SPINNER_MESSAGE } from '../../framework-config.js';
-import { isUsingTypeScript } from '../../../utils/setup-utils.js';
-import { getCloudUrlFromRegion } from '../../../utils/urls.js';
-import { WIZARD_TOOL_NAMES } from '../../wizard-tools.js';
+import type { ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramRun } from '@lib/agent/agent-runner';
+import type { WizardSession } from '@lib/wizard-session';
+import { OutroKind } from '@lib/wizard-session';
+import { SPINNER_MESSAGE } from '@lib/framework-config';
+import { isUsingTypeScript } from '@utils/setup-utils';
+import { getCloudUrlFromRegion } from '@utils/urls';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { EVENTS_AUDIT_PROGRAM } from './steps.js';
-import { AUDIT_CHECKS_KEY } from '../audit/types.js';
-import { AUDIT_SEED_CHECKS, seedAuditLedger } from '../audit/seed.js';
+import { AUDIT_CHECKS_KEY } from '@lib/programs/audit/types';
+import { AUDIT_SEED_CHECKS, seedAuditLedger } from '@lib/programs/audit/seed';
 
 export const SETUP_REPORT_FILE = 'posthog-events-audit-report.md';
 

--- a/src/lib/programs/events-audit/steps.ts
+++ b/src/lib/programs/events-audit/steps.ts
@@ -8,15 +8,15 @@
  *     logic) instead of the integration intro.
  */
 
-import type { ProgramStep } from '../program-step.js';
-import type { WizardSession } from '../../wizard-session.js';
-import { RunPhase } from '../../wizard-session.js';
+import type { ProgramStep } from '@lib/programs/program-step';
+import type { WizardSession } from '@lib/wizard-session';
+import { RunPhase } from '@lib/wizard-session';
 import {
   evaluateWizardReadiness,
   WizardReadiness,
   SIGNUP_WIZARD_READINESS_CONFIG,
   getBlockingServiceKeys,
-} from '../../health-checks/readiness.js';
+} from '@lib/health-checks/readiness';
 
 function needsSetup(session: WizardSession): boolean {
   const config = session.frameworkConfig;

--- a/src/lib/programs/mcp/index.ts
+++ b/src/lib/programs/mcp/index.ts
@@ -7,7 +7,7 @@
  * every other program (no special-cases in screen-sequences.ts).
  */
 
-import type { ProgramConfig } from '../program-step.js';
+import type { ProgramConfig } from '@lib/programs/program-step';
 
 export const mcpAddConfig: ProgramConfig = {
   id: 'mcp-add',

--- a/src/lib/programs/migration/content/free-tier.tsx
+++ b/src/lib/programs/migration/content/free-tier.tsx
@@ -4,8 +4,8 @@
  */
 
 import { Text } from 'ink';
-import { Colors } from '../../../../ui/tui/styles.js';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
+import { Colors } from '@ui/tui/styles';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 export const FREE_TIER_BLOCK: ContentBlock = {
   type: 'lines',

--- a/src/lib/programs/migration/content/index.tsx
+++ b/src/lib/programs/migration/content/index.tsx
@@ -16,14 +16,14 @@
  */
 
 import { Text } from 'ink';
-import type { WizardStore } from '../../../../ui/tui/store.js';
-import { Colors } from '../../../../ui/tui/styles.js';
-import { TextRevealMode } from '../../../../ui/tui/primitives/TextBlock.js';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
-import { StatusPeekTrigger } from '../../../../ui/tui/components/StatusPeekTrigger.js';
-import { PRODUCT_SUITE_BLOCK } from '../../posthog-integration/content/product-suite.js';
-import { LINE_CHART_BLOCK } from '../../posthog-integration/content/line-chart.js';
-import { FUNNEL_BLOCK } from '../../posthog-integration/content/funnel.js';
+import type { WizardStore } from '@ui/tui/store';
+import { Colors } from '@ui/tui/styles';
+import { TextRevealMode } from '@ui/tui/primitives/TextBlock';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
+import { StatusPeekTrigger } from '@ui/tui/components/StatusPeekTrigger';
+import { PRODUCT_SUITE_BLOCK } from '@lib/programs/posthog-integration/content/product-suite';
+import { LINE_CHART_BLOCK } from '@lib/programs/posthog-integration/content/line-chart';
+import { FUNNEL_BLOCK } from '@lib/programs/posthog-integration/content/funnel';
 import { VENDOR_STACK_BLOCK } from './vendor-stack.js';
 import { FREE_TIER_BLOCK } from './free-tier.js';
 import { PRICING_STRUCTURE_BLOCK } from './pricing-structure.js';

--- a/src/lib/programs/migration/content/pricing-structure.tsx
+++ b/src/lib/programs/migration/content/pricing-structure.tsx
@@ -3,8 +3,8 @@
  */
 
 import { Text } from 'ink';
-import { Colors } from '../../../../ui/tui/styles.js';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
+import { Colors } from '@ui/tui/styles';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 export const PRICING_STRUCTURE_BLOCK: ContentBlock = {
   type: 'lines',

--- a/src/lib/programs/migration/content/vendor-stack.tsx
+++ b/src/lib/programs/migration/content/vendor-stack.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Text } from 'ink';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 export const VENDOR_STACK_BLOCK: ContentBlock = {
   type: 'lines',

--- a/src/lib/programs/migration/index.ts
+++ b/src/lib/programs/migration/index.ts
@@ -1,6 +1,6 @@
-import type { ProgramConfig } from '../program-step.js';
-import type { AbortCase } from '../../agent/agent-runner.js';
-import { WIZARD_TOOL_NAMES } from '../../wizard-tools.js';
+import type { ProgramConfig } from '@lib/programs/program-step';
+import type { AbortCase } from '@lib/agent/agent-runner';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { MIGRATION_PROGRAM } from './steps.js';
 import { getContentBlocks } from './content/index.js';
 

--- a/src/lib/programs/migration/steps.ts
+++ b/src/lib/programs/migration/steps.ts
@@ -1,5 +1,5 @@
-import type { ProgramStep } from '../program-step.js';
-import { RunPhase } from '../../wizard-session.js';
+import type { ProgramStep } from '@lib/programs/program-step';
+import { RunPhase } from '@lib/wizard-session';
 
 export const MIGRATION_PROGRAM: ProgramStep[] = [
   {

--- a/src/lib/programs/posthog-doctor/__tests__/doctor-schema.test.ts
+++ b/src/lib/programs/posthog-doctor/__tests__/doctor-schema.test.ts
@@ -1,9 +1,12 @@
-import { HealthIssueListResponseSchema, HealthIssueSchema } from '../types';
+import {
+  HealthIssueListResponseSchema,
+  HealthIssueSchema,
+} from '@lib/programs/posthog-doctor/types';
 import {
   getKindMeta,
   KIND_METADATA,
   UNKNOWN_KIND_META,
-} from '../kind-metadata';
+} from '@lib/programs/posthog-doctor/kind-metadata';
 
 describe('posthog-doctor schema', () => {
   const canned = {

--- a/src/lib/programs/posthog-doctor/fetch.ts
+++ b/src/lib/programs/posthog-doctor/fetch.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
-import { analytics } from '../../../utils/analytics';
-import { handleApiError } from '../../api';
-import { WIZARD_USER_AGENT } from '../../constants';
+import { analytics } from '@utils/analytics';
+import { handleApiError } from '@lib/api';
+import { WIZARD_USER_AGENT } from '@lib/constants';
 import { HealthIssueListResponseSchema, type HealthIssue } from './types';
 
 export async function fetchHealthIssues(

--- a/src/lib/programs/posthog-doctor/index.ts
+++ b/src/lib/programs/posthog-doctor/index.ts
@@ -1,5 +1,5 @@
-import type { ProgramConfig } from '../program-step.js';
-import { WIZARD_TOOL_NAMES } from '../../wizard-tools.js';
+import type { ProgramConfig } from '@lib/programs/program-step';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { POSTHOG_DOCTOR_PROGRAM } from './steps.js';
 
 export const posthogDoctorConfig: ProgramConfig = {

--- a/src/lib/programs/posthog-doctor/kind-metadata.ts
+++ b/src/lib/programs/posthog-doctor/kind-metadata.ts
@@ -1,4 +1,4 @@
-import { POSTHOG_DOCS_URL } from '../../constants';
+import { POSTHOG_DOCS_URL } from '@lib/constants';
 
 export interface KindMeta {
   title: string;

--- a/src/lib/programs/posthog-doctor/steps.ts
+++ b/src/lib/programs/posthog-doctor/steps.ts
@@ -1,4 +1,4 @@
-import type { ProgramStep } from '../program-step.js';
+import type { ProgramStep } from '@lib/programs/program-step';
 
 export const POSTHOG_DOCTOR_PROGRAM: ProgramStep[] = [
   {

--- a/src/lib/programs/posthog-integration/content/data-flow.tsx
+++ b/src/lib/programs/posthog-integration/content/data-flow.tsx
@@ -3,8 +3,8 @@
  */
 
 import { Text } from 'ink';
-import { Colors } from '../../../../ui/tui/styles.js';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
+import { Colors } from '@ui/tui/styles';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 export const POSTHOG_DATA_FLOW: ContentBlock = {
   type: 'lines',

--- a/src/lib/programs/posthog-integration/content/funnel.tsx
+++ b/src/lib/programs/posthog-integration/content/funnel.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Text } from 'ink';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 export const FUNNEL_BLOCK: ContentBlock = {
   type: 'lines',

--- a/src/lib/programs/posthog-integration/content/index.tsx
+++ b/src/lib/programs/posthog-integration/content/index.tsx
@@ -5,11 +5,11 @@
  */
 
 import { Text } from 'ink';
-import { Colors } from '../../../../ui/tui/styles.js';
-import type { WizardStore } from '../../../../ui/tui/store.js';
-import { TextRevealMode } from '../../../../ui/tui/primitives/TextBlock.js';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
-import { StatusPeekTrigger } from '../../../../ui/tui/components/StatusPeekTrigger.js';
+import { Colors } from '@ui/tui/styles';
+import type { WizardStore } from '@ui/tui/store';
+import { TextRevealMode } from '@ui/tui/primitives/TextBlock';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
+import { StatusPeekTrigger } from '@ui/tui/components/StatusPeekTrigger';
 import { POSTHOG_DATA_FLOW } from './data-flow.js';
 import { PRODUCT_SUITE_BLOCK } from './product-suite.js';
 import { LINE_CHART_BLOCK } from './line-chart.js';

--- a/src/lib/programs/posthog-integration/content/line-chart.tsx
+++ b/src/lib/programs/posthog-integration/content/line-chart.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Text } from 'ink';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 export const LINE_CHART_BLOCK: ContentBlock = {
   type: 'lines',

--- a/src/lib/programs/posthog-integration/content/product-suite.tsx
+++ b/src/lib/programs/posthog-integration/content/product-suite.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Text } from 'ink';
-import type { ContentBlock } from '../../../../ui/tui/primitives/content-types.js';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 export const PRODUCT_SUITE_BLOCK: ContentBlock = {
   type: 'lines',

--- a/src/lib/programs/posthog-integration/detect.ts
+++ b/src/lib/programs/posthog-integration/detect.ts
@@ -9,14 +9,14 @@
  * extracted here so the `integrate` subcommand can reuse it.
  */
 
-import type { ProgramReadyContext } from '../program-step.js';
-import { FRAMEWORK_REGISTRY } from '../../registry.js';
+import type { ProgramReadyContext } from '@lib/programs/program-step';
+import { FRAMEWORK_REGISTRY } from '@lib/registry';
 import {
   detectFramework,
   discoverFeatures,
   gatherFrameworkContext,
   checkFrameworkVersion,
-} from '../../detection/index.js';
+} from '@lib/detection/index';
 
 export async function detectPostHogIntegration(
   ctx: ProgramReadyContext,

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -1,24 +1,21 @@
 import opn from 'opn';
-import type { ProgramConfig } from '../program-step.js';
-import type { ProgramRun } from '../../agent/agent-runner.js';
-import { WIZARD_TOOL_NAMES } from '../../wizard-tools.js';
-import type { WizardSession } from '../../wizard-session.js';
-import { OutroKind } from '../../wizard-session.js';
-import { AgentSignals } from '../../agent/agent-interface.js';
+import type { ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramRun } from '@lib/agent/agent-runner';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
+import type { WizardSession } from '@lib/wizard-session';
+import { OutroKind } from '@lib/wizard-session';
+import { AgentSignals } from '@lib/agent/agent-interface';
 import {
   DEFAULT_PACKAGE_INSTALLATION,
   SPINNER_MESSAGE,
-} from '../../framework-config.js';
-import {
-  tryGetPackageJson,
-  isUsingTypeScript,
-} from '../../../utils/setup-utils.js';
-import { analytics } from '../../../utils/analytics.js';
-import { WIZARD_INTERACTION_EVENT_NAME } from '../../constants.js';
-import { getUI } from '../../../ui/index.js';
-import { getCloudUrlFromRegion } from '../../../utils/urls.js';
-import { requestDeepLink } from '../../../utils/provisioning.js';
-import type { CloudRegion } from '../../../utils/types.js';
+} from '@lib/framework-config';
+import { tryGetPackageJson, isUsingTypeScript } from '@utils/setup-utils';
+import { analytics } from '@utils/analytics';
+import { WIZARD_INTERACTION_EVENT_NAME } from '@lib/constants';
+import { getUI } from '@ui/index';
+import { getCloudUrlFromRegion } from '@utils/urls';
+import { requestDeepLink } from '@utils/provisioning';
+import type { CloudRegion } from '@utils/types';
 import { POSTHOG_INTEGRATION_PROGRAM } from './steps.js';
 import { getContentBlocks } from './content/index.js';
 
@@ -68,9 +65,7 @@ export const posthogIntegrationConfig: ProgramConfig = {
         installDir: session.installDir,
       });
       if (packageJson) {
-        const { hasPackageInstalled } = await import(
-          '../../../utils/package-json.js'
-        );
+        const { hasPackageInstalled } = await import('@utils/package-json');
         if (!hasPackageInstalled(config.detection.packageName, packageJson)) {
           getUI().log.warn(
             `${config.detection.packageDisplayName} does not seem to be installed. Continuing anyway — the agent will handle it.`,
@@ -172,7 +167,7 @@ Important: Use the detect_package_manager tool (from the wizard-tools MCP server
         );
         if (config.environment.uploadToHosting) {
           const { uploadEnvironmentVariablesStep } = await import(
-            '../../../steps/index.js'
+            '@steps/index'
           );
           const uploadedEnvVars = await uploadEnvironmentVariablesStep(
             envVars,

--- a/src/lib/programs/posthog-integration/steps.ts
+++ b/src/lib/programs/posthog-integration/steps.ts
@@ -6,15 +6,15 @@
  * definitions — no hardcoded per-flow logic in the store.
  */
 
-import type { ProgramStep } from '../program-step.js';
-import type { WizardSession } from '../../wizard-session.js';
-import { RunPhase } from '../../wizard-session.js';
+import type { ProgramStep } from '@lib/programs/program-step';
+import type { WizardSession } from '@lib/wizard-session';
+import { RunPhase } from '@lib/wizard-session';
 import {
   evaluateWizardReadiness,
   WizardReadiness,
   SIGNUP_WIZARD_READINESS_CONFIG,
   getBlockingServiceKeys,
-} from '../../health-checks/readiness.js';
+} from '@lib/health-checks/readiness';
 import { detectPostHogIntegration } from './detect.js';
 
 function needsSetup(session: WizardSession): boolean {

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -1,10 +1,10 @@
-import type { WizardSession, DiscoveredFeature } from '../wizard-session';
-import type { WizardReadinessResult } from '../health-checks/readiness.js';
-import type { ProgramRun } from '../agent/agent-runner.js';
-import type { Integration } from '../constants.js';
-import type { FrameworkConfig } from '../framework-config.js';
-import type { ContentBlock } from '../../ui/tui/primitives/index.js';
-import type { WizardStore } from '../../ui/tui/store.js';
+import type { WizardSession, DiscoveredFeature } from '@lib/wizard-session';
+import type { WizardReadinessResult } from '@lib/health-checks/readiness';
+import type { ProgramRun } from '@lib/agent/agent-runner';
+import type { Integration } from '@lib/constants';
+import type { FrameworkConfig } from '@lib/framework-config';
+import type { ContentBlock } from '@ui/tui/primitives/index';
+import type { WizardStore } from '@ui/tui/store';
 
 /**
  * A program step is the primary unit of the wizard's execution model.

--- a/src/lib/programs/revenue-analytics/content/index.tsx
+++ b/src/lib/programs/revenue-analytics/content/index.tsx
@@ -4,4 +4,4 @@
  * revenue narrative grows its own diagrams or talking points.
  */
 
-export { getContentBlocks } from '../../agent-skill/content/index.js';
+export { getContentBlocks } from '@lib/programs/agent-skill/content/index';

--- a/src/lib/programs/revenue-analytics/detect.ts
+++ b/src/lib/programs/revenue-analytics/detect.ts
@@ -8,9 +8,9 @@
 import type { Dirent } from 'fs';
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { join, relative } from 'path';
-import { IGNORED_DIRS } from '../../../utils/file-utils.js';
-import type { WizardSession } from '../../wizard-session.js';
-import type { AbortCase } from '../../agent/agent-runner.js';
+import { IGNORED_DIRS } from '@utils/file-utils';
+import type { WizardSession } from '@lib/wizard-session';
+import type { AbortCase } from '@lib/agent/agent-runner';
 
 export const POSTHOG_SDKS = [
   'posthog-js',

--- a/src/lib/programs/revenue-analytics/index.ts
+++ b/src/lib/programs/revenue-analytics/index.ts
@@ -1,5 +1,5 @@
-import type { ProgramConfig } from '../program-step.js';
-import { WIZARD_TOOL_NAMES } from '../../wizard-tools.js';
+import type { ProgramConfig } from '@lib/programs/program-step';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { REVENUE_ANALYTICS_PROGRAM } from './steps.js';
 import { REVENUE_ABORT_CASES } from './detect.js';
 import { getContentBlocks } from './content/index.js';

--- a/src/lib/programs/revenue-analytics/steps.ts
+++ b/src/lib/programs/revenue-analytics/steps.ts
@@ -5,8 +5,8 @@
  * and agent run live in the program runner (see agent-runner.ts).
  */
 
-import type { ProgramStep } from '../program-step.js';
-import { RunPhase } from '../../wizard-session.js';
+import type { ProgramStep } from '@lib/programs/program-step';
+import { RunPhase } from '@lib/wizard-session';
 import { detectRevenuePrerequisites } from './detect.js';
 
 export const REVENUE_ANALYTICS_PROGRAM: ProgramStep[] = [

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,26 +1,26 @@
 import type { FrameworkConfig } from './framework-config';
 import { Integration } from './constants';
-import { NEXTJS_AGENT_CONFIG } from '../frameworks/nextjs/nextjs-wizard-agent';
-import { NUXT_AGENT_CONFIG } from '../frameworks/nuxt/nuxt-wizard-agent';
-import { VUE_AGENT_CONFIG } from '../frameworks/vue/vue-wizard-agent';
-import { REACT_ROUTER_AGENT_CONFIG } from '../frameworks/react-router/react-router-wizard-agent';
-import { TANSTACK_ROUTER_AGENT_CONFIG } from '../frameworks/tanstack-router/tanstack-router-wizard-agent';
-import { TANSTACK_START_AGENT_CONFIG } from '../frameworks/tanstack-start/tanstack-start-wizard-agent';
-import { REACT_NATIVE_AGENT_CONFIG } from '../frameworks/react-native/react-native-wizard-agent';
-import { ANGULAR_AGENT_CONFIG } from '../frameworks/angular/angular-wizard-agent';
-import { ASTRO_AGENT_CONFIG } from '../frameworks/astro/astro-wizard-agent';
-import { DJANGO_AGENT_CONFIG } from '../frameworks/django/django-wizard-agent';
-import { FLASK_AGENT_CONFIG } from '../frameworks/flask/flask-wizard-agent';
-import { FASTAPI_AGENT_CONFIG } from '../frameworks/fastapi/fastapi-wizard-agent';
-import { LARAVEL_AGENT_CONFIG } from '../frameworks/laravel/laravel-wizard-agent';
-import { SVELTEKIT_AGENT_CONFIG } from '../frameworks/svelte/svelte-wizard-agent';
-import { SWIFT_AGENT_CONFIG } from '../frameworks/swift/swift-wizard-agent';
-import { ANDROID_AGENT_CONFIG } from '../frameworks/android/android-wizard-agent';
-import { RAILS_AGENT_CONFIG } from '../frameworks/rails/rails-wizard-agent';
-import { PYTHON_AGENT_CONFIG } from '../frameworks/python/python-wizard-agent';
-import { RUBY_AGENT_CONFIG } from '../frameworks/ruby/ruby-wizard-agent';
-import { JAVASCRIPT_NODE_AGENT_CONFIG } from '../frameworks/javascript-node/javascript-node-wizard-agent';
-import { JAVASCRIPT_WEB_AGENT_CONFIG } from '../frameworks/javascript-web/javascript-web-wizard-agent';
+import { NEXTJS_AGENT_CONFIG } from '@frameworks/nextjs/nextjs-wizard-agent';
+import { NUXT_AGENT_CONFIG } from '@frameworks/nuxt/nuxt-wizard-agent';
+import { VUE_AGENT_CONFIG } from '@frameworks/vue/vue-wizard-agent';
+import { REACT_ROUTER_AGENT_CONFIG } from '@frameworks/react-router/react-router-wizard-agent';
+import { TANSTACK_ROUTER_AGENT_CONFIG } from '@frameworks/tanstack-router/tanstack-router-wizard-agent';
+import { TANSTACK_START_AGENT_CONFIG } from '@frameworks/tanstack-start/tanstack-start-wizard-agent';
+import { REACT_NATIVE_AGENT_CONFIG } from '@frameworks/react-native/react-native-wizard-agent';
+import { ANGULAR_AGENT_CONFIG } from '@frameworks/angular/angular-wizard-agent';
+import { ASTRO_AGENT_CONFIG } from '@frameworks/astro/astro-wizard-agent';
+import { DJANGO_AGENT_CONFIG } from '@frameworks/django/django-wizard-agent';
+import { FLASK_AGENT_CONFIG } from '@frameworks/flask/flask-wizard-agent';
+import { FASTAPI_AGENT_CONFIG } from '@frameworks/fastapi/fastapi-wizard-agent';
+import { LARAVEL_AGENT_CONFIG } from '@frameworks/laravel/laravel-wizard-agent';
+import { SVELTEKIT_AGENT_CONFIG } from '@frameworks/svelte/svelte-wizard-agent';
+import { SWIFT_AGENT_CONFIG } from '@frameworks/swift/swift-wizard-agent';
+import { ANDROID_AGENT_CONFIG } from '@frameworks/android/android-wizard-agent';
+import { RAILS_AGENT_CONFIG } from '@frameworks/rails/rails-wizard-agent';
+import { PYTHON_AGENT_CONFIG } from '@frameworks/python/python-wizard-agent';
+import { RUBY_AGENT_CONFIG } from '@frameworks/ruby/ruby-wizard-agent';
+import { JAVASCRIPT_NODE_AGENT_CONFIG } from '@frameworks/javascript-node/javascript-node-wizard-agent';
+import { JAVASCRIPT_WEB_AGENT_CONFIG } from '@frameworks/javascript-web/javascript-web-wizard-agent';
 
 export const FRAMEWORK_REGISTRY: Record<Integration, FrameworkConfig> = {
   [Integration.nextjs]: NEXTJS_AGENT_CONFIG,

--- a/src/lib/task-stream/__tests__/task-stream-push.test.ts
+++ b/src/lib/task-stream/__tests__/task-stream-push.test.ts
@@ -1,8 +1,11 @@
-import { TaskStreamPush } from '../task-stream-push';
-import { StreamEvent } from '../types';
-import type { TaskStreamDestination, TaskStreamUpdate } from '../types';
-import type { WizardStore, TaskItem } from '../../../ui/tui/store';
-import { RunPhase } from '../../wizard-session';
+import { TaskStreamPush } from '@lib/task-stream/task-stream-push';
+import { StreamEvent } from '@lib/task-stream/types';
+import type {
+  TaskStreamDestination,
+  TaskStreamUpdate,
+} from '@lib/task-stream/types';
+import type { WizardStore, TaskItem } from '@ui/tui/store';
+import { RunPhase } from '@lib/wizard-session';
 
 // Mocks and stuff
 

--- a/src/lib/task-stream/destinations/file.ts
+++ b/src/lib/task-stream/destinations/file.ts
@@ -3,8 +3,8 @@ import type {
   TaskStreamDestination,
   TaskStreamUpdate,
   StreamEvent,
-} from '../types';
-import { WIZARD_TASK_STREAM_LOG } from '../../../utils/paths';
+} from '@lib/task-stream/types';
+import { WIZARD_TASK_STREAM_LOG } from '@utils/paths';
 
 export class FileDestination implements TaskStreamDestination {
   readonly name = 'file';

--- a/src/lib/task-stream/destinations/posthog.ts
+++ b/src/lib/task-stream/destinations/posthog.ts
@@ -2,7 +2,7 @@ import type {
   TaskStreamDestination,
   TaskStreamUpdate,
   StreamEvent,
-} from '../types';
+} from '@lib/task-stream/types';
 
 export class PostHogDestination implements TaskStreamDestination {
   readonly name = 'posthog';

--- a/src/lib/task-stream/task-stream-push.ts
+++ b/src/lib/task-stream/task-stream-push.ts
@@ -3,9 +3,9 @@
  * and fans out async to all registered destinations.
  */
 
-import type { WizardStore, TaskItem } from '../../ui/tui/store';
-import { TaskStatus } from '../../ui/wizard-ui';
-import { RunPhase } from '../wizard-session';
+import type { WizardStore, TaskItem } from '@ui/tui/store';
+import { TaskStatus } from '@ui/wizard-ui';
+import { RunPhase } from '@lib/wizard-session';
 import {
   type TaskStreamDestination,
   type TaskStreamUpdate,

--- a/src/lib/task-stream/types.ts
+++ b/src/lib/task-stream/types.ts
@@ -7,7 +7,7 @@
  * transport with a different program_id / skill_id pair.
  */
 
-import type { RunPhase } from '../wizard-session';
+import type { RunPhase } from '@lib/wizard-session';
 
 export enum StreamTaskStatus {
   Pending = 'pending',

--- a/src/lib/wizard-ask-bridge.ts
+++ b/src/lib/wizard-ask-bridge.ts
@@ -12,7 +12,7 @@
  */
 import { randomUUID } from 'crypto';
 
-import { analytics } from '../utils/analytics';
+import { analytics } from '@utils/analytics';
 import type {
   AskAnswers,
   AskQuestion,

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -13,9 +13,9 @@ import path from 'path';
 import fs from 'fs';
 import { execFileSync } from 'child_process';
 import { z } from 'zod';
-import { logToFile } from '../utils/debug';
-import { analytics } from '../utils/analytics';
-import { skillTmpPath } from '../utils/paths';
+import { logToFile } from '@utils/debug';
+import { analytics } from '@utils/analytics';
+import { skillTmpPath } from '@utils/paths';
 import type { PackageManagerDetector } from './detection/package-manager';
 import {
   AUDIT_CHECKS_FILE,

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -16,8 +16,8 @@ import path from 'path';
 import fg from 'fast-glob';
 import { scan, scanSkillDirectory } from './yara-scanner';
 import type { YaraMatch, ScanResult } from './yara-scanner';
-import { logToFile } from '../utils/debug';
-import { analytics } from '../utils/analytics';
+import { logToFile } from '@utils/debug';
+import { analytics } from '@utils/analytics';
 import { isSkillInstallCommand } from './skill-install';
 
 // ─── Types ───────────────────────────────────────────────────────
@@ -105,7 +105,7 @@ export function formatScanReport(): string | null {
   return lines.join('\n');
 }
 
-import { WIZARD_YARA_REPORT_FILE } from '../utils/paths';
+import { WIZARD_YARA_REPORT_FILE } from '@utils/paths';
 
 /** Write the scan report to a JSON file. Returns the file path, or null if no scans occurred. */
 export function writeScanReport(): string | null {

--- a/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
@@ -2,7 +2,7 @@ import {
   buildMCPUrl,
   getDefaultServerConfig,
   getNativeHTTPServerConfig,
-} from '../defaults';
+} from '@steps/add-mcp-server-to-clients/defaults';
 
 describe('defaults', () => {
   describe('buildMCPUrl', () => {

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -1,4 +1,4 @@
-import { ClaudeCodeMCPClient } from '../claude-code';
+import { ClaudeCodeMCPClient } from '@steps/add-mcp-server-to-clients/clients/claude-code';
 
 jest.mock('child_process', () => ({
   execSync: jest.fn(),
@@ -18,7 +18,7 @@ jest.mock('../../../../utils/debug', () => ({
 
 describe('ClaudeCodeMCPClient — plugin methods', () => {
   const { execSync } = require('child_process');
-  const { analytics } = require('../../../../utils/analytics');
+  const { analytics } = require('@utils/analytics');
   const execSyncMock = execSync as jest.Mock;
 
   beforeEach(() => {

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
@@ -2,8 +2,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { ClaudeMCPClient } from '../claude';
-import { getDefaultServerConfig } from '../../defaults';
+import { ClaudeMCPClient } from '@steps/add-mcp-server-to-clients/clients/claude';
+import { getDefaultServerConfig } from '@steps/add-mcp-server-to-clients/defaults';
 
 jest.mock('fs', () => ({
   promises: {
@@ -51,7 +51,9 @@ describe('ClaudeMCPClient', () => {
     getDefaultServerConfigMock.mockReturnValue(mockServerConfig);
 
     // Mock the Zod schema parse method
-    const { DefaultMCPClientConfig } = require('../../defaults');
+    const {
+      DefaultMCPClientConfig,
+    } = require('@steps/add-mcp-server-to-clients/defaults');
     DefaultMCPClientConfig.parse.mockImplementation((data: any) => data);
   });
 

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -1,4 +1,4 @@
-import { CodexMCPClient } from '../codex';
+import { CodexMCPClient } from '@steps/add-mcp-server-to-clients/clients/codex';
 
 jest.mock('node:child_process', () => ({
   execSync: jest.fn(),
@@ -18,7 +18,7 @@ jest.mock('../../../../utils/analytics', () => ({
 describe('CodexMCPClient', () => {
   const { execSync, spawnSync } = require('node:child_process');
   const fs = require('node:fs');
-  const analytics = require('../../../../utils/analytics').analytics;
+  const analytics = require('@utils/analytics').analytics;
 
   const spawnSyncMock = spawnSync as jest.Mock;
   const execSyncMock = execSync as jest.Mock;

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -1,10 +1,13 @@
-import { DefaultMCPClient } from '../MCPClient';
-import { DefaultMCPClientConfig } from '../defaults';
-import { PluginCapable, PluginInstallResult } from '../plugin-client';
+import { DefaultMCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
+import { DefaultMCPClientConfig } from '@steps/add-mcp-server-to-clients/defaults';
+import {
+  PluginCapable,
+  PluginInstallResult,
+} from '@steps/add-mcp-server-to-clients/plugin-client';
 import { z } from 'zod';
 import { execSync } from 'child_process';
-import { analytics } from '../../../utils/analytics';
-import { debug } from '../../../utils/debug';
+import { analytics } from '@utils/analytics';
+import { debug } from '@utils/debug';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';

--- a/src/steps/add-mcp-server-to-clients/clients/claude.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude.ts
@@ -1,7 +1,7 @@
-import { DefaultMCPClient } from '../MCPClient';
+import { DefaultMCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
 import * as path from 'path';
 import * as os from 'os';
-import { DefaultMCPClientConfig } from '../defaults';
+import { DefaultMCPClientConfig } from '@steps/add-mcp-server-to-clients/defaults';
 import { runtimeEnv } from '@env';
 import { z } from 'zod';
 

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -4,11 +4,14 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { DefaultMCPClient } from '../MCPClient';
-import { DefaultMCPClientConfig } from '../defaults';
-import { PluginCapable, PluginInstallResult } from '../plugin-client';
+import { DefaultMCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
+import { DefaultMCPClientConfig } from '@steps/add-mcp-server-to-clients/defaults';
+import {
+  PluginCapable,
+  PluginInstallResult,
+} from '@steps/add-mcp-server-to-clients/plugin-client';
 
-import { analytics } from '../../../utils/analytics';
+import { analytics } from '@utils/analytics';
 
 export const CodexMCPConfig = DefaultMCPClientConfig;
 

--- a/src/steps/add-mcp-server-to-clients/clients/cursor.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/cursor.ts
@@ -1,7 +1,13 @@
-import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
+import {
+  DefaultMCPClient,
+  MCPServerConfig,
+} from '@steps/add-mcp-server-to-clients/MCPClient';
 import * as path from 'path';
 import * as os from 'os';
-import { DefaultMCPClientConfig, getNativeHTTPServerConfig } from '../defaults';
+import {
+  DefaultMCPClientConfig,
+  getNativeHTTPServerConfig,
+} from '@steps/add-mcp-server-to-clients/defaults';
 import { z } from 'zod';
 
 export const CursorMCPConfig = DefaultMCPClientConfig;

--- a/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
@@ -1,8 +1,11 @@
 import z from 'zod';
 import * as path from 'path';
 import * as os from 'os';
-import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
-import { getNativeHTTPServerConfig } from '../defaults';
+import {
+  DefaultMCPClient,
+  MCPServerConfig,
+} from '@steps/add-mcp-server-to-clients/MCPClient';
+import { getNativeHTTPServerConfig } from '@steps/add-mcp-server-to-clients/defaults';
 import { runtimeEnv } from '@env';
 
 export const VisualStudioCodeMCPConfig = z

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -1,8 +1,11 @@
 import z from 'zod';
 import * as path from 'path';
 import * as os from 'os';
-import { DefaultMCPClient, MCPServerConfig } from '../MCPClient';
-import { getNativeHTTPServerConfig } from '../defaults';
+import {
+  DefaultMCPClient,
+  MCPServerConfig,
+} from '@steps/add-mcp-server-to-clients/MCPClient';
+import { getNativeHTTPServerConfig } from '@steps/add-mcp-server-to-clients/defaults';
 import { runtimeEnv } from '@env';
 
 export const ZedMCPConfig = z

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -1,8 +1,8 @@
-import type { Integration } from '../../lib/constants';
-import type { CloudRegion } from '../../utils/types';
+import type { Integration } from '@lib/constants';
+import type { CloudRegion } from '@utils/types';
 import { withProgress } from '../../telemetry';
-import { analytics } from '../../utils/analytics';
-import { getUI } from '../../ui';
+import { analytics } from '@utils/analytics';
+import { getUI } from '@ui';
 import { MCPClient } from './MCPClient';
 import { CursorMCPClient } from './clients/cursor';
 import { ClaudeCodeMCPClient } from './clients/claude-code';
@@ -10,7 +10,7 @@ import { VisualStudioCodeClient } from './clients/visual-studio-code';
 import { ZedClient } from './clients/zed';
 import { CodexMCPClient } from './clients/codex';
 import { ALL_FEATURE_VALUES } from './defaults';
-import { debug } from '../../utils/debug';
+import { debug } from '@utils/debug';
 import { isPluginCapable, PluginCapable } from './plugin-client';
 
 export const getSupportedClients = async (): Promise<MCPClient[]> => {

--- a/src/steps/add-or-update-environment-variables.ts
+++ b/src/steps/add-or-update-environment-variables.ts
@@ -1,8 +1,8 @@
-import type { Integration } from '../lib/constants';
+import type { Integration } from '@lib/constants';
 import { withProgress } from '../telemetry';
-import { analytics } from '../utils/analytics';
-import { getUI } from '../ui';
-import { getDotGitignore } from '../utils/file-utils';
+import { analytics } from '@utils/analytics';
+import { getUI } from '@ui';
+import { getDotGitignore } from '@utils/file-utils';
 import * as fs from 'fs';
 import path from 'path';
 

--- a/src/steps/run-prettier.ts
+++ b/src/steps/run-prettier.ts
@@ -1,14 +1,14 @@
-import type { Integration } from '../lib/constants';
+import type { Integration } from '@lib/constants';
 import { withProgress } from '../telemetry';
-import { analytics } from '../utils/analytics';
-import { getUI } from '../ui';
+import { analytics } from '@utils/analytics';
+import { getUI } from '@ui';
 import {
   tryGetPackageJson,
   getUncommittedOrUntrackedFiles,
   isInGitRepo,
-} from '../utils/setup-utils';
-import { hasPackageInstalled } from '../utils/package-json';
-import type { WizardOptions } from '../utils/types';
+} from '@utils/setup-utils';
+import { hasPackageInstalled } from '@utils/package-json';
+import type { WizardOptions } from '@utils/types';
 import * as childProcess from 'node:child_process';
 
 export async function runPrettierStep({

--- a/src/steps/upload-environment-variables/index.ts
+++ b/src/steps/upload-environment-variables/index.ts
@@ -1,8 +1,8 @@
-import type { Integration } from '../../lib/constants';
+import type { Integration } from '@lib/constants';
 import { withProgress } from '../../telemetry';
-import { analytics } from '../../utils/analytics';
-import { getUI } from '../../ui';
-import type { WizardSession } from '../../lib/wizard-session';
+import { analytics } from '@utils/analytics';
+import { getUI } from '@ui';
+import type { WizardSession } from '@lib/wizard-session';
 import { EnvironmentProvider } from './EnvironmentProvider';
 import { VercelEnvironmentProvider } from './providers/vercel';
 

--- a/src/steps/upload-environment-variables/providers/__tests__/vercel.test.ts
+++ b/src/steps/upload-environment-variables/providers/__tests__/vercel.test.ts
@@ -1,4 +1,4 @@
-import { VercelEnvironmentProvider } from '../vercel';
+import { VercelEnvironmentProvider } from '@steps/upload-environment-variables/providers/vercel';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
 

--- a/src/steps/upload-environment-variables/providers/vercel.ts
+++ b/src/steps/upload-environment-variables/providers/vercel.ts
@@ -1,9 +1,9 @@
 import { execSync, spawn, spawnSync } from 'child_process';
-import { EnvironmentProvider } from '../EnvironmentProvider';
+import { EnvironmentProvider } from '@steps/upload-environment-variables/EnvironmentProvider';
 import * as fs from 'fs';
 import * as path from 'path';
-import { getUI } from '../../../ui';
-import { analytics } from '../../../utils/analytics';
+import { getUI } from '@ui';
+import { analytics } from '@utils/analytics';
 
 export class VercelEnvironmentProvider extends EnvironmentProvider {
   name = 'Vercel';

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,4 +1,4 @@
-import { analytics } from './utils/analytics';
+import { analytics } from '@utils/analytics';
 
 export function withProgress<T>(step: string, callback: () => T): T {
   updateProgress(step);

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -10,17 +10,17 @@ import {
   type SpinnerHandle,
   type AuthErrorDetail,
 } from './wizard-ui';
-import type { SettingsConflict } from '../lib/agent/agent-interface';
+import type { SettingsConflict } from '@lib/agent/agent-interface';
 import {
   type WizardReadinessResult,
   getBlockingServiceKeys,
   SERVICE_LABELS,
-} from '../lib/health-checks/readiness.js';
+} from '@lib/health-checks/readiness';
 import type {
   AskAnswers,
   OutroData,
   PendingQuestion,
-} from '../lib/wizard-session';
+} from '@lib/wizard-session';
 
 export class LoggingUI implements WizardUI {
   intro(message: string): void {

--- a/src/ui/tui/__tests__/keyboard-hints.test.ts
+++ b/src/ui/tui/__tests__/keyboard-hints.test.ts
@@ -5,7 +5,7 @@ import {
   deduplicateAndSort,
   KeyMatch,
   type KeyboardHint,
-} from '../hooks/keyboard-hints-utils.js';
+} from '@ui/tui/hooks/keyboard-hints-utils';
 
 /** Helper to create a key flags object with all booleans false by default. */
 function makeKey(

--- a/src/ui/tui/__tests__/layout-helpers.test.ts
+++ b/src/ui/tui/__tests__/layout-helpers.test.ts
@@ -1,8 +1,8 @@
 import {
   estimateBlockHeight,
   computeVisibleRange,
-} from '../primitives/layout-helpers.js';
-import type { ContentBlock } from '../primitives/content-types.js';
+} from '@ui/tui/primitives/layout-helpers';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
 
 describe('estimateBlockHeight', () => {
   it('counts wrapped lines for a short string that fits in one line', () => {

--- a/src/ui/tui/__tests__/mcp-installer.test.ts
+++ b/src/ui/tui/__tests__/mcp-installer.test.ts
@@ -1,4 +1,4 @@
-import { createMcpInstaller } from '../services/mcp-installer';
+import { createMcpInstaller } from '@ui/tui/services/mcp-installer';
 
 jest.mock('../../../steps/add-mcp-server-to-clients/index.js', () => ({
   getSupportedClients: jest.fn(),
@@ -22,9 +22,9 @@ jest.mock('../../../utils/analytics.js', () => ({
 
 describe('createMcpInstaller — installPlugins', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const mcpModule = require('../../../steps/add-mcp-server-to-clients/index.js');
+  const mcpModule = require('@steps/add-mcp-server-to-clients/index');
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { analytics } = require('../../../utils/analytics.js');
+  const { analytics } = require('@utils/analytics');
 
   const mockClaudeClient = { name: 'Claude Code' };
   const mockCursorClient = { name: 'Cursor' };

--- a/src/ui/tui/__tests__/programs.test.ts
+++ b/src/ui/tui/__tests__/programs.test.ts
@@ -1,10 +1,7 @@
-import { buildSession, RunPhase } from '../../../lib/wizard-session.js';
-import { WizardReadiness } from '../../../lib/health-checks/readiness.js';
-import { PROGRAM_SEQUENCES, ScreenId } from '../screen-sequences.js';
-import {
-  Program,
-  type ProgramId,
-} from '../../../lib/programs/program-registry.js';
+import { buildSession, RunPhase } from '@lib/wizard-session';
+import { WizardReadiness } from '@lib/health-checks/readiness';
+import { PROGRAM_SEQUENCES, ScreenId } from '@ui/tui/screen-sequences';
+import { Program, type ProgramId } from '@lib/programs/program-registry';
 
 function getEntry(program: ProgramId, id: ScreenId) {
   const entry = PROGRAM_SEQUENCES[program].find(

--- a/src/ui/tui/__tests__/router.test.ts
+++ b/src/ui/tui/__tests__/router.test.ts
@@ -1,6 +1,6 @@
-import { buildSession, RunPhase } from '../../../lib/wizard-session.js';
-import { WizardReadiness } from '../../../lib/health-checks/readiness.js';
-import { WizardRouter, ScreenId, Overlay, Program } from '../router.js';
+import { buildSession, RunPhase } from '@lib/wizard-session';
+import { WizardReadiness } from '@lib/health-checks/readiness';
+import { WizardRouter, ScreenId, Overlay, Program } from '@ui/tui/router';
 
 function baseWizardSession() {
   return buildSession({});

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -7,15 +7,15 @@ import {
   Overlay,
   RunPhase,
   McpOutcome,
-} from '../store.js';
-import { OutroKind, AdditionalFeature } from '../../../lib/wizard-session.js';
+} from '@ui/tui/store';
+import { OutroKind, AdditionalFeature } from '@lib/wizard-session';
 import {
   WizardReadiness,
   evaluateWizardReadiness,
-} from '../../../lib/health-checks/readiness.js';
-import { buildSession } from '../../../lib/wizard-session.js';
-import { Integration } from '../../../lib/constants.js';
-import { analytics } from '../../../utils/analytics.js';
+} from '@lib/health-checks/readiness';
+import { buildSession } from '@lib/wizard-session';
+import { Integration } from '@lib/constants';
+import { analytics } from '@utils/analytics';
 
 jest.mock('../../../utils/analytics.js', () => ({
   analytics: {

--- a/src/ui/tui/components/LearnCard.tsx
+++ b/src/ui/tui/components/LearnCard.tsx
@@ -8,12 +8,12 @@
  */
 
 import { Box, Text } from 'ink';
-import { Colors } from '../styles.js';
-import type { WizardStore } from '../store.js';
-import { ContentSequencer, TextRevealMode } from '../primitives/index.js';
-import type { ContentBlock } from '../primitives/index.js';
-import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
-import { COLLAPSED_COUNT, EXPANDED_COUNT } from '../primitives/TabContainer.js';
+import { Colors } from '@ui/tui/styles';
+import type { WizardStore } from '@ui/tui/store';
+import { ContentSequencer, TextRevealMode } from '@ui/tui/primitives/index';
+import type { ContentBlock } from '@ui/tui/primitives/index';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
+import { COLLAPSED_COUNT, EXPANDED_COUNT } from '@ui/tui/primitives/TabContainer';
 
 /** Fixed chrome: ScreenContainer (3) + TabContainer tab bar (2) */
 const FIXED_CHROME = 5;

--- a/src/ui/tui/components/ServiceHealthList.tsx
+++ b/src/ui/tui/components/ServiceHealthList.tsx
@@ -11,9 +11,9 @@ import {
   type ComponentHealthResult,
   type ComponentStatus,
   type HealthCheckKey,
-} from '../../../lib/health-checks/types.js';
-import { SERVICE_LABELS } from '../../../lib/health-checks/readiness.js';
-import { Icons } from '../styles.js';
+} from '@lib/health-checks/types';
+import { SERVICE_LABELS } from '@lib/health-checks/readiness';
+import { Icons } from '@ui/tui/styles';
 
 /** Keys that are component-level detail — shown inline under their parent. */
 const COMPONENT_KEYS: HealthCheckKey[] = [

--- a/src/ui/tui/components/StatusPeekTrigger.tsx
+++ b/src/ui/tui/components/StatusPeekTrigger.tsx
@@ -7,7 +7,7 @@
 
 import { Text } from 'ink';
 import { useEffect } from 'react';
-import type { WizardStore } from '../store.js';
+import type { WizardStore } from '@ui/tui/store';
 
 let peekedOnce = false;
 

--- a/src/ui/tui/components/TipsCard.tsx
+++ b/src/ui/tui/components/TipsCard.tsx
@@ -5,12 +5,12 @@
  */
 
 import { Box, Text, useInput } from 'ink';
-import type { WizardStore } from '../store.js';
-import { Colors, Icons } from '../styles.js';
+import type { WizardStore } from '@ui/tui/store';
+import { Colors, Icons } from '@ui/tui/styles';
 import {
   DiscoveredFeature,
   AdditionalFeature,
-} from '../../../lib/wizard-session.js';
+} from '@lib/wizard-session';
 
 /** A discrete tip shown in the TipsCard during the agent run. */
 interface Tip {

--- a/src/ui/tui/components/TitleBar.tsx
+++ b/src/ui/tui/components/TitleBar.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'ink';
-import { Colors } from '../styles.js';
+import { Colors } from '@ui/tui/styles';
 
 const FEEDBACK = 'Feedback: wizard@posthog.com ';
 const FEEDBACK_SHORT = ' wizard@posthog.com ';

--- a/src/ui/tui/hooks/__tests__/file-watcher.test.ts
+++ b/src/ui/tui/hooks/__tests__/file-watcher.test.ts
@@ -1,7 +1,10 @@
 import { mkdtempSync, rmSync, writeFileSync, renameSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
-import { startFileWatcher, type FileWatcherHandle } from '../file-watcher.js';
+import {
+  startFileWatcher,
+  type FileWatcherHandle,
+} from '@ui/tui/hooks/file-watcher';
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -6,16 +6,16 @@
  * The router derives the active screen from session state.
  */
 
-import type { WizardUI, SpinnerHandle, AuthErrorDetail } from '../wizard-ui.js';
+import type { WizardUI, SpinnerHandle, AuthErrorDetail } from '@ui/wizard-ui';
 import type { WizardStore } from './store.js';
-import type { SettingsConflict } from '../../lib/agent/agent-interface.js';
-import type { WizardReadinessResult } from '../../lib/health-checks/readiness.js';
+import type { SettingsConflict } from '@lib/agent/agent-interface';
+import type { WizardReadinessResult } from '@lib/health-checks/readiness';
 import type {
   AskAnswers,
   OutroData,
   PendingQuestion,
-} from '../../lib/wizard-session.js';
-import { RunPhase, OutroKind } from '../../lib/wizard-session.js';
+} from '@lib/wizard-session';
+import { RunPhase, OutroKind } from '@lib/wizard-session';
 
 // Strip ANSI escape codes (chalk formatting) from strings
 // eslint-disable-next-line no-control-regex

--- a/src/ui/tui/playground/PlaygroundApp.tsx
+++ b/src/ui/tui/playground/PlaygroundApp.tsx
@@ -5,8 +5,8 @@
  *   intro → (press enter) → run (tabbed demo view)
  */
 
-import { ScreenContainer, TabContainer } from '../primitives/index.js';
-import type { WizardStore } from '../store.js';
+import { ScreenContainer, TabContainer } from '@ui/tui/primitives/index';
+import type { WizardStore } from '@ui/tui/store';
 import { WelcomeDemo } from './demos/WelcomeDemo.js';
 import { LayoutDemo } from './demos/LayoutDemo.js';
 import { InputDemo } from './demos/InputDemo.js';

--- a/src/ui/tui/playground/demos/AuditChecksDemo.tsx
+++ b/src/ui/tui/playground/demos/AuditChecksDemo.tsx
@@ -5,8 +5,8 @@
  */
 
 import { Box } from 'ink';
-import type { AuditCheck } from '../../../../lib/programs/audit/types.js';
-import { AuditChecksViewer } from '../../screens/audit/AuditChecksViewer/AuditChecksViewer.js';
+import type { AuditCheck } from '@lib/programs/audit/types';
+import { AuditChecksViewer } from '@ui/tui/screens/audit/AuditChecksViewer/AuditChecksViewer';
 
 const MOCK_CHECKS: AuditCheck[] = [
   {

--- a/src/ui/tui/playground/demos/DoctorReportDemo.tsx
+++ b/src/ui/tui/playground/demos/DoctorReportDemo.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from 'ink';
-import { Colors, Icons } from '../../styles.js';
-import { IssueTable } from '../../screens/doctor/IssueTable.js';
-import type { HealthIssue } from '../../../../lib/programs/posthog-doctor/index.js';
+import { Colors, Icons } from '@ui/tui/styles';
+import { IssueTable } from '@ui/tui/screens/doctor/IssueTable';
+import type { HealthIssue } from '@lib/programs/posthog-doctor/index';
 
 const NOW = '2026-04-27T15:00:00Z';
 

--- a/src/ui/tui/playground/demos/HealthCheckDemo.tsx
+++ b/src/ui/tui/playground/demos/HealthCheckDemo.tsx
@@ -11,12 +11,12 @@
 
 import { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
-import { LoadingBox, ModalOverlay } from '../../primitives/index.js';
-import { Icons } from '../../styles.js';
-import { ServiceHealthList } from '../../components/ServiceHealthList.js';
-import { getBlockingServiceKeys } from '../../../../lib/health-checks/readiness.js';
-import { ServiceHealthStatus } from '../../../../lib/health-checks/types.js';
-import type { AllServicesHealth } from '../../../../lib/health-checks/types.js';
+import { LoadingBox, ModalOverlay } from '@ui/tui/primitives/index';
+import { Icons } from '@ui/tui/styles';
+import { ServiceHealthList } from '@ui/tui/components/ServiceHealthList';
+import { getBlockingServiceKeys } from '@lib/health-checks/readiness';
+import { ServiceHealthStatus } from '@lib/health-checks/types';
+import type { AllServicesHealth } from '@lib/health-checks/types';
 
 const HEALTHY = { status: ServiceHealthStatus.Healthy } as const;
 

--- a/src/ui/tui/playground/demos/InputDemo.tsx
+++ b/src/ui/tui/playground/demos/InputDemo.tsx
@@ -4,8 +4,8 @@
 
 import { Box, Text } from 'ink';
 import { useState } from 'react';
-import { PickerMenu, ConfirmationInput } from '../../primitives/index.js';
-import { Colors } from '../../styles.js';
+import { PickerMenu, ConfirmationInput } from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
 
 enum DemoStep {
   Single = 'single',

--- a/src/ui/tui/playground/demos/KeyboardHintsDemo.tsx
+++ b/src/ui/tui/playground/demos/KeyboardHintsDemo.tsx
@@ -13,8 +13,8 @@ import {
   PickerMenu,
   GroupedPickerMenu,
   ConfirmationInput,
-} from '../../primitives/index.js';
-import { Colors } from '../../styles.js';
+} from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
 
 enum DemoStep {
   SingleSelect = 'single',

--- a/src/ui/tui/playground/demos/LayoutDemo.tsx
+++ b/src/ui/tui/playground/demos/LayoutDemo.tsx
@@ -5,8 +5,8 @@
 
 import { Box, Text, useInput } from 'ink';
 import { useState } from 'react';
-import { CardLayout, SplitView } from '../../primitives/index.js';
-import { HAlign, VAlign, Colors } from '../../styles.js';
+import { CardLayout, SplitView } from '@ui/tui/primitives/index';
+import { HAlign, VAlign, Colors } from '@ui/tui/styles';
 
 const hAligns = [HAlign.Left, HAlign.Center, HAlign.Right];
 const vAligns = [VAlign.Top, VAlign.Center, VAlign.Bottom];

--- a/src/ui/tui/playground/demos/LearnDeckDemo.tsx
+++ b/src/ui/tui/playground/demos/LearnDeckDemo.tsx
@@ -24,14 +24,14 @@ import {
   ProgressList,
   SplitView,
   TextRevealMode,
-} from '../../primitives/index.js';
-import type { ContentBlock, ProgressItem } from '../../primitives/index.js';
-import { Colors } from '../../styles.js';
-import type { WizardStore } from '../../store.js';
-import { PROGRAM_REGISTRY } from '../../../../lib/programs/program-registry.js';
-import { AUDIT_AREA_SLIDES } from '../../screens/audit/slides/index.js';
-import { AUDIT_3000_AREA_SLIDES } from '../../screens/audit-3000/slides/index.js';
-import type { AreaSlide } from '../../screens/audit/slides/shared.js';
+} from '@ui/tui/primitives/index';
+import type { ContentBlock, ProgressItem } from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
+import type { WizardStore } from '@ui/tui/store';
+import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
+import { AUDIT_AREA_SLIDES } from '@ui/tui/screens/audit/slides/index';
+import { AUDIT_3000_AREA_SLIDES } from '@ui/tui/screens/audit-3000/slides/index';
+import type { AreaSlide } from '@ui/tui/screens/audit/slides/shared';
 
 interface Deck {
   id: string;

--- a/src/ui/tui/playground/demos/LogDemo.tsx
+++ b/src/ui/tui/playground/demos/LogDemo.tsx
@@ -8,8 +8,8 @@ import { useEffect, useState } from 'react';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { LogViewer } from '../../primitives/index.js';
-import { Colors } from '../../styles.js';
+import { LogViewer } from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
 
 const DEMO_LOG_PATH = path.join(os.tmpdir(), 'posthog-playground.log');
 

--- a/src/ui/tui/playground/demos/McpDemo.tsx
+++ b/src/ui/tui/playground/demos/McpDemo.tsx
@@ -5,9 +5,9 @@
  * a short install delay, and a successful result.
  */
 
-import { WizardStore } from '../../store.js';
-import { McpScreen } from '../../screens/McpScreen.js';
-import type { McpInstaller } from '../../services/mcp-installer.js';
+import { WizardStore } from '@ui/tui/store';
+import { McpScreen } from '@ui/tui/screens/McpScreen';
+import type { McpInstaller } from '@ui/tui/services/mcp-installer';
 
 const MOCK_CLIENTS = [
   { name: 'Claude Code', supportsPlugin: true },

--- a/src/ui/tui/playground/demos/ModalDemo.tsx
+++ b/src/ui/tui/playground/demos/ModalDemo.tsx
@@ -5,8 +5,8 @@
  */
 
 import { Box, Text } from 'ink';
-import { ModalOverlay } from '../../primitives/index.js';
-import { Icons } from '../../styles.js';
+import { ModalOverlay } from '@ui/tui/primitives/index';
+import { Icons } from '@ui/tui/styles';
 
 export const ModalDemo = () => {
   return (

--- a/src/ui/tui/playground/demos/ProgressDemo.tsx
+++ b/src/ui/tui/playground/demos/ProgressDemo.tsx
@@ -5,9 +5,9 @@
 
 import { Box, Text } from 'ink';
 import { useState, useEffect } from 'react';
-import { ProgressList, LoadingBox } from '../../primitives/index.js';
-import type { ProgressItem } from '../../primitives/index.js';
-import { Colors } from '../../styles.js';
+import { ProgressList, LoadingBox } from '@ui/tui/primitives/index';
+import type { ProgressItem } from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
 
 const INITIAL_ITEMS: ProgressItem[] = [
   {

--- a/src/ui/tui/playground/demos/RunScreenDemo.tsx
+++ b/src/ui/tui/playground/demos/RunScreenDemo.tsx
@@ -5,8 +5,8 @@
  */
 
 import { useEffect, useRef, useSyncExternalStore } from 'react';
-import { WizardStore, TaskStatus } from '../../store.js';
-import { DiscoveredFeature } from '../../../../lib/wizard-session.js';
+import { WizardStore, TaskStatus } from '@ui/tui/store';
+import { DiscoveredFeature } from '@lib/wizard-session';
 import {
   TabContainer,
   SplitView,
@@ -14,12 +14,12 @@ import {
   LogViewer,
   EventPlanViewer,
   HNViewer,
-} from '../../primitives/index.js';
-import type { ProgressItem } from '../../primitives/index.js';
-import { LearnCard } from '../../components/LearnCard.js';
-import { TipsCard } from '../../components/TipsCard.js';
-import { getContentBlocks as getMigrationContentBlocks } from '../../../../lib/programs/migration/content/index.js';
-import { WIZARD_LOG_FILE } from '../../../../utils/paths.js';
+} from '@ui/tui/primitives/index';
+import type { ProgressItem } from '@ui/tui/primitives/index';
+import { LearnCard } from '@ui/tui/components/LearnCard';
+import { TipsCard } from '@ui/tui/components/TipsCard';
+import { getContentBlocks as getMigrationContentBlocks } from '@lib/programs/migration/content/index';
+import { WIZARD_LOG_FILE } from '@utils/paths';
 
 const MOCK_TASKS = [
   {

--- a/src/ui/tui/playground/demos/WelcomeDemo.tsx
+++ b/src/ui/tui/playground/demos/WelcomeDemo.tsx
@@ -3,8 +3,8 @@
  */
 
 import { Box, Text, useInput } from 'ink';
-import type { WizardStore } from '../../store.js';
-import { Colors, Icons } from '../../styles.js';
+import type { WizardStore } from '@ui/tui/store';
+import { Colors, Icons } from '@ui/tui/styles';
 
 interface WelcomeDemoProps {
   store: WizardStore;

--- a/src/ui/tui/playground/start-playground.ts
+++ b/src/ui/tui/playground/start-playground.ts
@@ -4,9 +4,9 @@
 
 import { render } from 'ink';
 import { createElement } from 'react';
-import { WizardStore } from '../store.js';
+import { WizardStore } from '@ui/tui/store';
 import { PlaygroundApp } from './PlaygroundApp.js';
-import { WizardReadiness } from '../../../lib/health-checks/readiness.js';
+import { WizardReadiness } from '@lib/health-checks/readiness';
 
 export function startPlayground(version: string): void {
   const store = new WizardStore();

--- a/src/ui/tui/primitives/CardLayout.tsx
+++ b/src/ui/tui/primitives/CardLayout.tsx
@@ -4,7 +4,7 @@
 
 import { Box } from 'ink';
 import type { ReactNode } from 'react';
-import { HAlign, VAlign } from '../styles.js';
+import { HAlign, VAlign } from '@ui/tui/styles';
 
 interface CardLayoutProps {
   hAlign?: HAlign;

--- a/src/ui/tui/primitives/ConfirmationInput.tsx
+++ b/src/ui/tui/primitives/ConfirmationInput.tsx
@@ -8,9 +8,9 @@
 
 import { Box, Text } from 'ink';
 import { useState } from 'react';
-import { Icons, Colors } from '../styles.js';
+import { Icons, Colors } from '@ui/tui/styles';
 import { PromptLabel } from './PromptLabel.js';
-import { useKeyBindings, KeyMatch } from '../hooks/useKeyBindings.js';
+import { useKeyBindings, KeyMatch } from '@ui/tui/hooks/useKeyBindings';
 
 interface ConfirmationInputProps {
   message: string;

--- a/src/ui/tui/primitives/EventPlanViewer.tsx
+++ b/src/ui/tui/primitives/EventPlanViewer.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Box, Text } from 'ink';
-import type { PlannedEvent } from '../store.js';
+import type { PlannedEvent } from '@ui/tui/store';
 
 interface EventPlanViewerProps {
   events: PlannedEvent[];

--- a/src/ui/tui/primitives/GroupedPickerMenu.tsx
+++ b/src/ui/tui/primitives/GroupedPickerMenu.tsx
@@ -14,10 +14,10 @@
 
 import { Box, Text } from 'ink';
 import { useState, useMemo } from 'react';
-import { Icons, Colors } from '../styles.js';
+import { Icons, Colors } from '@ui/tui/styles';
 import { PromptLabel } from './PromptLabel.js';
-import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
-import { useKeyBindings, KeyMatch } from '../hooks/useKeyBindings.js';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
+import { useKeyBindings, KeyMatch } from '@ui/tui/hooks/useKeyBindings';
 
 interface GroupOption {
   value: string;

--- a/src/ui/tui/primitives/HNViewer.tsx
+++ b/src/ui/tui/primitives/HNViewer.tsx
@@ -7,8 +7,8 @@
 
 import { Box, Text } from 'ink';
 import { useState, useEffect } from 'react';
-import { Colors } from '../styles.js';
-import { useKeyBindings } from '../hooks/useKeyBindings.js';
+import { Colors } from '@ui/tui/styles';
+import { useKeyBindings } from '@ui/tui/hooks/useKeyBindings';
 
 const HN_API = 'https://hacker-news.firebaseio.com/v0';
 

--- a/src/ui/tui/primitives/KeyboardHintsBar.tsx
+++ b/src/ui/tui/primitives/KeyboardHintsBar.tsx
@@ -7,8 +7,8 @@
  */
 
 import { Box, Text } from 'ink';
-import { useKeyboardHintsContext } from '../hooks/useKeyboardHints.js';
-import { Colors } from '../styles.js';
+import { useKeyboardHintsContext } from '@ui/tui/hooks/useKeyboardHints';
+import { Colors } from '@ui/tui/styles';
 
 export const KeyboardHintsBar = () => {
   const { hints, visible } = useKeyboardHintsContext();

--- a/src/ui/tui/primitives/LogViewer.tsx
+++ b/src/ui/tui/primitives/LogViewer.tsx
@@ -6,7 +6,7 @@
 import { Box, Text } from 'ink';
 import { useState, useEffect } from 'react';
 import * as fs from 'fs';
-import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 
 /** Rows consumed by TitleBar + spacer + ScreenContainer padding + status bar + tab bar */
 const CHROME_ROWS = 8;

--- a/src/ui/tui/primitives/PickerMenu.tsx
+++ b/src/ui/tui/primitives/PickerMenu.tsx
@@ -9,13 +9,13 @@
 
 import { Box, Text } from 'ink';
 import { useState } from 'react';
-import { Icons, Colors } from '../styles.js';
+import { Icons, Colors } from '@ui/tui/styles';
 import { PromptLabel } from './PromptLabel.js';
 import {
   useKeyBindings,
   KeyMatch,
   type KeyBinding,
-} from '../hooks/useKeyBindings.js';
+} from '@ui/tui/hooks/useKeyBindings';
 
 interface PickerOption<T> {
   label: string;

--- a/src/ui/tui/primitives/ProgressList.tsx
+++ b/src/ui/tui/primitives/ProgressList.tsx
@@ -5,7 +5,7 @@
 
 import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
-import { Colors, Icons } from '../styles.js';
+import { Colors, Icons } from '@ui/tui/styles';
 import { LoadingBox } from './LoadingBox.js';
 
 export interface ProgressItem {

--- a/src/ui/tui/primitives/PromptLabel.tsx
+++ b/src/ui/tui/primitives/PromptLabel.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Box, Text } from 'ink';
-import { Colors } from '../styles.js';
+import { Colors } from '@ui/tui/styles';
 
 interface PromptLabelProps {
   message?: string;

--- a/src/ui/tui/primitives/ScreenContainer.tsx
+++ b/src/ui/tui/primitives/ScreenContainer.tsx
@@ -12,13 +12,13 @@
 
 import { Box } from 'ink';
 import { useSyncExternalStore, type ReactNode } from 'react';
-import { TitleBar } from '../components/TitleBar.js';
-import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
-import { KeyboardHintsProvider } from '../hooks/useKeyboardHints.js';
+import { TitleBar } from '@ui/tui/components/TitleBar';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
+import { KeyboardHintsProvider } from '@ui/tui/hooks/useKeyboardHints';
 import { DissolveTransition } from './DissolveTransition.js';
 import { KeyboardHintsBar } from './KeyboardHintsBar.js';
 import { ScreenErrorBoundary } from './ScreenErrorBoundary.js';
-import type { WizardStore } from '../store.js';
+import type { WizardStore } from '@ui/tui/store';
 
 const MIN_WIDTH = 80;
 export const MAX_WIDTH = 120;

--- a/src/ui/tui/primitives/ScreenErrorBoundary.tsx
+++ b/src/ui/tui/primitives/ScreenErrorBoundary.tsx
@@ -7,8 +7,8 @@
 
 import { Box, Text } from 'ink';
 import { Component, type ReactNode } from 'react';
-import type { WizardStore } from '../store.js';
-import { OutroKind, RunPhase } from '../../../lib/wizard-session.js';
+import type { WizardStore } from '@ui/tui/store';
+import { OutroKind, RunPhase } from '@lib/wizard-session';
 
 interface Props {
   store: WizardStore;

--- a/src/ui/tui/primitives/TabContainer.tsx
+++ b/src/ui/tui/primitives/TabContainer.tsx
@@ -8,13 +8,13 @@
 
 import { Box, Text } from 'ink';
 import { useState, useMemo, type ReactNode } from 'react';
-import { Colors, Icons } from '../styles.js';
+import { Colors, Icons } from '@ui/tui/styles';
 import {
   useKeyBindings,
   KeyMatch,
   type KeyBinding,
-} from '../hooks/useKeyBindings.js';
-import type { WizardStore } from '../store.js';
+} from '@ui/tui/hooks/useKeyBindings';
+import type { WizardStore } from '@ui/tui/store';
 
 export interface TabDefinition {
   id: string;

--- a/src/ui/tui/primitives/TextBlock.tsx
+++ b/src/ui/tui/primitives/TextBlock.tsx
@@ -14,7 +14,7 @@
 
 import { Text } from 'ink';
 import { useState, useEffect, useRef, useMemo, type ReactNode } from 'react';
-import { Colors } from '../styles.js';
+import { Colors } from '@ui/tui/styles';
 import {
   splitSentences,
   sentenceEndChars,

--- a/src/ui/tui/router.ts
+++ b/src/ui/tui/router.ts
@@ -12,11 +12,8 @@
  * No switch statements, no hardcoded transitions in business logic.
  */
 
-import type { WizardSession } from '../../lib/wizard-session.js';
-import {
-  Program,
-  type ProgramId,
-} from '../../lib/programs/program-registry.js';
+import type { WizardSession } from '@lib/wizard-session';
+import { Program, type ProgramId } from '@lib/programs/program-registry';
 import {
   PROGRAM_SEQUENCES,
   ScreenId,

--- a/src/ui/tui/screen-sequences.ts
+++ b/src/ui/tui/screen-sequences.ts
@@ -6,12 +6,12 @@
  * appending the exit screen). Pure leaf module — no store, no React.
  */
 
-import type { WizardSession } from '../../lib/wizard-session.js';
+import type { WizardSession } from '@lib/wizard-session';
 import {
   PROGRAM_REGISTRY,
   type ProgramId,
-} from '../../lib/programs/program-registry.js';
-import { createProgramSequence } from '../../lib/programs/program-step.js';
+} from '@lib/programs/program-registry';
+import { createProgramSequence } from '@lib/programs/program-step';
 
 /** Screens that participate in linear programs. */
 export enum ScreenId {

--- a/src/ui/tui/screens/AgentSkillIntroScreen.tsx
+++ b/src/ui/tui/screens/AgentSkillIntroScreen.tsx
@@ -8,7 +8,7 @@
 import { Box, Text } from 'ink';
 import type { ReactNode } from 'react';
 import { useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
+import type { WizardStore } from '@ui/tui/store';
 import { IntroScreenLayout } from './IntroScreenLayout.js';
 import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
 

--- a/src/ui/tui/screens/AuthErrorScreen.tsx
+++ b/src/ui/tui/screens/AuthErrorScreen.tsx
@@ -10,8 +10,8 @@
 
 import { Box, Text, useInput } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { Colors } from '../styles.js';
+import type { WizardStore } from '@ui/tui/store';
+import { Colors } from '@ui/tui/styles';
 
 interface AuthErrorScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/AuthScreen.tsx
+++ b/src/ui/tui/screens/AuthScreen.tsx
@@ -8,9 +8,9 @@
 
 import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { LoadingBox } from '../primitives/index.js';
-import { Colors } from '../styles.js';
+import type { WizardStore } from '@ui/tui/store';
+import { LoadingBox } from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
 
 interface AuthScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/IntroScreenLayout.tsx
+++ b/src/ui/tui/screens/IntroScreenLayout.tsx
@@ -13,7 +13,7 @@
 import path from 'path';
 import { Box, Text } from 'ink';
 import type { ReactNode } from 'react';
-import { PickerMenu } from '../primitives/index.js';
+import { PickerMenu } from '@ui/tui/primitives/index';
 
 export interface DetectionRow {
   label: string;

--- a/src/ui/tui/screens/KeepSkillsScreen.tsx
+++ b/src/ui/tui/screens/KeepSkillsScreen.tsx
@@ -14,10 +14,10 @@ import { readdir, rm, access } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const WIZARD_MARKER = '.posthog-wizard';
-import type { WizardStore } from '../store.js';
-import { ConfirmationInput } from '../primitives/index.js';
-import { Colors } from '../styles.js';
-import { CONTEXT_MILL_URL } from '../../../lib/constants.js';
+import type { WizardStore } from '@ui/tui/store';
+import { ConfirmationInput } from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
+import { CONTEXT_MILL_URL } from '@lib/constants';
 
 interface KeepSkillsScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/ManagedSettingsScreen.tsx
+++ b/src/ui/tui/screens/ManagedSettingsScreen.tsx
@@ -8,10 +8,10 @@
 
 import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { ConfirmationInput, ModalOverlay } from '../primitives/index.js';
-import { Icons } from '../styles.js';
-import type { SettingsConflict } from '../../../lib/agent/agent-interface.js';
+import type { WizardStore } from '@ui/tui/store';
+import { ConfirmationInput, ModalOverlay } from '@ui/tui/primitives/index';
+import { Icons } from '@ui/tui/styles';
+import type { SettingsConflict } from '@lib/agent/agent-interface';
 
 function sourceLabel(source: SettingsConflict['source']): string {
   switch (source) {

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -14,18 +14,18 @@
 import { Box, Text, useInput } from 'ink';
 import { useState, useEffect } from 'react';
 import { useSyncExternalStore } from 'react';
-import { type WizardStore, McpOutcome } from '../store.js';
+import { type WizardStore, McpOutcome } from '@ui/tui/store';
 import {
   ConfirmationInput,
   PickerMenu,
   GroupedPickerMenu,
-} from '../primitives/index.js';
-import { Colors } from '../styles.js';
-import type { McpInstaller, McpClientInfo } from '../services/mcp-installer.js';
+} from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
+import type { McpInstaller, McpClientInfo } from '@ui/tui/services/mcp-installer';
 import {
   AVAILABLE_FEATURES,
   ALL_FEATURE_VALUES,
-} from '../../../steps/add-mcp-server-to-clients/defaults.js';
+} from '@steps/add-mcp-server-to-clients/defaults';
 
 export type McpMode = 'install' | 'remove';
 

--- a/src/ui/tui/screens/MigrationIntroScreen.tsx
+++ b/src/ui/tui/screens/MigrationIntroScreen.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
+import type { WizardStore } from '@ui/tui/store';
 import { IntroScreenLayout } from './IntroScreenLayout.js';
 
 interface MigrationIntroScreenProps {

--- a/src/ui/tui/screens/OutroScreen.tsx
+++ b/src/ui/tui/screens/OutroScreen.tsx
@@ -8,9 +8,9 @@
 
 import { Box, Text, useInput } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { OutroKind } from '../../../lib/wizard-session.js';
-import { Colors } from '../styles.js';
+import type { WizardStore } from '@ui/tui/store';
+import { OutroKind } from '@lib/wizard-session';
+import { Colors } from '@ui/tui/styles';
 
 interface OutroScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/PortConflictScreen.tsx
+++ b/src/ui/tui/screens/PortConflictScreen.tsx
@@ -6,9 +6,9 @@
 
 import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { OAUTH_PORTS } from '../../../lib/constants.js';
-import { ConfirmationInput, ModalOverlay } from '../primitives/index.js';
+import type { WizardStore } from '@ui/tui/store';
+import { OAUTH_PORTS } from '@lib/constants';
+import { ConfirmationInput, ModalOverlay } from '@ui/tui/primitives/index';
 
 interface PortConflictScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -12,16 +12,16 @@ import { Box, Text } from 'ink';
 import { spawnSync } from 'node:child_process';
 import type { ReactNode } from 'react';
 import { useEffect, useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
+import type { WizardStore } from '@ui/tui/store';
 import {
   Integration,
   WIZARD_TOOLS_MENU_FLAG_KEY,
-} from '../../../lib/constants.js';
-import { PickerMenu, LoadingBox } from '../primitives/index.js';
+} from '@lib/constants';
+import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
 import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
-import { releaseTerminal } from '../start-tui.js';
-import { analytics } from '../../../utils/analytics.js';
+import { releaseTerminal } from '@ui/tui/start-tui';
+import { analytics } from '@utils/analytics';
 
 const TOOLS = [
   { label: 'Troubleshoot Integration', command: 'doctor' },
@@ -60,7 +60,7 @@ const FrameworkPicker = ({
       options={options}
       onSelect={(value) => {
         const integration = Array.isArray(value) ? value[0] : value;
-        void import('../../../lib/registry.js').then(
+        void import('@lib/registry').then(
           ({ FRAMEWORK_REGISTRY }) => {
             const config = FRAMEWORK_REGISTRY[integration];
             store.setFrameworkConfig(integration, config);

--- a/src/ui/tui/screens/RevenueIntroScreen.tsx
+++ b/src/ui/tui/screens/RevenueIntroScreen.tsx
@@ -11,14 +11,14 @@
 
 import { Box, Text } from 'ink';
 import { useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { PickerMenu } from '../primitives/index.js';
+import type { WizardStore } from '@ui/tui/store';
+import { PickerMenu } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
 import {
   POSTHOG_SDKS,
   STRIPE_SDKS,
   type RevenueDetectError,
-} from '../../../lib/programs/revenue-analytics/index.js';
+} from '@lib/programs/revenue-analytics/index';
 
 interface RevenueIntroScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/RunScreen.tsx
+++ b/src/ui/tui/screens/RunScreen.tsx
@@ -9,7 +9,7 @@
 import { useMemo, useSyncExternalStore } from 'react';
 import { join } from 'node:path';
 import { Box } from 'ink';
-import type { WizardStore } from '../store.js';
+import type { WizardStore } from '@ui/tui/store';
 import {
   TabContainer,
   SplitView,
@@ -17,18 +17,18 @@ import {
   LogViewer,
   EventPlanViewer,
   HNViewer,
-} from '../primitives/index.js';
-import type { ProgressItem } from '../primitives/index.js';
-import { ADDITIONAL_FEATURE_LABELS } from '../../../lib/wizard-session.js';
-import { LearnCard } from '../components/LearnCard.js';
-import { TipsCard } from '../components/TipsCard.js';
-import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
-import { useFileWatcher } from '../hooks/file-watcher.js';
-import { EVENT_PLAN_FILE } from '../../../lib/programs/posthog-integration/index.js';
-import { getProgramConfig } from '../../../lib/programs/program-registry.js';
-import { getContentBlocks as getSkillContentBlocks } from '../../../lib/programs/agent-skill/content/index.js';
+} from '@ui/tui/primitives/index';
+import type { ProgressItem } from '@ui/tui/primitives/index';
+import { ADDITIONAL_FEATURE_LABELS } from '@lib/wizard-session';
+import { LearnCard } from '@ui/tui/components/LearnCard';
+import { TipsCard } from '@ui/tui/components/TipsCard';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
+import { useFileWatcher } from '@ui/tui/hooks/file-watcher';
+import { EVENT_PLAN_FILE } from '@lib/programs/posthog-integration/index';
+import { getProgramConfig } from '@lib/programs/program-registry';
+import { getContentBlocks as getSkillContentBlocks } from '@lib/programs/agent-skill/content/index';
 
-import { WIZARD_LOG_FILE } from '../../../utils/paths.js';
+import { WIZARD_LOG_FILE } from '@utils/paths';
 
 interface RunScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/SettingsOverrideScreen.tsx
+++ b/src/ui/tui/screens/SettingsOverrideScreen.tsx
@@ -1,9 +1,9 @@
 import { Box, Text } from 'ink';
 import { useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { ConfirmationInput, ModalOverlay } from '../primitives/index.js';
-import { Icons } from '../styles.js';
-import type { SettingsConflictSource } from '../../../lib/agent/agent-interface.js';
+import type { WizardStore } from '@ui/tui/store';
+import { ConfirmationInput, ModalOverlay } from '@ui/tui/primitives/index';
+import { Icons } from '@ui/tui/styles';
+import type { SettingsConflictSource } from '@lib/agent/agent-interface';
 
 function sourcePath(source: SettingsConflictSource): string {
   switch (source) {

--- a/src/ui/tui/screens/SetupScreen.tsx
+++ b/src/ui/tui/screens/SetupScreen.tsx
@@ -9,10 +9,10 @@
 import { Box, Text } from 'ink';
 import { useState, useEffect } from 'react';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { PickerMenu } from '../primitives/index.js';
-import { Colors } from '../styles.js';
-import type { SetupQuestion } from '../../../lib/framework-config.js';
+import type { WizardStore } from '@ui/tui/store';
+import { PickerMenu } from '@ui/tui/primitives/index';
+import { Colors } from '@ui/tui/styles';
+import type { SetupQuestion } from '@lib/framework-config';
 
 interface SetupScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/SkillSourceInfo.tsx
+++ b/src/ui/tui/screens/SkillSourceInfo.tsx
@@ -13,8 +13,8 @@
 
 import { Box, Text } from 'ink';
 import { useEffect, useState } from 'react';
-import { fetchSkillMenu, type SkillEntry } from '../../../lib/wizard-tools.js';
-import { getSkillsBaseUrl } from '../../../lib/constants.js';
+import { fetchSkillMenu, type SkillEntry } from '@lib/wizard-tools';
+import { getSkillsBaseUrl } from '@lib/constants';
 
 export function useSkillEntry(
   skillId: string | null,

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -9,10 +9,10 @@
 import { Box, Text } from 'ink';
 import { TextInput } from '@inkjs/ui';
 import { useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../store.js';
-import { ModalOverlay, PickerMenu } from '../primitives/index.js';
-import { Colors, Icons } from '../styles.js';
-import type { AskAnswers, AskQuestion } from '../../../lib/wizard-session.js';
+import type { WizardStore } from '@ui/tui/store';
+import { ModalOverlay, PickerMenu } from '@ui/tui/primitives/index';
+import { Colors, Icons } from '@ui/tui/styles';
+import type { AskAnswers, AskQuestion } from '@lib/wizard-session';
 
 interface WizardAskScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/audit-3000/Audit3000AreaPane.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000AreaPane.tsx
@@ -9,8 +9,8 @@
 import { Fragment } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { spawn } from 'node:child_process';
-import { Colors } from '../../styles.js';
-import { type AuditCheck } from '../../../../lib/programs/audit/types.js';
+import { Colors } from '@ui/tui/styles';
+import { type AuditCheck } from '@lib/programs/audit/types';
 import { AUDIT_3000_AREA_SLIDES, type AreaSlide } from './slides/index.js';
 
 const FINDING_STATUSES: AuditCheck['status'][] = [

--- a/src/ui/tui/screens/audit-3000/Audit3000ChecksPanel.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000ChecksPanel.tsx
@@ -13,9 +13,9 @@ import { Spinner } from '@inkjs/ui';
 import {
   type AuditCheck,
   type AuditStatus,
-} from '../../../../lib/programs/audit/types.js';
-import { Colors, Icons } from '../../styles.js';
-import { LoadingBox } from '../../primitives/index.js';
+} from '@lib/programs/audit/types';
+import { Colors, Icons } from '@ui/tui/styles';
+import { LoadingBox } from '@ui/tui/primitives/index';
 
 const NEON_PINK = '#F54E00';
 const NEON_GOLD = '#F9BD2B';

--- a/src/ui/tui/screens/audit-3000/Audit3000IntroScreen.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000IntroScreen.tsx
@@ -1,8 +1,8 @@
 import { Box, Text } from 'ink';
 import { useEffect, useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../../store.js';
-import { IntroScreenLayout } from '../IntroScreenLayout.js';
-import { SkillSourceInfo, useSkillEntry } from '../SkillSourceInfo.js';
+import type { WizardStore } from '@ui/tui/store';
+import { IntroScreenLayout } from '@ui/tui/screens/IntroScreenLayout';
+import { SkillSourceInfo, useSkillEntry } from '@ui/tui/screens/SkillSourceInfo';
 import { NEON_BLUE, NEON_GOLD, NEON_PINK } from './arcade-colors.js';
 
 const AUDIT3000_SKILL_ID = 'audit-3000';

--- a/src/ui/tui/screens/audit-3000/Audit3000OutroScreen.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000OutroScreen.tsx
@@ -11,15 +11,15 @@
 import { join } from 'node:path';
 import { Box, Text, useInput } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../../store.js';
-import { OutroKind } from '../../../../lib/wizard-session.js';
-import { Colors } from '../../styles.js';
+import type { WizardStore } from '@ui/tui/store';
+import { OutroKind } from '@lib/wizard-session';
+import { Colors } from '@ui/tui/styles';
 import {
   getAuditChecks,
   type AuditCheck,
   type AuditStatus,
-} from '../../../../lib/programs/audit/types.js';
-import { AuditChecksOutroSection } from '../audit/AuditChecksOutroSection.js';
+} from '@lib/programs/audit/types';
+import { AuditChecksOutroSection } from '@ui/tui/screens/audit/AuditChecksOutroSection';
 
 const NEON_PINK = '#F54E00';
 const NEON_GOLD = '#F9BD2B';

--- a/src/ui/tui/screens/audit-3000/Audit3000RunScreen.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000RunScreen.tsx
@@ -1,16 +1,16 @@
 import { useState, useSyncExternalStore } from 'react';
 import { join } from 'node:path';
 import { Box } from 'ink';
-import type { WizardStore } from '../../store.js';
+import type { WizardStore } from '@ui/tui/store';
 import {
   TabContainer,
   SplitView,
   LogViewer,
   HNViewer,
-} from '../../primitives/index.js';
-import { useStdoutDimensions } from '../../hooks/useStdoutDimensions.js';
-import { useFileWatcher } from '../../hooks/file-watcher.js';
-import { AuditChecksViewer } from '../audit/AuditChecksViewer/AuditChecksViewer.js';
+} from '@ui/tui/primitives/index';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
+import { useFileWatcher } from '@ui/tui/hooks/file-watcher';
+import { AuditChecksViewer } from '@ui/tui/screens/audit/AuditChecksViewer/AuditChecksViewer';
 import { Audit3000AreaPane } from './Audit3000AreaPane.js';
 import { Audit3000ChecksPanel } from './Audit3000ChecksPanel.js';
 import { HedgehogRunner } from './HedgehogRunner.js';
@@ -20,9 +20,9 @@ import {
   AUDIT_CHECKS_KEY,
   coerceAuditChecks,
   getAuditChecks,
-} from '../../../../lib/programs/audit/types.js';
-import { getProgramConfig } from '../../../../lib/programs/program-registry.js';
-import { WIZARD_LOG_FILE } from '../../../../utils/paths.js';
+} from '@lib/programs/audit/types';
+import { getProgramConfig } from '@lib/programs/program-registry';
+import { WIZARD_LOG_FILE } from '@utils/paths';
 
 const AUDIT_3000_REPORT_FILE_FALLBACK = 'posthog-audit-3000-report.md';
 

--- a/src/ui/tui/screens/audit-3000/HedgehogRunner.tsx
+++ b/src/ui/tui/screens/audit-3000/HedgehogRunner.tsx
@@ -9,14 +9,14 @@
 
 import { Box, Text } from 'ink';
 import { Fragment, useEffect, type Dispatch, type SetStateAction } from 'react';
-import { Colors } from '../../styles.js';
+import { Colors } from '@ui/tui/styles';
 import { NEON_BLUE, NEON_GOLD, NEON_PINK } from './arcade-colors.js';
-import { useStdoutDimensions } from '../../hooks/useStdoutDimensions.js';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 import {
   useKeyBindings,
   KeyMatch,
   type KeyBinding,
-} from '../../hooks/useKeyBindings.js';
+} from '@ui/tui/hooks/useKeyBindings';
 import {
   HEDGEHOG_COL,
   PLAYFIELD_WIDTH,

--- a/src/ui/tui/screens/audit-3000/__tests__/hedgehog-runner-engine.test.ts
+++ b/src/ui/tui/screens/audit-3000/__tests__/hedgehog-runner-engine.test.ts
@@ -9,7 +9,7 @@ import {
   restart,
   tick,
   type GameState,
-} from '../hedgehog-runner-engine.js';
+} from '@ui/tui/screens/audit-3000/hedgehog-runner-engine';
 
 describe('hedgehog-runner-engine', () => {
   describe('initialState', () => {

--- a/src/ui/tui/screens/audit-3000/slides/eventQuality.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/eventQuality.tsx
@@ -1,5 +1,5 @@
 import { Text } from 'ink';
-import { VisualBox, type AreaSlide } from '../../audit/slides/shared.js';
+import { VisualBox, type AreaSlide } from '@ui/tui/screens/audit/slides/shared';
 
 const EventQualityVisual = () => (
   <VisualBox>

--- a/src/ui/tui/screens/audit-3000/slides/expansion.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/expansion.tsx
@@ -1,5 +1,5 @@
 import { Text } from 'ink';
-import { VisualBox, type AreaSlide } from '../../audit/slides/shared.js';
+import { VisualBox, type AreaSlide } from '@ui/tui/screens/audit/slides/shared';
 
 const ExpansionVisual = () => (
   <VisualBox>

--- a/src/ui/tui/screens/audit-3000/slides/featureFlags.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/featureFlags.tsx
@@ -1,5 +1,5 @@
 import { Text } from 'ink';
-import { VisualBox, type AreaSlide } from '../../audit/slides/shared.js';
+import { VisualBox, type AreaSlide } from '@ui/tui/screens/audit/slides/shared';
 
 const FeatureFlagsVisual = () => (
   <VisualBox>

--- a/src/ui/tui/screens/audit-3000/slides/index.ts
+++ b/src/ui/tui/screens/audit-3000/slides/index.ts
@@ -4,10 +4,10 @@
  * arcade-flavoured slides for the three new areas the v3000 audit covers.
  */
 
-import type { AreaSlide } from '../../audit/slides/shared.js';
-import { InstallationSlide } from '../../audit/slides/installation.js';
-import { IdentificationSlide } from '../../audit/slides/identification.js';
-import { EventCaptureSlide } from '../../audit/slides/eventCapture.js';
+import type { AreaSlide } from '@ui/tui/screens/audit/slides/shared';
+import { InstallationSlide } from '@ui/tui/screens/audit/slides/installation';
+import { IdentificationSlide } from '@ui/tui/screens/audit/slides/identification';
+import { EventCaptureSlide } from '@ui/tui/screens/audit/slides/eventCapture';
 import { EventQualitySlide } from './eventQuality.js';
 import { FeatureFlagsSlide } from './featureFlags.js';
 import { ExpansionSlide } from './expansion.js';

--- a/src/ui/tui/screens/audit/AuditAreaPane.tsx
+++ b/src/ui/tui/screens/audit/AuditAreaPane.tsx
@@ -16,8 +16,8 @@
 import { Fragment } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { spawn } from 'node:child_process';
-import { Colors } from '../../styles.js';
-import { type AuditCheck } from '../../../../lib/programs/audit/types.js';
+import { Colors } from '@ui/tui/styles';
+import { type AuditCheck } from '@lib/programs/audit/types';
 import { AUDIT_AREA_SLIDES, type AreaSlide } from './slides/index.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/ui/tui/screens/audit/AuditChecksOutroSection.tsx
+++ b/src/ui/tui/screens/audit/AuditChecksOutroSection.tsx
@@ -2,8 +2,8 @@ import { Box, Text } from 'ink';
 import {
   AUDIT_SEVERITY_STYLE,
   type AuditCheck,
-} from '../../../../lib/programs/audit/types.js';
-import { relativeToInstallDir } from '../../../../utils/paths.js';
+} from '@lib/programs/audit/types';
+import { relativeToInstallDir } from '@utils/paths';
 
 interface AuditChecksOutroSectionProps {
   checks: AuditCheck[];

--- a/src/ui/tui/screens/audit/AuditChecksViewer/AuditChecksViewer.tsx
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/AuditChecksViewer.tsx
@@ -17,13 +17,13 @@
 
 import { Box, Text } from 'ink';
 import { Fragment, useMemo, useState, type ReactNode } from 'react';
-import { useStdoutDimensions } from '../../../hooks/useStdoutDimensions.js';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 import {
   KeyMatch,
   useKeyBindings,
   type KeyBinding,
-} from '../../../hooks/useKeyBindings.js';
-import type { AuditCheck } from '../../../../../lib/programs/audit/types.js';
+} from '@ui/tui/hooks/useKeyBindings';
+import type { AuditCheck } from '@lib/programs/audit/types';
 import { AreaHeaderRow } from './AreaHeaderRow.js';
 import { CheckRow } from './CheckRow.js';
 import { DetailRow } from './DetailRow.js';

--- a/src/ui/tui/screens/audit/AuditChecksViewer/CheckRow.tsx
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/CheckRow.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from 'ink';
 import {
   AUDIT_SEVERITY_STYLE,
   type AuditCheck,
-} from '../../../../../lib/programs/audit/types.js';
+} from '@lib/programs/audit/types';
 import { truncate, type ViewerLayout } from './layout.js';
 
 interface CheckRowProps {

--- a/src/ui/tui/screens/audit/AuditChecksViewer/DetailRow.tsx
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/DetailRow.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'ink';
-import type { AuditCheck } from '../../../../../lib/programs/audit/types.js';
+import type { AuditCheck } from '@lib/programs/audit/types';
 import type { ViewerLayout } from './layout.js';
 
 interface DetailRowProps {

--- a/src/ui/tui/screens/audit/AuditChecksViewer/Footer.tsx
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/Footer.tsx
@@ -1,6 +1,6 @@
 import { Legend } from './Legend.js';
 import { Summary } from './Header.js';
-import type { AuditStatus } from '../../../../../lib/programs/audit/types.js';
+import type { AuditStatus } from '@lib/programs/audit/types';
 
 interface FooterProps {
   total: number;

--- a/src/ui/tui/screens/audit/AuditChecksViewer/Header.tsx
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/Header.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from 'ink';
 import type {
   AuditCheck,
   AuditStatus,
-} from '../../../../../lib/programs/audit/types.js';
+} from '@lib/programs/audit/types';
 import type { ViewerLayout } from './layout.js';
 
 interface HeaderProps {

--- a/src/ui/tui/screens/audit/AuditChecksViewer/layout.ts
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/layout.ts
@@ -1,4 +1,4 @@
-import { MAX_WIDTH } from '../../../primitives/ScreenContainer.js';
+import { MAX_WIDTH } from '@ui/tui/primitives/ScreenContainer';
 
 /** Terminal rows used by chrome outside the viewer
  *  (TitleBar, spacer, screen padding, status bar, tab bar). */

--- a/src/ui/tui/screens/audit/AuditChecksViewer/sort.ts
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/sort.ts
@@ -1,7 +1,4 @@
-import type {
-  AuditCheck,
-  AuditStatus,
-} from '../../../../../lib/programs/audit/types.js';
+import type { AuditCheck, AuditStatus } from '@lib/programs/audit/types';
 
 const STATUS_ORDER: Record<AuditStatus, number> = {
   error: 0,

--- a/src/ui/tui/screens/audit/AuditIntroScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditIntroScreen.tsx
@@ -1,8 +1,8 @@
 import { Box, Text } from 'ink';
 import { useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../../store.js';
-import { IntroScreenLayout } from '../IntroScreenLayout.js';
-import { SkillSourceInfo, useSkillEntry } from '../SkillSourceInfo.js';
+import type { WizardStore } from '@ui/tui/store';
+import { IntroScreenLayout } from '@ui/tui/screens/IntroScreenLayout';
+import { SkillSourceInfo, useSkillEntry } from '@ui/tui/screens/SkillSourceInfo';
 
 interface AuditIntroScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/audit/AuditOutroScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditOutroScreen.tsx
@@ -8,10 +8,10 @@
 import { join } from 'node:path';
 import { Box, Text, useInput } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../../store.js';
-import { OutroKind } from '../../../../lib/wizard-session.js';
-import { Colors } from '../../styles.js';
-import { getAuditChecks } from '../../../../lib/programs/audit/types.js';
+import type { WizardStore } from '@ui/tui/store';
+import { OutroKind } from '@lib/wizard-session';
+import { Colors } from '@ui/tui/styles';
+import { getAuditChecks } from '@lib/programs/audit/types';
 import { AuditChecksOutroSection } from './AuditChecksOutroSection.js';
 
 interface AuditOutroScreenProps {

--- a/src/ui/tui/screens/audit/AuditRunScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditRunScreen.tsx
@@ -1,15 +1,15 @@
 import { useSyncExternalStore } from 'react';
 import { join } from 'node:path';
 import { Box } from 'ink';
-import type { WizardStore } from '../../store.js';
+import type { WizardStore } from '@ui/tui/store';
 import {
   TabContainer,
   SplitView,
   LogViewer,
   HNViewer,
-} from '../../primitives/index.js';
-import { useStdoutDimensions } from '../../hooks/useStdoutDimensions.js';
-import { useFileWatcher } from '../../hooks/file-watcher.js';
+} from '@ui/tui/primitives/index';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
+import { useFileWatcher } from '@ui/tui/hooks/file-watcher';
 import { AuditChecksViewer } from './AuditChecksViewer/AuditChecksViewer.js';
 import { AuditAreaPane } from './AuditAreaPane.js';
 import { PendingChecksList } from './PendingChecksList.js';
@@ -19,9 +19,9 @@ import {
   AUDIT_REPORT_FILE,
   coerceAuditChecks,
   getAuditChecks,
-} from '../../../../lib/programs/audit/types.js';
-import { getProgramConfig } from '../../../../lib/programs/program-registry.js';
-import { WIZARD_LOG_FILE } from '../../../../utils/paths.js';
+} from '@lib/programs/audit/types';
+import { getProgramConfig } from '@lib/programs/program-registry';
+import { WIZARD_LOG_FILE } from '@utils/paths';
 
 interface AuditRunScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/audit/PendingChecksList.tsx
+++ b/src/ui/tui/screens/audit/PendingChecksList.tsx
@@ -3,10 +3,10 @@ import { Spinner } from '@inkjs/ui';
 import {
   AUDIT_SEVERITY_STYLE,
   type AuditCheck,
-} from '../../../../lib/programs/audit/types.js';
-import { Colors, Icons } from '../../styles.js';
-import { LoadingBox } from '../../primitives/index.js';
-import { useStdoutDimensions } from '../../hooks/useStdoutDimensions.js';
+} from '@lib/programs/audit/types';
+import { Colors, Icons } from '@ui/tui/styles';
+import { LoadingBox } from '@ui/tui/primitives/index';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 
 interface PendingChecksListProps {
   checks: AuditCheck[];

--- a/src/ui/tui/screens/audit/slides/shared.tsx
+++ b/src/ui/tui/screens/audit/slides/shared.tsx
@@ -1,6 +1,6 @@
 import { Box } from 'ink';
 import type { ReactNode } from 'react';
-import { Colors } from '../../../styles.js';
+import { Colors } from '@ui/tui/styles';
 
 /** Slide shape consumed by `AuditAreaPane`. One per `AuditCheck.area` value. */
 export interface AreaSlide {

--- a/src/ui/tui/screens/doctor/DoctorIntroScreen.tsx
+++ b/src/ui/tui/screens/doctor/DoctorIntroScreen.tsx
@@ -1,8 +1,8 @@
 import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
-import type { WizardStore } from '../../store.js';
-import { PickerMenu } from '../../primitives/index.js';
-import { Colors, Icons } from '../../styles.js';
+import type { WizardStore } from '@ui/tui/store';
+import { PickerMenu } from '@ui/tui/primitives/index';
+import { Colors, Icons } from '@ui/tui/styles';
 
 interface DoctorIntroScreenProps {
   store: WizardStore;

--- a/src/ui/tui/screens/doctor/DoctorReportScreen.tsx
+++ b/src/ui/tui/screens/doctor/DoctorReportScreen.tsx
@@ -1,16 +1,16 @@
 import { Box, Text } from 'ink';
 import { useEffect, useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../../store.js';
-import { LoadingBox, PickerMenu } from '../../primitives/index.js';
-import { Colors, Icons } from '../../styles.js';
+import type { WizardStore } from '@ui/tui/store';
+import { LoadingBox, PickerMenu } from '@ui/tui/primitives/index';
+import { Colors, Icons } from '@ui/tui/styles';
 import {
   fetchHealthIssues,
   type HealthIssue,
-} from '../../../../lib/programs/posthog-doctor/index.js';
-import { getUiHostFromHost } from '../../../../utils/urls.js';
-import { OutroKind } from '../../../../lib/wizard-session.js';
-import { ApiError } from '../../../../lib/api.js';
-import { POSTHOG_DOCS_URL } from '../../../../lib/constants.js';
+} from '@lib/programs/posthog-doctor/index';
+import { getUiHostFromHost } from '@utils/urls';
+import { OutroKind } from '@lib/wizard-session';
+import { ApiError } from '@lib/api';
+import { POSTHOG_DOCS_URL } from '@lib/constants';
 import { IssueTable, SEVERITY_LABEL, SEVERITY_ORDER } from './IssueTable.js';
 
 interface DoctorReportScreenProps {

--- a/src/ui/tui/screens/doctor/IssueTable.tsx
+++ b/src/ui/tui/screens/doctor/IssueTable.tsx
@@ -1,11 +1,11 @@
 import { Box, Text } from 'ink';
-import { useStdoutDimensions } from '../../hooks/useStdoutDimensions.js';
-import { Colors, Icons } from '../../styles.js';
+import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
+import { Colors, Icons } from '@ui/tui/styles';
 import {
   getKindMeta,
   type HealthIssue,
   type HealthIssueSeverity,
-} from '../../../../lib/programs/posthog-doctor/index.js';
+} from '@lib/programs/posthog-doctor/index';
 
 export const SEVERITY_ORDER: HealthIssueSeverity[] = [
   'critical',

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -9,22 +9,22 @@
 
 import { Box, Text, useInput } from 'ink';
 import { useState, useSyncExternalStore } from 'react';
-import type { WizardStore } from '../../store.js';
+import type { WizardStore } from '@ui/tui/store';
 import {
   ConfirmationInput,
   LoadingBox,
   ModalOverlay,
-} from '../../primitives/index.js';
-import { Colors, Icons } from '../../styles.js';
-import { ServiceHealthList } from '../../components/ServiceHealthList.js';
+} from '@ui/tui/primitives/index';
+import { Colors, Icons } from '@ui/tui/styles';
+import { ServiceHealthList } from '@ui/tui/components/ServiceHealthList';
 import {
   getBlockingServiceKeys,
   SIGNUP_WIZARD_READINESS_CONFIG,
-} from '../../../../lib/health-checks/readiness.js';
-import { ServiceHealthStatus } from '../../../../lib/health-checks/types.js';
-import { wizardAbort } from '../../../../utils/wizard-abort.js';
-import { fetchSkillMenu, downloadSkill } from '../../../../lib/wizard-tools.js';
-import { REMOTE_SKILLS_BASE_URL } from '../../../../lib/constants.js';
+} from '@lib/health-checks/readiness';
+import { ServiceHealthStatus } from '@lib/health-checks/types';
+import { wizardAbort } from '@utils/wizard-abort';
+import { fetchSkillMenu, downloadSkill } from '@lib/wizard-tools';
+import { REMOTE_SKILLS_BASE_URL } from '@lib/constants';
 
 interface HealthCheckScreenProps {
   store: WizardStore;

--- a/src/ui/tui/services/mcp-installer.ts
+++ b/src/ui/tui/services/mcp-installer.ts
@@ -11,11 +11,11 @@ import {
   getInstalledClients,
   getSupportedPluginClients,
   installPlugins as runPluginInstall,
-} from '../../../steps/add-mcp-server-to-clients/index.js';
-import { ALL_FEATURE_VALUES } from '../../../steps/add-mcp-server-to-clients/defaults.js';
-import { isPluginCapable } from '../../../steps/add-mcp-server-to-clients/plugin-client.js';
-import { logToFile } from '../../../utils/debug.js';
-import { analytics } from '../../../utils/analytics.js';
+} from '@steps/add-mcp-server-to-clients/index';
+import { ALL_FEATURE_VALUES } from '@steps/add-mcp-server-to-clients/defaults';
+import { isPluginCapable } from '@steps/add-mcp-server-to-clients/plugin-client';
+import { logToFile } from '@utils/debug';
+import { analytics } from '@utils/analytics';
 
 export interface McpClientInfo {
   name: string;

--- a/src/ui/tui/start-tui.ts
+++ b/src/ui/tui/start-tui.ts
@@ -10,9 +10,9 @@ import { render } from 'ink';
 import { createElement } from 'react';
 import { WizardStore, Program, type ProgramId } from './store.js';
 import { InkUI } from './ink-ui.js';
-import { setUI } from '../index.js';
+import { setUI } from '@ui/index';
 import { App } from './App.js';
-import { OutroKind } from '../../lib/wizard-session.js';
+import { OutroKind } from '@lib/wizard-session';
 
 // ANSI escape sequences
 const RESET_ATTRS = '\x1b[0m';

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -14,11 +14,7 @@
  */
 
 import { atom, map } from 'nanostores';
-import {
-  TaskStatus,
-  isTaskStatus,
-  type AuthErrorDetail,
-} from '../wizard-ui.js';
+import { TaskStatus, isTaskStatus, type AuthErrorDetail } from '@ui/wizard-ui';
 import {
   type WizardSession,
   type OutroData,
@@ -29,9 +25,9 @@ import {
   McpOutcome,
   RunPhase,
   buildSession,
-} from '../../lib/wizard-session.js';
-import type { SettingsConflict } from '../../lib/agent/agent-interface.js';
-import type { WizardReadinessResult } from '../../lib/health-checks/readiness.js';
+} from '@lib/wizard-session';
+import type { SettingsConflict } from '@lib/agent/agent-interface';
+import type { WizardReadinessResult } from '@lib/health-checks/readiness';
 import {
   WizardRouter,
   type ScreenName,
@@ -40,12 +36,12 @@ import {
   Program,
   type ProgramId,
 } from './router.js';
-import { analytics, sessionProperties } from '../../utils/analytics.js';
+import { analytics, sessionProperties } from '@utils/analytics';
 import type {
   StoreInitContext,
   ProgramReadyContext,
-} from '../../lib/programs/program-step.js';
-import { getProgramConfig } from '../../lib/programs/program-registry.js';
+} from '@lib/programs/program-step';
+import { getProgramConfig } from '@lib/programs/program-registry';
 
 export { TaskStatus, ScreenId, Overlay, Program, RunPhase, McpOutcome };
 export type { ScreenName, OutroData, WizardSession, ProgramId };

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -8,13 +8,13 @@
  * Session-mutating methods trigger reactive screen resolution in the TUI.
  */
 
-import type { SettingsConflict } from '../lib/agent/agent-interface';
-import type { WizardReadinessResult } from '../lib/health-checks/readiness.js';
+import type { SettingsConflict } from '@lib/agent/agent-interface';
+import type { WizardReadinessResult } from '@lib/health-checks/readiness';
 import type {
   AskAnswers,
   OutroData,
   PendingQuestion,
-} from '../lib/wizard-session';
+} from '@lib/wizard-session';
 
 export enum TaskStatus {
   Pending = 'pending',

--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -1,7 +1,7 @@
-import { Analytics } from '../analytics';
+import { Analytics } from '@utils/analytics';
 import { PostHog } from 'posthog-node';
 import { v4 as uuidv4 } from 'uuid';
-import { ANALYTICS_TEAM_TAG } from '../../lib/constants';
+import { ANALYTICS_TEAM_TAG } from '@lib/constants';
 
 jest.mock('posthog-node');
 jest.mock('uuid');

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { provisionNewAccount } from '../provisioning';
+import { provisionNewAccount } from '@utils/provisioning';
 
 jest.mock('axios');
 jest.mock('../debug', () => ({ logToFile: jest.fn() }));

--- a/src/utils/__tests__/semver.test.ts
+++ b/src/utils/__tests__/semver.test.ts
@@ -1,4 +1,4 @@
-import { createVersionBucket, fulfillsVersionRange } from '../semver';
+import { createVersionBucket, fulfillsVersionRange } from '@utils/semver';
 
 describe('createVersionBucket', () => {
   describe('without minimum threshold', () => {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -3,8 +3,8 @@ import {
   ANALYTICS_HOST_URL,
   ANALYTICS_POSTHOG_PUBLIC_PROJECT_WRITE_KEY,
   ANALYTICS_TEAM_TAG,
-} from '../lib/constants';
-import type { WizardSession } from '../lib/wizard-session';
+} from '@lib/constants';
+import type { WizardSession } from '@lib/wizard-session';
 import { v4 as uuidv4 } from 'uuid';
 import { debug } from './debug';
 

--- a/src/utils/custom-headers.ts
+++ b/src/utils/custom-headers.ts
@@ -1,4 +1,4 @@
-import { POSTHOG_FLAG_HEADER_PREFIX } from '../lib/constants';
+import { POSTHOG_FLAG_HEADER_PREFIX } from '@lib/constants';
 
 /**
  * Builds a list of custom headers for ANTHROPIC_CUSTOM_HEADERS.

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,6 +1,6 @@
 import { appendFileSync } from 'fs';
 import path from 'path';
-import { getUI } from '../ui';
+import { getUI } from '@ui';
 import { runtimeEnv } from '@env';
 import { WIZARD_LOG_FILE } from './paths';
 

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -7,7 +7,7 @@ const readEnv =
 import { tryGetPackageJson } from './setup-utils';
 import type { WizardOptions } from './types';
 import fg from 'fast-glob';
-import { IS_DEV } from '../lib/constants';
+import { IS_DEV } from '@lib/constants';
 
 export function isNonInteractiveEnvironment(): boolean {
   if (IS_DEV) {

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 import { logToFile } from './debug';
 import opn from 'opn';
 import { z } from 'zod';
-import { getUI } from '../ui';
+import { getUI } from '@ui';
 import {
   IS_DEV,
   ISSUES_URL,
@@ -15,7 +15,7 @@ import {
   POSTHOG_OAUTH_URL,
   POSTHOG_PROXY_CLIENT_ID,
   WIZARD_USER_AGENT,
-} from '../lib/constants';
+} from '@lib/constants';
 import { NODE_ENV } from '@env';
 import { abort } from './setup-utils';
 import { analytics } from './analytics';

--- a/src/utils/provisioning.ts
+++ b/src/utils/provisioning.ts
@@ -16,7 +16,7 @@ import {
   POSTHOG_US_CLIENT_ID,
   WIZARD_PROVISIONING_SCOPES,
   WIZARD_USER_AGENT,
-} from '../lib/constants';
+} from '@lib/constants';
 import { logToFile } from './debug';
 import { analytics } from './analytics';
 

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -19,9 +19,9 @@ import {
   DUMMY_PROJECT_API_KEY,
   ISSUES_URL,
   WIZARD_OAUTH_SCOPES,
-} from '../lib/constants';
+} from '@lib/constants';
 import { analytics } from './analytics';
-import { getUI } from '../ui';
+import { getUI } from '@ui';
 import {
   getCloudUrlFromRegion,
   getHostFromRegion,
@@ -29,7 +29,7 @@ import {
 } from './urls';
 import { performOAuthFlow } from './oauth';
 import { provisionNewAccount } from './provisioning';
-import { fetchUserData, fetchProjectData } from '../lib/api';
+import { fetchUserData, fetchProjectData } from '@lib/api';
 import { fulfillsVersionRange } from './semver';
 import { wizardAbort } from './wizard-abort';
 

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { IS_DEV, WIZARD_USER_AGENT } from '../lib/constants';
+import { IS_DEV, WIZARD_USER_AGENT } from '@lib/constants';
 import type { CloudRegion } from './types';
 
 export const getAssetHostFromHost = (host: string) => {

--- a/src/utils/wizard-abort.ts
+++ b/src/utils/wizard-abort.ts
@@ -7,8 +7,8 @@
  * The legacy abort() in setup-utils.ts delegates here.
  */
 import { analytics } from './analytics';
-import { getUI } from '../ui';
-import { OutroKind, type OutroData } from '../lib/wizard-session';
+import { getUI } from '@ui';
+import { OutroKind, type OutroData } from '@lib/wizard-session';
 
 export class WizardError extends Error {
   constructor(

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -21,7 +21,9 @@
       "@env": ["./src/env.ts"],
       "@lib/*": ["./src/lib/*"],
       "@utils/*": ["./src/utils/*"],
+      "@ui": ["./src/ui/index.ts"],
       "@ui/*": ["./src/ui/*"],
+      "@steps": ["./src/steps/index.ts"],
       "@steps/*": ["./src/steps/*"],
       "@frameworks/*": ["./src/frameworks/*"]
     }


### PR DESCRIPTION
## Summary

- The tsconfig already declared `@env`, `@lib/*`, `@utils/*`, `@ui/*`, `@steps/*`, and `@frameworks/*` aliases, but only `@env` was actually being used — everything else still leaned on `../../../...` chains. This sweep makes the codebase actually use them.
- Adds non-wildcard `@ui` and `@steps` aliases (mirrored in Jest's `moduleNameMapper`) so directory-style imports like `import { getUI } from '@ui'` resolve through the package's `index.ts`. The existing wildcard aliases only handle nested paths.
- Rewrites every relative import that crossed a top-level src/ boundary to use the appropriate alias. Same-directory imports (`./foo`) are intentionally left alone.
- Drops the `.js` suffix from aliased imports — Jest's mapper can't resolve `@lib/foo.js` to a `.ts` file, and the bundler resolves aliased paths without needing the extension.

253 files touched, no behavior changes.

## Test plan

- [x] `pnpm build` passes (smoke test included)
- [x] `pnpm jest` — 645/645 tests pass
- [x] `pnpm lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm typecheck` clean