### PR TITLE
fix(oauth): force project selection screen on every login

### DIFF
--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -282,6 +282,7 @@ export async function performOAuthFlow(
       authUrl.searchParams.set('code_challenge_method', 'S256');
       authUrl.searchParams.set('scope', config.scopes.join(' '));
       authUrl.searchParams.set('required_access_level', 'project');
+      authUrl.searchParams.set('approval_prompt', 'force');
 
       const signupUrl = new URL(
         `${POSTHOG_OAUTH_URL}/signup?next=${encodeURIComponent(


### PR DESCRIPTION
## Problem

Users running `npx @posthog/wizard` who have already authorized the wizard in their browser sometimes never see the OAuth scope authorization / project picker screen on subsequent runs. The wizard silently picks up the previously-authorized project from the OAuth token response and ends up "mangling" an unrelated existing project instead of letting the user pick or create the right one.

Reported on Slack by Michael Matloka and reproduced intermittently by Edwin.

Root cause: the wizard constructs the OAuth authorize URL with `required_access_level=project` but no `approval_prompt`. Django OAuth Toolkit (which powers PostHog's OAuth server) defaults to `approval_prompt=auto`, which short-circuits the authorization screen when a valid prior consent exists. On a silent re-consent, the server hands back a token scoped to the user's previously-selected project; in `setup-utils.ts` the wizard reads `tokenResponse.scoped_teams?.[0]` without any further confirmation, so the wrong project gets wired up.

## Changes

Pass `approval_prompt=force` on the OAuth authorize URL in `src/utils/oauth.ts` so the PostHog authorization server always renders the project authorization screen, even when the browser still has an active PostHog session and a prior consent on file.

## Test plan

- [ ] Run `pnpm try --install-dir=<path>` after having previously completed an OAuth login (cookie still warm) and confirm the project picker is shown.
- [ ] Run twice in a row against the same browser; the second run should still show the picker.
- [ ] Verify US and EU regions both hit the picker.
- [ ] Existing first-time OAuth flow continues to work end-to-end.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*