### PR TITLE
fix: sharing health check step with agent-skill program

### DIFF
--- a/src/lib/programs/__tests__/agent-skill.test.ts
+++ b/src/lib/programs/__tests__/agent-skill.test.ts
@@ -49,9 +49,10 @@ describe('createSkillProgram', () => {
 });
 
 describe('AGENT_SKILL_STEPS', () => {
-  it('is intro → auth → run → outro → skills, all with screens and working predicates', () => {
+  it('is intro → health-check → auth → run → outro → skills, all with screens and working predicates', () => {
     expect(AGENT_SKILL_STEPS.map((s) => s.id)).toEqual([
       'intro',
+      'health-check',
       'auth',
       'run',
       'outro',
@@ -59,7 +60,7 @@ describe('AGENT_SKILL_STEPS', () => {
     ]);
 
     const session = buildSession({});
-    const [intro, auth, run, outro] = AGENT_SKILL_STEPS;
+    const [intro, , auth, run, outro] = AGENT_SKILL_STEPS;
 
     // Intro gate starts closed
     expect(intro.gate!(session)).toBe(false);

--- a/src/lib/programs/agent-skill/steps.ts
+++ b/src/lib/programs/agent-skill/steps.ts
@@ -1,12 +1,13 @@
 /**
  * Generic agent skill step list.
  *
- * Minimal flow: auth → run → outro → skills.
+ * Minimal flow: intro → health-check → auth → run → outro → skills.
  * No detection, no setup, no MCP.
  */
 
 import type { ProgramStep } from '@lib/programs/program-step';
 import { RunPhase } from '@lib/wizard-session';
+import { HEALTH_CHECK_STEP } from '@lib/programs/shared/health-check-step';
 
 export const AGENT_SKILL_STEPS: ProgramStep[] = [
   {
@@ -15,6 +16,7 @@ export const AGENT_SKILL_STEPS: ProgramStep[] = [
     screenId: 'agent-skill-intro',
     gate: (session) => session.setupConfirmed,
   },
+  HEALTH_CHECK_STEP,
   {
     id: 'auth',
     label: 'Authentication',

--- a/src/lib/programs/events-audit/steps.ts
+++ b/src/lib/programs/events-audit/steps.ts
@@ -11,12 +11,7 @@
 import type { ProgramStep } from '@lib/programs/program-step';
 import type { WizardSession } from '@lib/wizard-session';
 import { RunPhase } from '@lib/wizard-session';
-import {
-  evaluateWizardReadiness,
-  WizardReadiness,
-  SIGNUP_WIZARD_READINESS_CONFIG,
-  getBlockingServiceKeys,
-} from '@lib/health-checks/readiness';
+import { HEALTH_CHECK_STEP } from '@lib/programs/shared/health-check-step';
 
 function needsSetup(session: WizardSession): boolean {
   const config = session.frameworkConfig;
@@ -27,27 +22,6 @@ function needsSetup(session: WizardSession): boolean {
   );
 }
 
-function healthCheckReady(session: WizardSession): boolean {
-  if (!session.readinessResult) return false;
-
-  if (session.signup) {
-    const hardBlocking = getBlockingServiceKeys(
-      session.readinessResult.health,
-      SIGNUP_WIZARD_READINESS_CONFIG,
-    );
-    const defaultBlocking = getBlockingServiceKeys(
-      session.readinessResult.health,
-    );
-    if (hardBlocking.length === 0 && defaultBlocking.length === 0) return true;
-    return session.outageDismissed;
-  }
-
-  if (session.readinessResult.decision === WizardReadiness.No) {
-    return session.outageDismissed;
-  }
-  return true;
-}
-
 export const EVENTS_AUDIT_PROGRAM: ProgramStep[] = [
   {
     id: 'intro',
@@ -55,25 +29,7 @@ export const EVENTS_AUDIT_PROGRAM: ProgramStep[] = [
     screenId: 'audit-intro',
     gate: (session) => session.setupConfirmed,
   },
-  {
-    id: 'health-check',
-    label: 'Health check',
-    screenId: 'health-check',
-    gate: healthCheckReady,
-    onInit: (ctx) => {
-      evaluateWizardReadiness()
-        .then((readiness) => {
-          ctx.setReadinessResult(readiness);
-        })
-        .catch(() => {
-          ctx.setReadinessResult({
-            decision: WizardReadiness.Yes,
-            health: {} as never,
-            reasons: [],
-          });
-        });
-    },
-  },
+  HEALTH_CHECK_STEP,
   {
     id: 'setup',
     label: 'Setup',

--- a/src/lib/programs/migration/steps.ts
+++ b/src/lib/programs/migration/steps.ts
@@ -1,5 +1,6 @@
 import type { ProgramStep } from '@lib/programs/program-step';
 import { RunPhase } from '@lib/wizard-session';
+import { HEALTH_CHECK_STEP } from '@lib/programs/shared/health-check-step';
 
 export const MIGRATION_PROGRAM: ProgramStep[] = [
   {
@@ -8,6 +9,7 @@ export const MIGRATION_PROGRAM: ProgramStep[] = [
     screenId: 'migration-intro',
     gate: (session) => session.setupConfirmed,
   },
+  HEALTH_CHECK_STEP,
   {
     id: 'auth',
     label: 'Authentication',

--- a/src/lib/programs/posthog-doctor/steps.ts
+++ b/src/lib/programs/posthog-doctor/steps.ts
@@ -1,4 +1,5 @@
 import type { ProgramStep } from '@lib/programs/program-step';
+import { HEALTH_CHECK_STEP } from '@lib/programs/shared/health-check-step';
 
 export const POSTHOG_DOCTOR_PROGRAM: ProgramStep[] = [
   {
@@ -7,6 +8,7 @@ export const POSTHOG_DOCTOR_PROGRAM: ProgramStep[] = [
     screenId: 'doctor-intro',
     gate: (session) => session.setupConfirmed,
   },
+  HEALTH_CHECK_STEP,
   {
     id: 'auth',
     label: 'Authentication',

--- a/src/lib/programs/posthog-integration/steps.ts
+++ b/src/lib/programs/posthog-integration/steps.ts
@@ -9,12 +9,7 @@
 import type { ProgramStep } from '@lib/programs/program-step';
 import type { WizardSession } from '@lib/wizard-session';
 import { RunPhase } from '@lib/wizard-session';
-import {
-  evaluateWizardReadiness,
-  WizardReadiness,
-  SIGNUP_WIZARD_READINESS_CONFIG,
-  getBlockingServiceKeys,
-} from '@lib/health-checks/readiness';
+import { HEALTH_CHECK_STEP } from '@lib/programs/shared/health-check-step';
 import { detectPostHogIntegration } from './detect.js';
 
 function needsSetup(session: WizardSession): boolean {
@@ -24,27 +19,6 @@ function needsSetup(session: WizardSession): boolean {
   return config.metadata.setup.questions.some(
     (q: { key: string }) => !(q.key in session.frameworkContext),
   );
-}
-
-function healthCheckReady(session: WizardSession): boolean {
-  if (!session.readinessResult) return false;
-
-  if (session.signup) {
-    const hardBlocking = getBlockingServiceKeys(
-      session.readinessResult.health,
-      SIGNUP_WIZARD_READINESS_CONFIG,
-    );
-    const defaultBlocking = getBlockingServiceKeys(
-      session.readinessResult.health,
-    );
-    if (hardBlocking.length === 0 && defaultBlocking.length === 0) return true;
-    return session.outageDismissed;
-  }
-
-  if (session.readinessResult.decision === WizardReadiness.No) {
-    return session.outageDismissed;
-  }
-  return true;
 }
 
 export const POSTHOG_INTEGRATION_PROGRAM: ProgramStep[] = [
@@ -63,25 +37,7 @@ export const POSTHOG_INTEGRATION_PROGRAM: ProgramStep[] = [
     screenId: 'intro',
     gate: (session) => session.setupConfirmed,
   },
-  {
-    id: 'health-check',
-    label: 'Health check',
-    screenId: 'health-check',
-    gate: healthCheckReady,
-    onInit: (ctx) => {
-      evaluateWizardReadiness()
-        .then((readiness) => {
-          ctx.setReadinessResult(readiness);
-        })
-        .catch(() => {
-          ctx.setReadinessResult({
-            decision: WizardReadiness.Yes,
-            health: {} as never,
-            reasons: [],
-          });
-        });
-    },
-  },
+  HEALTH_CHECK_STEP,
   {
     id: 'setup',
     label: 'Setup',

--- a/src/lib/programs/revenue-analytics/steps.ts
+++ b/src/lib/programs/revenue-analytics/steps.ts
@@ -7,6 +7,7 @@
 
 import type { ProgramStep } from '@lib/programs/program-step';
 import { RunPhase } from '@lib/wizard-session';
+import { HEALTH_CHECK_STEP } from '@lib/programs/shared/health-check-step';
 import { detectRevenuePrerequisites } from './detect.js';
 
 export const REVENUE_ANALYTICS_PROGRAM: ProgramStep[] = [
@@ -26,6 +27,7 @@ export const REVENUE_ANALYTICS_PROGRAM: ProgramStep[] = [
     screenId: 'revenue-intro',
     gate: (session) => session.setupConfirmed,
   },
+  HEALTH_CHECK_STEP,
   {
     id: 'auth',
     label: 'Authentication',

--- a/src/lib/programs/shared/health-check-step.ts
+++ b/src/lib/programs/shared/health-check-step.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared health-check step used by every program that runs an agent.
+ *
+ * Renders the HealthCheckScreen between intro and auth, kicks off the
+ * readiness probe in onInit, and gates the screen on either a clean
+ * readiness result or an explicit user dismissal of the outage.
+ *
+ * Programs without this step that hit a blocking outage gridlock the
+ * router: agent-runner calls wizardAbort, which awaits outroDismissed,
+ * but the router can't advance past the still-incomplete auth step to
+ * render the OutroScreen.
+ */
+
+import type { ProgramStep } from '@lib/programs/program-step';
+import type { WizardSession } from '@lib/wizard-session';
+import {
+  evaluateWizardReadiness,
+  WizardReadiness,
+  SIGNUP_WIZARD_READINESS_CONFIG,
+  getBlockingServiceKeys,
+} from '@lib/health-checks/readiness';
+
+export function healthCheckReady(session: WizardSession): boolean {
+  if (!session.readinessResult) return false;
+
+  if (session.signup) {
+    const hardBlocking = getBlockingServiceKeys(
+      session.readinessResult.health,
+      SIGNUP_WIZARD_READINESS_CONFIG,
+    );
+    const defaultBlocking = getBlockingServiceKeys(
+      session.readinessResult.health,
+    );
+    if (hardBlocking.length === 0 && defaultBlocking.length === 0) return true;
+    return session.outageDismissed;
+  }
+
+  if (session.readinessResult.decision === WizardReadiness.No) {
+    return session.outageDismissed;
+  }
+  return true;
+}
+
+export const HEALTH_CHECK_STEP: ProgramStep = {
+  id: 'health-check',
+  label: 'Health check',
+  screenId: 'health-check',
+  gate: healthCheckReady,
+  onInit: (ctx) => {
+    evaluateWizardReadiness()
+      .then((readiness) => {
+        ctx.setReadinessResult(readiness);
+      })
+      .catch(() => {
+        ctx.setReadinessResult({
+          decision: WizardReadiness.Yes,
+          health: {} as never,
+          reasons: [],
+        });
+      });
+  },
+};

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -1054,9 +1054,17 @@ describe('WizardStore', () => {
 
       // Step 1: Confirm intro
       store.completeSetup();
+      expect(store.currentScreen).toBe(ScreenId.HealthCheck);
+
+      // Step 2: Clear the health-check screen with a healthy readiness result
+      store.setReadinessResult({
+        decision: WizardReadiness.Yes,
+        health: {} as never,
+        reasons: [],
+      });
       expect(store.currentScreen).toBe(ScreenId.Auth);
 
-      // Step 2: Authenticate
+      // Step 3: Authenticate
       store.setCredentials({
         accessToken: 'tok',
         projectApiKey: 'pk',
@@ -1065,14 +1073,14 @@ describe('WizardStore', () => {
       });
       expect(store.currentScreen).toBe(ScreenId.Run);
 
-      // Step 3: Start and complete run
+      // Step 4: Start and complete run
       store.setRunPhase(RunPhase.Running);
       expect(store.currentScreen).toBe(ScreenId.Run);
 
       store.setRunPhase(RunPhase.Completed);
       expect(store.currentScreen).toBe(ScreenId.Outro);
 
-      // Step 4: Dismiss outro
+      // Step 5: Dismiss outro
       store.setOutroDismissed();
       expect(store.currentScreen).toBe('keep-skills');
     });

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -1084,9 +1084,17 @@ describe('WizardStore', () => {
 
       // Step 1: Confirm intro
       store.completeSetup();
+      expect(store.currentScreen).toBe(ScreenId.HealthCheck);
+
+      // Step 2: Clear the health-check screen with a healthy readiness result
+      store.setReadinessResult({
+        decision: WizardReadiness.Yes,
+        health: {} as never,
+        reasons: [],
+      });
       expect(store.currentScreen).toBe(ScreenId.Auth);
 
-      // Step 2: Authenticate
+      // Step 3: Authenticate
       store.setCredentials({
         accessToken: 'tok',
         projectApiKey: 'pk',
@@ -1095,14 +1103,14 @@ describe('WizardStore', () => {
       });
       expect(store.currentScreen).toBe(ScreenId.Run);
 
-      // Step 3: Start and complete run
+      // Step 4: Start and complete run
       store.setRunPhase(RunPhase.Running);
       expect(store.currentScreen).toBe(ScreenId.Run);
 
       store.setRunPhase(RunPhase.Completed);
       expect(store.currentScreen).toBe(ScreenId.Outro);
 
-      // Step 4: Dismiss outro
+      // Step 5: Dismiss outro
       store.setOutroDismissed();
       expect(store.currentScreen).toBe('keep-skills');
     });


### PR DESCRIPTION
## Problem

`agent-skill` program would fail if Anthropic or other dependent services were in a degraded state because there was no health check screen to resolve 

Make health check screen reusable for all programs