### PR TITLE
feat: enrich oauth login failure telemetry for diagnosis

### DIFF
--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -361,8 +361,20 @@ export async function performOAuthFlow(
           );
         }
 
+        const oauthErrorCode = error.message.startsWith('OAuth error: ')
+          ? error.message.slice('OAuth error: '.length)
+          : error.message.includes('timeout')
+          ? 'timeout'
+          : 'unknown';
+
         analytics.captureException(error, {
           step: 'oauth_flow',
+          oauth_error_code: oauthErrorCode,
+          client_id: clientId,
+          requested_scopes: config.scopes.join(' '),
+          // Collapse OAuth callback failures of the same kind into one issue
+          // instead of fragmenting by each user's install path in the stack trace.
+          $exception_fingerprint: `wizard_oauth_${oauthErrorCode}`,
         });
 
         await abort();


### PR DESCRIPTION
## Problem

On OAuth login failure the wizard captured a generic exception with no context beyond the error message. Because the stack trace includes each user's install path (local source checkout, npx cache, bundled `dist`), the same underlying failure fragmented into many separate Error Tracking issues, with each failed run reporting as a new anonymous user. That made OAuth failures hard to triage and impossible to alert on cleanly.

This matters because the platform's per-app OAuth scope ceiling can reject the wizard's requested scopes at `/authorize` with `invalid_scope` when an app's ceiling isn't seeded with everything the wizard asks for. When that happens, the wizard is the failing client but the telemetry doesn't say which client, which scopes, or why.

## Changes

In `performOAuthFlow`'s failure path, attach `oauth_error_code` (parsed from the callback `error`), `client_id`, and `requested_scopes` to the captured exception, and set a stable `$exception_fingerprint` (`wizard_oauth_<code>`) so failures of the same kind collapse into one issue regardless of where the wizard is installed. No change to the auth flow itself.

## Test plan

- `pnpm build` (typecheck + smoke test) and `pnpm test` pass; `pnpm fix` clean.
- The enrichment is on the existing `captureException` call in the catch block; no new control flow.
- Covered by CI.

## Related

- Server-side log on the rejection path (platform repo): https://github.com/PostHog/posthog/pull/61216

## LLM context

Authored by Claude Code (Opus 4.8) as follow-up observability, paired with the server-side log linked above. `region` was intentionally not added (the wizard can't know it until after auth succeeds, and this fires pre-auth); the runbook link rides on the downstream alert rather than being hardcoded into source.
