### PR TITLE
feat(audit-3000): create notebook in customer project + UI polish

### DIFF
--- a/src/lib/programs/audit-3000/index.ts
+++ b/src/lib/programs/audit-3000/index.ts
@@ -7,6 +7,7 @@ import {
 import type { ProgramStep, ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { WizardSession } from '@lib/wizard-session';
+import { OutroKind } from '@lib/wizard-session';
 import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { AUDIT_ABORT_CASES } from '@lib/programs/audit/detect';
 import {
@@ -18,6 +19,29 @@ import { AUDIT_SEED_CHECKS } from '@lib/programs/audit/seed';
 import { logToFile } from '@utils/debug';
 
 const AUDIT3000_REPORT_FILE = 'posthog-audit-3000-report.md';
+const AUDIT3000_NOTEBOOK_URL_FILE = '/tmp/posthog-notebook-url.txt';
+
+/**
+ * Read the notebook URL that step 10 of the audit-3000 skill writes to
+ * `/tmp/posthog-notebook-url.txt`, then delete the file so it never lingers
+ * across runs. Returns `null` if the file is missing or unreadable.
+ */
+const readAndConsumeNotebookUrl = (): string | null => {
+  try {
+    if (!fs.existsSync(AUDIT3000_NOTEBOOK_URL_FILE)) {
+      return null;
+    }
+    const raw = fs.readFileSync(AUDIT3000_NOTEBOOK_URL_FILE, 'utf8').trim();
+    fs.unlinkSync(AUDIT3000_NOTEBOOK_URL_FILE);
+    if (!raw || !/^https?:\/\//.test(raw)) {
+      return null;
+    }
+    return raw;
+  } catch (err) {
+    logToFile(`readAndConsumeNotebookUrl: ${(err as Error).message}`);
+    return null;
+  }
+};
 
 // Extra checks the v3000 audit adds on top of the base 10. IDs must match
 // those referenced in the audit-3000 skill's step files (Event Quality,
@@ -106,74 +130,74 @@ const AUDIT3000_EXTRA_CHECKS: AuditCheck[] = [
     label: 'Mobile sampling configured',
     status: 'pending',
   },
-  // ── Use Case: Expansion (Step 9) ──
+  // ── Stack consolidation (Step 9) ──
   {
     id: 'expansion-product-analytics',
-    area: 'Use Case: Expansion',
+    area: 'Stack consolidation',
     label: 'Product analytics coverage',
     status: 'pending',
   },
   {
     id: 'expansion-error-tracking',
-    area: 'Use Case: Expansion',
+    area: 'Stack consolidation',
     label: 'Error tracking coverage',
     status: 'pending',
   },
   {
     id: 'expansion-llm-observability',
-    area: 'Use Case: Expansion',
+    area: 'Stack consolidation',
     label: 'LLM observability coverage',
     status: 'pending',
   },
   {
     id: 'expansion-session-replay',
-    area: 'Use Case: Expansion',
+    area: 'Stack consolidation',
     label: 'Session replay coverage',
     status: 'pending',
   },
   {
     id: 'expansion-feature-flags',
-    area: 'Use Case: Expansion',
+    area: 'Stack consolidation',
     label: 'Feature flags coverage',
     status: 'pending',
   },
   {
     id: 'expansion-surveys',
-    area: 'Use Case: Expansion',
+    area: 'Stack consolidation',
     label: 'Surveys coverage',
     status: 'pending',
   },
   {
     id: 'expansion-logs',
-    area: 'Use Case: Expansion',
+    area: 'Stack consolidation',
     label: 'Logs coverage',
     status: 'pending',
   },
   {
     id: 'expansion-web-analytics',
-    area: 'Use Case: Expansion',
+    area: 'Stack consolidation',
     label: 'Web analytics coverage',
     status: 'pending',
   },
-  // ── Additional Sections (Steps 7, 8, 10 phase markers) ──
+  // ── Wrap-up & notebook (Steps 7, 8, 10 phase markers) ──
   // Tracked in the ledger so the UI can surface "did it run / was it
   // skipped" alongside the regular checks. use-case-expansion is omitted
   // because the eight `expansion-*` checks above cover that phase.
   {
     id: 'customer-enrichment',
-    area: 'Additional Sections',
+    area: 'Wrap-up & notebook',
     label: 'Customer enrichment (Harmonic + PDL)',
     status: 'pending',
   },
   {
     id: 'use-case-match',
-    area: 'Additional Sections',
+    area: 'Wrap-up & notebook',
     label: 'Use-case match',
     status: 'pending',
   },
   {
     id: 'final-report',
-    area: 'Additional Sections',
+    area: 'Wrap-up & notebook',
     label: 'Final audit report written',
     status: 'pending',
   },
@@ -223,14 +247,25 @@ const baseConfig = createSkillProgram({
     'Audit an existing PostHog integration (v3000 — adds event quality, stale-flag hygiene, customer enrichment, use-case match)',
   integrationLabel: 'audit-3000',
   customPrompt:
-    'Run the audit-3000 skill end-to-end. Follow the step chain starting at references/1-version.md. Do not modify any project files — only create the final audit report and (when enrichment is enabled) the enrichment report.',
-  successMessage: `Audit complete! View the report at ./${AUDIT3000_REPORT_FILE}`,
+    'Run the audit-3000 skill end-to-end. Follow the step chain starting at references/1-version.md. Do not modify any project files. The ONLY deliverable is the audit notebook created inside the customer PostHog project (via mcp__posthog-wizard__notebooks-create in step 10). IMPORTANT: ignore any later instruction that asks you to write a markdown report file at the project root — the audit notebook IS the report. Do not write posthog-audit-3000-report.md, posthog-audit-report.md, or any similar markdown summary file. Step 7 may stage enrichment content in /tmp; that is fine and is cleaned up in step 10.',
+  successMessage: 'Audit complete!',
   reportFile: AUDIT3000_REPORT_FILE,
   docsUrl: 'https://posthog.com/docs/product-analytics/best-practices',
   spinnerMessage: 'Running PostHog Audit 3000...',
   estimatedDurationMinutes: 6,
   requires: ['posthog-integration'],
   abortCases: AUDIT_ABORT_CASES,
+  buildOutroData: (_sess, _credentials, _cloudRegion) => {
+    const notebookUrl = readAndConsumeNotebookUrl();
+    return {
+      kind: OutroKind.Success,
+      message: notebookUrl
+        ? 'Audit complete!'
+        : 'Audit complete — notebook URL not captured.',
+      notebookUrl: notebookUrl ?? undefined,
+      docsUrl: 'https://posthog.com/docs/product-analytics/best-practices',
+    };
+  },
 });
 
 const audit3000Run = async (session: WizardSession): Promise<ProgramRun> => {

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -92,6 +92,8 @@ export interface OutroData {
   reportFile?: string;
   /** PostHog dashboard URL the program created on the user's behalf. */
   dashboardUrl?: string;
+  /** PostHog notebook URL the program created on the user's behalf (audit-3000). */
+  notebookUrl?: string;
 }
 
 /** A single question rendered by the WizardAsk overlay. */

--- a/src/ui/tui/screens/KeepSkillsScreen.tsx
+++ b/src/ui/tui/screens/KeepSkillsScreen.tsx
@@ -109,8 +109,22 @@ export const KeepSkillsScreen = ({ store }: KeepSkillsScreenProps) => {
     }, 600);
   };
 
+  // Surface the audit-3000 notebook URL here too — by this screen the
+  // outro has already scrolled away. Conditional on outroData.notebookUrl
+  // so other workflows render unchanged.
+  const notebookUrl = store.session.outroData?.notebookUrl;
+
   return (
     <Box flexDirection="column" flexGrow={1}>
+      {notebookUrl && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text color="green" bold>
+            {'\u2714'} Your audit notebook is ready:
+          </Text>
+          <Text color="cyan">{notebookUrl}</Text>
+          <Text dimColor>Open in your browser to read the full audit.</Text>
+        </Box>
+      )}
       <Text bold color={Colors.accent}>
         Keep the skills?
       </Text>

--- a/src/ui/tui/screens/audit-3000/Audit3000AreaPane.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000AreaPane.tsx
@@ -6,7 +6,7 @@
  * "LEVEL N: <area>" framing instead of "Verifying ...".
  */
 
-import { Fragment } from 'react';
+import { Fragment, memo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { spawn } from 'node:child_process';
 import { Colors } from '@ui/tui/styles';
@@ -43,7 +43,7 @@ interface Audit3000AreaPaneProps {
   reportPath: string;
 }
 
-export const Audit3000AreaPane = ({
+const Audit3000AreaPaneImpl = ({
   checks,
   reportPath,
 }: Audit3000AreaPaneProps) => {
@@ -67,8 +67,17 @@ export const Audit3000AreaPane = ({
 
   if (slide) {
     const hasFindings = checks.some(isFinding);
+    // "First level, no check resolved yet" = we're at the very start of the run.
+    // Show the orientation preamble above the slide content until something happens.
+    const showPreamble =
+      level === 1 && checks.every((c) => c.status === 'pending');
     return (
-      <ActiveSlide slide={slide} level={level} hasFindings={hasFindings} />
+      <ActiveSlide
+        slide={slide}
+        level={level}
+        hasFindings={hasFindings}
+        showPreamble={showPreamble}
+      />
     );
   }
 
@@ -79,16 +88,51 @@ export const Audit3000AreaPane = ({
   return <WritingReport reportPath={reportPath} />;
 };
 
+const OrientationPreamble = () => (
+  <Box
+    flexDirection="column"
+    borderStyle="single"
+    borderColor={Colors.accent}
+    paddingX={1}
+    marginBottom={1}
+  >
+    <Text bold color={Colors.accent}>
+      {'\u25B6'} What's happening
+    </Text>
+    <Box height={1} />
+    <Text>
+      We're running <Text bold>34 checks across 9 levels</Text> on your PostHog
+      integration. Each level explains what it's looking at here on the left as
+      it starts. The whole audit takes about <Text bold>5-7 minutes</Text>.
+    </Text>
+    <Box height={1} />
+    <Text>
+      The final output is a <Text bold>notebook inside your PostHog</Text>{' '}
+      project (we'll print the direct link at the end) — nothing in your
+      codebase is modified.
+    </Text>
+    <Box height={1} />
+    <Text dimColor>
+      Use <Text color={Colors.accent}>{'\u2190 \u2192'}</Text> to switch tabs:
+      Hi-score Table (live report), Play (a game), HN, or Tail logs. Or just
+      leave it running and come back.
+    </Text>
+  </Box>
+);
+
 const ActiveSlide = ({
   slide,
   level,
   hasFindings,
+  showPreamble,
 }: {
   slide: AreaSlide;
   level: number | null;
   hasFindings: boolean;
+  showPreamble: boolean;
 }) => (
   <Box flexDirection="column" paddingX={1}>
+    {showPreamble && <OrientationPreamble />}
     <Text bold color={Colors.accent}>
       {level ? `LEVEL ${level}: ` : ''}
       {slide.area.toUpperCase()}
@@ -121,22 +165,33 @@ const ActiveSlide = ({
   </Box>
 );
 
-const WritingReport = ({ reportPath }: { reportPath: string }) => (
+const WritingReport = ({ reportPath: _reportPath }: { reportPath: string }) => (
   <Box flexDirection="column" paddingX={1}>
     <Text bold color={Colors.accent}>
       STAGE CLEAR.
     </Text>
     <Box height={1} />
     <Text>
-      All checks resolved. Compiling your high-score reel at{' '}
-      <Text color="cyan">{reportPath}</Text>.
+      All checks resolved. Writing your audit notebook into your PostHog project
+      now.
     </Text>
     <Box height={1} />
     <Text>
-      The report covers everything we checked, what we found, and what to do
-      next.
+      The notebook covers everything we checked, what we found, and what to do
+      next. We'll print the link when it's done.
     </Text>
     <Box height={1} />
     <Text dimColor>{'Stand by\u2026'}</Text>
   </Box>
+);
+
+/**
+ * Memo'd to skip re-renders when neither `checks` nor `reportPath` changed.
+ * Pairs with the same memo on `Audit3000ChecksPanel` to cut flicker from
+ * unrelated store updates (status messages, polling ticks). Audit-3000 only.
+ */
+export const Audit3000AreaPane = memo(
+  Audit3000AreaPaneImpl,
+  (prev, next) =>
+    prev.checks === next.checks && prev.reportPath === next.reportPath,
 );

--- a/src/ui/tui/screens/audit-3000/Audit3000ChecksPanel.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000ChecksPanel.tsx
@@ -8,12 +8,9 @@
  * stage overview.
  */
 
+import { memo } from 'react';
 import { Box, Text } from 'ink';
-import { Spinner } from '@inkjs/ui';
-import {
-  type AuditCheck,
-  type AuditStatus,
-} from '@lib/programs/audit/types';
+import { type AuditCheck, type AuditStatus } from '@lib/programs/audit/types';
 import { Colors, Icons } from '@ui/tui/styles';
 import { LoadingBox } from '@ui/tui/primitives/index';
 
@@ -109,9 +106,11 @@ const GroupHeader = ({
   return (
     <Box>
       {isActive ? (
-        <Box marginRight={1}>
-          <Spinner />
-        </Box>
+        <Text>
+          <Text bold color={NEON_PINK}>
+            {'\u25B6'}
+          </Text>{' '}
+        </Text>
       ) : showIcon ? (
         <Text>
           <Text color={color}>{icon}</Text>{' '}
@@ -128,13 +127,32 @@ const GroupHeader = ({
   );
 };
 
-export const Audit3000ChecksPanel = ({ checks }: Audit3000ChecksPanelProps) => {
+const Audit3000ChecksPanelImpl = ({ checks }: Audit3000ChecksPanelProps) => {
   if (checks.length === 0) {
     return (
       <Box flexDirection="column">
-        <Text bold>AUDIT-3000</Text>
+        <Text bold color={NEON_PINK}>
+          AUDIT-3000
+        </Text>
         <Text> </Text>
         <LoadingBox message="Booting up arcade cabinet..." />
+        <Box marginTop={1} flexDirection="column">
+          <Text dimColor>
+            Reviewing your PostHog integration across 34 checks. ~5\u20137 min.
+          </Text>
+          <Text dimColor> </Text>
+          <Text dimColor>
+            Use <Text color={NEON_GOLD}>{'\u2190 \u2192'}</Text> to switch tabs:
+          </Text>
+          <Text dimColor>
+            {'  '}Arcade · Hi-score Table · Play · Tail logs · HN
+          </Text>
+          <Text dimColor> </Text>
+          <Text dimColor>
+            Output: a notebook in your PostHog project (link printed at the
+            end).
+          </Text>
+        </Box>
       </Box>
     );
   }
@@ -169,3 +187,16 @@ export const Audit3000ChecksPanel = ({ checks }: Audit3000ChecksPanelProps) => {
     </Box>
   );
 };
+
+/**
+ * Memo'd to skip re-renders when the `checks` array reference is stable.
+ * The parent `Audit3000RunScreen` subscribes to the whole wizard store
+ * (status messages, file watcher events) and re-renders on every change;
+ * without this memo, the right pane redraws on every spinner tick / status
+ * line, which compounds Ink's frame-redraw flicker. Other workflows are
+ * unaffected — this is audit-3000 only.
+ */
+export const Audit3000ChecksPanel = memo(
+  Audit3000ChecksPanelImpl,
+  (prev, next) => prev.checks === next.checks,
+);

--- a/src/ui/tui/screens/audit-3000/Audit3000IntroScreen.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000IntroScreen.tsx
@@ -2,7 +2,10 @@ import { Box, Text } from 'ink';
 import { useEffect, useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { IntroScreenLayout } from '@ui/tui/screens/IntroScreenLayout';
-import { SkillSourceInfo, useSkillEntry } from '@ui/tui/screens/SkillSourceInfo';
+import {
+  SkillSourceInfo,
+  useSkillEntry,
+} from '@ui/tui/screens/SkillSourceInfo';
 import { NEON_BLUE, NEON_GOLD, NEON_PINK } from './arcade-colors.js';
 
 const AUDIT3000_SKILL_ID = 'audit-3000';
@@ -98,14 +101,25 @@ export const Audit3000IntroScreen = ({ store }: Audit3000IntroScreenProps) => {
       </Text>
       <Box marginTop={1}>
         <Text>
-          Results stream live to the{' '}
+          The run takes roughly <Text bold>5\u20137 minutes</Text>. Results
+          stream live to the{' '}
           <Text color="cyan" bold>
             Hi-score Table
           </Text>{' '}
-          tab during the run — that&apos;s your live report. When the audit
-          finishes, the same report is also exported to{' '}
-          <Text color="cyan">./posthog-audit-3000-report.md</Text> in your
-          project folder.
+          tab during the run. When the audit finishes, the full report is
+          written as a notebook inside your PostHog project and the wizard
+          prints the direct link.
+        </Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text>
+          Use{' '}
+          <Text color="cyan" bold>
+            {'\u2190 \u2192'}
+          </Text>{' '}
+          arrow keys to switch tabs (Arcade · Hi-score Table · Play a game ·
+          Tail logs · Hacker News) — or just leave the wizard running in the
+          background and come back when it's done.
         </Text>
       </Box>
       <Box marginTop={1}>
@@ -120,14 +134,18 @@ export const Audit3000IntroScreen = ({ store }: Audit3000IntroScreenProps) => {
     <Box flexDirection="column" alignItems="center">
       <ArcadeBanner />
       <Box marginTop={1} flexDirection="column" alignItems="center">
-        <Text bold>34 checks. 9 levels. 1 final report.</Text>
+        <Text bold>34 checks · 9 levels · ~5\u20137 min</Text>
         <Text dimColor>
           High-score your PostHog integration before the boss fight.
         </Text>
-        <Box marginTop={1}>
+        <Box marginTop={1} flexDirection="column" alignItems="center">
           <Text dimColor>
             Live report: <Text color={NEON_GOLD}>Hi-score Table</Text> tab ·
-            Export: ./posthog-audit-3000-report.md
+            Output: notebook in your PostHog project
+          </Text>
+          <Text dimColor>
+            Use {'\u2190 \u2192'} to switch tabs (Play / HN tabs available while
+            you wait)
           </Text>
         </Box>
       </Box>

--- a/src/ui/tui/screens/audit-3000/Audit3000OutroScreen.tsx
+++ b/src/ui/tui/screens/audit-3000/Audit3000OutroScreen.tsx
@@ -156,7 +156,18 @@ export const Audit3000OutroScreen = ({ store }: Audit3000OutroScreenProps) => {
             </Text>
           </Box>
 
-          {outroData.reportFile && (
+          {outroData.notebookUrl ? (
+            <Box flexDirection="column" marginTop={1}>
+              <Text bold color="cyan">
+                High-score reel saved to your PostHog notebook:
+              </Text>
+              <Text color={NEON_GOLD}>{outroData.notebookUrl}</Text>
+              <Text dimColor>
+                Open in your browser to view the full audit (live charts coming
+                in a future release).
+              </Text>
+            </Box>
+          ) : outroData.reportFile ? (
             <Box flexDirection="column" marginTop={1}>
               <Text bold color="cyan">
                 High-score reel saved to:
@@ -169,7 +180,7 @@ export const Audit3000OutroScreen = ({ store }: Audit3000OutroScreenProps) => {
                 to read the full audit.
               </Text>
             </Box>
-          )}
+          ) : null}
 
           <AuditChecksOutroSection
             checks={checks}

--- a/src/ui/tui/screens/audit-3000/slides/additionalSections.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/additionalSections.tsx
@@ -1,0 +1,30 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../../audit/slides/shared.js';
+
+const AdditionalSectionsVisual = () => (
+  <VisualBox>
+    <Text>
+      <Text color="cyan">{'customer enrichment'}</Text>
+      <Text dimColor>{'  Harmonic / PDL'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'use-case match     '}</Text>
+      <Text dimColor>{'  playbook scoring'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'audit notebook     '}</Text>
+      <Text dimColor>{'  written to your tenant'}</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const AdditionalSectionsSlide: AreaSlide = {
+  area: 'Wrap-up & notebook',
+  intro: [
+    'Wrapping up — enrichment, use-case match, and writing the final audit notebook into your PostHog project.',
+    "If a Harmonic key is present, we pull a company profile (industry, scale, traction signals). If PDL is available, we add an operator profile. These don't change the score — they give downstream readers the business context for the technical findings.",
+    "Then we score the enriched profile against PostHog's product playbooks (product intelligence, AI agents, conversion optimization, etc.) and pick a primary + secondary fit. Finally, everything is composed into a notebook inside your PostHog project — that's the artifact you'll share.",
+  ],
+  visual: <AdditionalSectionsVisual />,
+  docsUrl: 'https://posthog.com/docs',
+};

--- a/src/ui/tui/screens/audit-3000/slides/eventQuality.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/eventQuality.tsx
@@ -25,9 +25,9 @@ const EventQualityVisual = () => (
 export const EventQualitySlide: AreaSlide = {
   area: 'Event Quality',
   intro: [
-    'LEVEL 5: EVENT QUALITY. The capture call-sites are clean. The events themselves are the real boss fight.',
-    'Scanning for: naming inconsistencies, semantic duplicates, kitchen-sink event payloads, and (if your PostHog project is linked) which captured events actually drive insights and dashboards.',
-    '4 subagents fan out in parallel. The ticker shows them clearing checks live.',
+    'Even when the capture call-sites are clean, the events themselves can drift — inconsistent names, accidental duplicates, properties stuffed onto a single event — which quietly distorts every downstream funnel, retention, and dashboard.',
+    "We're checking naming consistency, looking for semantic duplicates (the same user action captured under two names), spotting kitchen-sink payloads, and — if your PostHog project is reachable — whether the events being captured actually drive any insight or dashboard.",
+    '4 subagents fan out in parallel; the score ticker on the right shows them clearing checks live.',
   ],
   visual: <EventQualityVisual />,
   docsUrl: 'https://posthog.com/docs/product-analytics/best-practices',

--- a/src/ui/tui/screens/audit-3000/slides/expansion.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/expansion.tsx
@@ -6,31 +6,33 @@ const ExpansionVisual = () => (
     <Text>
       <Text color="cyan">{'product analytics  '}</Text>
       <Text color="green">{'\u25A0\u25A0\u25A0\u25A0\u25A0'}</Text>
+      <Text dimColor>{'  in use'}</Text>
     </Text>
     <Text>
       <Text color="cyan">{'error tracking     '}</Text>
-      <Text color="red">{'\u25A1\u25A1\u25A1\u25A1\u25A1'}</Text>
-      <Text dimColor>{'  sentry detected'}</Text>
+      <Text color="yellow">{'\u25A1\u25A1\u25A1\u25A1\u25A1'}</Text>
+      <Text dimColor>{'  separate tool detected'}</Text>
     </Text>
     <Text>
       <Text color="cyan">{'session replay     '}</Text>
       <Text color="yellow">{'\u25A0\u25A0\u25A1\u25A1\u25A1'}</Text>
-      <Text dimColor>{'  partial'}</Text>
+      <Text dimColor>{'  partial coverage'}</Text>
     </Text>
     <Text>
       <Text color="cyan">{'llm observability  '}</Text>
-      <Text color="red">{'\u25A1\u25A1\u25A1\u25A1\u25A1'}</Text>
-      <Text dimColor>{'  greenfield'}</Text>
+      <Text dimColor>
+        {'\u25A1\u25A1\u25A1\u25A1\u25A1  nothing in place yet'}
+      </Text>
     </Text>
   </VisualBox>
 );
 
 export const ExpansionSlide: AreaSlide = {
-  area: 'Use Case: Expansion',
+  area: 'Stack consolidation',
   intro: [
-    'BONUS ROUND: EXPANSION. You might be paying for tools PostHog covers natively.',
-    'Scanning for competitive SDKs (Sentry, LaunchDarkly, Mixpanel, Datadog, OpenTelemetry, GA4) and PostHog coverage gaps across 8 product surfaces.',
-    '8 subagents in two waves of 4. Each one returns one of: cross-sell, greenfield, gap, or pass.',
+    'Maintaining several point tools for analytics, error tracking, replay, flags, and so on is expensive — separate contracts, mismatched user IDs, and a lot of glue code to keep the data consistent.',
+    "We're scanning the codebase for which of these concerns are currently covered by PostHog, which are handled by a separate tool, and which are not addressed at all. The point is to see where consolidating onto one platform would simplify your stack — not to push every product.",
+    "Each of PostHog's eight product surfaces gets one verdict: already covered by PostHog, handled by a separate tool, partial coverage, or no tool in place. The notebook lays out the findings so you can decide where consolidation actually helps.",
   ],
   visual: <ExpansionVisual />,
   docsUrl: 'https://posthog.com/docs',

--- a/src/ui/tui/screens/audit-3000/slides/featureFlags.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/featureFlags.tsx
@@ -24,9 +24,9 @@ const FeatureFlagsVisual = () => (
 export const FeatureFlagsSlide: AreaSlide = {
   area: 'Feature Flags',
   intro: [
-    'LEVEL 6: STALE FLAGS. Old flags add evaluation overhead and confuse the next engineer who wonders if a flag is still live.',
-    "Cross-referencing PostHog's stale-flag classification against your source tree. Each flag scored: safe-to-disable, needs-review, or unknown.",
-    'The final report ships with a copy-paste cleanup prompt. We never touch a flag.',
+    "Old flags that are no longer in use still get evaluated on every flag call and clutter the dashboard — they're the silent compounding noise of a long-running PostHog project.",
+    "Cross-referencing PostHog's stale-flag list against your source tree. Each flag is scored as safe-to-disable, needs-review, or unknown.",
+    'The notebook ships with a copy-paste cleanup prompt so you can disable the safe ones from any PostHog MCP-enabled chat — we never touch a flag automatically.',
   ],
   visual: <FeatureFlagsVisual />,
   docsUrl: 'https://posthog.com/docs/feature-flags',

--- a/src/ui/tui/screens/audit-3000/slides/index.ts
+++ b/src/ui/tui/screens/audit-3000/slides/index.ts
@@ -1,7 +1,11 @@
 /**
  * Audit-3000 slide registry. Re-uses the original audit slides for the
  * shared areas (Installation, Identification, Event Capture) and adds
- * arcade-flavoured slides for the three new areas the v3000 audit covers.
+ * arcade-flavoured slides for the new areas the v3000 audit covers.
+ *
+ * Order matters: the index in this array is the "LEVEL N" number shown
+ * on the run-screen left pane. Must match the ledger area order in
+ * `lib/workflows/audit-3000/index.ts`.
  */
 
 import type { AreaSlide } from '@ui/tui/screens/audit/slides/shared';
@@ -10,15 +14,21 @@ import { IdentificationSlide } from '@ui/tui/screens/audit/slides/identification
 import { EventCaptureSlide } from '@ui/tui/screens/audit/slides/eventCapture';
 import { EventQualitySlide } from './eventQuality.js';
 import { FeatureFlagsSlide } from './featureFlags.js';
+import { SessionReplaySlide } from './sessionReplay.js';
+import { SessionReplayOptimizeSlide } from './sessionReplayOptimize.js';
 import { ExpansionSlide } from './expansion.js';
+import { AdditionalSectionsSlide } from './additionalSections.js';
 
 export type { AreaSlide };
 
 export const AUDIT_3000_AREA_SLIDES: AreaSlide[] = [
-  InstallationSlide,
-  IdentificationSlide,
-  EventCaptureSlide,
-  EventQualitySlide,
-  FeatureFlagsSlide,
-  ExpansionSlide,
+  InstallationSlide, // L1
+  IdentificationSlide, // L2
+  EventCaptureSlide, // L3
+  EventQualitySlide, // L4
+  FeatureFlagsSlide, // L5
+  SessionReplaySlide, // L6
+  SessionReplayOptimizeSlide, // L7
+  ExpansionSlide, // L8
+  AdditionalSectionsSlide, // L9
 ];

--- a/src/ui/tui/screens/audit-3000/slides/sessionReplay.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/sessionReplay.tsx
@@ -1,0 +1,35 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../../audit/slides/shared.js';
+
+const SessionReplayVisual = () => (
+  <VisualBox>
+    <Text>
+      <Text color="cyan">{'min duration       '}</Text>
+      <Text color="yellow">{'2000ms?'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'mask inputs        '}</Text>
+      <Text color="yellow">{'on?    '}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'CI / test guard    '}</Text>
+      <Text color="yellow">{'gated? '}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'strict min         '}</Text>
+      <Text color="yellow">{'opt-in?'}</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const SessionReplaySlide: AreaSlide = {
+  area: 'Session Replay',
+  intro: [
+    'Recording correctness — making sure replays capture useful sessions without leaking sensitive data or flooding the pipeline with noise.',
+    'Checking that bounce sessions are filtered out (minimumDuration), inputs are masked on sensitive screens, replay is gated in test/CI environments, and strictMinimumDuration is on to future-proof your config.',
+    'These are codebase checks against your init call — no PostHog data is queried here.',
+  ],
+  visual: <SessionReplayVisual />,
+  docsUrl:
+    'https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record',
+};

--- a/src/ui/tui/screens/audit-3000/slides/sessionReplayOptimize.tsx
+++ b/src/ui/tui/screens/audit-3000/slides/sessionReplayOptimize.tsx
@@ -1,0 +1,35 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../../audit/slides/shared.js';
+
+const SessionReplayOptimizeVisual = () => (
+  <VisualBox>
+    <Text>
+      <Text color="cyan">{'sampling rate      '}</Text>
+      <Text dimColor>{'100% \u2192 ?  '}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'recording triggers '}</Text>
+      <Text dimColor>{'event / URL / flag'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'network filtering  '}</Text>
+      <Text dimColor>{'noisy?    '}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'mobile sampling    '}</Text>
+      <Text dimColor>{'separate? '}</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const SessionReplayOptimizeSlide: AreaSlide = {
+  area: 'Session Replay \u2014 Optimize',
+  intro: [
+    'Cost side of replay — making sure you only pay to record the sessions that actually inform the team.',
+    'Looking at sampling rate, recording triggers (event / URL / feature flag), network payload filtering, and per-platform sampling on mobile. Each one is a lever for keeping replay volume in check.',
+    'These checks read your PostHog project settings via MCP when available; locally they show as `mcp_skipped: true`.',
+  ],
+  visual: <SessionReplayOptimizeVisual />,
+  docsUrl:
+    'https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record',
+};

--- a/src/ui/tui/screens/audit/AuditChecksViewer/sort.ts
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/sort.ts
@@ -19,8 +19,8 @@ const AREA_ORDER: string[] = [
   'Feature Flags',
   'Session Replay',
   'Session Replay — Optimize',
-  'Use Case: Expansion',
-  'Additional Sections',
+  'Stack consolidation',
+  'Wrap-up & notebook',
 ];
 
 function areaRank(area: string): number {

--- a/src/ui/tui/start-tui.ts
+++ b/src/ui/tui/start-tui.ts
@@ -35,11 +35,13 @@ function getExitLine(store: WizardStore): string {
 
   if (outro?.kind === OutroKind.Success) {
     const message = outro.message ?? `${label} completed successfully.`;
-    const reportSuffix =
-      outro.reportFile && !message.includes(outro.reportFile)
-        ? ` Check ./${outro.reportFile} for details.`
-        : '';
-    return `${GREEN}${BOLD}\u2714${RESET_ATTRS} ${message}${reportSuffix}`;
+    let suffix = '';
+    if (outro.notebookUrl) {
+      suffix = ` Notebook: ${outro.notebookUrl}`;
+    } else if (outro.reportFile && !message.includes(outro.reportFile)) {
+      suffix = ` Check ./${outro.reportFile} for details.`;
+    }
+    return `${GREEN}${BOLD}\u2714${RESET_ATTRS} ${message}${suffix}`;
   }
 
   return `${DIM}${label} exited.${RESET_ATTRS}`;


### PR DESCRIPTION
## Summary

- **Replaces local markdown report with a PostHog Notebook** created inside the customer's project (via `mcp__posthog-wizard__notebooks-create`). The notebook URL is surfaced on the outro, KeepSkills, and exit line — no more hunting for a `.md` file.
- **UI/UX polish** to make audit-3000 more customer-facing and self-running:
  - Orientation preamble box ("What's happening") on first load
  - Renamed sales-y areas: *Use Case: Expansion* → **Stack consolidation**, *Additional Sections* → **Wrap-up & notebook**
  - 3 new orientation slides (sessionReplay, sessionReplayOptimize, additionalSections) so all 9 levels render correct content (previously L6–L9 fell back to the wrong slide)
  - Expansion slide rewritten from customer-value angle
  - `React.memo` on audit-3000 panels to cut TUI flicker

## Companion PR

This depends on the matching step 10 rewrite in context-mill: PostHog/context-mill#164

## Test plan

- [ ] Wizard boots; intro renders all 9 slides in order
- [ ] Run screen shows orientation preamble on first load
- [ ] Renamed areas appear in checks panel + sort order
- [ ] On a successful end-to-end run, `/tmp/posthog-notebook-url.txt` is consumed and the notebook URL appears on outro + KeepSkills + exit line
- [ ] Apologies — couldn't fully verify end-to-end locally due to Anthropic API rate-limit errors yesterday and today

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*