### PR TITLE
fix: make seeded audit ledger customizable

### DIFF
--- a/.claude/skills/wizard-development/references/ANTI-PATTERNS.md
+++ b/.claude/skills/wizard-development/references/ANTI-PATTERNS.md
@@ -79,3 +79,17 @@ Each section describes a pattern that looks reasonable in isolation but degrades
 
 **What to do instead:** Use the `requires` field on `ProgramConfig` to make program dependencies explicit. For shared data, use `frameworkContext` with documented keys — the `setFrameworkContext` setter ensures `emitChange()` fires and downstream predicates re-evaluate. If two programs need the same detection result, factor the detection into a shared module that both programs' `onReady` hooks call, rather than relying on one program to populate what another reads.
 
+---
+
+## Single-turn generation of long structured documents
+
+**The pattern:** A skill asks the agent to compose a multi-thousand-token artifact — a markdown audit report, a ProseMirror notebook tree, a large JSON inventory — in one turn, then `Write` (or call an MCP tool) once with the assembled result. The instruction reads naturally: "compose the report, then write it." It also looks token-efficient — one Write call, one assistant turn, no intermediate state.
+
+**What happens next:** The LLM streaming connection from the wizard to PostHog's LLM gateway (`gateway.us.posthog.com/wizard` → `api.anthropic.com`) is held open for the entire generation. Composing 10–15K output tokens at the standard service tier takes minutes; SSE connections at any hop in that chain (gateway, Anthropic edge, Cloudflare) have streaming timeouts in the 5–10 minute range. Past that, the socket dies mid-stream. The SDK surfaces it as `"API Error: The socket connection was closed unexpectedly"`, the runner aborts with `AgentErrorType.API_ERROR`, and everything the agent had composed for that turn is lost. The user re-runs and the same generation hits the same wall.
+
+**The cost:** Resilience is gated by raw token throughput. Skills that grow more capable (more sections, richer formatting, larger inventories) become more failure-prone over time, not less. Wizard-side mitigations — retries, longer timeouts — live at the wrong layer; they hide the root cause and burn money on the failed attempts.
+
+**What to do instead:** Chunk the generation across turns by writing a skeleton with placeholder markers and filling each placeholder with one `Edit`. The first turn writes structure (small generation). Each subsequent turn fills one section (bounded generation). The SSE timer resets at every tool call. The on-disk file is the source of truth, so a dropped turn loses at most one section, not the whole document. For ProseMirror or other structured JSON, use a transient scratch file (e.g. `.posthog-notebook-payload.json`), Write the skeleton with placeholder nodes, Edit each section in place, then Read + invoke the MCP tool with the assembled tree. Same pattern, same payoff. The wizard's `Write` and `Edit` are always available; this approach doesn't depend on feature-flagged MCP tools.
+
+**When a single Write is fine:** When the artifact is bounded — a few hundred tokens of output, a small JSON config, a one-paragraph summary — a single turn is cheaper and clearer. The chunking pattern adds value once you cross the SSE-timeout cliff, not before.
+

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -80,6 +80,12 @@ export const AgentSignals = {
    * onto `session.dashboardUrl` and surfaced by programs in their outro.
    */
   DASHBOARD_URL: '[DASHBOARD_URL]',
+  /**
+   * Signal emitted when the agent has uploaded a report to a PostHog
+   * notebook. Format: `[NOTEBOOK_URL] <full https url>`. The URL is captured
+   * onto `session.notebookUrl` and surfaced by programs in their outro.
+   */
+  NOTEBOOK_URL: '[NOTEBOOK_URL]',
 } as const;
 
 export type AgentSignal = (typeof AgentSignals)[keyof typeof AgentSignals];
@@ -1549,6 +1555,19 @@ function handleSDKMessage(
             const dashboardMatch = block.text.match(dashboardRegex);
             if (dashboardMatch) {
               getUI().setDashboardUrl(dashboardMatch[1].trim());
+            }
+
+            // Check for [NOTEBOOK_URL] markers
+            const notebookRegex = new RegExp(
+              `${AgentSignals.NOTEBOOK_URL.replace(
+                /[.*+?^${}()|[\]\\]/g,
+                '\\$&',
+              )}\\s*(\\S+)`,
+              'm',
+            );
+            const notebookMatch = block.text.match(notebookRegex);
+            if (notebookMatch) {
+              getUI().setNotebookUrl(notebookMatch[1].trim());
             }
           }
 

--- a/src/lib/agent/agent-runner.ts
+++ b/src/lib/agent/agent-runner.ts
@@ -490,24 +490,30 @@ export async function runProgram(
   }
 
   // 11. Outro
-  if (config.buildOutroData) {
-    session.outroData = config.buildOutroData(
-      session,
-      { accessToken, projectApiKey, host, projectId },
-      cloudRegion,
-    );
-  } else {
-    const continueUrl = session.signup
-      ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
-      : undefined;
-
-    session.outroData = {
-      kind: OutroKind.Success,
-      message: config.successMessage,
-      reportFile: config.reportFile,
-      docsUrl: config.docsUrl,
-      continueUrl,
-    };
+  // Push outro data through the UI (not via direct `session.outroData = ...`
+  // mutation) so the live store gets the value. agent-runner's `session`
+  // parameter is captured at runAgent() invocation time, and any `setKey`
+  // call between then and here (e.g. setDashboardUrl, setNotebookUrl) forks
+  // the session reference — direct mutation then lands on a stale snapshot
+  // that the screen never reads. UI.setOutroData() goes through the store
+  // and also merges in any post-snapshot URLs from the live session.
+  const outroData = config.buildOutroData
+    ? config.buildOutroData(
+        session,
+        { accessToken, projectApiKey, host, projectId },
+        cloudRegion,
+      )
+    : {
+        kind: OutroKind.Success,
+        message: config.successMessage,
+        reportFile: config.reportFile,
+        docsUrl: config.docsUrl,
+        continueUrl: session.signup
+          ? `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`
+          : undefined,
+      };
+  if (outroData) {
+    getUI().setOutroData(outroData);
   }
 
   getUI().outro(config.successMessage);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -103,6 +103,9 @@ export const DUMMY_PROJECT_API_KEY = '_YOUR_POSTHOG_PROJECT_TOKEN_';
  * - query:read        run HogQL queries when the agent needs data
  * - dashboard:write   create the onboarding dashboard during setup
  * - insight:write     create the onboarding insights during setup
+ * - notebook:write    upload the events-audit report as a PostHog notebook
+ *                     in step 6 of the events-audit skill (notebooks-create
+ *                     MCP tool requires this scope)
  *
  * Must be a subset of `ALLOWED_PROVISIONING_SCOPES` in
  * `ee/api/agentic_provisioning/views.py` on the backend.
@@ -114,6 +117,7 @@ export const WIZARD_PROVISIONING_SCOPES = [
   'dashboard:write',
   'insight:write',
   'query:read',
+  'notebook:write',
 ] as const;
 
 /**

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -77,6 +77,12 @@ const auditRun = async (session: WizardSession): Promise<ProgramRun> => {
           ? `${cloudUrl}/products?source=wizard`
           : undefined;
 
+      // Note: `sess` here is the agent-runner's snapshot of session at
+      // runAgent() invocation time. Any URL emissions during the run land
+      // on the live store, NOT on this snapshot. The UI layer
+      // (InkUI.setOutroData) merges live URLs in on top of this return
+      // value, so it's safe to leave dashboardUrl/notebookUrl as undefined
+      // here when the snapshot doesn't have them.
       return {
         kind: OutroKind.Success as const,
         message: baseRun.successMessage,

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -5,7 +5,9 @@ import {
 import type { ProgramStep, ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { WizardSession } from '@lib/wizard-session';
+import { OutroKind } from '@lib/wizard-session';
 import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
+import { getCloudUrlFromRegion } from '@utils/urls';
 import { AUDIT_ABORT_CASES } from './detect.js';
 import { AUDIT_CHECKS_KEY, AUDIT_REPORT_FILE } from './types.js';
 import { AUDIT_SEED_CHECKS, seedAuditLedger } from './seed.js';
@@ -56,9 +58,36 @@ const auditRun = async (session: WizardSession): Promise<ProgramRun> => {
     throw new Error('Audit program has no run configuration.');
   }
 
-  return typeof baseConfig.run === 'function'
-    ? baseConfig.run(session)
-    : baseConfig.run;
+  const baseRun =
+    typeof baseConfig.run === 'function'
+      ? await baseConfig.run(session)
+      : baseConfig.run;
+
+  return {
+    ...baseRun,
+    // Override the default outro so the dashboard + notebook URLs the
+    // agent emits via `[DASHBOARD_URL]` / `[NOTEBOOK_URL]` are surfaced
+    // on the post-run screen.
+    buildOutroData: (sess, _credentials, cloudRegion) => {
+      const cloudUrl = cloudRegion
+        ? getCloudUrlFromRegion(cloudRegion)
+        : undefined;
+      const continueUrl =
+        sess.signup && cloudUrl
+          ? `${cloudUrl}/products?source=wizard`
+          : undefined;
+
+      return {
+        kind: OutroKind.Success as const,
+        message: baseRun.successMessage,
+        reportFile: baseRun.reportFile,
+        docsUrl: baseRun.docsUrl,
+        continueUrl,
+        dashboardUrl: sess.dashboardUrl ?? undefined,
+        notebookUrl: sess.notebookUrl ?? undefined,
+      };
+    },
+  };
 };
 
 export const auditConfig: ProgramConfig = {

--- a/src/lib/programs/audit/seed.ts
+++ b/src/lib/programs/audit/seed.ts
@@ -71,6 +71,12 @@ export const AUDIT_SEED_CHECKS: AuditCheck[] = [
     status: 'pending',
   },
   {
+    id: 'write-report',
+    area: 'Write report',
+    label: 'Create posthog-audit-report.md',
+    status: 'pending',
+  },
+  {
     id: 'upload-notebook',
     area: 'Upload notebook',
     label: 'Write the report into a PostHog notebook',

--- a/src/lib/programs/audit/seed.ts
+++ b/src/lib/programs/audit/seed.ts
@@ -3,7 +3,12 @@ import path from 'path';
 import { logToFile } from '@utils/debug';
 import { AUDIT_CHECKS_FILE, type AuditCheck } from './types.js';
 
-/** The 10 data-integrity checks the audit runs. */
+/**
+ * The 10 data-integrity checks the audit runs, plus one workflow row for the
+ * notebook upload at the end (so the skill's `audit_resolve_checks` call for
+ * `upload-notebook` succeeds — the skill writes the report to a PostHog
+ * notebook as its final step).
+ */
 export const AUDIT_SEED_CHECKS: AuditCheck[] = [
   {
     id: 'sdk-installed',
@@ -63,6 +68,12 @@ export const AUDIT_SEED_CHECKS: AuditCheck[] = [
     id: 'capture-growth-events',
     area: 'Event Capture',
     label: 'Key activation events captured',
+    status: 'pending',
+  },
+  {
+    id: 'upload-notebook',
+    area: 'Upload notebook',
+    label: 'Write the report into a PostHog notebook',
     status: 'pending',
   },
 ];

--- a/src/lib/programs/audit/seed.ts
+++ b/src/lib/programs/audit/seed.ts
@@ -67,13 +67,19 @@ export const AUDIT_SEED_CHECKS: AuditCheck[] = [
   },
 ];
 
-/** Atomically write the seeded ledger to the project's audit checks file. */
-export function seedAuditLedger(installDir: string): void {
+/**
+ * Atomically write a seeded ledger to the project's audit checks file.
+ *
+ * Each audit-flavored program (doctor, events-audit) owns its own seed
+ * shape — pass the seed in so this writer stays program-agnostic.
+ */
+export function seedAuditLedger(
+  installDir: string,
+  checks: AuditCheck[] = AUDIT_SEED_CHECKS,
+): void {
   const target = path.join(installDir, AUDIT_CHECKS_FILE);
   const tmp = `${target}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(AUDIT_SEED_CHECKS, null, 2), 'utf8');
+  fs.writeFileSync(tmp, JSON.stringify(checks, null, 2), 'utf8');
   fs.renameSync(tmp, target);
-  logToFile(
-    `seedAuditLedger: wrote ${AUDIT_SEED_CHECKS.length} entries to ${target}`,
-  );
+  logToFile(`seedAuditLedger: wrote ${checks.length} entries to ${target}`);
 }

--- a/src/lib/programs/events-audit/index.ts
+++ b/src/lib/programs/events-audit/index.ts
@@ -75,6 +75,11 @@ Project context:
         const dashboardUrl =
           sess.dashboardUrl ?? (cloudUrl ? `${cloudUrl}/dashboard` : undefined);
 
+        // The agent emits `[NOTEBOOK_URL] <url>` once it uploads the report
+        // to a PostHog notebook. No fallback: if the notebook upload was
+        // skipped (e.g. MCP unavailable) we just don't show a link.
+        const notebookUrl = sess.notebookUrl ?? undefined;
+
         return {
           kind: OutroKind.Success as const,
           message: 'Your events audit was successful',
@@ -83,6 +88,7 @@ Project context:
           docsUrl: DOCS_URL,
           continueUrl,
           dashboardUrl,
+          notebookUrl,
         };
       },
     });

--- a/src/lib/programs/events-audit/index.ts
+++ b/src/lib/programs/events-audit/index.ts
@@ -8,7 +8,8 @@ import { getCloudUrlFromRegion } from '@utils/urls';
 import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { EVENTS_AUDIT_PROGRAM } from './steps.js';
 import { AUDIT_CHECKS_KEY } from '@lib/programs/audit/types';
-import { AUDIT_SEED_CHECKS, seedAuditLedger } from '@lib/programs/audit/seed';
+import { seedAuditLedger } from '@lib/programs/audit/seed';
+import { EVENTS_AUDIT_SEED_CHECKS } from './seed.js';
 
 export const SETUP_REPORT_FILE = 'posthog-events-audit-report.md';
 
@@ -33,9 +34,10 @@ export const eventsAuditConfig: ProgramConfig = {
     session.typescript = typeScriptDetected;
 
     // Seed the audit ledger so AuditRunScreen has something to render
-    // before the agent emits its first check update.
-    seedAuditLedger(session.installDir);
-    session.frameworkContext[AUDIT_CHECKS_KEY] = AUDIT_SEED_CHECKS;
+    // before the agent emits its first check update. The events-audit
+    // ledger is the 6-phase pipeline, not the doctor's 10 integrity checks.
+    seedAuditLedger(session.installDir, EVENTS_AUDIT_SEED_CHECKS);
+    session.frameworkContext[AUDIT_CHECKS_KEY] = EVENTS_AUDIT_SEED_CHECKS;
 
     return Promise.resolve({
       skillId: 'events-audit',

--- a/src/lib/programs/events-audit/seed.ts
+++ b/src/lib/programs/events-audit/seed.ts
@@ -1,12 +1,14 @@
 import type { AuditCheck } from '@lib/programs/audit/types';
 
 /**
- * The 6 phases the events-audit skill marches through. One check per area
+ * The 7 phases the events-audit skill marches through. One check per area
  * so PendingChecksList renders a clean linear pipeline (area = bold header,
  * single row = the active spinner).
  *
  * Phase ids match what the skill's step files resolve via
- * `mcp__wizard-tools__audit_resolve_checks` as each phase completes.
+ * `mcp__wizard-tools__audit_resolve_checks` as each phase completes. The
+ * skill's step 1 also seeds these same ids — keep both in sync so the
+ * wizard pre-seed and the skill's MCP seed agree.
  */
 export const EVENTS_AUDIT_SEED_CHECKS: AuditCheck[] = [
   {
@@ -43,6 +45,12 @@ export const EVENTS_AUDIT_SEED_CHECKS: AuditCheck[] = [
     id: 'create-dashboard',
     area: 'Create dashboard',
     label: 'Optional: dashboard for resolved events',
+    status: 'pending',
+  },
+  {
+    id: 'upload-notebook',
+    area: 'Upload notebook',
+    label: 'Write the report into a PostHog notebook',
     status: 'pending',
   },
 ];

--- a/src/lib/programs/events-audit/seed.ts
+++ b/src/lib/programs/events-audit/seed.ts
@@ -38,7 +38,7 @@ export const EVENTS_AUDIT_SEED_CHECKS: AuditCheck[] = [
   {
     id: 'write-report',
     area: 'Write report',
-    label: 'Render posthog-events-audit-report.md',
+    label: 'Create posthog-events-audit-report.md',
     status: 'pending',
   },
   {

--- a/src/lib/programs/events-audit/seed.ts
+++ b/src/lib/programs/events-audit/seed.ts
@@ -1,0 +1,48 @@
+import type { AuditCheck } from '@lib/programs/audit/types';
+
+/**
+ * The 6 phases the events-audit skill marches through. One check per area
+ * so PendingChecksList renders a clean linear pipeline (area = bold header,
+ * single row = the active spinner).
+ *
+ * Phase ids match what the skill's step files resolve via
+ * `mcp__wizard-tools__audit_resolve_checks` as each phase completes.
+ */
+export const EVENTS_AUDIT_SEED_CHECKS: AuditCheck[] = [
+  {
+    id: 'detect-sdk',
+    area: 'Detect SDK',
+    label: 'Identify PostHog SDK(s) in dependencies',
+    status: 'pending',
+  },
+  {
+    id: 'scan-sites',
+    area: 'Scan capture sites',
+    label: 'Grep capture/identify/group call sites',
+    status: 'pending',
+  },
+  {
+    id: 'enrich-sites',
+    area: 'Enrich',
+    label: 'Subagent fan-out to read capture files',
+    status: 'pending',
+  },
+  {
+    id: 'query-volume',
+    area: 'Query PostHog',
+    label: '30-day volume + last_seen via MCP',
+    status: 'pending',
+  },
+  {
+    id: 'write-report',
+    area: 'Write report',
+    label: 'Render posthog-events-audit-report.md',
+    status: 'pending',
+  },
+  {
+    id: 'create-dashboard',
+    area: 'Create dashboard',
+    label: 'Optional: dashboard for resolved events',
+    status: 'pending',
+  },
+];

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -93,6 +93,8 @@ export interface OutroData {
   reportFile?: string;
   /** PostHog dashboard URL the program created on the user's behalf. */
   dashboardUrl?: string;
+  /** PostHog notebook URL the program uploaded the report to. */
+  notebookUrl?: string;
 }
 
 /** A single question rendered by the WizardAsk overlay. */
@@ -230,6 +232,7 @@ export interface WizardSession {
   } | null;
   outroData: OutroData | null;
   dashboardUrl: string | null;
+  notebookUrl: string | null;
 
   // Additional features queue (drained via stop hook after main integration)
   additionalFeatureQueue: AdditionalFeature[];
@@ -309,6 +312,7 @@ export function buildSession(args: {
     portConflictProcess: null,
     outroData: null,
     dashboardUrl: null,
+    notebookUrl: null,
     additionalFeatureQueue: [],
     programLabel: null,
     skillId: null,

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -162,6 +162,42 @@ function logYaraMatch(
   });
 }
 
+// ─── Wizard-documentation allowlist ───────────────────────────────
+//
+// Files the wizard's own programs write to describe events the user's
+// codebase already captures, or events the integration program is
+// proposing to add. When the agent copies a literal
+// `posthog.capture('event', { email: ... })` snippet (or a property
+// list including PII-shaped keys) into one of these files, the
+// `pii_in_capture_call` rule (category: posthog_pii) fires even though
+// the wizard is documenting / planning, not introducing, the pattern.
+// Suppress posthog_pii matches on these paths only; every other rule
+// (secrets, prompt injection, supply chain, destructive ops) still
+// fires normally so the file cannot be used as a smuggling vector for
+// actual violations.
+
+const WIZARD_DOC_BASENAMES = new Set([
+  // events-audit
+  '.posthog-events-inventory.json',
+  'posthog-events-audit-report.md',
+  // doctor (audit)
+  'posthog-audit-report.md',
+  // posthog-integration event plan
+  '.posthog-events.json',
+]);
+
+const WIZARD_DOC_PATTERNS: RegExp[] = [
+  // events-audit subagent part-files (e.g. `.posthog-events-inventory.part-3.json`)
+  /^\.posthog-events-inventory\.part-\d+\.json$/,
+];
+
+function isWizardDocumentationPath(filePath: string | undefined): boolean {
+  if (!filePath) return false;
+  const basename = path.basename(filePath);
+  if (WIZARD_DOC_BASENAMES.has(basename)) return true;
+  return WIZARD_DOC_PATTERNS.some((re) => re.test(basename));
+}
+
 // ─── Severity helpers ────────────────────────────────────────────
 
 const SEVERITY_RANK: Record<string, number> = {
@@ -271,6 +307,30 @@ export function createPostToolUseYaraHooks(): HookCallbackMatcher[] {
             const tool = toolName;
             const result = scan(content, 'PostToolUse', tool);
             if (!result.matched) return Promise.resolve({});
+
+            // Wizard-documentation paths: suppress posthog_pii matches that
+            // come from the agent verbatim-copying the user's existing
+            // capture calls into an inventory / report, or planning new
+            // events with PII-shaped property keys. Every other category
+            // still triggers the revert.
+            const filePath = toolInput?.file_path as string | undefined;
+            if (isWizardDocumentationPath(filePath)) {
+              const nonPiiMatches = result.matches.filter(
+                (m) => m.rule.category !== 'posthog_pii',
+              );
+              if (nonPiiMatches.length === 0) {
+                logToFile(
+                  `[YARA] posthog_pii match suppressed on wizard doc ${path.basename(
+                    filePath ?? '',
+                  )} (rule: ${result.matches[0]?.rule.name})`,
+                );
+                return Promise.resolve({});
+              }
+              // Some non-PII rule also fired — fall through and revert on
+              // that one. Replace the matches set so the user sees the
+              // actually-actionable rule, not the suppressed PII one.
+              result.matches = nonPiiMatches;
+            }
 
             const match = highestSeverityMatch(result.matches);
             logYaraMatch('PostToolUse', tool, match, 'reverted');

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -246,6 +246,10 @@ export class LoggingUI implements WizardUI {
     // No-op in CI mode
   }
 
+  setOutroData(_data: import('@lib/wizard-session').OutroData): void {
+    // No-op in CI mode
+  }
+
   setFrameworkContext(_key: string, _value: unknown): void {
     // No-op in CI mode
   }

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -242,6 +242,10 @@ export class LoggingUI implements WizardUI {
     // No-op in CI mode
   }
 
+  setNotebookUrl(_url: string): void {
+    // No-op in CI mode
+  }
+
   setFrameworkContext(_key: string, _value: unknown): void {
     // No-op in CI mode
   }

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -213,6 +213,10 @@ export class InkUI implements WizardUI {
     this.store.setDashboardUrl(url);
   }
 
+  setNotebookUrl(url: string): void {
+    this.store.setNotebookUrl(url);
+  }
+
   setFrameworkContext(key: string, value: unknown): void {
     this.store.setFrameworkContext(key, value);
   }

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -35,17 +35,17 @@ export class InkUI implements WizardUI {
   outro(message: string): void {
     this.store.pushStatus(stripAnsi(message));
 
-    // agent-runner mutates session.outroData directly before calling outro().
-    // Direct mutation doesn't notify nanostore subscribers, so re-set the
-    // value through setOutroData() to push it to React. If there's no
-    // pre-built outroData, fall back to a minimal success record.
+    // Outro data is pushed by agent-runner via setOutroData() above. If it
+    // wasn't (e.g. CI path where outro is called directly with just a
+    // message), fall back to a minimal success record so the screen still
+    // renders something useful.
     const existing = this.store.session.outroData;
-    this.store.setOutroData(
-      existing ?? {
+    if (!existing) {
+      this.store.setOutroData({
         kind: OutroKind.Success,
         message: stripAnsi(message),
-      },
-    );
+      });
+    }
 
     // Signal that the main work is done — router resolves to mcp or outro
     if (this.store.session.runPhase === RunPhase.Running) {
@@ -215,6 +215,21 @@ export class InkUI implements WizardUI {
 
   setNotebookUrl(url: string): void {
     this.store.setNotebookUrl(url);
+  }
+
+  setOutroData(data: OutroData): void {
+    // Merge in URLs the agent emitted via `[DASHBOARD_URL]` / `[NOTEBOOK_URL]`
+    // markers. These land on the live store during the run; agent-runner's
+    // `session` snapshot misses them (setKey forks the reference). The live
+    // store wins over the `data` payload so a real emission always beats any
+    // fallback the program's buildOutroData may have computed from the stale
+    // snapshot (e.g. events-audit defaults dashboardUrl to `${cloudUrl}/dashboard`).
+    const live = this.store.session;
+    this.store.setOutroData({
+      ...data,
+      dashboardUrl: live.dashboardUrl ?? data.dashboardUrl ?? undefined,
+      notebookUrl: live.notebookUrl ?? data.notebookUrl ?? undefined,
+    });
   }
 
   setFrameworkContext(key: string, value: unknown): void {

--- a/src/ui/tui/primitives/LogViewer.tsx
+++ b/src/ui/tui/primitives/LogViewer.tsx
@@ -1,6 +1,13 @@
 /**
  * LogViewer — Real-time log tail, pinned to available terminal height.
  * Only renders the last N lines that fit on screen.
+ *
+ * Reads only the last TAIL_BYTES of the file on each refresh and throttles
+ * fs.watch callbacks to one refresh per WATCH_THROTTLE_MS. Without this,
+ * fs.readFileSync allocates a string the size of the entire log on every
+ * append — during subagent fan-out that's tens of writes per second against
+ * a log that grows into the hundreds of MB, producing OOM-grade allocation
+ * pressure on V8's heap.
  */
 
 import { Box, Text } from 'ink';
@@ -11,10 +18,38 @@ import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 /** Rows consumed by TitleBar + spacer + ScreenContainer padding + status bar + tab bar */
 const CHROME_ROWS = 8;
 
+/** Bytes read from the end of the log per refresh — large enough to contain
+ *  any practical visible window of lines, small enough to allocate cheaply. */
+const TAIL_BYTES = 256 * 1024;
+
+/** Minimum gap between watch-triggered refreshes. fs.watch fires on every
+ *  append */
+const WATCH_THROTTLE_MS = 250;
+
 interface LogViewerProps {
   filePath: string;
   /** Fixed visible height. Defaults to terminal rows minus chrome. */
   height?: number;
+}
+
+function readTailLines(filePath: string, visibleLines: number): string[] {
+  const stat = fs.statSync(filePath);
+  if (stat.size === 0) return [];
+  const start = Math.max(0, stat.size - TAIL_BYTES);
+  const length = stat.size - start;
+  const buf = Buffer.alloc(length);
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    fs.readSync(fd, buf, 0, length, start);
+  } finally {
+    fs.closeSync(fd);
+  }
+  let text = buf.toString('utf-8');
+  if (start > 0) {
+    const firstNewline = text.indexOf('\n');
+    if (firstNewline >= 0) text = text.slice(firstNewline + 1);
+  }
+  return text.split('\n').slice(-visibleLines);
 }
 
 export const LogViewer = ({ filePath, height }: LogViewerProps) => {
@@ -24,41 +59,60 @@ export const LogViewer = ({ filePath, height }: LogViewerProps) => {
   const [lines, setLines] = useState<string[]>([]);
 
   useEffect(() => {
+    let lastReadAt = 0;
+    let pendingTimer: ReturnType<typeof setTimeout> | undefined;
+
     const readTail = () => {
       try {
-        const content = fs.readFileSync(filePath, 'utf-8');
-        const allLines = content.split('\n');
-        setLines(allLines.slice(-visibleLines));
+        setLines(readTailLines(filePath, visibleLines));
       } catch {
         setLines(['(No log file found)']);
       }
     };
 
+    const scheduleRead = () => {
+      const now = Date.now();
+      const elapsed = now - lastReadAt;
+      if (elapsed >= WATCH_THROTTLE_MS) {
+        lastReadAt = now;
+        readTail();
+        return;
+      }
+      if (pendingTimer) return;
+      pendingTimer = setTimeout(() => {
+        pendingTimer = undefined;
+        lastReadAt = Date.now();
+        readTail();
+      }, WATCH_THROTTLE_MS - elapsed);
+    };
+
     readTail();
+    lastReadAt = Date.now();
 
     let watcher: fs.FSWatcher | undefined;
     try {
-      watcher = fs.watch(filePath, () => {
-        readTail();
-      });
+      watcher = fs.watch(filePath, () => scheduleRead());
     } catch {
-      // File might not exist yet — retry when it appears
       const interval = setInterval(() => {
         try {
           fs.accessSync(filePath);
           readTail();
           clearInterval(interval);
-          watcher = fs.watch(filePath, () => readTail());
+          watcher = fs.watch(filePath, () => scheduleRead());
         } catch {
-          // Still waiting
+          // Still waiting for the file to appear
         }
       }, 1000);
 
-      return () => clearInterval(interval);
+      return () => {
+        clearInterval(interval);
+        if (pendingTimer) clearTimeout(pendingTimer);
+      };
     }
 
     return () => {
       watcher?.close();
+      if (pendingTimer) clearTimeout(pendingTimer);
     };
   }, [filePath, visibleLines]);
 

--- a/src/ui/tui/screens/OutroScreen.tsx
+++ b/src/ui/tui/screens/OutroScreen.tsx
@@ -95,7 +95,7 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
           {outroData.notebookUrl && (
             <Box marginTop={1}>
               <Text>
-                And mirrored the report to a notebook:{' '}
+                And uploaded the report to a PostHog notebook:{' '}
                 <Text color="cyan">{outroData.notebookUrl}</Text>
               </Text>
             </Box>

--- a/src/ui/tui/screens/OutroScreen.tsx
+++ b/src/ui/tui/screens/OutroScreen.tsx
@@ -92,6 +92,15 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
             </Box>
           )}
 
+          {outroData.notebookUrl && (
+            <Box marginTop={1}>
+              <Text>
+                And mirrored the report to a notebook:{' '}
+                <Text color="cyan">{outroData.notebookUrl}</Text>
+              </Text>
+            </Box>
+          )}
+
           {outroData.docsUrl && (
             <Box marginTop={1}>
               <Text>

--- a/src/ui/tui/screens/audit/AuditAreaPane.tsx
+++ b/src/ui/tui/screens/audit/AuditAreaPane.tsx
@@ -52,14 +52,20 @@ const openLink = (url: string) => {
 interface AuditAreaPaneProps {
   checks: AuditCheck[];
   reportPath: string;
+  /** Slide registry to look the active area up in. Defaults to the doctor
+   * (`audit` program) slides; events-audit passes its own 6-phase set. */
+  slides?: AreaSlide[];
 }
 
-export const AuditAreaPane = ({ checks, reportPath }: AuditAreaPaneProps) => {
+export const AuditAreaPane = ({
+  checks,
+  reportPath,
+  slides = AUDIT_AREA_SLIDES,
+}: AuditAreaPaneProps) => {
   const pendingChecks = checks.filter((c) => c.status === 'pending');
   const activeArea = pendingChecks[0]?.area;
   const slide = activeArea
-    ? AUDIT_AREA_SLIDES.find((s) => s.area === activeArea) ??
-      fallbackSlide(activeArea)
+    ? slides.find((s) => s.area === activeArea) ?? fallbackSlide(activeArea)
     : null;
 
   useInput((input) => {

--- a/src/ui/tui/screens/audit/AuditAreaPane.tsx
+++ b/src/ui/tui/screens/audit/AuditAreaPane.tsx
@@ -55,12 +55,20 @@ interface AuditAreaPaneProps {
   /** Slide registry to look the active area up in. Defaults to the doctor
    * (`audit` program) slides; events-audit passes its own 6-phase set. */
   slides?: AreaSlide[];
+  /** Dashboard URL once the agent emits `[DASHBOARD_URL]`. Shown as a sticky
+   * footer so the user can grab the link while later phases still run. */
+  dashboardUrl?: string | null;
+  /** Notebook URL once the agent emits `[NOTEBOOK_URL]`. Same sticky-footer
+   * treatment as the dashboard URL. */
+  notebookUrl?: string | null;
 }
 
 export const AuditAreaPane = ({
   checks,
   reportPath,
   slides = AUDIT_AREA_SLIDES,
+  dashboardUrl,
+  notebookUrl,
 }: AuditAreaPaneProps) => {
   const pendingChecks = checks.filter((c) => c.status === 'pending');
   const activeArea = pendingChecks[0]?.area;
@@ -74,10 +82,20 @@ export const AuditAreaPane = ({
     }
   });
 
+  const urlsFooter =
+    dashboardUrl || notebookUrl ? (
+      <UrlsFooter dashboardUrl={dashboardUrl} notebookUrl={notebookUrl} />
+    ) : null;
+
   // Active area — agent is still resolving checks for this slide's area.
   if (slide) {
     const hasFindings = checks.some(isFinding);
-    return <ActiveSlide slide={slide} hasFindings={hasFindings} />;
+    return (
+      <Box flexDirection="column">
+        <ActiveSlide slide={slide} hasFindings={hasFindings} />
+        {urlsFooter}
+      </Box>
+    );
   }
 
   // Ledger empty — the seed hook fires synchronously at intro `onReady`,
@@ -88,7 +106,12 @@ export const AuditAreaPane = ({
   }
 
   // Every check is resolved and the agent is composing the report.
-  return <WritingReport reportPath={reportPath} />;
+  return (
+    <Box flexDirection="column">
+      <WritingReport reportPath={reportPath} />
+      {urlsFooter}
+    </Box>
+  );
 };
 
 // ── States ───────────────────────────────────────────────────────────
@@ -129,6 +152,28 @@ const ActiveSlide = ({
         )}
       </Text>
     </Box>
+  </Box>
+);
+
+const UrlsFooter = ({
+  dashboardUrl,
+  notebookUrl,
+}: {
+  dashboardUrl?: string | null;
+  notebookUrl?: string | null;
+}) => (
+  <Box flexDirection="column" paddingX={1} marginTop={1}>
+    <Text dimColor>{'─'.repeat(40)}</Text>
+    {dashboardUrl && (
+      <Text>
+        Dashboard: <Text color="cyan">{dashboardUrl}</Text>
+      </Text>
+    )}
+    {notebookUrl && (
+      <Text>
+        Notebook: <Text color="cyan">{notebookUrl}</Text>
+      </Text>
+    )}
   </Box>
 );
 

--- a/src/ui/tui/screens/audit/AuditChecksOutroSection.tsx
+++ b/src/ui/tui/screens/audit/AuditChecksOutroSection.tsx
@@ -58,7 +58,9 @@ export const AuditChecksOutroSection = ({
             );
           })}
           {hidden > 0 && (
-            <Text dimColor>… and {hidden} more — see the report.</Text>
+            <Text dimColor>
+              … and {hidden} more. See the report for details.
+            </Text>
           )}
         </>
       )}

--- a/src/ui/tui/screens/audit/AuditOutroScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditOutroScreen.tsx
@@ -66,6 +66,22 @@ export const AuditOutroScreen = ({ store }: AuditOutroScreenProps) => {
             installDir={store.session.installDir}
           />
 
+          {outroData.dashboardUrl && (
+            <Box marginTop={1}>
+              <Text>
+                Dashboard: <Text color="cyan">{outroData.dashboardUrl}</Text>
+              </Text>
+            </Box>
+          )}
+
+          {outroData.notebookUrl && (
+            <Box marginTop={1}>
+              <Text>
+                Notebook: <Text color="cyan">{outroData.notebookUrl}</Text>
+              </Text>
+            </Box>
+          )}
+
           {outroData.docsUrl && (
             <Box marginTop={1}>
               <Text>

--- a/src/ui/tui/screens/audit/AuditOutroScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditOutroScreen.tsx
@@ -55,8 +55,8 @@ export const AuditOutroScreen = ({ store }: AuditOutroScreenProps) => {
                 {join(store.session.installDir, outroData.reportFile)}
               </Text>
               <Text dimColor>
-                A markdown file in your project folder — open it in any editor
-                to read the full audit.
+                A markdown file in your project folder. Open it in any editor to
+                read the full audit.
               </Text>
             </Box>
           )}

--- a/src/ui/tui/screens/audit/AuditOutroScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditOutroScreen.tsx
@@ -46,6 +46,22 @@ export const AuditOutroScreen = ({ store }: AuditOutroScreenProps) => {
             ✔ {outroData.message || 'Audit complete!'}
           </Text>
 
+          {outroData.dashboardUrl && (
+            <Box marginTop={1}>
+              <Text>
+                Dashboard: <Text color="cyan">{outroData.dashboardUrl}</Text>
+              </Text>
+            </Box>
+          )}
+
+          {outroData.notebookUrl && (
+            <Box marginTop={1}>
+              <Text>
+                Notebook: <Text color="cyan">{outroData.notebookUrl}</Text>
+              </Text>
+            </Box>
+          )}
+
           {outroData.reportFile && (
             <Box flexDirection="column" marginTop={1}>
               <Text color="cyan" bold>
@@ -65,22 +81,6 @@ export const AuditOutroScreen = ({ store }: AuditOutroScreenProps) => {
             checks={getAuditChecks(store.session)}
             installDir={store.session.installDir}
           />
-
-          {outroData.dashboardUrl && (
-            <Box marginTop={1}>
-              <Text>
-                Dashboard: <Text color="cyan">{outroData.dashboardUrl}</Text>
-              </Text>
-            </Box>
-          )}
-
-          {outroData.notebookUrl && (
-            <Box marginTop={1}>
-              <Text>
-                Notebook: <Text color="cyan">{outroData.notebookUrl}</Text>
-              </Text>
-            </Box>
-          )}
 
           {outroData.docsUrl && (
             <Box marginTop={1}>

--- a/src/ui/tui/screens/audit/AuditRunScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditRunScreen.tsx
@@ -55,7 +55,13 @@ export const AuditRunScreen = ({ store }: AuditRunScreenProps) => {
       ? EVENTS_AUDIT_AREA_SLIDES
       : AUDIT_AREA_SLIDES;
   const areaPane = (
-    <AuditAreaPane checks={checks} reportPath={reportPath} slides={slides} />
+    <AuditAreaPane
+      checks={checks}
+      reportPath={reportPath}
+      slides={slides}
+      dashboardUrl={store.session.dashboardUrl}
+      notebookUrl={store.session.notebookUrl}
+    />
   );
 
   // Narrow terminals: drop the area pane.

--- a/src/ui/tui/screens/audit/AuditRunScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditRunScreen.tsx
@@ -12,6 +12,8 @@ import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 import { useFileWatcher } from '@ui/tui/hooks/file-watcher';
 import { AuditChecksViewer } from './AuditChecksViewer/AuditChecksViewer.js';
 import { AuditAreaPane } from './AuditAreaPane.js';
+import { AUDIT_AREA_SLIDES } from './slides/index.js';
+import { EVENTS_AUDIT_AREA_SLIDES } from './slides/events-audit/index.js';
 import { PendingChecksList } from './PendingChecksList.js';
 import {
   AUDIT_CHECKS_FILE,
@@ -48,7 +50,13 @@ export const AuditRunScreen = ({ store }: AuditRunScreenProps) => {
     AUDIT_REPORT_FILE;
   const reportPath = `./${reportFile}`;
   const pendingChecksList = <PendingChecksList checks={checks} />;
-  const areaPane = <AuditAreaPane checks={checks} reportPath={reportPath} />;
+  const slides =
+    store.session.skillId === 'events-audit'
+      ? EVENTS_AUDIT_AREA_SLIDES
+      : AUDIT_AREA_SLIDES;
+  const areaPane = (
+    <AuditAreaPane checks={checks} reportPath={reportPath} slides={slides} />
+  );
 
   // Narrow terminals: drop the area pane.
   const statusComponent =

--- a/src/ui/tui/screens/audit/slides/events-audit/createDashboard.tsx
+++ b/src/ui/tui/screens/audit/slides/events-audit/createDashboard.tsx
@@ -27,7 +27,6 @@ export const CreateDashboardSlide: AreaSlide = {
   area: 'Create dashboard',
   intro: [
     'Finally we build a live PostHog dashboard for the events your code captures. Use it to watch volume over time, spot new phantoms, and see how traffic shifts as you ship changes.',
-    "Skipped if PostHog wasn't reachable in the previous step. The report still ships without it.",
     'Open the dashboard from the wrap-up screen when the audit completes.',
   ],
   visual: <DashboardVisual />,

--- a/src/ui/tui/screens/audit/slides/events-audit/createDashboard.tsx
+++ b/src/ui/tui/screens/audit/slides/events-audit/createDashboard.tsx
@@ -1,0 +1,35 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const DashboardVisual = () => (
+  <VisualBox>
+    <Text dimColor>events audit dashboard</Text>
+    <Text>
+      <Text color="cyan">{'pageview    '}</Text>
+      <Text color="green">{'████████████'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'signup      '}</Text>
+      <Text color="green">{'████████'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'activated   '}</Text>
+      <Text color="green">{'█████'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'purchased   '}</Text>
+      <Text color="green">{'██'}</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const CreateDashboardSlide: AreaSlide = {
+  area: 'Create dashboard',
+  intro: [
+    'Finally we build a live PostHog dashboard for the events your code captures. Use it to watch volume over time, spot new phantoms, and see how traffic shifts as you ship changes.',
+    "Skipped if PostHog wasn't reachable in the previous step. The report still ships without it.",
+    'Open the dashboard from the wrap-up screen when the audit completes.',
+  ],
+  visual: <DashboardVisual />,
+  docsUrl: 'https://posthog.com/docs/product-analytics/dashboards',
+};

--- a/src/ui/tui/screens/audit/slides/events-audit/detectSdk.tsx
+++ b/src/ui/tui/screens/audit/slides/events-audit/detectSdk.tsx
@@ -1,0 +1,30 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const DetectVisual = () => (
+  <VisualBox>
+    <Text dimColor>package.json</Text>
+    <Text>
+      <Text dimColor>{'  └─ '}</Text>
+      <Text color="green">posthog-js</Text>
+      <Text dimColor>{'  ^1.200.0'}</Text>
+    </Text>
+    <Text dimColor>requirements.txt</Text>
+    <Text>
+      <Text dimColor>{'  └─ '}</Text>
+      <Text color="green">posthog</Text>
+      <Text dimColor>{'     ==4.0.1'}</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const DetectSdkSlide: AreaSlide = {
+  area: 'Detect SDK',
+  intro: [
+    'First we find which PostHog SDKs your project uses. The audit needs to know the right languages and frameworks before it looks at any code.',
+    'Only dependency manifests get read here: package.json, requirements.txt, go.mod, and similar files. Source files come in a later step.',
+    'If your project is a monorepo with more than one SDK, we handle each one.',
+  ],
+  visual: <DetectVisual />,
+  docsUrl: 'https://posthog.com/docs/libraries',
+};

--- a/src/ui/tui/screens/audit/slides/events-audit/enrichSites.tsx
+++ b/src/ui/tui/screens/audit/slides/events-audit/enrichSites.tsx
@@ -1,0 +1,35 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const EnrichVisual = () => (
+  <VisualBox>
+    <Text dimColor>orchestrator</Text>
+    <Text dimColor>{'  │'}</Text>
+    <Text>
+      <Text dimColor>{'  ├─ '}</Text>
+      <Text color="cyan">subagent 1</Text>
+      <Text dimColor>{'  → part-1.json'}</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  ├─ '}</Text>
+      <Text color="cyan">subagent 2</Text>
+      <Text dimColor>{'  → part-2.json'}</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  └─ '}</Text>
+      <Text color="cyan">subagent N</Text>
+      <Text dimColor>{'  → part-N.json'}</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const EnrichSitesSlide: AreaSlide = {
+  area: 'Enrich',
+  intro: [
+    'Now we look inside each file that captures events. The goal is to know not just that an event fires, but what it is, where it lives, and what data goes with it.',
+    'For every capture site we pull out the event name, the properties, the area of your codebase it sits in, and the surrounding function or component.',
+    'This is the only step that opens source files. Large codebases run in parallel so it finishes in one pass.',
+  ],
+  visual: <EnrichVisual />,
+  docsUrl: 'https://posthog.com/docs/product-analytics/best-practices',
+};

--- a/src/ui/tui/screens/audit/slides/events-audit/index.ts
+++ b/src/ui/tui/screens/audit/slides/events-audit/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Slide registry for the events-audit program. Each entry is keyed by
+ * `AuditCheck.area` and corresponds to one phase of the 6-phase pipeline.
+ *
+ * `AuditAreaPane` looks up the active phase's slide here when the active
+ * program is events-audit.
+ */
+
+import type { AreaSlide } from '../shared.js';
+import { DetectSdkSlide } from './detectSdk.js';
+import { ScanSitesSlide } from './scanSites.js';
+import { EnrichSitesSlide } from './enrichSites.js';
+import { QueryVolumeSlide } from './queryVolume.js';
+import { WriteReportSlide } from './writeReport.js';
+import { CreateDashboardSlide } from './createDashboard.js';
+
+export const EVENTS_AUDIT_AREA_SLIDES: AreaSlide[] = [
+  DetectSdkSlide,
+  ScanSitesSlide,
+  EnrichSitesSlide,
+  QueryVolumeSlide,
+  WriteReportSlide,
+  CreateDashboardSlide,
+];

--- a/src/ui/tui/screens/audit/slides/events-audit/index.ts
+++ b/src/ui/tui/screens/audit/slides/events-audit/index.ts
@@ -13,6 +13,7 @@ import { EnrichSitesSlide } from './enrichSites.js';
 import { QueryVolumeSlide } from './queryVolume.js';
 import { WriteReportSlide } from './writeReport.js';
 import { CreateDashboardSlide } from './createDashboard.js';
+import { UploadNotebookSlide } from './uploadNotebook.js';
 
 export const EVENTS_AUDIT_AREA_SLIDES: AreaSlide[] = [
   DetectSdkSlide,
@@ -21,4 +22,5 @@ export const EVENTS_AUDIT_AREA_SLIDES: AreaSlide[] = [
   QueryVolumeSlide,
   WriteReportSlide,
   CreateDashboardSlide,
+  UploadNotebookSlide,
 ];

--- a/src/ui/tui/screens/audit/slides/events-audit/queryVolume.tsx
+++ b/src/ui/tui/screens/audit/slides/events-audit/queryVolume.tsx
@@ -1,0 +1,32 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const QueryVisual = () => (
+  <VisualBox>
+    <Text dimColor>{'SELECT event, count() AS volume_30d'}</Text>
+    <Text dimColor>
+      {'FROM events WHERE timestamp > now() - INTERVAL 30 DAY'}
+    </Text>
+    <Text dimColor>{'GROUP BY event ORDER BY volume_30d DESC'}</Text>
+    <Text> </Text>
+    <Text>
+      <Text color="cyan">{'pageview          '}</Text>
+      <Text color="green">{'12,430'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">{'signup_completed  '}</Text>
+      <Text color="green">{'   840'}</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const QueryVolumeSlide: AreaSlide = {
+  area: 'Query PostHog',
+  intro: [
+    'We ask PostHog how often each event in the inventory has fired in the last 30 days.',
+    "Events your code captures but PostHog has never seen are flagged as phantoms. Phantoms usually mean a typo, a dead code path, or instrumentation that hasn't shipped yet. Worth cleaning up.",
+    "If PostHog isn't reachable the audit still finishes. The report just notes where volume numbers would have gone.",
+  ],
+  visual: <QueryVisual />,
+  docsUrl: 'https://posthog.com/docs/product-analytics/sql',
+};

--- a/src/ui/tui/screens/audit/slides/events-audit/scanSites.tsx
+++ b/src/ui/tui/screens/audit/slides/events-audit/scanSites.tsx
@@ -1,0 +1,31 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const ScanVisual = () => (
+  <VisualBox>
+    <Text dimColor>grep -rn 'posthog\.(capture|identify|group)'</Text>
+    <Text>
+      <Text color="cyan">src/checkout/Checkout.tsx:88</Text>
+      <Text dimColor>{'  posthog.capture(...)'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">src/auth/login.ts:42</Text>
+      <Text dimColor>{'        posthog.identify(...)'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">src/onboarding/step.tsx:17</Text>
+      <Text dimColor>{'  posthog.capture(...)'}</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const ScanSitesSlide: AreaSlide = {
+  area: 'Scan capture sites',
+  intro: [
+    'Next we map every place your code captures PostHog events. This is the inventory the rest of the audit builds on.',
+    'We search your project for PostHog SDK calls: capture, identify, group, and more. No source files are opened yet, that comes in the next step.',
+    "Test files are excluded so they don't pollute the inventory.",
+  ],
+  visual: <ScanVisual />,
+  docsUrl: 'https://posthog.com/docs/product-analytics/capture-events',
+};

--- a/src/ui/tui/screens/audit/slides/events-audit/uploadNotebook.tsx
+++ b/src/ui/tui/screens/audit/slides/events-audit/uploadNotebook.tsx
@@ -1,0 +1,27 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const NotebookVisual = () => (
+  <VisualBox>
+    <Text dimColor>posthog-events-audit-report.md</Text>
+    <Text dimColor>{'  │'}</Text>
+    <Text>
+      <Text dimColor>{'  ▼ '}</Text>
+      <Text color="cyan">PostHog notebook</Text>
+    </Text>
+    <Text dimColor>{'     # Identity & segmentation'}</Text>
+    <Text dimColor>{'     # Coverage map'}</Text>
+    <Text dimColor>{'     # Events by file & area'}</Text>
+  </VisualBox>
+);
+
+export const UploadNotebookSlide: AreaSlide = {
+  area: 'Upload notebook',
+  intro: [
+    'Next we upload the report into a PostHog notebook so you can share it with your team as a URL.',
+    'Hang tight.',
+    'The markdown file on disk is still there for you to read locally.',
+  ],
+  visual: <NotebookVisual />,
+  docsUrl: 'https://posthog.com/docs/notebooks',
+};

--- a/src/ui/tui/screens/audit/slides/events-audit/writeReport.tsx
+++ b/src/ui/tui/screens/audit/slides/events-audit/writeReport.tsx
@@ -1,0 +1,35 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const ReportVisual = () => (
+  <VisualBox>
+    <Text dimColor>posthog-events-audit-report.md</Text>
+    <Text>
+      <Text dimColor>{'  # '}</Text>
+      <Text>Identity &amp; segmentation</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  # '}</Text>
+      <Text>Coverage map</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  # '}</Text>
+      <Text>Data quality</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  # '}</Text>
+      <Text>Events by file &amp; area</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const WriteReportSlide: AreaSlide = {
+  area: 'Write report',
+  intro: [
+    'We package everything we found into one report at ./posthog-events-audit-report.md. This is what you hand to the team.',
+    'The report covers how users get identified, which parts of your codebase capture which events, data quality issues like duplicates and phantoms, and a volume map of every event your code captures.',
+    'Nothing in your project is modified. The report is the only file you keep.',
+  ],
+  visual: <ReportVisual />,
+  docsUrl: 'https://posthog.com/docs/product-analytics/best-practices',
+};

--- a/src/ui/tui/screens/audit/slides/index.ts
+++ b/src/ui/tui/screens/audit/slides/index.ts
@@ -8,6 +8,8 @@ import type { AreaSlide } from './shared.js';
 import { InstallationSlide } from './installation.js';
 import { IdentificationSlide } from './identification.js';
 import { EventCaptureSlide } from './eventCapture.js';
+import { WriteReportSlide } from './writeReport.js';
+import { UploadNotebookSlide } from './uploadNotebook.js';
 
 export type { AreaSlide };
 
@@ -15,4 +17,6 @@ export const AUDIT_AREA_SLIDES: AreaSlide[] = [
   InstallationSlide,
   IdentificationSlide,
   EventCaptureSlide,
+  WriteReportSlide,
+  UploadNotebookSlide,
 ];

--- a/src/ui/tui/screens/audit/slides/uploadNotebook.tsx
+++ b/src/ui/tui/screens/audit/slides/uploadNotebook.tsx
@@ -1,0 +1,27 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from './shared.js';
+
+const NotebookVisual = () => (
+  <VisualBox>
+    <Text dimColor>posthog-audit-report.md</Text>
+    <Text dimColor>{'  │'}</Text>
+    <Text>
+      <Text dimColor>{'  ▼ '}</Text>
+      <Text color="cyan">PostHog notebook</Text>
+    </Text>
+    <Text dimColor>{'     # Summary'}</Text>
+    <Text dimColor>{'     # Recommended actions'}</Text>
+    <Text dimColor>{'     # Full audit'}</Text>
+  </VisualBox>
+);
+
+export const UploadNotebookSlide: AreaSlide = {
+  area: 'Upload notebook',
+  intro: [
+    'Next we upload the report into a PostHog notebook so you can share it with your team as a URL.',
+    'Hang tight.',
+    'The markdown file on disk is still there for you to read locally.',
+  ],
+  visual: <NotebookVisual />,
+  docsUrl: 'https://posthog.com/docs/notebooks',
+};

--- a/src/ui/tui/screens/audit/slides/writeReport.tsx
+++ b/src/ui/tui/screens/audit/slides/writeReport.tsx
@@ -1,0 +1,31 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from './shared.js';
+
+const ReportVisual = () => (
+  <VisualBox>
+    <Text dimColor>posthog-audit-report.md</Text>
+    <Text>
+      <Text dimColor>{'  # '}</Text>
+      <Text>Summary</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  # '}</Text>
+      <Text>Recommended actions</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  # '}</Text>
+      <Text>Full audit</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const WriteReportSlide: AreaSlide = {
+  area: 'Write report',
+  intro: [
+    'Now we write an audit report at ./posthog-audit-report.md. that summarizes our findings.',
+    'The report leads with a summary, then a prioritized list of fixes with file:line citations, then every check we ran grouped by area so nothing is hidden.',
+    'We will upload the report into a PostHog notebook in the next step.',
+  ],
+  visual: <ReportVisual />,
+  docsUrl: 'https://posthog.com/docs/product-analytics/best-practices',
+};

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -14,6 +14,7 @@
  */
 
 import { atom, map } from 'nanostores';
+import { logToFile } from '@utils/debug';
 import { TaskStatus, isTaskStatus, type AuthErrorDetail } from '@ui/wizard-ui';
 import {
   type WizardSession,
@@ -551,11 +552,13 @@ export class WizardStore {
   }
 
   setDashboardUrl(url: string): void {
+    logToFile(`store.setDashboardUrl: ${url}`);
     this.$session.setKey('dashboardUrl', url);
     this.emitChange();
   }
 
   setNotebookUrl(url: string): void {
+    logToFile(`store.setNotebookUrl: ${url}`);
     this.$session.setKey('notebookUrl', url);
     this.emitChange();
   }

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -555,6 +555,11 @@ export class WizardStore {
     this.emitChange();
   }
 
+  setNotebookUrl(url: string): void {
+    this.$session.setKey('notebookUrl', url);
+    this.emitChange();
+  }
+
   setFrameworkContext(key: string, value: unknown): void {
     const ctx = { ...this.$session.get().frameworkContext, [key]: value };
     this.$session.setKey('frameworkContext', ctx);

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -174,6 +174,11 @@ export interface WizardUI {
   // ── Notebook URL emitted by the agent via [NOTEBOOK_URL] marker ──
   setNotebookUrl(url: string): void;
 
+  // ── Outro payload built by agent-runner ──
+  // Replaces the direct `session.outroData = X` mutation that breaks once
+  // setKey-based store mutations have forked the session reference.
+  setOutroData(data: OutroData): void;
+
   // ── Generic frameworkContext setter for program file watchers ─────
   setFrameworkContext(key: string, value: unknown): void;
 }

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -171,6 +171,9 @@ export interface WizardUI {
   // ── Dashboard URL emitted by the agent via [DASHBOARD_URL] marker ──
   setDashboardUrl(url: string): void;
 
+  // ── Notebook URL emitted by the agent via [NOTEBOOK_URL] marker ──
+  setNotebookUrl(url: string): void;
+
   // ── Generic frameworkContext setter for program file watchers ─────
   setFrameworkContext(key: string, value: unknown): void;
 }

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -96,6 +96,7 @@ describe('provisionNewAccount', () => {
       'dashboard:write',
       'insight:write',
       'query:read',
+      'notebook:write',
     ]);
 
     // Verify token exchange includes code_verifier


### PR DESCRIPTION
## Problem

Updating the programs `audit` and `events audit`

- More customizable ledgers
- Upload to markdown reports to PostHog notebooks
- Requesting `notebook:write` scope
- Notebook URL convention

<img width="865" height="518" alt="image" src="https://github.com/user-attachments/assets/fefc25f4-14ec-417d-9855-2e1c506299ec" />
