### PR TITLE
feat: request read-data-schema + notebook OAuth scopes and document the scope set

### DIFF
--- a/.claude/skills/wizard-development/references/MAINTAINING-SKILLS.md
+++ b/.claude/skills/wizard-development/references/MAINTAINING-SKILLS.md
@@ -76,6 +76,23 @@ Skills carry a `version` field in their frontmatter. Bump it as follows:
 
 When you bump a version, also bump the `version` in any reference file that shipped as part of the change. Version churn is itself a maintenance signal — a skill that's bumped majors three times in a year is probably teaching an abstraction that hasn't stabilized.
 
+## Keep the README's OAuth scopes in sync with `constants.ts`
+
+The wizard's required OAuth scopes are defined once, in `WIZARD_OAUTH_SCOPES`
+(and its `WIZARD_PROVISIONING_SCOPES` subset) in `src/lib/constants.ts`. That
+constant is the source of truth — it's what the wizard actually requests at
+login. The README's "OAuth Scopes" section documents the same list for
+operators who grant scopes on the PostHog OAuth application (US / EU regions).
+
+These two drift apart easily: someone adds a scope to the constant for a new
+capability (e.g. `notebook:write` for the notebooks MCP tools) and the README
+keeps listing the old set, or vice versa. **Whenever you add or remove a scope
+in `constants.ts`, update the README's "OAuth Scopes" table and copy-pasteable
+list in the same change** — and confirm the new scope is granted on the OAuth
+application in every region, or the corresponding tool calls fail at runtime.
+The header comment on `WIZARD_OAUTH_SCOPES` carries the reverse pointer back to
+the README.
+
 ## The maintainer's question
 
 When you finish updating a skill, ask: "If a contributor with no prior context follows this exactly, will they produce work the architecture currently asks for?" Not "will they produce something that works" — works is necessary but not sufficient. The skill should produce idiomatic output, not just functional output. If following the skill produces a bin.ts edit that the registry would have done automatically, the skill is asking for work that should be automatic.

--- a/.claude/skills/wizard-development/references/MAINTAINING-SKILLS.md
+++ b/.claude/skills/wizard-development/references/MAINTAINING-SKILLS.md
@@ -78,20 +78,7 @@ When you bump a version, also bump the `version` in any reference file that ship
 
 ## Keep the README's OAuth scopes in sync with `constants.ts`
 
-The wizard's required OAuth scopes are defined once, in `WIZARD_OAUTH_SCOPES`
-(and its `WIZARD_PROVISIONING_SCOPES` subset) in `src/lib/constants.ts`. That
-constant is the source of truth — it's what the wizard actually requests at
-login. The README's "OAuth Scopes" section documents the same list for
-operators who grant scopes on the PostHog OAuth application (US / EU regions).
-
-These two drift apart easily: someone adds a scope to the constant for a new
-capability (e.g. `notebook:write` for the notebooks MCP tools) and the README
-keeps listing the old set, or vice versa. **Whenever you add or remove a scope
-in `constants.ts`, update the README's "OAuth Scopes" table and copy-pasteable
-list in the same change** — and confirm the new scope is granted on the OAuth
-application in every region, or the corresponding tool calls fail at runtime.
-The header comment on `WIZARD_OAUTH_SCOPES` carries the reverse pointer back to
-the README.
+`WIZARD_OAUTH_SCOPES` in `src/lib/constants.ts` is the source of truth. When you add or remove a scope there, update the README's "OAuth Scopes" list in the same change, and confirm the scope is granted on the OAuth application in every region (US / EU) or the matching tool calls fail at runtime.
 
 ## The maintainer's question
 

--- a/.claude/skills/wizard-development/references/MAINTAINING-SKILLS.md
+++ b/.claude/skills/wizard-development/references/MAINTAINING-SKILLS.md
@@ -76,9 +76,13 @@ Skills carry a `version` field in their frontmatter. Bump it as follows:
 
 When you bump a version, also bump the `version` in any reference file that shipped as part of the change. Version churn is itself a maintenance signal — a skill that's bumped majors three times in a year is probably teaching an abstraction that hasn't stabilized.
 
-## Keep the README's OAuth scopes in sync with `constants.ts`
+## Keep the README's OAuth scopes in sync with the scope constants
 
-`WIZARD_OAUTH_SCOPES` in `src/lib/constants.ts` is the source of truth. When you add or remove a scope there, update the README's "OAuth Scopes" list in the same change, and confirm the scope is granted on the OAuth application in every region (US / EU) or the matching tool calls fail at runtime.
+Three surfaces define what the wizard requests: `WIZARD_PROVISIONING_SCOPES` and `WIZARD_OAUTH_SCOPES` in `src/lib/constants.ts` (the base set, where `WIZARD_OAUTH_SCOPES` spreads the provisioning set), and `PROGRAM_SCOPE_ADDITIONS` in `src/lib/oauth/program-scopes.ts` (per-program extras). When you add or remove a scope in any of them:
+
+- update the README's "OAuth Scopes" section in the same change;
+- if it's a **provisioning** scope, add it to `ALLOWED_PROVISIONING_SCOPES` in the monorepo's `ee/api/agentic_provisioning/views.py` first, or the signup/provisioning call will reject the unknown scope;
+- confirm the scope is granted on the PostHog OAuth application in **every region (US / EU)**, or the matching tool calls fail at runtime even though the wizard requested it.
 
 ## The maintainer's question
 

--- a/README.md
+++ b/README.md
@@ -108,38 +108,24 @@ The following CLI arguments are available:
 
 # OAuth Scopes
 
-The default interactive flow (`npx @posthog/wizard`) authenticates via OAuth.
-During login the wizard's main basic integration program requests the following
-scopes:
+`npx @posthog/wizard` authenticates via OAuth, requesting:
 
-| Scope                  | Why the wizard needs it                                                     |
-| ---------------------- | --------------------------------------------------------------------------- |
-| `user:read`            | Identify the user for analytics + agent context                             |
-| `project:read`         | Look up the freshly-provisioned project and its API token                   |
-| `llm_gateway:read`     | Authenticate the agent's LLM calls to `gateway.{us,eu}.posthog.com/wizard`  |
-| `dashboard:write`      | Create the onboarding dashboard during setup                                |
-| `insight:write`        | Create the onboarding insights during setup                                 |
-| `query:read`           | Run HogQL queries when the agent needs data                                 |
-| `health_issue:read`    | Power `wizard doctor` health checks                                         |
-| `wizard_session:read`  | List / retrieve / stream wizard sessions                                    |
-| `wizard_session:write` | Stream run state to `/api/projects/{id}/wizard/sessions/`                    |
-| `notebook:write`       | Create and edit notebooks via the notebooks MCP tools                       |
+| Scope                       | Why                                                          |
+| --------------------------- | ----------------------------------------------------------- |
+| `user:read`                 | Identify the user for analytics + agent context             |
+| `project:read`              | Look up the provisioned project and its API token           |
+| `llm_gateway:read`          | Authenticate the agent's LLM calls to the gateway           |
+| `dashboard:write`           | Create the onboarding dashboard                             |
+| `insight:write`             | Create the onboarding insights                             |
+| `query:read`                | Run HogQL queries when the agent needs data                 |
+| `event_definition:read`     | Read event schema (`read-data-schema` MCP tool)             |
+| `property_definition:read`  | Read property schema (`read-data-schema` MCP tool)          |
+| `health_issue:read`         | Power `wizard doctor` health checks                         |
+| `wizard_session:read`       | List / retrieve / stream wizard sessions                    |
+| `wizard_session:write`      | Stream run state to `/api/projects/{id}/wizard/sessions/`   |
+| `notebook:write`            | Create / edit notebooks via the notebooks MCP tools         |
 
-As a copy-pasteable list for granting scopes on the OAuth application:
-
-```
-user:read,project:read,llm_gateway:read,dashboard:write,insight:write,query:read,health_issue:read,wizard_session:read,wizard_session:write,notebook:write
-```
-
-Every scope above must be granted on the PostHog OAuth application in **each
-region (US / EU)** or the corresponding tool calls fail at runtime. The
-provisioning signup flow (`--signup`) requests a narrower subset and must stay
-within the backend's `ALLOWED_PROVISIONING_SCOPES` allowlist.
-
-> **Source of truth:** these scopes are defined by `WIZARD_OAUTH_SCOPES` (and
-> the `WIZARD_PROVISIONING_SCOPES` subset) in `src/lib/constants.ts`. This table
-> and the list above must be kept in sync with that constant whenever scopes
-> are added or removed.
+Grant every scope on the PostHog OAuth app in both regions (US / EU) or the matching tool calls fail. Source of truth: `WIZARD_OAUTH_SCOPES` in `src/lib/constants.ts` — keep this list in sync.
 
 
 # CI Mode

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The following CLI arguments are available:
 
 # OAuth Scopes
 
-`npx @posthog/wizard` authenticates via OAuth, requesting:
+`npx @posthog/wizard` authenticates via OAuth. Every program requests this **base** set:
 
 | Scope                       | Why                                                          |
 | --------------------------- | ----------------------------------------------------------- |
@@ -119,13 +119,27 @@ The following CLI arguments are available:
 | `insight:write`             | Create the onboarding insights                             |
 | `query:read`                | Run HogQL queries when the agent needs data                 |
 | `notebook:write`            | Create / edit notebooks via the notebooks MCP tools         |
+| `event_definition:read`     | Read the project's event schema (`read-data-schema` MCP tool)    |
+| `property_definition:read`  | Read the project's property schema (`read-data-schema` MCP tool) |
 | `health_issue:read`         | Power `wizard doctor` health checks                         |
 | `wizard_session:read`       | List / retrieve / stream wizard sessions                    |
 | `wizard_session:write`      | Stream run state to `/api/projects/{id}/wizard/sessions/`   |
-| `event_definition:read`     | Read event schema (`read-data-schema` MCP tool)             |
-| `property_definition:read`  | Read property schema (`read-data-schema` MCP tool)          |
 
-Grant every scope on the PostHog OAuth app in both regions (US / EU) or the matching tool calls fail. Source of truth: `WIZARD_OAUTH_SCOPES` in `src/lib/constants.ts` — keep this list in sync.
+The first nine scopes (through `property_definition:read`) are the **provisioning** scopes,
+requested on both the signup/provisioning path and the OAuth login path; the three
+`health_issue` / `wizard_session` scopes are login-only. Some programs request **additional**
+read-only scopes on top of the base set — for example the MCP tutorial layers in reads across
+feature flags, experiments, surveys, replays, error tracking, warehouse, and more. The actual
+set is resolved per-program by `getOAuthScopesForProgram`.
+
+Sources of truth: `WIZARD_PROVISIONING_SCOPES` / `WIZARD_OAUTH_SCOPES` in `src/lib/constants.ts`
+(base) and `PROGRAM_SCOPE_ADDITIONS` in `src/lib/oauth/program-scopes.ts` (per-program). Every
+scope the wizard can request must also be:
+
+- added to `ALLOWED_PROVISIONING_SCOPES` in the monorepo's `ee/api/agentic_provisioning/views.py`
+  if it's a provisioning scope (otherwise the signup call rejects it), and
+- granted on the PostHog OAuth application in **both regions (US / EU)** — otherwise the matching
+  tool calls fail at runtime even though the wizard requested the scope.
 
 
 # CI Mode

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ The following CLI arguments are available:
 | `dashboard:write`           | Create the onboarding dashboard                             |
 | `insight:write`             | Create the onboarding insights                             |
 | `query:read`                | Run HogQL queries when the agent needs data                 |
-| `event_definition:read`     | Read event schema (`read-data-schema` MCP tool)             |
-| `property_definition:read`  | Read property schema (`read-data-schema` MCP tool)          |
+| `notebook:write`            | Create / edit notebooks via the notebooks MCP tools         |
 | `health_issue:read`         | Power `wizard doctor` health checks                         |
 | `wizard_session:read`       | List / retrieve / stream wizard sessions                    |
 | `wizard_session:write`      | Stream run state to `/api/projects/{id}/wizard/sessions/`   |
-| `notebook:write`            | Create / edit notebooks via the notebooks MCP tools         |
+| `event_definition:read`     | Read event schema (`read-data-schema` MCP tool)             |
+| `property_definition:read`  | Read property schema (`read-data-schema` MCP tool)          |
 
 Grant every scope on the PostHog OAuth app in both regions (US / EU) or the matching tool calls fail. Source of truth: `WIZARD_OAUTH_SCOPES` in `src/lib/constants.ts` — keep this list in sync.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,42 @@ The following CLI arguments are available:
 | `--api-key`       | PostHog personal API key (phx_xxx) for authentication            | string  |         |                                                      | `POSTHOG_WIZARD_API_KEY`       |
 
 
+# OAuth Scopes
+
+The default interactive flow (`npx @posthog/wizard`) authenticates via OAuth.
+During login the wizard's main basic integration program requests the following
+scopes:
+
+| Scope                  | Why the wizard needs it                                                     |
+| ---------------------- | --------------------------------------------------------------------------- |
+| `user:read`            | Identify the user for analytics + agent context                             |
+| `project:read`         | Look up the freshly-provisioned project and its API token                   |
+| `llm_gateway:read`     | Authenticate the agent's LLM calls to `gateway.{us,eu}.posthog.com/wizard`  |
+| `dashboard:write`      | Create the onboarding dashboard during setup                                |
+| `insight:write`        | Create the onboarding insights during setup                                 |
+| `query:read`           | Run HogQL queries when the agent needs data                                 |
+| `health_issue:read`    | Power `wizard doctor` health checks                                         |
+| `wizard_session:read`  | List / retrieve / stream wizard sessions                                    |
+| `wizard_session:write` | Stream run state to `/api/projects/{id}/wizard/sessions/`                    |
+| `notebook:write`       | Create and edit notebooks via the notebooks MCP tools                       |
+
+As a copy-pasteable list for granting scopes on the OAuth application:
+
+```
+user:read,project:read,llm_gateway:read,dashboard:write,insight:write,query:read,health_issue:read,wizard_session:read,wizard_session:write,notebook:write
+```
+
+Every scope above must be granted on the PostHog OAuth application in **each
+region (US / EU)** or the corresponding tool calls fail at runtime. The
+provisioning signup flow (`--signup`) requests a narrower subset and must stay
+within the backend's `ALLOWED_PROVISIONING_SCOPES` allowlist.
+
+> **Source of truth:** these scopes are defined by `WIZARD_OAUTH_SCOPES` (and
+> the `WIZARD_PROVISIONING_SCOPES` subset) in `src/lib/constants.ts`. This table
+> and the list above must be kept in sync with that constant whenever scopes
+> are added or removed.
+
+
 # CI Mode
 
 > ⚠️ **CI mode is not currently supported in published builds.** PostHog's LLM

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -106,9 +106,17 @@ export const DUMMY_PROJECT_API_KEY = '_YOUR_POSTHOG_PROJECT_TOKEN_';
  * - notebook:write    upload the events-audit report as a PostHog notebook
  *                     in step 6 of the events-audit skill (notebooks-create
  *                     MCP tool requires this scope)
+ * - event_definition:read     read the project's event schema via the
+ *                     read-data-schema MCP tool, so the agent instruments
+ *                     real event names instead of guessing from capture()
+ *                     calls in code
+ * - property_definition:read  read the project's property schema via the
+ *                     same read-data-schema MCP tool
  *
  * Must be a subset of `ALLOWED_PROVISIONING_SCOPES` in
- * `ee/api/agentic_provisioning/views.py` on the backend.
+ * `ee/api/agentic_provisioning/views.py` on the backend — `event_definition:read`
+ * and `property_definition:read` must be added there before this list ships,
+ * or the provisioning signup call will reject the unknown scopes.
  */
 export const WIZARD_PROVISIONING_SCOPES = [
   'user:read',
@@ -118,29 +126,32 @@ export const WIZARD_PROVISIONING_SCOPES = [
   'insight:write',
   'query:read',
   'notebook:write',
+  'event_definition:read',
+  'property_definition:read',
 ] as const;
 
 /**
  * Scopes the wizard requests during the OAuth login flow. Superset of
  * `WIZARD_PROVISIONING_SCOPES` with scopes that only apply to the login
  * path and are not in the provisioning allowlist:
- * - health_issue:read        used by `wizard doctor`
- * - wizard_session:read      list / retrieve / stream sessions
- * - wizard_session:write     stream run state to /api/projects/{id}/wizard/sessions/
- * - event_definition:read    read event schema via the read-data-schema MCP tool
- * - property_definition:read read property schema via the read-data-schema MCP tool
+ * - health_issue:read     used by `wizard doctor`
+ * - wizard_session:read   list / retrieve / stream sessions
+ * - wizard_session:write  stream run state to /api/projects/{id}/wizard/sessions/
  *
- * Each scope here must also be granted on the PostHog OAuth application in
- * every region (US / EU). When this list changes, update the "OAuth Scopes"
- * section of README.md to match — it documents this constant for operators.
+ * This is the BASE set every program requests. A program can layer extra
+ * read scopes on top via `PROGRAM_SCOPE_ADDITIONS` in
+ * `src/lib/oauth/program-scopes.ts` (e.g. the MCP tutorial) — the actual
+ * requested set is resolved per-program by `getOAuthScopesForProgram`.
+ *
+ * Every scope the wizard can request (base + program additions) must also be
+ * granted on the PostHog OAuth application in every region (US / EU). When
+ * this list changes, update the "OAuth Scopes" section of README.md to match.
  */
 export const WIZARD_OAUTH_SCOPES = [
   ...WIZARD_PROVISIONING_SCOPES,
   'health_issue:read',
   'wizard_session:read',
   'wizard_session:write',
-  'event_definition:read',
-  'property_definition:read',
 ] as const;
 
 // ── Wizard run / variants ───────────────────────────────────────────

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -120,10 +120,12 @@ export const WIZARD_PROVISIONING_SCOPES = [
  * Scopes the wizard requests during the OAuth login flow. Superset of
  * `WIZARD_PROVISIONING_SCOPES` with scopes that only apply to the login
  * path and are not in the provisioning allowlist:
- * - health_issue:read     used by `wizard doctor`
- * - wizard_session:read   list / retrieve / stream sessions
- * - wizard_session:write  stream run state to /api/projects/{id}/wizard/sessions/
- * - notebook:write        create / edit notebooks via the notebooks MCP tools
+ * - health_issue:read        used by `wizard doctor`
+ * - wizard_session:read      list / retrieve / stream sessions
+ * - wizard_session:write     stream run state to /api/projects/{id}/wizard/sessions/
+ * - notebook:write           create / edit notebooks via the notebooks MCP tools
+ * - event_definition:read    read event schema via the read-data-schema MCP tool
+ * - property_definition:read read property schema via the read-data-schema MCP tool
  *
  * Each scope here must also be granted on the PostHog OAuth application in
  * every region (US / EU). When this list changes, update the "OAuth Scopes"
@@ -135,6 +137,8 @@ export const WIZARD_OAUTH_SCOPES = [
   'wizard_session:read',
   'wizard_session:write',
   'notebook:write',
+  'event_definition:read',
+  'property_definition:read',
 ] as const;
 
 // ── Wizard run / variants ───────────────────────────────────────────

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -123,12 +123,18 @@ export const WIZARD_PROVISIONING_SCOPES = [
  * - health_issue:read     used by `wizard doctor`
  * - wizard_session:read   list / retrieve / stream sessions
  * - wizard_session:write  stream run state to /api/projects/{id}/wizard/sessions/
+ * - notebook:write        create / edit notebooks via the notebooks MCP tools
+ *
+ * Each scope here must also be granted on the PostHog OAuth application in
+ * every region (US / EU). When this list changes, update the "OAuth Scopes"
+ * section of README.md to match — it documents this constant for operators.
  */
 export const WIZARD_OAUTH_SCOPES = [
   ...WIZARD_PROVISIONING_SCOPES,
   'health_issue:read',
   'wizard_session:read',
   'wizard_session:write',
+  'notebook:write',
 ] as const;
 
 // ── Wizard run / variants ───────────────────────────────────────────

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -127,7 +127,6 @@ export const WIZARD_PROVISIONING_SCOPES = [
  * - health_issue:read        used by `wizard doctor`
  * - wizard_session:read      list / retrieve / stream sessions
  * - wizard_session:write     stream run state to /api/projects/{id}/wizard/sessions/
- * - notebook:write           create / edit notebooks via the notebooks MCP tools
  * - event_definition:read    read event schema via the read-data-schema MCP tool
  * - property_definition:read read property schema via the read-data-schema MCP tool
  *
@@ -140,7 +139,6 @@ export const WIZARD_OAUTH_SCOPES = [
   'health_issue:read',
   'wizard_session:read',
   'wizard_session:write',
-  'notebook:write',
   'event_definition:read',
   'property_definition:read',
 ] as const;

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -97,6 +97,8 @@ describe('provisionNewAccount', () => {
       'insight:write',
       'query:read',
       'notebook:write',
+      'event_definition:read',
+      'property_definition:read',
     ]);
 
     // Verify token exchange includes code_verifier


### PR DESCRIPTION
## Problem

The wizard agent's schema-discovery tool (`read-data-schema`) is gated on `event_definition:read` + `property_definition:read`. The wizard never requested those scopes on its base scope set, so schema discovery failed and the agent fell back to guessing event names from `capture()` calls in code.

The OAuth scopes the wizard requests also weren't documented anywhere operators could find them, and the README had no guard against drifting from the constants.

## Changes

- **`src/lib/constants.ts`** — add `event_definition:read` + `property_definition:read` to **`WIZARD_PROVISIONING_SCOPES`** (not just the OAuth set). Because `WIZARD_OAUTH_SCOPES` spreads the provisioning set, **both** auth paths now request them with no duplication:
  - signup / provisioning path (`provisioning.ts` → `WIZARD_PROVISIONING_SCOPES`)
  - OAuth login path (`setup-utils.ts` → `getOAuthScopesForProgram`)

  This is the key correction over the earlier version of this branch, which added the scopes only to `WIZARD_OAUTH_SCOPES` and left newly-provisioned users without schema access.
- **`src/utils/__tests__/provisioning.test.ts`** — assert the two new provisioning scopes.
- **README** — an honest "OAuth Scopes" section: the base set every program requests, a note that the set is **program-dependent** (programs like the MCP tutorial layer extra read scopes via `PROGRAM_SCOPE_ADDITIONS`), and both grant prerequisites spelled out.
- **`MAINTAINING-SKILLS.md`** — note covering all three scope surfaces (`WIZARD_PROVISIONING_SCOPES`, `WIZARD_OAUTH_SCOPES`, `PROGRAM_SCOPE_ADDITIONS`) and the two grant prerequisites.

## ⚠️ Prerequisites before this ships (out of repo)

This change is **inert** until both land — and the first is a hard requirement or signup breaks:

1. Add `event_definition:read` + `property_definition:read` to `ALLOWED_PROVISIONING_SCOPES` in the monorepo's `ee/api/agentic_provisioning/views.py`, **or the provisioning signup call will reject the unknown scopes.**
2. Grant both scopes on the PostHog OAuth application in **both regions (US / EU)**, or `read-data-schema` still fails at runtime.

## Test plan

- `pnpm build` — passes
- `pnpm test` — 811 tests pass (52 suites)
- `pnpm fix` — formatting clean
- Additive scopes only; no behavior change beyond requesting the scopes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
