### PR TITLE
draft: --autonomy onboarding

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -198,6 +198,13 @@ const cli = yargs(hideBin(process.argv))
             'Name for account creation with --ci --signup\nenv: POSTHOG_WIZARD_NAME',
           type: 'string',
         },
+        autonomy: {
+          default: false,
+          describe:
+            'Plan PostHog Autonomy (scouts + responders) after integration\nenv: POSTHOG_WIZARD_AUTONOMY',
+          type: 'boolean',
+          hidden: true,
+        },
       });
     },
     (argv) => {
@@ -652,7 +659,9 @@ function runWizard(
       const installDir = (options.installDir as string) || process.cwd();
 
       const { startTUI } = await import('@ui/tui/start-tui');
-      const { buildSession, RunPhase } = await import('@lib/wizard-session');
+      const { buildSession, RunPhase, AdditionalFeature } = await import(
+        '@lib/wizard-session'
+      );
       const { TaskStreamPush } = await import('@lib/task-stream/index');
       const { PostHogDestination } = await import(
         '@lib/task-stream/destinations/posthog'
@@ -677,6 +686,7 @@ function runWizard(
         benchmark: options.benchmark as boolean | undefined,
         yaraReport: options.yaraReport as boolean | undefined,
         noTelemetry: resolveNoTelemetry(options),
+        autonomy: options.autonomy as boolean | undefined,
       });
       session.programLabel = config.id;
       if (options.skillId) {
@@ -686,6 +696,13 @@ function runWizard(
       }
 
       activeTui.store.session = session;
+
+      // Stop hook drains the feature queue after the main integration run;
+      // queueing here means the autonomy prompt fires in the same agent
+      // session, with all integration context still loaded.
+      if (session.autonomy) {
+        activeTui.store.enableFeature(AdditionalFeature.Autonomy);
+      }
 
       const taskStreamEnabled = !session.noTelemetry;
       taskStream = new TaskStreamPush({

--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -421,4 +421,25 @@ describe('createStopHook', () => {
     expect(first).toHaveProperty('decision', 'block');
     expect((first as { reason: string }).reason).toContain('WIZARD-REMARK');
   });
+
+  it('Autonomy feature injects its planning prompt then remark then allows stop', () => {
+    const hook = createStopHook([AdditionalFeature.Autonomy]);
+
+    const first = hook(hookInput);
+    expect(first).toHaveProperty('decision', 'block');
+    expect((first as { reason: string }).reason).toBe(
+      ADDITIONAL_FEATURE_PROMPTS[AdditionalFeature.Autonomy],
+    );
+    expect((first as { reason: string }).reason).toContain('PostHog Autonomy');
+    expect((first as { reason: string }).reason).toContain(
+      '.posthog/autonomy/autonomy.json',
+    );
+
+    const second = hook(hookInput);
+    expect(second).toHaveProperty('decision', 'block');
+    expect((second as { reason: string }).reason).toContain('WIZARD-REMARK');
+
+    const third = hook(hookInput);
+    expect(third).toEqual({});
+  });
 });

--- a/src/lib/programs/posthog-integration/steps.ts
+++ b/src/lib/programs/posthog-integration/steps.ts
@@ -66,6 +66,13 @@ export const POSTHOG_INTEGRATION_PROGRAM: ProgramStep[] = [
     isComplete: (session) => session.mcpComplete,
   },
   {
+    id: 'autonomy-onboarding',
+    label: 'Autonomy',
+    screenId: 'autonomy-onboarding',
+    show: (session) => session.autonomy,
+    isComplete: (session) => session.autonomyOnboardingDismissed,
+  },
+  {
     id: 'outro',
     label: 'Done',
     screenId: 'outro',

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -51,16 +51,84 @@ export enum DiscoveredFeature {
 /** Additional features the agent can integrate after the main setup */
 export enum AdditionalFeature {
   LLM = 'llm',
+  Autonomy = 'autonomy',
 }
 
 /** Human-readable labels for additional features (used in TUI progress) */
 export const ADDITIONAL_FEATURE_LABELS: Record<AdditionalFeature, string> = {
   [AdditionalFeature.LLM]: 'LLM analytics',
+  [AdditionalFeature.Autonomy]: 'Autonomy onboarding',
 };
 
 /** Agent prompts for each additional feature, injected via the stop hook */
 export const ADDITIONAL_FEATURE_PROMPTS: Record<AdditionalFeature, string> = {
   [AdditionalFeature.LLM]: `Now integrate LLM analytics with PostHog. Use the PostHog MCP server to find the appropriate LLM analytics skill, install it, and follow its workflow. PostHog basics are already installed. Update the setup report markdown file when complete with additions from this task. `,
+  [AdditionalFeature.Autonomy]: `Now plan PostHog Autonomy for this product.
+
+PostHog Autonomy runs two kinds of agents against the user's product:
+  - Scouts: scheduled agents (cadence + prompt) that watch one product area.
+  - Responders: reactive agents that fire on a signal (a new Error Tracking issue, a new support ticket).
+
+Your job, in one phase:
+  1. Look at the code in this project and figure out what product it is. Pick 3 to 6 distinct product areas worth watching with their own Scout — bias toward user-facing surfaces, not infrastructure.
+  2. For each area, author a Scout skill file under .posthog/autonomy/scouts/<slug>.md with YAML frontmatter (name, description, cadence, mcp_servers, metadata.type=scout, metadata.area) and a prompt body that tells the Scout exactly what to watch for and which PostHog MCP tools (or other relevant MCPs) to use. Reference real PostHog MCP tools you have access to here — do not invent names.
+  3. Decide which Responders to enable. \`error-tracking\` should be enabled by default. \`support\` should be enabled only if you see evidence the project uses PostHog Conversations / PostHog support.
+  4. Write a manifest to .posthog/autonomy/autonomy.json matching the schema below.
+
+Each Scout file is essentially a small skill: YAML frontmatter on top, a clear prompt body underneath. Keep it focused on one area, name PostHog MCP tools concretely (e.g. \`mcp__posthog__query-trends\`, \`mcp__posthog__query-error-tracking-issues-list\`, \`mcp__posthog__execute-sql\`, \`mcp__posthog__query-funnel\`, \`mcp__posthog__query-retention\`, \`mcp__posthog__query-session-recordings-list\`), and pick a cadence of "hourly", "daily", or "weekly" appropriate to the area.
+
+autonomy.json schema:
+{
+  "schemaVersion": 1,
+  "generatedAt": "<ISO 8601 timestamp>",
+  "project": { "integration": "<framework id>", "host": "<posthog host>", "projectId": <number> },
+  "responders": [
+    {
+      "type": "error-tracking" | "support",
+      "enabled": <boolean>,
+      "rationale": "<one sentence>",
+      "trigger": { "kind": "new_issue" | "issue_reopen" | "volume_spike" | "new_ticket" }
+    }
+  ],
+  "scouts": [
+    {
+      "id": "<kebab-case slug>",
+      "name": "<short human title>",
+      "area": "<the product area this watches>",
+      "cadence": "hourly" | "daily" | "weekly",
+      "skillFile": "scouts/<id>.md",
+      "mcpServers": ["posthog", ...],
+      "rationale": "<one sentence on why this area earned a scout>"
+    }
+  ]
+}
+
+Skill file shape (for each scouts/<id>.md):
+---
+name: scout-<id>
+description: <one-line trigger summary — when to invoke this scout; this is what determines if the skill loads>
+cadence: <hourly|daily|weekly>
+mcp_servers:
+  - posthog
+metadata:
+  type: scout
+  area: <area string>
+---
+
+<the scout's prompt body — concrete, names PostHog MCP tools, says what to surface as a Report vs as a PR>
+
+Skill authoring essentials (from anthropics/skills/skill-creator):
+- The \`description\` line is the most important field. It is what an agent reads to decide whether to load this skill. It must clearly state when this scout should fire, in third person ("Scouts X for Y when Z"). Pack it with concrete trigger words.
+- Skill body should read as instructions to a future agent — second person ("you", "your"), imperative voice ("query trends, compare to baseline, file a Report if delta > 2x").
+- Body sections to include in this order: 1) Purpose (one sentence), 2) Signals to watch (concrete metrics/events with PostHog MCP tool names), 3) How to investigate (the actual workflow), 4) When to ship a PR vs surface a Report.
+- Be concrete with thresholds and time windows. "Significant" is bad; "delta > 2x week-over-week over the trailing 7 days" is good.
+
+Constraints:
+- Use the Write tool to create the files. Read each file immediately before writing it (commandment).
+- Do not run shell commands to make these files.
+- If the .posthog/ directory doesn't exist, create it via Write (writing a file auto-creates the parent dir).
+- After writing the files, briefly tell the user how many Scouts you planned and which Responders are enabled. Do NOT modify the integration's main setup report file — autonomy is its own concern.
+- Stay high-level. Don't ask the user clarifying questions; commit to your best read of the codebase.`,
 };
 
 /** Outcome of the MCP server installation step */
@@ -110,6 +178,36 @@ export interface AskQuestion {
 /** Map of question id → answer (string for single/text, string[] for multi). */
 export type AskAnswers = Record<string, string | string[]>;
 
+/** One PostHog Autonomy Scout as authored by the planning agent. */
+export interface AutonomyScout {
+  id: string;
+  name: string;
+  area: string;
+  cadence: 'hourly' | 'daily' | 'weekly';
+  skillFile: string;
+  mcpServers: string[];
+  rationale: string;
+}
+
+/** One PostHog Autonomy Responder as authored by the planning agent. */
+export interface AutonomyResponder {
+  type: 'error-tracking' | 'support';
+  enabled: boolean;
+  rationale: string;
+  trigger?: {
+    kind: 'new_issue' | 'issue_reopen' | 'volume_spike' | 'new_ticket';
+  };
+}
+
+/** Parsed contents of .posthog/autonomy/autonomy.json. */
+export interface AutonomyPlan {
+  schemaVersion: number;
+  generatedAt: string;
+  project?: { integration?: string; host?: string; projectId?: number };
+  responders: AutonomyResponder[];
+  scouts: AutonomyScout[];
+}
+
 /** A pending wizard_ask request held by the store. */
 export interface PendingQuestion {
   id: string;
@@ -143,6 +241,8 @@ export interface WizardSession {
   yaraReport: boolean;
   projectId?: number;
   noTelemetry: boolean;
+  /** Behind a hidden flag — when true, plan PostHog Autonomy after main integration. */
+  autonomy: boolean;
 
   // From detection + screens
   setupConfirmed: boolean;
@@ -202,6 +302,12 @@ export interface WizardSession {
   // Additional features queue (drained via stop hook after main integration)
   additionalFeatureQueue: AdditionalFeature[];
 
+  // Autonomy onboarding (gated by --autonomy)
+  /** Parsed manifest read from .posthog/autonomy/autonomy.json after the agent writes it. */
+  autonomyPlan: AutonomyPlan | null;
+  /** True once the user has dismissed the autonomy onboarding screen. */
+  autonomyOnboardingDismissed: boolean;
+
   // Program metadata (set by runWizard in bin.ts)
   programLabel: string | null;
   skillId: string | null;
@@ -233,6 +339,7 @@ export function buildSession(args: {
   yaraReport?: boolean;
   projectId?: string;
   noTelemetry?: boolean;
+  autonomy?: boolean;
 }): WizardSession {
   return {
     debug: args.debug ?? false,
@@ -250,6 +357,7 @@ export function buildSession(args: {
     yaraReport: args.yaraReport ?? false,
     projectId: parseProjectIdArg(args.projectId),
     noTelemetry: args.noTelemetry ?? false,
+    autonomy: args.autonomy ?? false,
 
     setupConfirmed: false,
     integration: args.integration ?? null,
@@ -278,6 +386,8 @@ export function buildSession(args: {
     outroData: null,
     dashboardUrl: null,
     additionalFeatureQueue: [],
+    autonomyPlan: null,
+    autonomyOnboardingDismissed: false,
     programLabel: null,
     skillId: null,
     frameworkConfig: null,

--- a/src/ui/tui/playground/PlaygroundApp.tsx
+++ b/src/ui/tui/playground/PlaygroundApp.tsx
@@ -20,6 +20,7 @@ import { McpDemo } from './demos/McpDemo.js';
 import { KeyboardHintsDemo } from './demos/KeyboardHintsDemo.js';
 import { AuditChecksDemo } from './demos/AuditChecksDemo.js';
 import { LearnDeckDemo } from './demos/LearnDeckDemo.js';
+import { AutonomyDemo } from './demos/AutonomyDemo.js';
 
 interface PlaygroundAppProps {
   store: WizardStore;
@@ -70,6 +71,11 @@ export const PlaygroundApp = ({ store }: PlaygroundAppProps) => {
       id: 'learn-deck',
       label: 'Learn deck',
       component: <LearnDeckDemo store={store} />,
+    },
+    {
+      id: 'autonomy',
+      label: 'Autonomy',
+      component: <AutonomyDemo store={store} />,
     },
   ];
 

--- a/src/ui/tui/playground/demos/AutonomyDemo.tsx
+++ b/src/ui/tui/playground/demos/AutonomyDemo.tsx
@@ -1,0 +1,80 @@
+import { useEffect } from 'react';
+import { WizardStore } from '@ui/tui/store';
+import { AutonomyOnboardingScreen } from '@ui/tui/screens/AutonomyOnboardingScreen';
+import type { AutonomyPlan } from '@lib/wizard-session';
+
+const FIXTURE: AutonomyPlan = {
+  schemaVersion: 1,
+  generatedAt: new Date().toISOString(),
+  project: {
+    integration: 'nextjs',
+    host: 'https://us.posthog.com',
+    projectId: 12345,
+  },
+  responders: [
+    {
+      type: 'error-tracking',
+      enabled: true,
+      rationale:
+        'PostHog Error Tracking is set up; auto-investigate new crashes.',
+      trigger: { kind: 'new_issue' },
+    },
+    {
+      type: 'support',
+      enabled: false,
+      rationale: 'No evidence of PostHog Conversations in this project.',
+      trigger: { kind: 'new_ticket' },
+    },
+  ],
+  scouts: [
+    {
+      id: 'onboarding-funnel',
+      name: 'Onboarding funnel health',
+      area: 'Signup + onboarding flow',
+      cadence: 'daily',
+      skillFile: 'scouts/onboarding-funnel.md',
+      mcpServers: ['posthog'],
+      rationale:
+        'Watch onboarding step-3 drop-off and surface deltas > 2x week-over-week.',
+    },
+    {
+      id: 'checkout-conversion',
+      name: 'Checkout conversion',
+      area: 'Cart → payment flow',
+      cadence: 'hourly',
+      skillFile: 'scouts/checkout-conversion.md',
+      mcpServers: ['posthog'],
+      rationale:
+        'Detect conversion drops and correlate with deploy timestamps.',
+    },
+    {
+      id: 'api-latency',
+      name: 'API latency budget',
+      area: 'Public API endpoints',
+      cadence: 'hourly',
+      skillFile: 'scouts/api-latency.md',
+      mcpServers: ['posthog'],
+      rationale: 'P95 latency above 800ms for any high-traffic endpoint.',
+    },
+    {
+      id: 'feature-adoption',
+      name: 'New feature adoption',
+      area: 'Recently shipped features (90d)',
+      cadence: 'weekly',
+      skillFile: 'scouts/feature-adoption.md',
+      mcpServers: ['posthog'],
+      rationale: 'Track adoption curves of recently launched features.',
+    },
+  ],
+};
+
+interface AutonomyDemoProps {
+  store: WizardStore;
+}
+
+export const AutonomyDemo = ({ store }: AutonomyDemoProps) => {
+  useEffect(() => {
+    store.setAutonomyPlan(FIXTURE);
+  }, [store]);
+  return <AutonomyOnboardingScreen store={store} />;
+};

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -32,6 +32,7 @@ import { SetupScreen } from './screens/SetupScreen.js';
 import { AuthScreen } from './screens/AuthScreen.js';
 import { RunScreen } from './screens/RunScreen.js';
 import { McpScreen } from './screens/McpScreen.js';
+import { AutonomyOnboardingScreen } from './screens/AutonomyOnboardingScreen.js';
 import { KeepSkillsScreen } from './screens/KeepSkillsScreen.js';
 import { OutroScreen } from './screens/OutroScreen.js';
 import { ExitScreen } from './screens/ExitScreen.js';
@@ -82,6 +83,7 @@ export function createScreens(
     [ScreenId.Mcp]: (
       <McpScreen store={store} installer={services.mcpInstaller} />
     ),
+    [ScreenId.AutonomyOnboarding]: <AutonomyOnboardingScreen store={store} />,
     [ScreenId.KeepSkills]: <KeepSkillsScreen store={store} />,
     [ScreenId.Outro]: <OutroScreen store={store} />,
     [ScreenId.Exit]: <ExitScreen />,

--- a/src/ui/tui/screen-sequences.ts
+++ b/src/ui/tui/screen-sequences.ts
@@ -32,6 +32,7 @@ export enum ScreenId {
   Auth = 'auth',
   Run = 'run',
   Mcp = 'mcp',
+  AutonomyOnboarding = 'autonomy-onboarding',
   KeepSkills = 'keep-skills',
   Outro = 'outro',
   Exit = 'exit',

--- a/src/ui/tui/screens/AutonomyOnboardingScreen.tsx
+++ b/src/ui/tui/screens/AutonomyOnboardingScreen.tsx
@@ -1,0 +1,371 @@
+import fs from 'fs';
+import path from 'path';
+import { Box, Text } from 'ink';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react';
+import type { WizardStore } from '@ui/tui/store';
+import type {
+  AutonomyPlan,
+  AutonomyResponder,
+  AutonomyScout,
+} from '@lib/wizard-session';
+import { Colors, Icons } from '@ui/tui/styles';
+import { useFileWatcher } from '@ui/tui/hooks/file-watcher';
+import {
+  useKeyBindings,
+  KeyMatch,
+  type KeyBinding,
+} from '@ui/tui/hooks/useKeyBindings';
+
+type Row =
+  | { kind: 'responder'; data: AutonomyResponder }
+  | { kind: 'scout'; data: AutonomyScout };
+
+interface PartitionedRows {
+  rows: Row[];
+  responders: { row: Row; idx: number }[];
+  scouts: { row: Row; idx: number }[];
+}
+
+interface Props {
+  store: WizardStore;
+}
+
+export const AutonomyOnboardingScreen = ({ store }: Props) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  const installDir = store.session.installDir;
+  const planFile = path.join(
+    installDir,
+    '.posthog',
+    'autonomy',
+    'autonomy.json',
+  );
+  const plan = store.session.autonomyPlan;
+
+  useFileWatcher(planFile, (parsed) => {
+    store.setAutonomyPlan(parsed as AutonomyPlan);
+  });
+
+  const [enabled, setEnabled] = useState<Record<string, boolean>>({});
+  useEffect(() => {
+    if (!plan) return;
+    const init: Record<string, boolean> = {};
+    for (const r of plan.responders) init[`responder:${r.type}`] = r.enabled;
+    for (const s of plan.scouts) init[`scout:${s.id}`] = true;
+    setEnabled(init);
+  }, [plan]);
+
+  const { rows, responders, scouts }: PartitionedRows = useMemo(() => {
+    if (!plan) return { rows: [], responders: [], scouts: [] };
+    const out: Row[] = [];
+    const responderEntries: { row: Row; idx: number }[] = [];
+    const scoutEntries: { row: Row; idx: number }[] = [];
+    plan.responders.forEach((data) => {
+      const row: Row = { kind: 'responder', data };
+      responderEntries.push({ row, idx: out.length });
+      out.push(row);
+    });
+    plan.scouts.forEach((data) => {
+      const row: Row = { kind: 'scout', data };
+      scoutEntries.push({ row, idx: out.length });
+      out.push(row);
+    });
+    return { rows: out, responders: responderEntries, scouts: scoutEntries };
+  }, [plan]);
+
+  const [focused, setFocused] = useState(0);
+  // Synced with `focused` so a same-tick toggle reads the new value before
+  // React reconciles. setState's batching can otherwise drop one of two
+  // keypresses arriving in the same microtask.
+  const focusedRef = useRef(focused);
+  focusedRef.current = focused;
+
+  const moveFocus = (delta: number): void => {
+    if (rows.length === 0) return;
+    const next = (focusedRef.current + delta + rows.length) % rows.length;
+    focusedRef.current = next;
+    setFocused(next);
+  };
+
+  const toggleFocused = (): void => {
+    const row = rows[focusedRef.current];
+    if (!row) return;
+    const key =
+      row.kind === 'responder'
+        ? `responder:${row.data.type}`
+        : `scout:${row.data.id}`;
+    setEnabled((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const confirm = (): void => {
+    if (plan) {
+      const finalPlan: AutonomyPlan = {
+        ...plan,
+        responders: plan.responders.map((r) => ({
+          ...r,
+          enabled: enabled[`responder:${r.type}`] ?? r.enabled,
+        })),
+        scouts: plan.scouts.filter((s) => enabled[`scout:${s.id}`] !== false),
+      };
+      try {
+        fs.writeFileSync(planFile, JSON.stringify(finalPlan, null, 2) + '\n');
+        store.setAutonomyPlan(finalPlan);
+      } catch {
+        // Best-effort persistence — the agent already wrote the file once.
+      }
+    }
+    store.setAutonomyOnboardingDismissed();
+  };
+
+  const dismissLoadError = (): void => store.setAutonomyOnboardingDismissed();
+
+  const bindings: KeyBinding[] = [
+    {
+      match: [KeyMatch.UpArrow, KeyMatch.DownArrow],
+      label: '↑↓',
+      action: 'select agent',
+      handler: (_input, key) => {
+        if (key.upArrow) moveFocus(-1);
+        if (key.downArrow) moveFocus(1);
+      },
+    },
+    {
+      match: KeyMatch.Space,
+      label: 'space',
+      action: 'toggle',
+      handler: () => toggleFocused(),
+    },
+    {
+      match: KeyMatch.Return,
+      label: 'enter',
+      action: plan ? 'confirm plan' : 'continue',
+      handler: () => (plan ? confirm() : dismissLoadError()),
+    },
+  ];
+
+  useKeyBindings('autonomy-onboarding', bindings);
+
+  if (!plan) {
+    return (
+      <Box
+        flexDirection="column"
+        flexGrow={1}
+        padding={1}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Text dimColor>Loading autonomy plan from {planFile}…</Text>
+      </Box>
+    );
+  }
+
+  const counts = countEnabled(rows, enabled);
+
+  return (
+    <Box flexDirection="column" flexGrow={1} paddingX={1}>
+      <Header />
+      <Box flexDirection="row" marginTop={1} flexGrow={1}>
+        <Box
+          flexDirection="column"
+          flexGrow={1}
+          marginRight={2}
+          overflow="hidden"
+        >
+          <SectionHeader>Responders</SectionHeader>
+          <Text dimColor>Reactive · one run per incoming signal.</Text>
+          <Box flexDirection="column" marginTop={1}>
+            {responders.map(({ row, idx }) => (
+              <ResponderRow
+                key={`responder:${(row.data as AutonomyResponder).type}`}
+                data={row.data as AutonomyResponder}
+                focused={focused === idx}
+                enabled={
+                  enabled[
+                    `responder:${(row.data as AutonomyResponder).type}`
+                  ] ?? (row.data as AutonomyResponder).enabled
+                }
+              />
+            ))}
+          </Box>
+
+          <Box marginTop={1}>
+            <SectionHeader>Scouts</SectionHeader>
+          </Box>
+          <Text dimColor>Scheduled · one run per cadence tick.</Text>
+          <Box flexDirection="column" marginTop={1}>
+            {scouts.map(({ row, idx }) => (
+              <ScoutRow
+                key={`scout:${(row.data as AutonomyScout).id}`}
+                data={row.data as AutonomyScout}
+                focused={focused === idx}
+                enabled={
+                  enabled[`scout:${(row.data as AutonomyScout).id}`] ?? true
+                }
+              />
+            ))}
+          </Box>
+        </Box>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>
+          {counts.scouts} scout{counts.scouts === 1 ? '' : 's'} ·{' '}
+          {counts.responders} responder
+          {counts.responders === 1 ? '' : 's'} will be saved to
+          .posthog/autonomy/autonomy.json
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+const Header = () => (
+  <Box flexDirection="column">
+    <Text bold>
+      <Text color="#1D4AFF">{'█'}</Text>
+      <Text color="#F54E00">{'█'}</Text>
+      <Text color="#F9BD2B">{'█'}</Text> PostHog Autonomy
+    </Text>
+    <Text dimColor>
+      A plan for self-driving agents on your product. Toggle what you want.
+    </Text>
+  </Box>
+);
+
+const SectionHeader = ({ children }: { children: ReactNode }) => (
+  <Text bold color={Colors.accent}>
+    {children}
+  </Text>
+);
+
+interface RowViewProps {
+  title: string;
+  subtitle: string;
+  rightTag: string;
+  focused: boolean;
+  enabled: boolean;
+}
+
+const RowView = ({
+  title,
+  subtitle,
+  rightTag,
+  focused,
+  enabled,
+}: RowViewProps) => {
+  let titleColor: string | undefined;
+  if (focused) titleColor = Colors.accent;
+  else if (!enabled) titleColor = Colors.muted;
+
+  const checkbox = enabled ? Icons.squareFilled : Icons.squareOpen;
+  const indicator = focused ? Icons.triangleSmallRight : ' ';
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={focused ? Colors.accent : undefined}>{indicator} </Text>
+        <Text color={enabled ? '#F9BD2B' : Colors.muted}>{checkbox}</Text>
+        <Text color={titleColor} bold={focused}>
+          {' '}
+          {truncate(title, 32)}
+        </Text>
+        {rightTag ? (
+          <Text dimColor>
+            {'  '}· {rightTag}
+          </Text>
+        ) : null}
+      </Box>
+      {subtitle ? (
+        <Box marginLeft={4}>
+          <Text dimColor wrap="truncate-end">
+            {subtitle}
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
+const ResponderRow = ({
+  data,
+  focused,
+  enabled,
+}: {
+  data: AutonomyResponder;
+  focused: boolean;
+  enabled: boolean;
+}) => (
+  <RowView
+    title={responderTitle(data.type)}
+    subtitle={data.rationale}
+    rightTag={data.trigger?.kind ? humanTrigger(data.trigger.kind) : ''}
+    focused={focused}
+    enabled={enabled}
+  />
+);
+
+const ScoutRow = ({
+  data,
+  focused,
+  enabled,
+}: {
+  data: AutonomyScout;
+  focused: boolean;
+  enabled: boolean;
+}) => (
+  <RowView
+    title={data.name}
+    subtitle={data.rationale || data.area}
+    rightTag={data.cadence}
+    focused={focused}
+    enabled={enabled}
+  />
+);
+
+function responderTitle(type: AutonomyResponder['type']): string {
+  if (type === 'error-tracking') return 'Error Tracking responder';
+  return 'Support responder';
+}
+
+function humanTrigger(
+  kind: NonNullable<AutonomyResponder['trigger']>['kind'],
+): string {
+  const map: Record<NonNullable<AutonomyResponder['trigger']>['kind'], string> =
+    {
+      new_issue: 'on new issue',
+      issue_reopen: 'on reopen',
+      volume_spike: 'on volume spike',
+      new_ticket: 'on new ticket',
+    };
+  return map[kind];
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + '…';
+}
+
+function countEnabled(
+  rows: Row[],
+  enabled: Record<string, boolean>,
+): { scouts: number; responders: number } {
+  let scouts = 0;
+  let responders = 0;
+  for (const r of rows) {
+    if (r.kind === 'scout' && enabled[`scout:${r.data.id}`] !== false)
+      scouts += 1;
+    if (r.kind === 'responder' && enabled[`responder:${r.data.type}`])
+      responders += 1;
+  }
+  return { scouts, responders };
+}

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -263,6 +263,16 @@ export class WizardStore {
     this.emitChange();
   }
 
+  setAutonomyPlan(plan: WizardSession['autonomyPlan']): void {
+    this.$session.setKey('autonomyPlan', plan);
+    this.emitChange();
+  }
+
+  setAutonomyOnboardingDismissed(): void {
+    this.$session.setKey('autonomyOnboardingDismissed', true);
+    this.emitChange();
+  }
+
   setCredentials(credentials: WizardSession['credentials']): void {
     this.$session.setKey('credentials', credentials);
     analytics.wizardCapture('auth complete', {


### PR DESCRIPTION
Behind a hidden \`--autonomy\` flag for now. Adds a second agent phase after the main integration that plans PostHog Autonomy (scouts + responders) and a new TUI screen where you confirm what to keep. Output is written to \`.posthog/autonomy/autonomy.json\` plus per-scout markdown files.

Branched off an older commit (\`e70f51b\`) so it'll need a rebase onto current main before merging — main's bin.ts refactor (#489) restructured where this flag would live.

<img width="2064" height="1048" alt="screenshot_2026-06-03_at_10 10 29_2x" src="https://github.com/user-attachments/assets/d567c694-6239-47d0-990a-22d6174a24e1" />

