### PR TITLE
fix: Bound the two uncapped in-memory buffers in the agent run

### DIFF
--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -1,8 +1,5 @@
-import {
-  runAgent,
-  createStopHook,
-  AgentOutputSignals,
-} from '@lib/agent/agent-interface';
+import { runAgent, createStopHook } from '@lib/agent/agent-interface';
+import { AgentOutputSignals } from '@lib/agent/output-signals';
 import type { WizardRunOptions } from '@utils/types';
 import type { SpinnerHandle } from '@ui';
 import {
@@ -425,61 +422,5 @@ describe('createStopHook', () => {
     const first = hook(hookInput);
     expect(first).toHaveProperty('decision', 'block');
     expect((first as { reason: string }).reason).toContain('WIZARD-REMARK');
-  });
-});
-
-describe('AgentOutputSignals', () => {
-  it('drops prose but detects each signal marker', () => {
-    const signals = new AgentOutputSignals();
-    signals.push('Thinking about the integration plan...'); // prose, dropped
-    signals.push('Reading files and editing config'); // prose, dropped
-    signals.push('Hit a wall. API Error: 401 unauthorized');
-    signals.push('[ERROR-MCP-MISSING] could not reach MCP');
-
-    expect(signals.has('API_ERROR')).toBe(true);
-    expect(signals.has('API_ERROR_401')).toBe(true);
-    expect(signals.has('API_ERROR_429')).toBe(false);
-    expect(signals.has('MCP_MISSING')).toBe(true);
-    expect(signals.has('RESOURCE_MISSING')).toBe(false);
-    expect(signals.hasYaraViolation()).toBe(false);
-    expect(signals.remark()).toBeUndefined();
-  });
-
-  it('detects YARA violations from either marker', () => {
-    const critical = new AgentOutputSignals();
-    critical.push('[YARA CRITICAL] prompt injection detected');
-    expect(critical.hasYaraViolation()).toBe(true);
-
-    const scannerErr = new AgentOutputSignals();
-    scannerErr.push('[YARA] Scanner error: failed to load rules');
-    expect(scannerErr.hasYaraViolation()).toBe(true);
-  });
-
-  it('extracts only the API Error lines for the message', () => {
-    const signals = new AgentOutputSignals();
-    signals.push('Some prose before the error');
-    signals.push('Request failed: API Error: 429 rate limited, retry later');
-
-    expect(signals.has('API_ERROR_429')).toBe(true);
-    expect(signals.apiErrorMessage()).toBe(
-      'API Error: 429 rate limited, retry later',
-    );
-  });
-
-  it('extracts the trimmed remark after the marker', () => {
-    const signals = new AgentOutputSignals();
-    signals.push(
-      'Done. [WIZARD-REMARK] The MCP schema was larger than expected.',
-    );
-
-    expect(signals.remark()).toBe('The MCP schema was larger than expected.');
-  });
-
-  it('returns undefined extractions when no matching lines were retained', () => {
-    const signals = new AgentOutputSignals();
-    signals.push('Nothing interesting here');
-
-    expect(signals.apiErrorMessage()).toBeUndefined();
-    expect(signals.remark()).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -1,4 +1,8 @@
-import { runAgent, createStopHook } from '@lib/agent/agent-interface';
+import {
+  runAgent,
+  createStopHook,
+  AgentOutputSignals,
+} from '@lib/agent/agent-interface';
 import type { WizardRunOptions } from '@utils/types';
 import type { SpinnerHandle } from '@ui';
 import {
@@ -393,30 +397,89 @@ describe('createStopHook', () => {
   });
 
   it('allows stop immediately on API error (401)', () => {
-    const collectedText = [
+    const signals = new AgentOutputSignals();
+    signals.push(
       'Failed to authenticate. API Error: 401 {"detail":"Authentication required"}',
-    ];
-    const hook = createStopHook([AdditionalFeature.LLM], collectedText);
+    );
+    const hook = createStopHook([AdditionalFeature.LLM], signals);
 
     const result = hook(hookInput);
     expect(result).toEqual({});
   });
 
   it('allows stop immediately on generic API error', () => {
-    const collectedText = ['API Error: 500 Internal Server Error'];
-    const hook = createStopHook([AdditionalFeature.LLM], collectedText);
+    const signals = new AgentOutputSignals();
+    signals.push('API Error: 500 Internal Server Error');
+    const hook = createStopHook([AdditionalFeature.LLM], signals);
 
     const result = hook(hookInput);
     expect(result).toEqual({});
   });
 
-  it('proceeds normally when collectedText has no API error', () => {
-    const collectedText = ['Some normal agent output'];
-    const hook = createStopHook([], collectedText);
+  it('proceeds normally when output has no API error', () => {
+    const signals = new AgentOutputSignals();
+    signals.push('Some normal agent output'); // dropped: carries no signal
+    const hook = createStopHook([], signals);
 
     // First call → remark prompt (normal behavior)
     const first = hook(hookInput);
     expect(first).toHaveProperty('decision', 'block');
     expect((first as { reason: string }).reason).toContain('WIZARD-REMARK');
+  });
+});
+
+describe('AgentOutputSignals', () => {
+  it('drops prose but detects each signal marker', () => {
+    const signals = new AgentOutputSignals();
+    signals.push('Thinking about the integration plan...'); // prose, dropped
+    signals.push('Reading files and editing config'); // prose, dropped
+    signals.push('Hit a wall. API Error: 401 unauthorized');
+    signals.push('[ERROR-MCP-MISSING] could not reach MCP');
+
+    expect(signals.has('API_ERROR')).toBe(true);
+    expect(signals.has('API_ERROR_401')).toBe(true);
+    expect(signals.has('API_ERROR_429')).toBe(false);
+    expect(signals.has('MCP_MISSING')).toBe(true);
+    expect(signals.has('RESOURCE_MISSING')).toBe(false);
+    expect(signals.hasYaraViolation()).toBe(false);
+    expect(signals.remark()).toBeUndefined();
+  });
+
+  it('detects YARA violations from either marker', () => {
+    const critical = new AgentOutputSignals();
+    critical.push('[YARA CRITICAL] prompt injection detected');
+    expect(critical.hasYaraViolation()).toBe(true);
+
+    const scannerErr = new AgentOutputSignals();
+    scannerErr.push('[YARA] Scanner error: failed to load rules');
+    expect(scannerErr.hasYaraViolation()).toBe(true);
+  });
+
+  it('extracts only the API Error lines for the message', () => {
+    const signals = new AgentOutputSignals();
+    signals.push('Some prose before the error');
+    signals.push('Request failed: API Error: 429 rate limited, retry later');
+
+    expect(signals.has('API_ERROR_429')).toBe(true);
+    expect(signals.apiErrorMessage()).toBe(
+      'API Error: 429 rate limited, retry later',
+    );
+  });
+
+  it('extracts the trimmed remark after the marker', () => {
+    const signals = new AgentOutputSignals();
+    signals.push(
+      'Done. [WIZARD-REMARK] The MCP schema was larger than expected.',
+    );
+
+    expect(signals.remark()).toBe('The MCP schema was larger than expected.');
+  });
+
+  it('returns undefined extractions when no matching lines were retained', () => {
+    const signals = new AgentOutputSignals();
+    signals.push('Nothing interesting here');
+
+    expect(signals.apiErrorMessage()).toBeUndefined();
+    expect(signals.remark()).toBeUndefined();
   });
 });

--- a/src/lib/agent/__tests__/output-signals.test.ts
+++ b/src/lib/agent/__tests__/output-signals.test.ts
@@ -1,0 +1,66 @@
+import { AgentOutputSignals } from '@lib/agent/output-signals';
+
+describe('AgentOutputSignals', () => {
+  it('drops prose but detects each signal marker', () => {
+    const signals = new AgentOutputSignals();
+    signals.push('Thinking about the integration plan...'); // prose, dropped
+    signals.push('Reading files and editing config'); // prose, dropped
+    signals.push('Hit a wall. API Error: 401 unauthorized');
+    signals.push('[ERROR-MCP-MISSING] could not reach MCP');
+
+    expect(signals.hasApiError()).toBe(true);
+    expect(signals.hasApiErrorStatus(401)).toBe(true);
+    expect(signals.hasApiErrorStatus(429)).toBe(false);
+    expect(signals.has('MCP_MISSING')).toBe(true);
+    expect(signals.has('RESOURCE_MISSING')).toBe(false);
+    expect(signals.hasYaraViolation()).toBe(false);
+    expect(signals.remark()).toBeUndefined();
+  });
+
+  it('treats the API error status as a parameter, not a fixed marker', () => {
+    const signals = new AgentOutputSignals();
+    signals.push('API Error: 503 service unavailable');
+
+    expect(signals.hasApiError()).toBe(true); // generic match via the prefix
+    expect(signals.hasApiErrorStatus(503)).toBe(true);
+    expect(signals.hasApiErrorStatus(500)).toBe(false);
+  });
+
+  it('detects YARA violations from either marker', () => {
+    const critical = new AgentOutputSignals();
+    critical.push('[YARA CRITICAL] prompt injection detected');
+    expect(critical.hasYaraViolation()).toBe(true);
+
+    const scannerErr = new AgentOutputSignals();
+    scannerErr.push('[YARA] Scanner error: failed to load rules');
+    expect(scannerErr.hasYaraViolation()).toBe(true);
+  });
+
+  it('extracts only the API Error lines for the message', () => {
+    const signals = new AgentOutputSignals();
+    signals.push('Some prose before the error');
+    signals.push('Request failed: API Error: 429 rate limited, retry later');
+
+    expect(signals.hasApiErrorStatus(429)).toBe(true);
+    expect(signals.apiErrorMessage()).toBe(
+      'API Error: 429 rate limited, retry later',
+    );
+  });
+
+  it('extracts the trimmed remark after the marker', () => {
+    const signals = new AgentOutputSignals();
+    signals.push(
+      'Done. [WIZARD-REMARK] The MCP schema was larger than expected.',
+    );
+
+    expect(signals.remark()).toBe('The MCP schema was larger than expected.');
+  });
+
+  it('returns undefined extractions when no matching lines were retained', () => {
+    const signals = new AgentOutputSignals();
+    signals.push('Nothing interesting here');
+
+    expect(signals.apiErrorMessage()).toBeUndefined();
+    expect(signals.remark()).toBeUndefined();
+  });
+});

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -328,7 +328,7 @@ export type StopHookResult =
  */
 export function createStopHook(
   featureQueue: readonly AdditionalFeature[],
-  collectedText?: string[],
+  signals?: AgentOutputSignals,
 ): (input: { stop_hook_active: boolean }) => StopHookResult {
   let featureIndex = 0;
   let remarkRequested = false;
@@ -343,12 +343,9 @@ export function createStopHook(
 
     // On API errors, allow stop immediately — blocking with remark/feature
     // prompts would just fail again. The auth error screen is shown separately.
-    if (collectedText) {
-      const text = collectedText.join('\n');
-      if (text.includes('API Error:')) {
-        logToFile('Stop hook: API error detected, allowing immediate stop');
-        return {};
-      }
+    if (signals?.has('API_ERROR')) {
+      logToFile('Stop hook: API error detected, allowing immediate stop');
+      return {};
     }
 
     // Phase 1: drain feature queue
@@ -799,14 +796,82 @@ export async function initializeAgent(
  * Check agent output for YARA scanner violations.
  * Used in both the success and catch paths of runAgent.
  */
+/**
+ * Single source of truth for the substrings runAgent scans agent output for.
+ * `AgentOutputSignals.push()` retains a line iff it contains one of these
+ * values; every query reads the same table by a typed key. Retention and
+ * consumers therefore cannot drift — adding a signal is one entry here, and it
+ * is both retained and queryable; nothing outside the table is ever kept.
+ * (`API Error: 401/429` are their own entries so no query composes needles.)
+ */
+const OUTPUT_SIGNALS = {
+  API_ERROR: 'API Error:',
+  API_ERROR_401: 'API Error: 401',
+  API_ERROR_429: 'API Error: 429',
+  YARA_CRITICAL: '[YARA CRITICAL]',
+  YARA_SCANNER_ERROR: '[YARA] Scanner error',
+  MCP_MISSING: AgentSignals.ERROR_MCP_MISSING,
+  RESOURCE_MISSING: AgentSignals.ERROR_RESOURCE_MISSING,
+  WIZARD_REMARK: AgentSignals.WIZARD_REMARK,
+} as const;
+
+type OutputSignal = keyof typeof OUTPUT_SIGNALS;
+const SIGNAL_NEEDLES = Object.values(OUTPUT_SIGNALS);
+
+/**
+ * Accumulates only the signal-bearing lines of agent output. The agent and SDK
+ * communicate non-content events (auth/API errors, YARA violations, missing
+ * MCP/resource, the end-of-run remark) by emitting marker strings inside their
+ * prose; this parses those out and discards everything else, so the buffer
+ * stays bounded regardless of run length.
+ */
+export class AgentOutputSignals {
+  private readonly lines: string[] = [];
+
+  /** Parse step: keep the line only if it carries a known signal; drop prose. */
+  push(text: string): void {
+    if (SIGNAL_NEEDLES.some((n) => text.includes(n))) this.lines.push(text);
+  }
+
+  private get text(): string {
+    return this.lines.join('\n');
+  }
+
+  /** True if any retained line contains the given signal's marker. */
+  has(signal: OutputSignal): boolean {
+    return this.text.includes(OUTPUT_SIGNALS[signal]);
+  }
+
+  hasYaraViolation(): boolean {
+    return this.has('YARA_CRITICAL') || this.has('YARA_SCANNER_ERROR');
+  }
+
+  /** Joined `API Error: …` lines for the user-facing message, or undefined. */
+  apiErrorMessage(): string | undefined {
+    const m = this.text.match(
+      new RegExp(`${OUTPUT_SIGNALS.API_ERROR} [^\\n]+`, 'g'),
+    );
+    return m ? m.join('\n') : undefined;
+  }
+
+  /** Text after the single `[WIZARD-REMARK]` marker, trimmed, or undefined. */
+  remark(): string | undefined {
+    const re = new RegExp(
+      `${OUTPUT_SIGNALS.WIZARD_REMARK.replace(
+        /[.*+?^${}()|[\]\\]/g,
+        '\\$&',
+      )}\\s*(.+?)(?:\\n|$)`,
+      's',
+    );
+    return this.text.match(re)?.[1]?.trim() || undefined;
+  }
+}
+
 function checkYaraViolation(
-  outputText: string,
+  signals: AgentOutputSignals,
   spinner: SpinnerHandle,
 ): { error: AgentErrorType } | null {
-  if (
-    outputText.includes('[YARA CRITICAL]') ||
-    outputText.includes('[YARA] Scanner error')
-  ) {
+  if (signals.hasYaraViolation()) {
     logToFile('Agent error: YARA_VIOLATION');
     spinner.stop('Security violation detected');
     return { error: AgentErrorType.YARA_VIOLATION };
@@ -855,7 +920,7 @@ export async function runAgent(
   logToFile('Prompt:', prompt);
 
   const startTime = Date.now();
-  const collectedText: string[] = [];
+  const signals = new AgentOutputSignals();
   // Track if we received a successful result (before any cleanup errors)
   let receivedSuccessResult = false;
   let loggedInitialContext = false;
@@ -904,20 +969,9 @@ export async function runAgent(
     }
 
     // Extract and capture the agent's reflection on the run
-    const outputText = collectedText.join('\n');
-    const remarkRegex = new RegExp(
-      `${AgentSignals.WIZARD_REMARK.replace(
-        /[.*+?^${}()|[\]\\]/g,
-        '\\$&',
-      )}\\s*(.+?)(?:\\n|$)`,
-      's',
-    );
-    const remarkMatch = outputText.match(remarkRegex);
-    if (remarkMatch && remarkMatch[1]) {
-      const remark = remarkMatch[1].trim();
-      if (remark) {
-        analytics.capture(WIZARD_REMARK_EVENT_NAME, { remark });
-      }
+    const remark = signals.remark();
+    if (remark) {
+      analytics.capture(WIZARD_REMARK_EVENT_NAME, { remark });
     }
 
     analytics.wizardCapture('agent completed', {
@@ -1101,10 +1155,7 @@ export async function runAgent(
           Stop: [
             {
               hooks: [
-                createStopHook(
-                  config?.additionalFeatureQueue ?? [],
-                  collectedText,
-                ),
+                createStopHook(config?.additionalFeatureQueue ?? [], signals),
               ],
               timeout: 30,
             },
@@ -1149,7 +1200,7 @@ export async function runAgent(
         message,
         options,
         spinner,
-        collectedText,
+        signals,
         receivedSuccessResult,
         tasks,
       );
@@ -1182,10 +1233,7 @@ export async function runAgent(
       }
 
       // 401: show auth error screen and exit immediately
-      if (
-        message.type === 'assistant' &&
-        collectedText.join('\n').includes('API Error: 401')
-      ) {
+      if (message.type === 'assistant' && signals.has('API_ERROR_401')) {
         signalDone!();
         spinner.stop('Authentication failed');
         // Re-check at error time: a settings conflict can be the *real* cause
@@ -1233,39 +1281,34 @@ export async function runAgent(
       return { error: AgentErrorType.ABORT, message: abortReason };
     }
 
-    const outputText = collectedText.join('\n');
-
     // Check for YARA scanner violations
-    const yaraResult = checkYaraViolation(outputText, spinner);
+    const yaraResult = checkYaraViolation(signals, spinner);
     if (yaraResult) return yaraResult;
 
     // Check for error markers in the agent's output
-    if (outputText.includes(AgentSignals.ERROR_MCP_MISSING)) {
+    if (signals.has('MCP_MISSING')) {
       logToFile('Agent error: MCP_MISSING');
       spinner.stop('Agent could not access PostHog MCP');
       return { error: AgentErrorType.MCP_MISSING };
     }
 
-    if (outputText.includes(AgentSignals.ERROR_RESOURCE_MISSING)) {
+    if (signals.has('RESOURCE_MISSING')) {
       logToFile('Agent error: RESOURCE_MISSING');
       spinner.stop('Agent could not access setup resource');
       return { error: AgentErrorType.RESOURCE_MISSING };
     }
 
     // Check for API errors (rate limits, etc.)
-    // Extract just the API error line(s), not the entire output
-    const apiErrorMatch = outputText.match(/API Error: [^\n]+/g);
-    const apiErrorMessage = apiErrorMatch
-      ? apiErrorMatch.join('\n')
-      : 'Unknown API error';
+    // Surface just the API error line(s), not the entire output
+    const apiErrorMessage = signals.apiErrorMessage() ?? 'Unknown API error';
 
-    if (outputText.includes('API Error: 429')) {
+    if (signals.has('API_ERROR_429')) {
       logToFile('Agent error: RATE_LIMIT');
       spinner.stop('Rate limit exceeded');
       return { error: AgentErrorType.RATE_LIMIT, message: apiErrorMessage };
     }
 
-    if (outputText.includes('API Error:')) {
+    if (signals.has('API_ERROR')) {
       logToFile('Agent error: API_ERROR');
       spinner.stop('API error occurred');
       return { error: AgentErrorType.API_ERROR, message: apiErrorMessage };
@@ -1292,25 +1335,21 @@ export async function runAgent(
     }
 
     // Check if we collected an error before the exception was thrown
-    const outputText = collectedText.join('\n');
 
     // Check for YARA scanner violations
-    const yaraResult = checkYaraViolation(outputText, spinner);
+    const yaraResult = checkYaraViolation(signals, spinner);
     if (yaraResult) return yaraResult;
 
-    // Extract just the API error line(s), not the entire output
-    const apiErrorMatch = outputText.match(/API Error: [^\n]+/g);
-    const apiErrorMessage = apiErrorMatch
-      ? apiErrorMatch.join('\n')
-      : 'Unknown API error';
+    // Surface just the API error line(s), not the entire output
+    const apiErrorMessage = signals.apiErrorMessage() ?? 'Unknown API error';
 
-    if (outputText.includes('API Error: 429')) {
+    if (signals.has('API_ERROR_429')) {
       logToFile('Agent error (caught): RATE_LIMIT');
       spinner.stop('Rate limit exceeded');
       return { error: AgentErrorType.RATE_LIMIT, message: apiErrorMessage };
     }
 
-    if (outputText.includes('API Error:')) {
+    if (signals.has('API_ERROR')) {
       logToFile('Agent error (caught): API_ERROR');
       spinner.stop('API error occurred');
       return { error: AgentErrorType.API_ERROR, message: apiErrorMessage };
@@ -1494,7 +1533,7 @@ function handleSDKMessage(
   message: SDKMessage,
   options: WizardRunOptions,
   spinner: SpinnerHandle,
-  collectedText: string[],
+  signals: AgentOutputSignals,
   receivedSuccessResult = false,
   tasks?: Map<string, TaskEntry>,
 ): void {
@@ -1527,7 +1566,7 @@ function handleSDKMessage(
       if (Array.isArray(content)) {
         for (const block of content) {
           if (block.type === 'text' && typeof block.text === 'string') {
-            collectedText.push(block.text);
+            signals.push(block.text);
 
             // Check for [STATUS] markers
             const statusRegex = new RegExp(
@@ -1628,7 +1667,7 @@ function handleSDKMessage(
       if (message.is_error) {
         logToFile('Agent result with error:', message.result);
         if (typeof message.result === 'string') {
-          collectedText.push(message.result);
+          signals.push(message.result);
         }
         // Only show errors to user if we haven't already succeeded.
         // Post-success errors are SDK cleanup noise (telemetry failures, streaming
@@ -1642,7 +1681,7 @@ function handleSDKMessage(
       } else if (message.subtype === 'success') {
         logToFile('Agent completed successfully');
         if (typeof message.result === 'string') {
-          collectedText.push(message.result);
+          signals.push(message.result);
         }
       } else {
         logToFile('Agent result with error:', message.result);

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -31,6 +31,14 @@ import {
 } from '@lib/yara-hooks';
 import { getWizardCommandments } from './commandments';
 import type { PackageManagerDetector } from '@lib/detection/package-manager';
+import { AgentSignals, AgentErrorType } from './signals';
+import { AgentOutputSignals } from './output-signals';
+
+// Signal vocabulary and the output parser live in dedicated modules; re-export
+// so existing importers of these from agent-interface keep working.
+export { AgentSignals, AgentErrorType } from './signals';
+export type { AgentSignal } from './signals';
+export { AgentOutputSignals } from './output-signals';
 
 // Dynamic import cache for ESM module
 let _sdkModule: any = null;
@@ -56,58 +64,6 @@ function getClaudeCodeExecutablePath(): string {
 type SDKMessage = any;
 type McpServersConfig = any;
 type AbortCaseMatcher = { match: RegExp };
-
-export const AgentSignals = {
-  /** Signal emitted when the agent reports progress to the user */
-  STATUS: '[STATUS]',
-  /** Signal emitted when the agent cannot access the PostHog MCP server */
-  ERROR_MCP_MISSING: '[ERROR-MCP-MISSING]',
-  /** Signal emitted when the agent cannot access the setup resource */
-  ERROR_RESOURCE_MISSING: '[ERROR-RESOURCE-MISSING]',
-  /**
-   * Signal emitted when the agent cannot complete the program and is
-   * aborting intentionally (distinct from errors). Format: "[ABORT] <reason>".
-   * Programs can declare an onAbort handler to render a custom screen.
-   */
-  ABORT: '[ABORT]',
-  /** Signal emitted when the agent provides a remark about its run */
-  WIZARD_REMARK: '[WIZARD-REMARK]',
-  /** Signal prefix for benchmark logging */
-  BENCHMARK: '[BENCHMARK]',
-  /**
-   * Signal emitted when the agent has created a PostHog dashboard for the
-   * user. Format: `[DASHBOARD_URL] <full https url>`. The URL is captured
-   * onto `session.dashboardUrl` and surfaced by programs in their outro.
-   */
-  DASHBOARD_URL: '[DASHBOARD_URL]',
-  /**
-   * Signal emitted when the agent has uploaded a report to a PostHog
-   * notebook. Format: `[NOTEBOOK_URL] <full https url>`. The URL is captured
-   * onto `session.notebookUrl` and surfaced by programs in their outro.
-   */
-  NOTEBOOK_URL: '[NOTEBOOK_URL]',
-} as const;
-
-export type AgentSignal = (typeof AgentSignals)[keyof typeof AgentSignals];
-
-/**
- * Error types that can be returned from agent execution.
- * These correspond to the error signals that the agent emits.
- */
-export enum AgentErrorType {
-  /** Agent could not access the PostHog MCP server */
-  MCP_MISSING = 'WIZARD_MCP_MISSING',
-  /** Agent could not access the setup resource */
-  RESOURCE_MISSING = 'WIZARD_RESOURCE_MISSING',
-  /** API rate limit exceeded */
-  RATE_LIMIT = 'WIZARD_RATE_LIMIT',
-  /** Generic API error */
-  API_ERROR = 'WIZARD_API_ERROR',
-  /** YARA scanner detected a security violation */
-  YARA_VIOLATION = 'WIZARD_YARA_VIOLATION',
-  /** Agent intentionally aborted the program (emitted [ABORT] <reason>) */
-  ABORT = 'WIZARD_ABORT',
-}
 
 const BLOCKING_ENV_KEYS = [
   'ANTHROPIC_API_KEY',
@@ -343,7 +299,7 @@ export function createStopHook(
 
     // On API errors, allow stop immediately — blocking with remark/feature
     // prompts would just fail again. The auth error screen is shown separately.
-    if (signals?.has('API_ERROR')) {
+    if (signals?.hasApiError()) {
       logToFile('Stop hook: API error detected, allowing immediate stop');
       return {};
     }
@@ -796,77 +752,6 @@ export async function initializeAgent(
  * Check agent output for YARA scanner violations.
  * Used in both the success and catch paths of runAgent.
  */
-/**
- * Single source of truth for the substrings runAgent scans agent output for.
- * `AgentOutputSignals.push()` retains a line iff it contains one of these
- * values; every query reads the same table by a typed key. Retention and
- * consumers therefore cannot drift — adding a signal is one entry here, and it
- * is both retained and queryable; nothing outside the table is ever kept.
- * (`API Error: 401/429` are their own entries so no query composes needles.)
- */
-const OUTPUT_SIGNALS = {
-  API_ERROR: 'API Error:',
-  API_ERROR_401: 'API Error: 401',
-  API_ERROR_429: 'API Error: 429',
-  YARA_CRITICAL: '[YARA CRITICAL]',
-  YARA_SCANNER_ERROR: '[YARA] Scanner error',
-  MCP_MISSING: AgentSignals.ERROR_MCP_MISSING,
-  RESOURCE_MISSING: AgentSignals.ERROR_RESOURCE_MISSING,
-  WIZARD_REMARK: AgentSignals.WIZARD_REMARK,
-} as const;
-
-type OutputSignal = keyof typeof OUTPUT_SIGNALS;
-const SIGNAL_NEEDLES = Object.values(OUTPUT_SIGNALS);
-
-/**
- * Accumulates only the signal-bearing lines of agent output. The agent and SDK
- * communicate non-content events (auth/API errors, YARA violations, missing
- * MCP/resource, the end-of-run remark) by emitting marker strings inside their
- * prose; this parses those out and discards everything else, so the buffer
- * stays bounded regardless of run length.
- */
-export class AgentOutputSignals {
-  private readonly lines: string[] = [];
-
-  /** Parse step: keep the line only if it carries a known signal; drop prose. */
-  push(text: string): void {
-    if (SIGNAL_NEEDLES.some((n) => text.includes(n))) this.lines.push(text);
-  }
-
-  private get text(): string {
-    return this.lines.join('\n');
-  }
-
-  /** True if any retained line contains the given signal's marker. */
-  has(signal: OutputSignal): boolean {
-    return this.text.includes(OUTPUT_SIGNALS[signal]);
-  }
-
-  hasYaraViolation(): boolean {
-    return this.has('YARA_CRITICAL') || this.has('YARA_SCANNER_ERROR');
-  }
-
-  /** Joined `API Error: …` lines for the user-facing message, or undefined. */
-  apiErrorMessage(): string | undefined {
-    const m = this.text.match(
-      new RegExp(`${OUTPUT_SIGNALS.API_ERROR} [^\\n]+`, 'g'),
-    );
-    return m ? m.join('\n') : undefined;
-  }
-
-  /** Text after the single `[WIZARD-REMARK]` marker, trimmed, or undefined. */
-  remark(): string | undefined {
-    const re = new RegExp(
-      `${OUTPUT_SIGNALS.WIZARD_REMARK.replace(
-        /[.*+?^${}()|[\]\\]/g,
-        '\\$&',
-      )}\\s*(.+?)(?:\\n|$)`,
-      's',
-    );
-    return this.text.match(re)?.[1]?.trim() || undefined;
-  }
-}
-
 function checkYaraViolation(
   signals: AgentOutputSignals,
   spinner: SpinnerHandle,
@@ -1233,7 +1118,7 @@ export async function runAgent(
       }
 
       // 401: show auth error screen and exit immediately
-      if (message.type === 'assistant' && signals.has('API_ERROR_401')) {
+      if (message.type === 'assistant' && signals.hasApiErrorStatus(401)) {
         signalDone!();
         spinner.stop('Authentication failed');
         // Re-check at error time: a settings conflict can be the *real* cause
@@ -1302,13 +1187,13 @@ export async function runAgent(
     // Surface just the API error line(s), not the entire output
     const apiErrorMessage = signals.apiErrorMessage() ?? 'Unknown API error';
 
-    if (signals.has('API_ERROR_429')) {
+    if (signals.hasApiErrorStatus(429)) {
       logToFile('Agent error: RATE_LIMIT');
       spinner.stop('Rate limit exceeded');
       return { error: AgentErrorType.RATE_LIMIT, message: apiErrorMessage };
     }
 
-    if (signals.has('API_ERROR')) {
+    if (signals.hasApiError()) {
       logToFile('Agent error: API_ERROR');
       spinner.stop('API error occurred');
       return { error: AgentErrorType.API_ERROR, message: apiErrorMessage };
@@ -1343,13 +1228,13 @@ export async function runAgent(
     // Surface just the API error line(s), not the entire output
     const apiErrorMessage = signals.apiErrorMessage() ?? 'Unknown API error';
 
-    if (signals.has('API_ERROR_429')) {
+    if (signals.hasApiErrorStatus(429)) {
       logToFile('Agent error (caught): RATE_LIMIT');
       spinner.stop('Rate limit exceeded');
       return { error: AgentErrorType.RATE_LIMIT, message: apiErrorMessage };
     }
 
-    if (signals.has('API_ERROR')) {
+    if (signals.hasApiError()) {
       logToFile('Agent error (caught): API_ERROR');
       spinner.stop('API error occurred');
       return { error: AgentErrorType.API_ERROR, message: apiErrorMessage };

--- a/src/lib/agent/output-signals.ts
+++ b/src/lib/agent/output-signals.ts
@@ -1,0 +1,80 @@
+/**
+ * Parses the signal-bearing lines out of agent output and discards the rest.
+ *
+ * The agent and SDK communicate non-content events (auth/API errors, YARA
+ * violations, missing MCP/resource, the end-of-run remark) by emitting marker
+ * strings inside their prose. `AgentOutputSignals` keeps only the lines that
+ * carry such a marker, so the buffer stays bounded regardless of run length.
+ */
+
+import { AgentSignals } from './signals';
+
+/**
+ * Single source of truth for the substrings runAgent scans agent output for.
+ * `push()` retains a line iff it contains one of these values; every query
+ * reads the same table, so retention and consumers cannot drift. API-error
+ * status codes are not separate entries — `API_ERROR` is the one needle and
+ * the code is a parameter to `hasApiErrorStatus`.
+ */
+const OUTPUT_SIGNALS = {
+  API_ERROR: 'API Error:',
+  YARA_CRITICAL: '[YARA CRITICAL]',
+  YARA_SCANNER_ERROR: '[YARA] Scanner error',
+  MCP_MISSING: AgentSignals.ERROR_MCP_MISSING,
+  RESOURCE_MISSING: AgentSignals.ERROR_RESOURCE_MISSING,
+  WIZARD_REMARK: AgentSignals.WIZARD_REMARK,
+} as const;
+
+type OutputSignal = keyof typeof OUTPUT_SIGNALS;
+const SIGNAL_NEEDLES = Object.values(OUTPUT_SIGNALS);
+
+export class AgentOutputSignals {
+  private readonly lines: string[] = [];
+
+  /** Parse step: keep the line only if it carries a known signal; drop prose. */
+  push(text: string): void {
+    if (SIGNAL_NEEDLES.some((n) => text.includes(n))) this.lines.push(text);
+  }
+
+  private get text(): string {
+    return this.lines.join('\n');
+  }
+
+  /** True if any retained line contains the given signal's marker. */
+  has(signal: OutputSignal): boolean {
+    return this.text.includes(OUTPUT_SIGNALS[signal]);
+  }
+
+  hasApiError(): boolean {
+    return this.has('API_ERROR');
+  }
+
+  /** True for a specific HTTP status, e.g. 401 (auth) or 429 (rate limit). */
+  hasApiErrorStatus(code: number): boolean {
+    return this.text.includes(`${OUTPUT_SIGNALS.API_ERROR} ${code}`);
+  }
+
+  hasYaraViolation(): boolean {
+    return this.has('YARA_CRITICAL') || this.has('YARA_SCANNER_ERROR');
+  }
+
+  /** Joined `API Error: …` lines for the user-facing message, or undefined. */
+  apiErrorMessage(): string | undefined {
+    const m = this.text.match(
+      new RegExp(`${OUTPUT_SIGNALS.API_ERROR} [^\\n]+`, 'g'),
+    );
+    return m ? m.join('\n') : undefined;
+  }
+
+  /** Text after the single `[WIZARD-REMARK]` marker, trimmed, or undefined. */
+  remark(): string | undefined {
+    const re = new RegExp(
+      `${OUTPUT_SIGNALS.WIZARD_REMARK.replace(
+        /[.*+?^${}()|[\]\\]/g,
+        '\\$&',
+      )}\\s*(.+?)(?:\\n|$)`,
+      's',
+    );
+    return this.text.match(re)?.[1]?.trim() || undefined;
+  }
+}

--- a/src/lib/agent/signals.ts
+++ b/src/lib/agent/signals.ts
@@ -1,0 +1,57 @@
+/**
+ * Agent signal vocabulary — the marker strings the agent emits and the error
+ * taxonomy the runner returns. Kept as a dependency-free leaf module so both
+ * `agent-interface.ts` and `output-signals.ts` can import it without a cycle.
+ */
+
+export const AgentSignals = {
+  /** Signal emitted when the agent reports progress to the user */
+  STATUS: '[STATUS]',
+  /** Signal emitted when the agent cannot access the PostHog MCP server */
+  ERROR_MCP_MISSING: '[ERROR-MCP-MISSING]',
+  /** Signal emitted when the agent cannot access the setup resource */
+  ERROR_RESOURCE_MISSING: '[ERROR-RESOURCE-MISSING]',
+  /**
+   * Signal emitted when the agent cannot complete the program and is
+   * aborting intentionally (distinct from errors). Format: "[ABORT] <reason>".
+   * Programs can declare an onAbort handler to render a custom screen.
+   */
+  ABORT: '[ABORT]',
+  /** Signal emitted when the agent provides a remark about its run */
+  WIZARD_REMARK: '[WIZARD-REMARK]',
+  /** Signal prefix for benchmark logging */
+  BENCHMARK: '[BENCHMARK]',
+  /**
+   * Signal emitted when the agent has created a PostHog dashboard for the
+   * user. Format: `[DASHBOARD_URL] <full https url>`. The URL is captured
+   * onto `session.dashboardUrl` and surfaced by programs in their outro.
+   */
+  DASHBOARD_URL: '[DASHBOARD_URL]',
+  /**
+   * Signal emitted when the agent has uploaded a report to a PostHog
+   * notebook. Format: `[NOTEBOOK_URL] <full https url>`. The URL is captured
+   * onto `session.notebookUrl` and surfaced by programs in their outro.
+   */
+  NOTEBOOK_URL: '[NOTEBOOK_URL]',
+} as const;
+
+export type AgentSignal = (typeof AgentSignals)[keyof typeof AgentSignals];
+
+/**
+ * Error types that can be returned from agent execution.
+ * These correspond to the error signals that the agent emits.
+ */
+export enum AgentErrorType {
+  /** Agent could not access the PostHog MCP server */
+  MCP_MISSING = 'WIZARD_MCP_MISSING',
+  /** Agent could not access the setup resource */
+  RESOURCE_MISSING = 'WIZARD_RESOURCE_MISSING',
+  /** API rate limit exceeded */
+  RATE_LIMIT = 'WIZARD_RATE_LIMIT',
+  /** Generic API error */
+  API_ERROR = 'WIZARD_API_ERROR',
+  /** YARA scanner detected a security violation */
+  YARA_VIOLATION = 'WIZARD_YARA_VIOLATION',
+  /** Agent intentionally aborted the program (emitted [ABORT] <reason>) */
+  ABORT = 'WIZARD_ABORT',
+}

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -607,6 +607,20 @@ describe('WizardStore', () => {
       store.pushStatus('msg');
       expect(cb).toHaveBeenCalledTimes(1);
     });
+
+    it('pushStatus caps history as a FIFO, dropping oldest', () => {
+      const store = createStore();
+      for (let i = 0; i < 250; i++) {
+        store.pushStatus(`msg ${i}`);
+      }
+
+      const msgs = store.statusMessages;
+      expect(msgs).toHaveLength(100);
+      // Newest retained, oldest dropped.
+      expect(msgs[msgs.length - 1]).toBe('msg 249');
+      expect(msgs[0]).toBe('msg 150');
+      expect(msgs).not.toContain('msg 0');
+    });
   });
 
   describe('tasks', () => {

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -9,6 +9,7 @@ import {
   McpOutcome,
 } from '@ui/tui/store';
 import { OutroKind, AdditionalFeature } from '@lib/wizard-session';
+import { EXPANDED_COUNT } from '@ui/tui/constants';
 import {
   WizardReadiness,
   evaluateWizardReadiness,
@@ -614,11 +615,12 @@ describe('WizardStore', () => {
         store.pushStatus(`msg ${i}`);
       }
 
+      // Cap is tied to EXPANDED_COUNT (the status bar's largest window).
       const msgs = store.statusMessages;
-      expect(msgs).toHaveLength(100);
+      expect(msgs).toHaveLength(EXPANDED_COUNT);
       // Newest retained, oldest dropped.
       expect(msgs[msgs.length - 1]).toBe('msg 249');
-      expect(msgs[0]).toBe('msg 150');
+      expect(msgs[0]).toBe(`msg ${250 - EXPANDED_COUNT}`);
       expect(msgs).not.toContain('msg 0');
     });
   });

--- a/src/ui/tui/constants.ts
+++ b/src/ui/tui/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Status-bar window sizes. How many status lines the bar shows collapsed vs
+ * expanded. Kept in a dependency-free module so both the renderer
+ * (TabContainer) and the store (which caps retained history to the window)
+ * share one definition.
+ */
+
+export const COLLAPSED_COUNT = 2;
+export const EXPANDED_COUNT = 10;

--- a/src/ui/tui/primitives/TabContainer.tsx
+++ b/src/ui/tui/primitives/TabContainer.tsx
@@ -15,15 +15,16 @@ import {
   type KeyBinding,
 } from '@ui/tui/hooks/useKeyBindings';
 import type { WizardStore } from '@ui/tui/store';
+import { COLLAPSED_COUNT, EXPANDED_COUNT } from '@ui/tui/constants';
+
+// Re-exported so existing importers (e.g. LearnCard) keep their path.
+export { COLLAPSED_COUNT, EXPANDED_COUNT };
 
 export interface TabDefinition {
   id: string;
   label: string;
   component: ReactNode;
 }
-
-export const COLLAPSED_COUNT = 2;
-export const EXPANDED_COUNT = 10;
 
 interface TabContainerProps {
   tabs: TabDefinition[];

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -43,6 +43,7 @@ import type {
   ProgramReadyContext,
 } from '@lib/programs/program-step';
 import { getProgramConfig } from '@lib/programs/program-registry';
+import { EXPANDED_COUNT } from '@ui/tui/constants';
 
 export { TaskStatus, ScreenId, Overlay, Program, RunPhase, McpOutcome };
 export type { ScreenName, OutroData, WizardSession, ProgramId };
@@ -68,11 +69,11 @@ interface GateEntry {
 }
 
 /**
- * FIFO cap on retained status lines. The status bar renders at most
- * EXPANDED_COUNT (10) and no consumer reads the full history, so this leaves
- * ample scrollback headroom while bounding both memory and per-push copy cost.
+ * FIFO cap on retained status lines. The status bar is the only consumer and
+ * renders at most EXPANDED_COUNT lines, so there is no reason to retain more —
+ * the cap is tied to the window it feeds.
  */
-const MAX_STATUS_MESSAGES = 100;
+const MAX_STATUS_MESSAGES = EXPANDED_COUNT;
 
 export class WizardStore {
   // ── Internal nanostore atoms ─────────────────────────────────────

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -67,6 +67,13 @@ interface GateEntry {
   resolved: boolean;
 }
 
+/**
+ * FIFO cap on retained status lines. The status bar renders at most
+ * EXPANDED_COUNT (10) and no consumer reads the full history, so this leaves
+ * ample scrollback headroom while bounding both memory and per-push copy cost.
+ */
+const MAX_STATUS_MESSAGES = 100;
+
 export class WizardStore {
   // ── Internal nanostore atoms ─────────────────────────────────────
   private $session = map<WizardSession>(buildSession({}));
@@ -655,9 +662,16 @@ export class WizardStore {
 
   pushStatus(message: string): void {
     const msgs = this.$statusMessages.get();
-    // Skip consecutive duplicate messages
+    // Skip consecutive duplicate messages (no allocation on the hot path)
     if (msgs.length > 0 && msgs[msgs.length - 1] === message) return;
-    this.$statusMessages.set([...msgs, message]);
+    // Nanostore detects change by reference equality, so a new array is
+    // required. At the cap, allocate exactly once at the final size (dropping
+    // the oldest entry) rather than push-then-truncate.
+    const next =
+      msgs.length >= MAX_STATUS_MESSAGES
+        ? [...msgs.slice(msgs.length - MAX_STATUS_MESSAGES + 1), message]
+        : [...msgs, message];
+    this.$statusMessages.set(next);
     this.emitChange();
   }
 


### PR DESCRIPTION
## What

Two buffers grew without limit during an agent run. This bounds both.

**collectedText** held every assistant text block for the whole run. Line 1187 re-joined the whole array on every assistant message, so cost was O(n squared). It is replaced by `AgentOutputSignals`, a class that keeps only lines containing a known signal and drops all other prose. One `OUTPUT_SIGNALS` table drives both what gets kept and every query, so the filter and the consumers cannot fall out of sync. Consumers now call typed methods like `has('API_ERROR_401')` instead of scanning raw strings.

**$statusMessages** appended forever via `pushStatus`. It now caps at 100 entries with a FIFO that drops the oldest. The status bar renders at most 10, so nothing visible changes.

## Why

Both buffers leaked memory for the lifetime of a run. The log file tailing was already safe. These were the real growth points.

## Behavior

Detection logic is byte for byte identical. No user facing change.

## Tests

* New tests for `AgentOutputSignals`: prose is dropped, each marker is detected, API error lines and the remark are extracted.
* New test for the status FIFO: 250 pushes leave 100 entries, newest kept, oldest dropped.
* Updated the 3 `createStopHook` tests to the new type. Assertions unchanged.
* `pnpm build && pnpm test && pnpm lint` all pass. 766 tests green.