### PR TITLE
feat(mcp): add Claude Desktop/Web to mcp add

### DIFF
--- a/src/steps/add-mcp-server-to-clients/browser-client.ts
+++ b/src/steps/add-mcp-server-to-clients/browser-client.ts
@@ -1,0 +1,24 @@
+/**
+ * Capability for MCP clients that are connected by opening a hosted page in
+ * the browser rather than writing a local config or running a CLI install.
+ *
+ * Mirrors the PluginCapable pattern in plugin-client.ts: the client carries the
+ * URL and instruction text (product knowledge); the TUI renders whatever the
+ * capability surfaces (generic machinery).
+ */
+
+export interface BrowserFinishable {
+  /** URL the user opens to finish connecting (also shown as copy-paste fallback). */
+  connectorUrl: string;
+  /** One-line instruction shown after the page opens. */
+  finishInstruction: string;
+}
+
+export function isBrowserFinishable<T>(c: T): c is T & BrowserFinishable {
+  return (
+    typeof c === 'object' &&
+    c !== null &&
+    'connectorUrl' in c &&
+    'finishInstruction' in c
+  );
+}

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-web.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-web.test.ts
@@ -1,0 +1,53 @@
+import opn from 'opn';
+import { ClaudeWebMCPClient } from '@steps/add-mcp-server-to-clients/clients/claude-web';
+import { isBrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+
+jest.mock('opn', () => jest.fn(() => Promise.resolve()));
+
+const opnMock = opn as unknown as jest.Mock;
+
+const CONNECTOR_URL = 'https://claude.ai/directory/connectors/posthog';
+
+describe('ClaudeWebMCPClient', () => {
+  let client: ClaudeWebMCPClient;
+
+  beforeEach(() => {
+    client = new ClaudeWebMCPClient();
+    jest.clearAllMocks();
+  });
+
+  it('has the expected name and connector metadata', () => {
+    expect(client.name).toBe('Claude Desktop/Web');
+    expect(client.connectorUrl).toBe(CONNECTOR_URL);
+    expect(client.finishInstruction).toBe(
+      'Sign in and click "Connect" to finish.',
+    );
+  });
+
+  it('is recognised as a browser-finishable client', () => {
+    expect(isBrowserFinishable(client)).toBe(true);
+  });
+
+  it('is supported on every platform', async () => {
+    await expect(client.isClientSupported()).resolves.toBe(true);
+  });
+
+  it('never reports the server as locally installed', async () => {
+    await expect(client.isServerInstalled()).resolves.toBe(false);
+  });
+
+  it('opens the connector page on addServer and reports success', async () => {
+    await expect(client.addServer()).resolves.toEqual({ success: true });
+    expect(opnMock).toHaveBeenCalledWith(CONNECTOR_URL, { wait: false });
+  });
+
+  it('still reports success when opening the browser fails', async () => {
+    opnMock.mockReturnValueOnce(Promise.reject(new Error('no browser')));
+    await expect(client.addServer()).resolves.toEqual({ success: true });
+  });
+
+  it('removeServer is a no-op that reports nothing removed', async () => {
+    await expect(client.removeServer()).resolves.toEqual({ success: false });
+    expect(opnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/steps/add-mcp-server-to-clients/clients/claude-web.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-web.ts
@@ -1,0 +1,47 @@
+import opn from 'opn';
+import { MCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
+import { BrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+
+/**
+ * Claude Desktop / Claude.ai (web). PostHog ships here as a hosted connector,
+ * not a local config — so instead of writing files we open the connector
+ * directory page and let the user sign in and click "Connect".
+ */
+export class ClaudeWebMCPClient extends MCPClient implements BrowserFinishable {
+  name = 'Claude Desktop/Web';
+  connectorUrl = 'https://claude.ai/directory/connectors/posthog';
+  finishInstruction = 'Sign in and click "Connect" to finish.';
+
+  isClientSupported(): Promise<boolean> {
+    // Browser-based — available on every platform.
+    return Promise.resolve(true);
+  }
+
+  isServerInstalled(): Promise<boolean> {
+    // The connector lives in the user's Claude account; nothing local to
+    // inspect. Returning false also keeps it out of `mcp remove`.
+    return Promise.resolve(false);
+  }
+
+  addServer(): Promise<{ success: boolean }> {
+    void opn(this.connectorUrl, { wait: false }).catch(() => {
+      // opn throws in environments without a browser (e.g. CI) — swallow it;
+      // the URL is still surfaced to the user on the Done screen.
+    });
+    return Promise.resolve({ success: true });
+  }
+
+  removeServer(): Promise<{ success: boolean }> {
+    return Promise.resolve({ success: false });
+  }
+
+  getConfigPath(): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+  getServerPropertyName(): string {
+    throw new Error('Not implemented');
+  }
+}
+
+export default ClaudeWebMCPClient;

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -6,6 +6,7 @@ import { getUI } from '@ui';
 import { MCPClient } from './MCPClient';
 import { CursorMCPClient } from './clients/cursor';
 import { ClaudeCodeMCPClient } from './clients/claude-code';
+import { ClaudeWebMCPClient } from './clients/claude-web';
 import { VisualStudioCodeClient } from './clients/visual-studio-code';
 import { ZedClient } from './clients/zed';
 import { CodexMCPClient } from './clients/codex';
@@ -16,6 +17,7 @@ import { isPluginCapable, PluginCapable } from './plugin-client';
 export const getSupportedClients = async (): Promise<MCPClient[]> => {
   const allClients = [
     new ClaudeCodeMCPClient(),
+    new ClaudeWebMCPClient(),
     new CodexMCPClient(),
     new CursorMCPClient(),
     new VisualStudioCodeClient(),

--- a/src/ui/tui/__tests__/mcp-installer.test.ts
+++ b/src/ui/tui/__tests__/mcp-installer.test.ts
@@ -115,3 +115,38 @@ describe('createMcpInstaller — installPlugins', () => {
     expect(result).toEqual(['Claude Code']);
   });
 });
+
+describe('createMcpInstaller — detectClients', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mcpModule = require('@steps/add-mcp-server-to-clients/index');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('surfaces the finish note for browser-finishable clients only', async () => {
+    mcpModule.getSupportedClients.mockResolvedValue([
+      { name: 'Cursor' },
+      {
+        name: 'Claude Desktop/Web',
+        connectorUrl: 'https://claude.ai/directory/connectors/posthog',
+        finishInstruction: 'Sign in and click "Connect" to finish.',
+      },
+    ]);
+
+    const installer = createMcpInstaller();
+    const detected = await installer.detectClients();
+
+    expect(detected).toEqual([
+      { name: 'Cursor', supportsPlugin: false, finish: undefined },
+      {
+        name: 'Claude Desktop/Web',
+        supportsPlugin: false,
+        finish: {
+          url: 'https://claude.ai/directory/connectors/posthog',
+          instruction: 'Sign in and click "Connect" to finish.',
+        },
+      },
+    ]);
+  });
+});

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -101,9 +101,20 @@ export const McpScreen = ({
     // Skip feature picker if CLI already specified features
     if (store.session.mcpFeatures) {
       void doInstall(clientNames, store.session.mcpFeatures);
-    } else {
-      setPhase(Phase.FeatureSelect);
+      return;
     }
+    // Skip the feature picker when no selected client consumes features —
+    // browser connectors (e.g. Claude Desktop/Web) configure features online,
+    // not through CLI-written config.
+    const anyNeedsFeatures = clientNames.some((name) => {
+      const info = clients.find((c) => c.name === name);
+      return !info?.finish;
+    });
+    if (!anyNeedsFeatures) {
+      void doInstall(clientNames, []);
+      return;
+    }
+    setPhase(Phase.FeatureSelect);
   };
 
   const handleConfirm = () => {
@@ -168,6 +179,18 @@ export const McpScreen = ({
     'Run SQL, build dashboards, ship flags, all from your IDE.',
     'No copy-pasting tokens or context. Your agent has the keys.',
   ];
+
+  // Clients connected via a browser page (e.g. Claude Desktop/Web) aren't truly
+  // "installed" — the user finishes in the browser. Split them out of the
+  // "installed for" list and render the finish instructions separately.
+  const finishNotes = clients.flatMap((c) =>
+    c.finish && resultClients.includes(c.name)
+      ? [{ name: c.name, url: c.finish.url, instruction: c.finish.instruction }]
+      : [],
+  );
+  const installedNow = resultClients.filter(
+    (name) => !finishNotes.some((n) => n.name === name),
+  );
 
   return (
     <Box flexDirection="column" flexGrow={1}>
@@ -253,26 +276,47 @@ export const McpScreen = ({
 
         {phase === Phase.Done && (
           <Box flexDirection="column">
-            {resultClients.length > 0 ? (
-              <>
-                <Text color="green" bold>
-                  {'\u2714'} MCP server
-                  {!isRemove && pluginClients.length > 0
-                    ? ' and plugin'
-                    : ''}{' '}
-                  {isRemove ? 'removed from' : 'installed for'}:
-                </Text>
-                {resultClients.map((name, i) => (
-                  <Text key={i}>
-                    {' '}
-                    {'\u2022'} {name}
-                  </Text>
-                ))}
-              </>
-            ) : (
+            {installedNow.length === 0 && finishNotes.length === 0 ? (
               <Text dimColor>
                 {isRemove ? 'Removal' : 'Installation'} skipped.
               </Text>
+            ) : (
+              <>
+                {installedNow.length > 0 && (
+                  <>
+                    <Text color="green" bold>
+                      {'\u2714'} MCP server
+                      {!isRemove && pluginClients.length > 0
+                        ? ' and plugin'
+                        : ''}{' '}
+                      {isRemove ? 'removed from' : 'installed for'}:
+                    </Text>
+                    {installedNow.map((name, i) => (
+                      <Text key={i}>
+                        {' '}
+                        {'\u2022'} {name}
+                      </Text>
+                    ))}
+                  </>
+                )}
+                {finishNotes.map((note) => (
+                  <Box key={note.name} flexDirection="column" marginTop={1}>
+                    <Text color="green" bold>
+                      {note.name} \u2014 finish in your browser:
+                    </Text>
+                    <Text>
+                      {'  '}Opened <Text color="cyan">{note.url}</Text>
+                    </Text>
+                    <Text dimColor>
+                      {'  '}
+                      {note.instruction}
+                    </Text>
+                    <Text dimColor>
+                      {'  '}(If it didn&apos;t open, paste the URL above.)
+                    </Text>
+                  </Box>
+                ))}
+              </>
             )}
           </Box>
         )}

--- a/src/ui/tui/services/mcp-installer.ts
+++ b/src/ui/tui/services/mcp-installer.ts
@@ -14,12 +14,18 @@ import {
 } from '@steps/add-mcp-server-to-clients/index';
 import { ALL_FEATURE_VALUES } from '@steps/add-mcp-server-to-clients/defaults';
 import { isPluginCapable } from '@steps/add-mcp-server-to-clients/plugin-client';
+import { isBrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
 import { logToFile } from '@utils/debug';
 import { analytics } from '@utils/analytics';
 
 export interface McpClientInfo {
   name: string;
   supportsPlugin: boolean;
+  /**
+   * Set for clients connected by opening a hosted page in the browser. The
+   * Done screen renders this so the user knows to finish setup in the browser.
+   */
+  finish?: { url: string; instruction: string };
 }
 
 export interface McpInstaller {
@@ -54,6 +60,9 @@ export function createMcpInstaller(): McpInstaller {
       return supported.map((c) => ({
         name: c.name,
         supportsPlugin: isPluginCapable(c) && c.supportsPlugin(),
+        finish: isBrowserFinishable(c)
+          ? { url: c.connectorUrl, instruction: c.finishInstruction }
+          : undefined,
       }));
     },
 


### PR DESCRIPTION
## Problem

`mcp add` lets users wire the PostHog MCP server into local editors (Cursor, VS Code, Zed) or via a CLI plugin (Claude Code, Codex), but there was no path for **Claude Desktop / Claude.ai (web)**, where PostHog ships as a hosted **connector** the user adds from the Claude connector directory — not as a local config.

## Changes

- New **"Claude Desktop/Web"** option in `mcp add`. Selecting it opens `https://claude.ai/directory/connectors/posthog` in the browser (`opn`, same pattern as the OAuth flow).
- New `BrowserFinishable` capability + `isBrowserFinishable` guard (`browser-client.ts`), mirroring the existing `PluginCapable` pattern — the connector URL and instruction live on the client, so `McpScreen` renders them generically with no Claude-specifics in the TUI.
- The Done screen shows the connector URL and "Sign in and click Connect to finish" (with copy-paste fallback) instead of claiming it's "installed".
- The feature picker is skipped when only a browser connector is selected — features are configured online, not via CLI-written config.
- `isServerInstalled()` returns false, so it stays out of `mcp remove`. The dormant file-based `ClaudeMCPClient` is left untouched (it's a `DefaultMCPClient` test reference).

## How did you test this code?

- New unit tests: `claude-web.test.ts` (client behavior, opn invocation, browser-finishable detection) and an added case in `mcp-installer.test.ts` (the `finish` note is surfaced only for browser connectors).
- `pnpm build && pnpm test` — 768 tests pass (50 suites); `pnpm lint` — 0 errors.
- Manual: ran the MCP flow via `pnpm try` — "Claude Desktop/Web" appears in detected clients; selecting it (alone or alongside an editor) opens the connector page and the Done screen shows the finish instructions; picking only the connector skips the feature prompt.

## Publish to changelog?

no