### PR TITLE
feat: pi runner (OpenAI Agents SDK)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@anthropic-ai/claude-agent-sdk": "0.3.146",
     "@inkjs/ui": "^2.0.0",
     "@langchain/core": "^0.3.40",
+    "@openai/agents": "^0.11.6",
+    "@openai/agents-extensions": "^0.11.6",
     "ai": "^6.0.193",
     "axios": "1.7.4",
     "fast-glob": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@langchain/core':
         specifier: ^0.3.40
         version: 0.3.40(openai@6.39.1(ws@8.18.1)(zod@3.24.2))
+      '@openai/agents':
+        specifier: ^0.11.6
+        version: 0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)
+      '@openai/agents-extensions':
+        specifier: ^0.11.6
+        version: 0.11.6(@ai-sdk/provider@3.0.10)(@cfworker/json-schema@4.1.1)(@openai/agents@0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2))(ai@6.0.193(zod@3.24.2))(ws@8.18.1)(zod@3.24.2)
       ai:
         specifier: ^6.0.193
         version: 6.0.193(zod@3.24.2)
@@ -1327,6 +1333,67 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@openai/agents-core@0.11.6':
+    resolution: {integrity: sha512-jWeo4mF+zjp9R80OPg+9prAnwF53dIpok2ymp9OkC3DpK2qcqBO8CfoEgocNp+E5HXXFW4uvCaY0olNCCcmTFw==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-extensions@0.11.6':
+    resolution: {integrity: sha512-lTWr0kFos15PXEqs/gbTPLjVHblFvYx/YKVYy3fK89g56vdW78Tusgvjh9enIFLdmqnzPacTBA3GB2V8V7pr7g==}
+    peerDependencies:
+      '@ai-sdk/provider': ^2.0.0 || ^3.0.0
+      '@blaxel/core': ^0.2.82
+      '@daytonaio/sdk': ^0.162.0
+      '@e2b/code-interpreter': ^2.3.3
+      '@openai/agents': '>=0.0.0'
+      '@openai/codex-sdk': '>=0.86.0'
+      '@runloop/api-client': ^1.16.2
+      '@vercel/sandbox': ^1.9.3
+      ai: ^6.0.0
+      e2b: ^2.14.1
+      modal: ^0.7.4
+      ws: ^8.18.1
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      '@ai-sdk/provider':
+        optional: true
+      '@blaxel/core':
+        optional: true
+      '@daytonaio/sdk':
+        optional: true
+      '@e2b/code-interpreter':
+        optional: true
+      '@openai/codex-sdk':
+        optional: true
+      '@runloop/api-client':
+        optional: true
+      '@vercel/sandbox':
+        optional: true
+      ai:
+        optional: true
+      e2b:
+        optional: true
+      modal:
+        optional: true
+
+  '@openai/agents-openai@0.11.6':
+    resolution: {integrity: sha512-63zXy+EPmg3WErLO12jLEjCTqGBZ/f0ApsW/t5wpccqUYCtImIT6IYZDgGM+zSEafHNGJmNOwGtEqHjz/Pyl+A==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents-realtime@0.11.6':
+    resolution: {integrity: sha512-jw4lLO6B2xyCBtgLtAXZmqhjEAqSLO1EtJzfwfrZuzGpPgs4nJBQ+O7ybtdPPKt8iWdIOlrYRDqxhBHv7Qqo7w==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents@0.11.6':
+    resolution: {integrity: sha512-YLwycYJQ65ETEq1SzjdFO6U9VhWHOKKIVh6wZCd/FmTZoqYq9UF/5uvX+wF8cZ58J+wIyyLynPdCmzEEov2rhw==}
+    peerDependencies:
+      zod: ^4.0.0
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -1590,6 +1657,9 @@ packages:
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -4991,7 +5061,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5141,7 +5211,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -5161,7 +5231,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5491,6 +5561,72 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@openai/agents-core@0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.39.1(ws@8.18.1)(zod@3.24.2)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.24.2)
+      zod: 3.24.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-extensions@0.11.6(@ai-sdk/provider@3.0.10)(@cfworker/json-schema@4.1.1)(@openai/agents@0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2))(ai@6.0.193(zod@3.24.2))(ws@8.18.1)(zod@3.24.2)':
+    dependencies:
+      '@openai/agents': 0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)
+      '@openai/agents-core': 0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.18.1
+      zod: 3.24.2
+    optionalDependencies:
+      '@ai-sdk/provider': 3.0.10
+      ai: 6.0.193(zod@3.24.2)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@openai/agents-openai@0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)':
+    dependencies:
+      '@openai/agents-core': 0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)
+      debug: 4.4.3
+      openai: 6.39.1(ws@8.18.1)(zod@3.24.2)
+      zod: 3.24.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.11.6(@cfworker/json-schema@4.1.1)(zod@3.24.2)':
+    dependencies:
+      '@openai/agents-core': 0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.18.1
+      zod: 3.24.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)':
+    dependencies:
+      '@openai/agents-core': 0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)
+      '@openai/agents-openai': 0.11.6(@cfworker/json-schema@4.1.1)(ws@8.18.1)(zod@3.24.2)
+      '@openai/agents-realtime': 0.11.6(@cfworker/json-schema@4.1.1)(zod@3.24.2)
+      debug: 4.4.3
+      openai: 6.39.1(ws@8.18.1)(zod@3.24.2)
+      zod: 3.24.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
   '@opentelemetry/api@1.9.1': {}
 
   '@oxc-project/types@0.126.0': {}
@@ -5738,6 +5874,10 @@ snapshots:
 
   '@types/uuid@10.0.0': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 18.19.76
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@16.0.9':
@@ -5796,7 +5936,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0
+      debug: 4.4.3
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.7.3)
     optionalDependencies:
@@ -5810,7 +5950,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
@@ -7593,7 +7733,6 @@ snapshots:
     optionalDependencies:
       ws: 8.18.1
       zod: 3.24.2
-    optional: true
 
   opn@5.5.0:
     dependencies:

--- a/src/lib/agent/runner/__tests__/select-runner.test.ts
+++ b/src/lib/agent/runner/__tests__/select-runner.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../index';
 import { AnthropicRunner } from '../anthropic-runner';
 import { VercelRunner } from '../vercel/vercel-runner';
+import { PiRunner } from '../pi/pi-runner';
 import { WIZARD_RUNNER_FLAG_KEY } from '../../../constants';
 
 // `runAgent` pulls in the full SDK-backed agent stack; runner selection is a
@@ -35,9 +36,14 @@ describe('selectRunner', () => {
     );
   });
 
-  // `pi` isn't implemented yet, so it (and any unknown value) falls back to
-  // AnthropicRunner, the safe default.
-  it.each(['anthropic', 'pi', 'bogus'])(
+  it('returns PiRunner for the pi variant', () => {
+    expect(selectRunner({ [WIZARD_RUNNER_FLAG_KEY]: 'pi' })).toBeInstanceOf(
+      PiRunner,
+    );
+  });
+
+  // Any unknown value falls back to AnthropicRunner, the safe default.
+  it.each(['anthropic', 'bogus'])(
     'returns AnthropicRunner for %p',
     (variant) => {
       expect(

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -18,6 +18,7 @@ import { logToFile } from '../../../utils/debug';
 import type { runAgent } from '../agent-interface';
 import { AnthropicRunner } from './anthropic-runner';
 import { VercelRunner } from './vercel/vercel-runner';
+import { PiRunner } from './pi/pi-runner';
 
 /** The agent backends the `wizard-runner` flag can select. */
 export type WizardRunnerVariant = 'anthropic' | 'pi' | 'vercel';
@@ -49,11 +50,9 @@ export function resolveRunnerVariant(
 }
 
 /**
- * Select the runner for this run and log which backend executed.
- *
- * The `pi` runner lands in #524; until then it falls back to `AnthropicRunner`
- * so the flag stays wired and observable without changing behavior. An unknown
- * value already resolved to `anthropic` in {@link resolveRunnerVariant}.
+ * Select the runner for this run and log which backend executed. Each variant
+ * maps to its backend; an unknown value already resolved to `anthropic`, the
+ * safe default, in {@link resolveRunnerVariant}.
  */
 export function selectRunner(flags: Record<string, string>): Runner {
   const variant = resolveRunnerVariant(flags);
@@ -62,10 +61,8 @@ export function selectRunner(flags: Record<string, string>): Runner {
       logToFile('[runner] wizard-runner=vercel → VercelRunner');
       return new VercelRunner();
     case 'pi':
-      logToFile(
-        '[runner] wizard-runner=pi → AnthropicRunner (fallback — not yet implemented)',
-      );
-      return new AnthropicRunner();
+      logToFile('[runner] wizard-runner=pi → PiRunner');
+      return new PiRunner();
     case 'anthropic':
     default:
       logToFile('[runner] wizard-runner=anthropic → AnthropicRunner');

--- a/src/lib/agent/runner/pi/__tests__/pi-adapters.test.ts
+++ b/src/lib/agent/runner/pi/__tests__/pi-adapters.test.ts
@@ -1,0 +1,46 @@
+import { toNonStrictParameters } from '../tools';
+import { descriptorToStreamableHttpOptions } from '../mcp';
+
+describe('toNonStrictParameters', () => {
+  it('fills in required and additionalProperties for the SDK shape', () => {
+    expect(
+      toNonStrictParameters({
+        type: 'object',
+        properties: { file_path: { type: 'string' } },
+        required: ['file_path'],
+      }),
+    ).toEqual({
+      type: 'object',
+      properties: { file_path: { type: 'string' } },
+      required: ['file_path'],
+      additionalProperties: true,
+    });
+  });
+
+  it('defaults missing required to [] and missing properties to {}', () => {
+    expect(toNonStrictParameters({ type: 'object' })).toEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: true,
+    });
+  });
+});
+
+describe('descriptorToStreamableHttpOptions', () => {
+  it('maps a neutral descriptor onto streamable-HTTP options with headers', () => {
+    expect(
+      descriptorToStreamableHttpOptions({
+        name: 'posthog-wizard',
+        url: 'https://mcp.posthog.com/mcp',
+        headers: { Authorization: 'Bearer phx_x', 'User-Agent': 'wizard' },
+      }),
+    ).toEqual({
+      name: 'posthog-wizard',
+      url: 'https://mcp.posthog.com/mcp',
+      requestInit: {
+        headers: { Authorization: 'Bearer phx_x', 'User-Agent': 'wizard' },
+      },
+    });
+  });
+});

--- a/src/lib/agent/runner/pi/mcp.ts
+++ b/src/lib/agent/runner/pi/mcp.ts
@@ -1,0 +1,60 @@
+import type { MCPServerStreamableHttp } from '@openai/agents';
+import type { HttpMcpDescriptor } from '../shared/mcp';
+
+/**
+ * Live MCP hosting for the `pi` runner.
+ *
+ * Unlike the AI SDK, the OpenAI Agents SDK ships first-class MCP support, so the
+ * neutral HTTP descriptors map directly onto `MCPServerStreamableHttp` and the
+ * Agent hosts them through `mcpServers`. The PostHog MCP the agent relies on is
+ * therefore live on this runner.
+ */
+
+/** Options for `new MCPServerStreamableHttp(...)`. */
+export interface StreamableHttpOptions {
+  url: string;
+  name: string;
+  /** Headers (auth, user-agent) are sent through the transport's requestInit. */
+  requestInit: { headers: Record<string, string> };
+}
+
+/** Project a neutral descriptor onto the SDK's streamable-HTTP server options. */
+export function descriptorToStreamableHttpOptions(
+  descriptor: HttpMcpDescriptor,
+): StreamableHttpOptions {
+  return {
+    url: descriptor.url,
+    name: descriptor.name,
+    requestInit: { headers: descriptor.headers },
+  };
+}
+
+/**
+ * Construct and connect the MCP servers for a run. The SDK is ESM-only, so it's
+ * imported dynamically. Each server is connected before the agent runs;
+ * {@link closePiMcpServers} closes them afterward.
+ */
+export async function createPiMcpServers(
+  descriptors: HttpMcpDescriptor[],
+): Promise<MCPServerStreamableHttp[]> {
+  if (descriptors.length === 0) return [];
+  const { MCPServerStreamableHttp } = await import('@openai/agents');
+  const servers = descriptors.map(
+    (d) => new MCPServerStreamableHttp(descriptorToStreamableHttpOptions(d)),
+  );
+  await Promise.all(servers.map((s) => s.connect()));
+  return servers;
+}
+
+/** Close MCP servers, swallowing per-server errors so teardown never throws. */
+export async function closePiMcpServers(
+  servers: MCPServerStreamableHttp[],
+): Promise<void> {
+  await Promise.all(
+    servers.map((s) =>
+      s.close().catch(() => {
+        // best-effort teardown
+      }),
+    ),
+  );
+}

--- a/src/lib/agent/runner/pi/model.ts
+++ b/src/lib/agent/runner/pi/model.ts
@@ -1,0 +1,34 @@
+import type { Model } from '@openai/agents';
+import { readGatewayEnv, buildGatewayHeaders } from '../shared/gateway';
+
+/**
+ * Build the OpenAI Agents SDK model for the `pi` runner, pointed at the PostHog
+ * LLM gateway.
+ *
+ * The OpenAI Agents SDK is model-agnostic through `@openai/agents-extensions`'
+ * `aisdk()` adapter, which wraps any Vercel AI SDK model as an Agents `Model`.
+ * We wrap the same gateway-pointed `@ai-sdk/anthropic` model the `vercel`
+ * runner uses, so both challengers hit the gateway identically (bearer auth +
+ * Bedrock-fallback + wizard metadata/flag headers) and only the surrounding
+ * loop differs.
+ *
+ * The model id passes through verbatim (a bare id like `claude-sonnet-4-6`) so
+ * the gateway's Bedrock fallback can match it. Both SDKs are ESM-only, so they
+ * load dynamically — mirroring agent-interface's `getSDKModule`.
+ */
+export async function createPiModel(
+  modelId: string,
+  wizardMetadata: Record<string, string>,
+  wizardFlags: Record<string, string>,
+): Promise<Model> {
+  const { createAnthropic } = await import('@ai-sdk/anthropic');
+  // `aisdk` lives on the package's `/ai-sdk` subpath, not the root export.
+  const { aisdk } = await import('@openai/agents-extensions/ai-sdk');
+  const { baseUrl, authToken } = readGatewayEnv();
+  const anthropic = createAnthropic({
+    baseURL: baseUrl,
+    authToken,
+    headers: buildGatewayHeaders(wizardMetadata, wizardFlags),
+  });
+  return aisdk(anthropic(modelId));
+}

--- a/src/lib/agent/runner/pi/model.ts
+++ b/src/lib/agent/runner/pi/model.ts
@@ -1,34 +1,27 @@
 import type { Model } from '@openai/agents';
-import { readGatewayEnv, buildGatewayHeaders } from '../shared/gateway';
+import { createGatewayAnthropicModel } from '../shared/model';
 
 /**
- * Build the OpenAI Agents SDK model for the `pi` runner, pointed at the PostHog
- * LLM gateway.
+ * Build the OpenAI Agents SDK model for the `pi` runner.
  *
  * The OpenAI Agents SDK is model-agnostic through `@openai/agents-extensions`'
  * `aisdk()` adapter, which wraps any Vercel AI SDK model as an Agents `Model`.
- * We wrap the same gateway-pointed `@ai-sdk/anthropic` model the `vercel`
- * runner uses, so both challengers hit the gateway identically (bearer auth +
- * Bedrock-fallback + wizard metadata/flag headers) and only the surrounding
- * loop differs.
+ * We wrap the same gateway-pointed `@ai-sdk/anthropic` model the `vercel` runner
+ * drives directly — built by the shared {@link createGatewayAnthropicModel}, so
+ * both challengers hit the gateway identically (bearer auth + Bedrock-fallback +
+ * wizard metadata/flag headers) and only the surrounding loop differs.
  *
- * The model id passes through verbatim (a bare id like `claude-sonnet-4-6`) so
- * the gateway's Bedrock fallback can match it. Both SDKs are ESM-only, so they
- * load dynamically — mirroring agent-interface's `getSDKModule`.
+ * `@openai/agents-extensions` is ESM-only, so it loads dynamically — mirroring
+ * agent-interface's `getSDKModule`.
  */
 export async function createPiModel(
   modelId: string,
   wizardMetadata: Record<string, string>,
   wizardFlags: Record<string, string>,
 ): Promise<Model> {
-  const { createAnthropic } = await import('@ai-sdk/anthropic');
   // `aisdk` lives on the package's `/ai-sdk` subpath, not the root export.
   const { aisdk } = await import('@openai/agents-extensions/ai-sdk');
-  const { baseUrl, authToken } = readGatewayEnv();
-  const anthropic = createAnthropic({
-    baseURL: baseUrl,
-    authToken,
-    headers: buildGatewayHeaders(wizardMetadata, wizardFlags),
-  });
-  return aisdk(anthropic(modelId));
+  return aisdk(
+    await createGatewayAnthropicModel(modelId, wizardMetadata, wizardFlags),
+  );
 }

--- a/src/lib/agent/runner/pi/pi-runner.ts
+++ b/src/lib/agent/runner/pi/pi-runner.ts
@@ -1,12 +1,7 @@
-import { getUI } from '../../../../ui';
-import { logToFile } from '../../../../utils/debug';
-import { AgentSignals } from '../../signals';
 import { getWizardCommandments } from '../../commandments';
 import type { Runner, RunnerRunArgs, RunnerResult } from '../index';
-import { RunBridge } from '../shared/run-bridge';
 import { concludeRun, concludeError } from '../shared/conclude';
-import { extractHttpMcpDescriptors } from '../shared/mcp';
-import type { TaskEntry, ToolContext } from '../shared/tools/types';
+import { setupRun, driveStream, type RunEvent } from '../shared/run-loop';
 import { createPiModel } from './model';
 import { createPiTools } from './tools';
 import { createPiMcpServers, closePiMcpServers } from './mcp';
@@ -19,111 +14,65 @@ import { createPiMcpServers, closePiMcpServers } from './mcp';
  * so the PostHog MCP servers are live here via `mcpServers`.
  *
  * It mirrors `runAgent`'s contract: same arguments, same `{ error?, message? }`
- * result, same spinner/TUI side effects. The shared {@link RunBridge} turns the
- * streamed assistant messages and task mutations into the same TUI updates and
- * signal-derived results the Anthropic SDK path produces; {@link concludeRun} /
- * {@link concludeError} handle the post-loop tail.
+ * result, same spinner/TUI side effects. {@link setupRun} builds the shared
+ * scaffolding and {@link driveStream} / `conclude*` drive the bridge and result
+ * identically to the `vercel` runner — so the only pi-specific code here is the
+ * SDK agent construction (with live MCP servers) and translating its run stream
+ * into neutral events.
  *
  * Out of scope here (per the runner epic): canUseTool + YARA security parity
- * (#525). The flag stays off until that lands.
+ * (#525) and per-variant benchmark instrumentation (#527). The flag stays off
+ * until those land.
  */
 export class PiRunner implements Runner {
   async run(...args: RunnerRunArgs): Promise<RunnerResult> {
-    const [agentConfig, prompt, , spinner, config, middleware] = args;
-    const {
-      spinnerMessage = 'Customizing your PostHog setup...',
-      successMessage = 'PostHog integration complete',
-      errorMessage = 'Integration failed',
-    } = config ?? {};
-
-    spinner.start(spinnerMessage);
-    const startTime = Date.now();
-    logToFile('[pi] starting run', { model: agentConfig.model });
-
-    const tasks = new Map<string, TaskEntry>();
-    const bridge = new RunBridge(getUI(), spinner);
-    const ctx: ToolContext = {
-      workingDirectory: agentConfig.workingDirectory,
-      tasks,
-      onTasksChange: (t) => bridge.syncTasks(t),
-    };
-    const conclude = {
-      bridge,
-      spinner,
-      startTime,
-      successMessage,
-      errorMessage,
-      label: 'pi',
-      middleware,
-    };
-
-    // agentConfig.mcpServers is the SDK's untyped (`any`) config map; narrow it
-    // to the record shape the neutral descriptor extractor expects.
-    const mcpDescriptors = extractHttpMcpDescriptors(
-      agentConfig.mcpServers as Record<string, unknown> | undefined,
-    );
-    logToFile(
-      `[pi] MCP descriptors: ${
-        mcpDescriptors.map((d) => d.name).join(', ') || '(none)'
-      }`,
-    );
+    const rc = setupRun(args, 'pi');
 
     // The SDK is ESM-only; load it lazily so constructing the runner (and
     // unit-testing selection) doesn't pull in the SDK — mirrors getSDKModule.
     const { Agent, run } = await import('@openai/agents');
 
-    const abortController = new AbortController();
     let mcpServers: Awaited<ReturnType<typeof createPiMcpServers>> = [];
     try {
-      mcpServers = await createPiMcpServers(mcpDescriptors);
-      const model = await createPiModel(
-        agentConfig.model,
-        agentConfig.wizardMetadata ?? {},
-        agentConfig.wizardFlags ?? {},
-      );
-      const tools = await createPiTools(ctx);
-
+      mcpServers = await createPiMcpServers(rc.mcpDescriptors);
       const agent = new Agent({
         name: 'PostHog Wizard',
         instructions: getWizardCommandments(),
-        model,
-        tools,
+        model: await createPiModel(rc.agentConfig.model, rc.metadata, rc.flags),
+        tools: await createPiTools(rc.toolCtx),
         mcpServers,
       });
 
-      const result = await run(agent, prompt, {
+      const result = await run(agent, rc.prompt, {
         stream: true,
-        signal: abortController.signal,
+        signal: rc.abortController.signal,
       });
 
-      for await (const event of result) {
-        try {
-          middleware?.onMessage(event);
-        } catch (e) {
-          logToFile(`${AgentSignals.BENCHMARK} Middleware onMessage error:`, e);
+      // Translate the SDK run stream into neutral events: each completed
+      // assistant message arrives as a `message_output_item` run-item event, so
+      // flush its whole text and markers split across it parse intact. Errors the
+      // SDK defers to completion surface by awaiting `result.completed`, which
+      // throws into the catch below.
+      const piEvents = async function* (): AsyncGenerator<RunEvent> {
+        for await (const event of result) {
+          if (
+            event.type === 'run_item_stream_event' &&
+            event.item.type === 'message_output_item'
+          ) {
+            yield { kind: 'assistantText', text: event.item.content };
+          }
         }
+        await result.completed;
+      };
 
-        // Each completed assistant message arrives as a run-item event; flush
-        // the whole message text to the bridge so markers parse intact.
-        if (
-          event.type === 'run_item_stream_event' &&
-          event.item.type === 'message_output_item'
-        ) {
-          const { abort } = bridge.handleAssistantText(event.item.content);
-          if (abort) abortController.abort();
-        }
-      }
-      // Surface any error the stream deferred to completion.
-      await result.completed;
+      await driveStream(piEvents(), rc.bridge, rc.abort);
     } catch (error) {
-      return concludeError(error, conclude);
+      return concludeError(error, rc.conclude);
     } finally {
+      // Close the live MCP servers before concluding, regardless of outcome.
       await closePiMcpServers(mcpServers);
     }
 
-    return concludeRun({
-      ...conclude,
-      finalizeMessage: { type: 'result', subtype: 'success' },
-    });
+    return concludeRun(rc.conclude);
   }
 }

--- a/src/lib/agent/runner/pi/pi-runner.ts
+++ b/src/lib/agent/runner/pi/pi-runner.ts
@@ -1,0 +1,129 @@
+import { getUI } from '../../../../ui';
+import { logToFile } from '../../../../utils/debug';
+import { AgentSignals } from '../../signals';
+import { getWizardCommandments } from '../../commandments';
+import type { Runner, RunnerRunArgs, RunnerResult } from '../index';
+import { RunBridge } from '../shared/run-bridge';
+import { concludeRun, concludeError } from '../shared/conclude';
+import { extractHttpMcpDescriptors } from '../shared/mcp';
+import type { TaskEntry, ToolContext } from '../shared/tools/types';
+import { createPiModel } from './model';
+import { createPiTools } from './tools';
+import { createPiMcpServers, closePiMcpServers } from './mcp';
+
+/**
+ * The `pi` runner — wraps the OpenAI Agents SDK's `run()` loop over a
+ * model-agnostic model (the gateway-pointed `@ai-sdk/anthropic` model adapted
+ * via `@openai/agents-extensions`' `aisdk()`). The SDK owns the tool-calling
+ * loop, streaming, and — unlike the `vercel` runner — first-class MCP hosting,
+ * so the PostHog MCP servers are live here via `mcpServers`.
+ *
+ * It mirrors `runAgent`'s contract: same arguments, same `{ error?, message? }`
+ * result, same spinner/TUI side effects. The shared {@link RunBridge} turns the
+ * streamed assistant messages and task mutations into the same TUI updates and
+ * signal-derived results the Anthropic SDK path produces; {@link concludeRun} /
+ * {@link concludeError} handle the post-loop tail.
+ *
+ * Out of scope here (per the runner epic): canUseTool + YARA security parity
+ * (#525). The flag stays off until that lands.
+ */
+export class PiRunner implements Runner {
+  async run(...args: RunnerRunArgs): Promise<RunnerResult> {
+    const [agentConfig, prompt, , spinner, config, middleware] = args;
+    const {
+      spinnerMessage = 'Customizing your PostHog setup...',
+      successMessage = 'PostHog integration complete',
+      errorMessage = 'Integration failed',
+    } = config ?? {};
+
+    spinner.start(spinnerMessage);
+    const startTime = Date.now();
+    logToFile('[pi] starting run', { model: agentConfig.model });
+
+    const tasks = new Map<string, TaskEntry>();
+    const bridge = new RunBridge(getUI(), spinner);
+    const ctx: ToolContext = {
+      workingDirectory: agentConfig.workingDirectory,
+      tasks,
+      onTasksChange: (t) => bridge.syncTasks(t),
+    };
+    const conclude = {
+      bridge,
+      spinner,
+      startTime,
+      successMessage,
+      errorMessage,
+      label: 'pi',
+      middleware,
+    };
+
+    // agentConfig.mcpServers is the SDK's untyped (`any`) config map; narrow it
+    // to the record shape the neutral descriptor extractor expects.
+    const mcpDescriptors = extractHttpMcpDescriptors(
+      agentConfig.mcpServers as Record<string, unknown> | undefined,
+    );
+    logToFile(
+      `[pi] MCP descriptors: ${
+        mcpDescriptors.map((d) => d.name).join(', ') || '(none)'
+      }`,
+    );
+
+    // The SDK is ESM-only; load it lazily so constructing the runner (and
+    // unit-testing selection) doesn't pull in the SDK — mirrors getSDKModule.
+    const { Agent, run } = await import('@openai/agents');
+
+    const abortController = new AbortController();
+    let mcpServers: Awaited<ReturnType<typeof createPiMcpServers>> = [];
+    try {
+      mcpServers = await createPiMcpServers(mcpDescriptors);
+      const model = await createPiModel(
+        agentConfig.model,
+        agentConfig.wizardMetadata ?? {},
+        agentConfig.wizardFlags ?? {},
+      );
+      const tools = await createPiTools(ctx);
+
+      const agent = new Agent({
+        name: 'PostHog Wizard',
+        instructions: getWizardCommandments(),
+        model,
+        tools,
+        mcpServers,
+      });
+
+      const result = await run(agent, prompt, {
+        stream: true,
+        signal: abortController.signal,
+      });
+
+      for await (const event of result) {
+        try {
+          middleware?.onMessage(event);
+        } catch (e) {
+          logToFile(`${AgentSignals.BENCHMARK} Middleware onMessage error:`, e);
+        }
+
+        // Each completed assistant message arrives as a run-item event; flush
+        // the whole message text to the bridge so markers parse intact.
+        if (
+          event.type === 'run_item_stream_event' &&
+          event.item.type === 'message_output_item'
+        ) {
+          const { abort } = bridge.handleAssistantText(event.item.content);
+          if (abort) abortController.abort();
+        }
+      }
+      // Surface any error the stream deferred to completion.
+      await result.completed;
+    } catch (error) {
+      return concludeError(error, conclude);
+    } finally {
+      await closePiMcpServers(mcpServers);
+    }
+
+    return concludeRun({
+      ...conclude,
+      finalizeMessage: { type: 'result', subtype: 'success' },
+    });
+  }
+}

--- a/src/lib/agent/runner/pi/tools.ts
+++ b/src/lib/agent/runner/pi/tools.ts
@@ -1,0 +1,70 @@
+import type { Tool } from '@openai/agents';
+import {
+  BUILTIN_TOOLS,
+  createToolDispatcher,
+  type ToolDispatcher,
+} from '../shared/tools/registry';
+import type { ToolContext, ToolDefinition } from '../shared/tools/types';
+
+/**
+ * The OpenAI Agents SDK's non-strict JSON-schema tool parameter shape. Building
+ * the parameters this way (rather than from a Zod schema) keeps the adapter off
+ * the SDK's `strict: true` + Zod path — our handlers already validate their
+ * input at runtime via Zod, so the model-facing schema only needs to advertise
+ * the shape.
+ */
+interface NonStrictParameters {
+  type: 'object';
+  properties: Record<string, Record<string, unknown>>;
+  required: string[];
+  additionalProperties: true;
+}
+
+/**
+ * Normalize a neutral `ToolDefinition.inputSchema` into the SDK's non-strict
+ * parameter object: it requires `required` and `additionalProperties` to be
+ * present, which our JSON Schemas leave implicit.
+ */
+export function toNonStrictParameters(
+  inputSchema: Record<string, unknown>,
+): NonStrictParameters {
+  const properties =
+    (inputSchema.properties as Record<string, Record<string, unknown>>) ?? {};
+  const required = Array.isArray(inputSchema.required)
+    ? (inputSchema.required as string[])
+    : [];
+  return { type: 'object', properties, required, additionalProperties: true };
+}
+
+/**
+ * Adapt the shared coding toolset to the OpenAI Agents SDK's `tool()` shape.
+ *
+ * Each neutral `ToolDefinition` becomes a non-strict function tool whose
+ * `execute` routes through the shared dispatcher; the SDK's `run()` loop drives
+ * the calls. The Task* handlers mutate the shared store and fire
+ * `ctx.onTasksChange` from inside these closures, which the runner wires to the
+ * TUI todo sync. Security gating (canUseTool + YARA) wraps the dispatcher in
+ * #525, not here. The SDK is ESM-only, so it's imported dynamically.
+ */
+export async function createPiTools(
+  ctx: ToolContext,
+  defs: ToolDefinition[] = BUILTIN_TOOLS,
+): Promise<Tool[]> {
+  const { tool } = await import('@openai/agents');
+  const dispatcher: ToolDispatcher = createToolDispatcher(ctx, defs);
+  return defs.map((def) =>
+    tool({
+      name: def.name,
+      description: def.description,
+      parameters: toNonStrictParameters(def.inputSchema),
+      strict: false,
+      async execute(input: unknown): Promise<string> {
+        const result = await dispatcher.dispatch({ name: def.name, input });
+        // Return the textual result even on error (rather than throwing) so the
+        // loop continues and the model can recover — matching the SDK path's
+        // tool_result with is_error.
+        return result.content;
+      },
+    }),
+  );
+}

--- a/src/lib/agent/runner/shared/model.ts
+++ b/src/lib/agent/runner/shared/model.ts
@@ -1,5 +1,14 @@
-import type { LanguageModel } from 'ai';
+import type { createAnthropic } from '@ai-sdk/anthropic';
 import { readGatewayEnv, buildGatewayHeaders } from './gateway';
+
+/**
+ * The provider model `@ai-sdk/anthropic` returns. Derived from the provider so
+ * we don't depend on `@ai-sdk/provider` (a transitive dep) for its name — and so
+ * the precise model type flows to both consumers: the `vercel` runner's
+ * `ToolLoopAgent` (which also accepts a bare id) and the `pi` runner's `aisdk()`
+ * adapter (which rejects the bare-id form, so it needs this exact type).
+ */
+type GatewayModel = ReturnType<ReturnType<typeof createAnthropic>>;
 
 /**
  * Build the gateway-pointed `@ai-sdk/anthropic` model both runners use.
@@ -19,7 +28,7 @@ export async function createGatewayAnthropicModel(
   modelId: string,
   wizardMetadata: Record<string, string>,
   wizardFlags: Record<string, string>,
-): Promise<LanguageModel> {
+): Promise<GatewayModel> {
   const { createAnthropic } = await import('@ai-sdk/anthropic');
   const { baseUrl, authToken } = readGatewayEnv();
   return createAnthropic({


### PR DESCRIPTION
Closes #524

**Epic:** #520 · **Behavior change:** none (flag off) · **Depends on:** #522

## Summary
Implement `PiRunner` on the OpenAI Agents SDK (`@openai/agents`), made **model-agnostic** via the AI SDK
model adapter so it drives the PostHog gateway. Selected at `wizard-runner=pi`.

## Scope
- Deps: `@openai/agents`, `@openai/agents-extensions` (aisdk adapter), `@ai-sdk/anthropic`.
- Model: wrap the gateway model with `aisdk(createAnthropic({ baseURL, headers, apiKey })(modelId))` so the
  Agents SDK runs a non-OpenAI model.
- Agent + loop: define an `Agent` with the shared coding toolset; run via the Agents SDK `run()`.
- MCP: `MCPServerStreamableHttp` for posthog-wizard (+ wizard-tools).
- Streaming: consume run stream events → shared stream→TUI bridge.
- Errors → `AgentErrorType`; honor `[ABORT]`.

## Acceptance criteria
- [ ] A text-only **and** a tool-using run complete end-to-end against the gateway through the aisdk adapter.
- [ ] Streaming + markers reach the TUI.
- [ ] Flag stays 0% `pi`; anthropic unaffected.
- [ ] Unit tests for runner wiring (mocked model) incl. stop guard.

## Files
- `src/lib/agent/runner/pi-runner.ts`

## Notes
The Agents SDK's tool-input **guardrails** are the natural home for the security layer (#525).

