### PR TITLE
fix: install skills without curl/unzip for Windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@langchain/core": "^0.3.40",
     "axios": "1.7.4",
     "fast-glob": "^3.3.3",
+    "fflate": "^0.8.2",
     "glob": "9.3.5",
     "ink": "^6.8.0",
     "inquirer": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       glob:
         specifier: 9.3.5
         version: 9.3.5
@@ -2375,6 +2378,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -6541,6 +6547,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   figures@2.0.0:
     dependencies:

--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { zipSync, strToU8 } from 'fflate';
 import {
   ASK_BATCH_THRESHOLD,
   DEFAULT_ASK_MAX_QUESTIONS,
@@ -341,5 +342,40 @@ describe('evaluateAskCap', () => {
       reason: 'max_questions',
       message: expect.any(String),
     });
+  });
+});
+
+describe('extractZipTo', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  it('writes nested files in-process without shelling out to unzip', () => {
+    const zip = zipSync({
+      'SKILL.md': strToU8('# skill'),
+      'references/guide.md': strToU8('details'),
+    });
+
+    __test.extractZipTo(zip, dir);
+
+    expect(fs.readFileSync(path.join(dir, 'SKILL.md'), 'utf8')).toBe('# skill');
+    expect(
+      fs.readFileSync(path.join(dir, 'references', 'guide.md'), 'utf8'),
+    ).toBe('details');
+  });
+
+  it('rejects zip-slip entries that escape the destination', () => {
+    const zip = zipSync({ '../escape.md': strToU8('pwned') });
+
+    expect(() => __test.extractZipTo(zip, dir)).toThrow(/unsafe path/i);
+    expect(fs.existsSync(path.join(path.dirname(dir), 'escape.md'))).toBe(
+      false,
+    );
   });
 });

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -11,11 +11,11 @@
 
 import path from 'path';
 import fs from 'fs';
-import { execFileSync } from 'child_process';
+import axios from 'axios';
+import { unzipSync } from 'fflate';
 import { z } from 'zod';
 import { logToFile } from '@utils/debug';
 import { analytics } from '@utils/analytics';
-import { skillTmpPath } from '@utils/paths';
 import type { PackageManagerDetector } from './detection/package-manager';
 import {
   AUDIT_CHECKS_FILE,
@@ -84,31 +84,30 @@ export async function fetchSkillMenu(
  * Download and extract a skill.
  * By default installs to `<installDir>/.claude/skills/<id>/`.
  * Pass `skillsRoot` to override the base directory (e.g. `.posthog/skills`).
+ *
+ * Downloads the zip into memory and extracts it in-process. This stays
+ * cross-platform: the earlier `curl`/`unzip` shell-out broke on Windows,
+ * which ships neither an `unzip` binary nor a `/tmp` directory.
  */
-export function downloadSkill(
+export async function downloadSkill(
   skillEntry: SkillEntry,
   installDir: string,
   skillsRoot?: string,
-): { success: boolean; error?: string } {
+): Promise<{ success: boolean; error?: string }> {
   const skillDir = skillsRoot
     ? path.join(installDir, skillsRoot, skillEntry.id)
     : path.join(installDir, '.claude', 'skills', skillEntry.id);
-  const tmpFile = skillTmpPath(skillEntry.id);
 
   try {
     fs.mkdirSync(skillDir, { recursive: true });
-    execFileSync('curl', ['-sL', skillEntry.downloadUrl, '-o', tmpFile], {
+
+    const resp = await axios.get<ArrayBuffer>(skillEntry.downloadUrl, {
+      responseType: 'arraybuffer',
       timeout: 30000,
     });
-    execFileSync('unzip', ['-o', tmpFile, '-d', skillDir], {
-      timeout: 30000,
-    });
+    extractZipTo(new Uint8Array(resp.data), skillDir);
+
     fs.writeFileSync(path.join(skillDir, '.posthog-wizard'), '');
-    try {
-      fs.unlinkSync(tmpFile);
-    } catch {
-      /* ignore cleanup errors */
-    }
 
     logToFile(
       `downloadSkill: installed ${skillEntry.id} from ${skillEntry.downloadUrl}`,
@@ -117,6 +116,24 @@ export function downloadSkill(
   } catch (err: any) {
     logToFile(`downloadSkill: error: ${err.message}`);
     return { success: false, error: err.message };
+  }
+}
+
+/**
+ * Extract a zip archive's bytes into `destDir`. Rejects entries whose path
+ * escapes `destDir` (zip-slip) before writing anything to disk.
+ */
+function extractZipTo(zip: Uint8Array, destDir: string): void {
+  const entries = unzipSync(zip);
+  for (const [name, data] of Object.entries(entries)) {
+    if (name.endsWith('/')) continue; // directory entry; parents made on demand
+    const dest = path.join(destDir, name);
+    const rel = path.relative(destDir, dest);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error(`unsafe path in skill archive: ${name}`);
+    }
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, data);
   }
 }
 
@@ -154,7 +171,7 @@ export async function installSkillById(
     .find((s) => s.id === skillId);
   if (!skill) return { kind: 'skill-not-found', skillId };
 
-  const result = downloadSkill(skill, installDir, skillsRoot);
+  const result = await downloadSkill(skill, installDir, skillsRoot);
   if (!result.success) {
     return { kind: 'download-failed', message: result.error ?? 'unknown' };
   }
@@ -735,7 +752,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
           'Skill ID from the skill menu (e.g., "integration-nextjs-app-router")',
         ),
     },
-    (args: { skillId: string }) => {
+    async (args: { skillId: string }) => {
       if (!/^[a-z0-9][a-z0-9_-]*$/.test(args.skillId)) {
         return {
           content: [
@@ -763,7 +780,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         };
       }
 
-      const result = downloadSkill(skill, workingDirectory);
+      const result = await downloadSkill(skill, workingDirectory);
       if (result.success) {
         return {
           content: [
@@ -1150,4 +1167,5 @@ export const __test = {
   applyAuditUpdates,
   makeMutex,
   AUDIT_CHECKS_FILE,
+  extractZipTo,
 };

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -135,7 +135,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
         s.id.startsWith(prefix),
       );
       for (const skill of skills) {
-        downloadSkill(skill, store.session.installDir, '.posthog/skills');
+        await downloadSkill(skill, store.session.installDir, '.posthog/skills');
       }
     }
     setDownloaded(true);

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -10,10 +10,6 @@ export const WIZARD_YARA_REPORT_FILE = join(
   TMP,
   'posthog-wizard-yara-report.json',
 );
-/** Temp path for a skill download zip. */
-export function skillTmpPath(skillId: string): string {
-  return join(TMP, `posthog-skill-${skillId}.zip`);
-}
 
 /**
  * Strip an absolute installDir prefix off a project file path so the UI


### PR DESCRIPTION
## Problem

Skill installation does not work on Windows. `downloadSkill` shells out to two external binaries:

```ts
execFileSync('curl', ['-sL', url, '-o', tmpFile])
execFileSync('unzip', ['-o', tmpFile, '-d', skillDir])
```

Windows ships `curl.exe`, but it has **no `unzip` binary**, so extraction throws and the skill never lands.

This is the same Windows breakage discussed on #410 (Matt's review). #417 fixed *where* the temp zip is written (`os.tmpdir()` instead of a hardcoded `/tmp`), but that only addressed the path — the `unzip` call one line later still fails on Windows, so skills still don't install there.

## Changes

Drop both external-binary dependencies in `downloadSkill` (`src/lib/wizard-tools.ts`):

- **Download** the zip into memory with `axios` (already a dependency, used in `api.ts` / `posthog-doctor`) instead of `curl`.
- **Extract** in-process with `fflate` (pure-JS, no native deps) via a new `extractZipTo` helper, with a **zip-slip guard** that rejects archive entries escaping the destination before any write.
- No temp file anymore → removed the now-dead `skillTmpPath` from `paths.ts`. This also moots the temp-file collision/cleanup concern raised on #410.
- `downloadSkill` is now `async`; updated all three call sites (`installSkillById`, the `install_skill` MCP handler, and `HealthCheckScreen`).

Net effect: one 8KB pure-JS dependency added, two process spawns (`curl` + `unzip`) removed.

## Test plan

- New unit tests in `wizard-tools.test.ts` for `extractZipTo`: nested-file extraction and zip-slip rejection.
- `pnpm build`, `pnpm typecheck`, and `pnpm lint` pass (0 errors).
- Full `wizard-tools` suite green (20 tests).