### PR TITLE
chore: Tidy wizard env vars: WIZARD_ prefix, ignore in prod builds

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run smoke test
         env:
-          POSTHOG_PERSONAL_API_KEY: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_POSTHOG_PERSONAL_KEY }}
+          WIZARD_API_KEY: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_POSTHOG_PERSONAL_KEY }}
           WIZARD_WORKBENCH_ROOT: ${{ github.workspace }}/wizard-workbench
           SMOKE_TEST_APP: ${{ inputs.app || 'basic-integration/next-js/15-app-router-todo' }}
         run: ./scripts/smoke-test-ci.sh "$SMOKE_TEST_APP"

--- a/README.md
+++ b/README.md
@@ -99,11 +99,14 @@ The following CLI arguments are available:
 | ----------------- | ---------------------------------------------------------------- | ------- | ------- | ---------------------------------------------------- | ------------------------------ |
 | `--help`          | Show help                                                        | boolean |         |                                                      |                                |
 | `--version`       | Show version number                                              | boolean |         |                                                      |                                |
-| `--debug`         | Enable verbose logging                                           | boolean | `false` |                                                      | `POSTHOG_WIZARD_DEBUG`         |
-| `--signup`        | Create a new PostHog account during setup                        | boolean | `false` |                                                      | `POSTHOG_WIZARD_SIGNUP`        |
-| `--install-dir`   | Directory to install PostHog in                                  | string  |         |                                                      | `POSTHOG_WIZARD_INSTALL_DIR`   |
-| `--ci`            | Enable CI mode for non-interactive execution                     | boolean | `false` |                                                      | `POSTHOG_WIZARD_CI`            |
-| `--api-key`       | PostHog personal API key (phx_xxx) for authentication            | string  |         |                                                      | `POSTHOG_WIZARD_API_KEY`       |
+| `--debug`         | Enable verbose logging                                           | boolean | `false` |                                                      | `WIZARD_DEBUG`                 |
+| `--signup`        | Create a new PostHog account during setup                        | boolean | `false` |                                                      | `WIZARD_SIGNUP`                |
+| `--install-dir`   | Directory to install PostHog in                                  | string  |         |                                                      | `WIZARD_INSTALL_DIR`           |
+| `--ci`            | Enable CI mode for non-interactive execution                     | boolean | `false` |                                                      | `WIZARD_CI`                    |
+| `--api-key`       | PostHog personal API key (phx_xxx) for authentication            | string  |         |                                                      | `WIZARD_API_KEY`               |
+
+> The `WIZARD_*` environment variables are a dev/CI-only convenience and are
+> ignored in the published package — drive the shipped CLI through the flags.
 
 
 # CI Mode
@@ -118,7 +121,7 @@ The following CLI arguments are available:
 Run the wizard non-interactive executions with `--ci`:
 
 ```bash
-npx @posthog/wizard --ci --api-key $POSTHOG_PERSONAL_API_KEY --install-dir .
+npx @posthog/wizard --ci --api-key $WIZARD_API_KEY --install-dir .
 ```
 
 When running in CI mode (`--ci`):
@@ -179,8 +182,8 @@ When the user authenticates, the wizard also streams live run state — current
 phase, task list, planned events — to `POST /api/projects/{id}/wizard/sessions/`
 so the PostHog web app can render real-time progress. Updates are debounced
 (250ms) with phase changes flushed immediately; failures fall back silently to
-the wizard's debug log without disturbing the TUI. Pass `--no-telemetry` (or
-set `POSTHOG_WIZARD_NO_TELEMETRY=1`) to disable.
+the wizard's debug log without disturbing the TUI. Pass `--no-telemetry` to
+disable (in dev/CI, `WIZARD_NO_TELEMETRY=1` works too).
 
 ## Leave rules behind
 
@@ -249,16 +252,15 @@ Built with [tsdown](https://tsdown.dev/) (Rolldown). `pnpm build` bundles `bin.t
 
 To add a new build-time constant, add it to `env` in `tsdown.config.ts` and export it from `src/env.ts`.
 
-**Runtime (allowlisted).** Runtime env reads go through `runtimeEnv()` in `src/env.ts`, which only accepts keys in the `RuntimeEnvKey` union:
+**Runtime (allowlisted).** Runtime env reads go through `runtimeEnv()` in `src/env.ts`, which only accepts keys in the `RuntimeEnvKey` union. The `WIZARD_*` keys are dev/CI-only — `runtimeEnv()` ignores them in published builds:
 
 | Variable | Purpose |
 |---|---|
-| `POSTHOG_WIZARD_BENCHMARK_CONFIG` | Path to benchmark config file |
-| `POSTHOG_WIZARD_BENCHMARK_FILE` | Output path for benchmark results |
-| `POSTHOG_WIZARD_LOG_DIR` | Log directory override |
-| `POSTHOG_WIZARD_DEBUG` / `DEBUG` | Enable debug output |
+| `WIZARD_BENCHMARK_CONFIG` | Path to benchmark config file |
+| `WIZARD_BENCHMARK_FILE` | Output path for benchmark results |
+| `WIZARD_LOG_DIR` | Log directory override |
+| `WIZARD_DEBUG` / `DEBUG` | Enable debug output |
 | `MCP_URL` | Override MCP server URL |
-| `POSTHOG_API_KEY` | API key for MCP subprocess auth |
 | `TERM`, `TERM_PROGRAM`, `CI`, etc. | Terminal/platform detection |
 | `APPDATA`, `XDG_CONFIG_HOME` | Platform path resolution |
 
@@ -377,8 +379,8 @@ This repo includes a helper script to run a full end‑to‑end smoke test of th
 - Point to a `wizard-workbench` checkout either by:
   - Setting `WIZARD_WORKBENCH_ROOT=/absolute/path/to/wizard-workbench`, or
   - Cloning `wizard-workbench` next to this repo (so it lives at `../wizard-workbench`).
-- Set `POSTHOG_PERSONAL_API_KEY` either in your shell or in `../wizard-workbench/.env`.
-- (Optional) Set `POSTHOG_PROJECT_ID` to target a specific PostHog project.
+- Set `WIZARD_API_KEY` either in your shell or in `../wizard-workbench/.env`.
+- (Optional) Set `WIZARD_PROJECT_ID` to target a specific PostHog project.
 
 **Usage**
 
@@ -390,8 +392,8 @@ This repo includes a helper script to run a full end‑to‑end smoke test of th
 ./scripts/smoke-test-ci.sh next-js/15-pages-router-saas
 
 # With API key (and optional project ID) inline
-POSTHOG_PERSONAL_API_KEY=phx_your_key_here \
-POSTHOG_PROJECT_ID=12345 \
+WIZARD_API_KEY=phx_your_key_here \
+WIZARD_PROJECT_ID=12345 \
 ./scripts/smoke-test-ci.sh next-js/15-pages-router-saas
 
 # Pointing at a custom wizard-workbench checkout

--- a/scripts/smoke-test-ci.sh
+++ b/scripts/smoke-test-ci.sh
@@ -4,7 +4,7 @@
 # wizard-workbench, and run in CI mode.
 #
 # Prerequisites:
-#   - POSTHOG_PERSONAL_API_KEY env var (or in .env)
+#   - WIZARD_API_KEY env var (or in .env)
 #   - A wizard-workbench repo checked out (for the test app), pointed to by:
 #       - WIZARD_WORKBENCH_ROOT=/path/to/wizard-workbench
 #         or
@@ -16,15 +16,15 @@
 #
 # Examples:
 #   # With API key inline:
-#   POSTHOG_PERSONAL_API_KEY=phx_your_key_here ./scripts/smoke-test-ci.sh
+#   WIZARD_API_KEY=phx_your_key_here ./scripts/smoke-test-ci.sh
 #
 #   # With project ID override:
-#   POSTHOG_PERSONAL_API_KEY=phx_your_key_here POSTHOG_PROJECT_ID=12345 ./scripts/smoke-test-ci.sh
+#   WIZARD_API_KEY=phx_your_key_here WIZARD_PROJECT_ID=12345 ./scripts/smoke-test-ci.sh
 #
 #   # Specific app:
-#   POSTHOG_PERSONAL_API_KEY=phx_your_key_here ./scripts/smoke-test-ci.sh basic-integration/next-js/15-pages-router-saas
+#   WIZARD_API_KEY=phx_your_key_here ./scripts/smoke-test-ci.sh basic-integration/next-js/15-pages-router-saas
 #
-#   # If ../wizard-workbench/.env has POSTHOG_PERSONAL_API_KEY, just:
+#   # If ../wizard-workbench/.env has WIZARD_API_KEY, just:
 #   ./scripts/smoke-test-ci.sh
 #
 set -euo pipefail
@@ -59,21 +59,21 @@ if [ ! -d "$APP_SRC" ]; then
   exit 1
 fi
 
-# Load .env from workbench if it exists (for POSTHOG_PERSONAL_API_KEY)
+# Load .env from workbench if it exists (for WIZARD_API_KEY)
 if [ -f "$WORKBENCH_ROOT/.env" ]; then
   set -a
   source "$WORKBENCH_ROOT/.env"
   set +a
 fi
 
-API_KEY="${POSTHOG_PERSONAL_API_KEY:-}"
+API_KEY="${WIZARD_API_KEY:-}"
 if [ -z "$API_KEY" ]; then
-  echo "ERROR: POSTHOG_PERSONAL_API_KEY not set"
+  echo "ERROR: WIZARD_API_KEY not set"
   echo "Set it in your environment or in $WORKBENCH_ROOT/.env"
   exit 1
 fi
 
-PROJECT_ID="${POSTHOG_PROJECT_ID:-}"
+PROJECT_ID="${WIZARD_PROJECT_ID:-}"
 
 # ── Build & Pack ────────────────────────────────────────────────────────────
 # Build the CI variant (NODE_ENV=ci): identical to the published build except

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -68,11 +68,11 @@ describe('CLI argument parsing', () => {
 
     // Reset environment
     process.env = { ...originalEnv };
-    delete process.env.POSTHOG_WIZARD_REGION;
-    delete process.env.POSTHOG_WIZARD_DEFAULT;
-    delete process.env.POSTHOG_WIZARD_CI;
-    delete process.env.POSTHOG_WIZARD_API_KEY;
-    delete process.env.POSTHOG_WIZARD_INSTALL_DIR;
+    delete process.env.WIZARD_REGION;
+    delete process.env.WIZARD_DEFAULT;
+    delete process.env.WIZARD_CI;
+    delete process.env.WIZARD_API_KEY;
+    delete process.env.WIZARD_INSTALL_DIR;
 
     // Mock process.exit so the test runner doesn't exit. The CLI dispatch is
     // async (it dynamically imports the matched command file), so a throwing
@@ -132,8 +132,8 @@ describe('CLI argument parsing', () => {
   });
 
   describe('environment variables', () => {
-    test('respects POSTHOG_WIZARD_REGION', async () => {
-      process.env.POSTHOG_WIZARD_REGION = 'eu';
+    test('respects WIZARD_REGION', async () => {
+      process.env.WIZARD_REGION = 'eu';
 
       await runCLI([]);
 
@@ -141,7 +141,7 @@ describe('CLI argument parsing', () => {
     });
 
     test('CLI args override environment variables', async () => {
-      process.env.POSTHOG_WIZARD_REGION = 'us';
+      process.env.WIZARD_REGION = 'us';
 
       await runCLI(['--region', 'eu']);
 
@@ -228,11 +228,11 @@ describe('CLI argument parsing', () => {
   });
 
   describe('CI environment variables', () => {
-    test('respects POSTHOG_WIZARD_CI', async () => {
-      process.env.POSTHOG_WIZARD_CI = 'true';
-      process.env.POSTHOG_WIZARD_REGION = 'us';
-      process.env.POSTHOG_WIZARD_API_KEY = 'phx_env_key';
-      process.env.POSTHOG_WIZARD_INSTALL_DIR = '/tmp/test';
+    test('respects WIZARD_CI', async () => {
+      process.env.WIZARD_CI = 'true';
+      process.env.WIZARD_REGION = 'us';
+      process.env.WIZARD_API_KEY = 'phx_env_key';
+      process.env.WIZARD_INSTALL_DIR = '/tmp/test';
 
       await runCLI([]);
 
@@ -240,11 +240,11 @@ describe('CLI argument parsing', () => {
       expect(args.ci).toBe(true);
     });
 
-    test('respects POSTHOG_WIZARD_API_KEY', async () => {
-      process.env.POSTHOG_WIZARD_CI = 'true';
-      process.env.POSTHOG_WIZARD_REGION = 'eu';
-      process.env.POSTHOG_WIZARD_API_KEY = 'phx_env_key';
-      process.env.POSTHOG_WIZARD_INSTALL_DIR = '/tmp/test';
+    test('respects WIZARD_API_KEY', async () => {
+      process.env.WIZARD_CI = 'true';
+      process.env.WIZARD_REGION = 'eu';
+      process.env.WIZARD_API_KEY = 'phx_env_key';
+      process.env.WIZARD_INSTALL_DIR = '/tmp/test';
 
       await runCLI([]);
 
@@ -253,10 +253,10 @@ describe('CLI argument parsing', () => {
     });
 
     test('CLI args override CI environment variables', async () => {
-      process.env.POSTHOG_WIZARD_CI = 'true';
-      process.env.POSTHOG_WIZARD_REGION = 'us';
-      process.env.POSTHOG_WIZARD_API_KEY = 'phx_env_key';
-      process.env.POSTHOG_WIZARD_INSTALL_DIR = '/tmp/test';
+      process.env.WIZARD_CI = 'true';
+      process.env.WIZARD_REGION = 'us';
+      process.env.WIZARD_API_KEY = 'phx_env_key';
+      process.env.WIZARD_INSTALL_DIR = '/tmp/test';
 
       await runCLI([
         '--region',

--- a/src/commands/basic-integration/index.ts
+++ b/src/commands/basic-integration/index.ts
@@ -1,3 +1,4 @@
+import { wizardEnvBool, wizardEnvDefault } from '@env';
 import { isNonInteractiveEnvironment } from '@utils/environment';
 import { provisionCommand } from '../provision';
 import type { Command } from '../command';
@@ -10,8 +11,8 @@ export const basicIntegrationCommand: Command = {
   children: [provisionCommand],
   options: {
     'install-dir': {
-      describe:
-        'Directory to install PostHog in\nenv: POSTHOG_WIZARD_INSTALL_DIR',
+      ...wizardEnvDefault('INSTALL_DIR'),
+      describe: 'Directory to install PostHog in\nenv: WIZARD_INSTALL_DIR',
       type: 'string',
     },
     playground: {
@@ -20,26 +21,27 @@ export const basicIntegrationCommand: Command = {
       type: 'boolean',
     },
     benchmark: {
-      default: false,
+      default: wizardEnvBool('BENCHMARK', false),
       describe:
-        'Run in benchmark mode with per-phase token tracking\nenv: POSTHOG_WIZARD_BENCHMARK',
+        'Run in benchmark mode with per-phase token tracking\nenv: WIZARD_BENCHMARK',
       type: 'boolean',
     },
     'yara-report': {
-      default: false,
+      default: wizardEnvBool('YARA_REPORT', false),
       describe:
-        'Print YARA scanner summary after the agent run\nenv: POSTHOG_WIZARD_YARA_REPORT',
+        'Print YARA scanner summary after the agent run\nenv: WIZARD_YARA_REPORT',
       type: 'boolean',
       hidden: true,
     },
     skill: {
-      describe:
-        'Run a specific context-mill skill by ID\nenv: POSTHOG_WIZARD_SKILL',
+      ...wizardEnvDefault('SKILL'),
+      describe: 'Run a specific context-mill skill by ID\nenv: WIZARD_SKILL',
       type: 'string',
     },
     name: {
+      ...wizardEnvDefault('NAME'),
       describe:
-        'Name for account creation with --ci --signup\nenv: POSTHOG_WIZARD_NAME',
+        'Name for account creation with --ci --signup\nenv: WIZARD_NAME',
       type: 'string',
     },
   },

--- a/src/env.ts
+++ b/src/env.ts
@@ -28,7 +28,9 @@ export const IS_DEV =
  * `process.env.NODE_ENV` as the literal `"production"` at build time, so this
  * collapses to `true` in `dist/` and stays `false` for `tsx`/dev/test runs
  * (where NODE_ENV is unset, `development`, or `test`). Used to gate features
- * that aren't supported in the shipped package — e.g. `--ci` mode.
+ * that aren't supported in the shipped package — `--ci` mode and the
+ * `WIZARD_*` env vars, which are dev/CI-only knobs (see `runtimeEnv` and
+ * `wizard.ts`). End users drive published builds through flags only.
  */
 export const IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production';
 
@@ -39,15 +41,15 @@ export const IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production';
  * Add new keys here when a new runtime dependency is needed.
  */
 type RuntimeEnvKey =
-  // Wizard CLI configuration (yargs POSTHOG_WIZARD_ prefix)
-  | 'POSTHOG_WIZARD_BENCHMARK_CONFIG'
-  | 'POSTHOG_WIZARD_BENCHMARK_FILE'
-  | 'POSTHOG_WIZARD_LOG_DIR'
-  | 'POSTHOG_WIZARD_DEBUG'
+  // Wizard CLI configuration (WIZARD_ prefix; dev/CI-only — gated out of
+  // published builds, see runtimeEnv below)
+  | 'WIZARD_BENCHMARK_CONFIG'
+  | 'WIZARD_BENCHMARK_FILE'
+  | 'WIZARD_LOG_DIR'
+  | 'WIZARD_DEBUG'
   | 'DEBUG'
   // Agent / MCP
   | 'MCP_URL'
-  | 'POSTHOG_API_KEY'
   // Platform: terminal detection
   | 'TERM'
   | 'TERM_PROGRAM'
@@ -60,7 +62,53 @@ type RuntimeEnvKey =
   | 'APPDATA'
   | 'XDG_CONFIG_HOME';
 
-/** Read a runtime environment variable. Only allowlisted keys compile. */
+/**
+ * Read a runtime environment variable. Only allowlisted keys compile.
+ *
+ * `WIZARD_*` keys are dev/CI-only configuration knobs; they are ignored in
+ * published builds (`IS_PRODUCTION_BUILD`) so the shipped package can't be
+ * driven by environment variables — end users use flags instead.
+ */
 export function runtimeEnv(key: RuntimeEnvKey): string | undefined {
+  if (IS_PRODUCTION_BUILD && key.startsWith('WIZARD_')) return undefined;
   return process.env[key];
+}
+
+// ── CLI option env overrides ─────────────────────────────────────────
+// Each global/command flag can also be set via a `WIZARD_<NAME>` env var
+// in dev/CI (e.g. `WIZARD_API_KEY` backs `--api-key`). These are wired as
+// per-option yargs defaults rather than yargs' `.env()` prefix on purpose:
+// the prefix greedily claims the whole `WIZARD_*` namespace and, under
+// strictOptions, rejects any stray var in it (the build's own
+// `WIZARD_BUILD_NODE_ENV`, the workbench's `WIZARD_PATH`, …). Reading only
+// the names we declare keeps unrelated `WIZARD_*` vars from breaking parsing.
+// Published builds ignore them (`IS_PRODUCTION_BUILD`) — flags only.
+
+/** Raw `WIZARD_<NAME>` option override, or undefined (dev/CI only). */
+function optionEnv(name: string): string | undefined {
+  if (IS_PRODUCTION_BUILD) return undefined;
+  const value = process.env[`WIZARD_${name}`];
+  return value == null || value === '' ? undefined : value;
+}
+
+/**
+ * `WIZARD_<NAME>` as a spreadable yargs string-option default, e.g.
+ * `{ ...wizardEnvDefault('API_KEY') }`. Returns `{ default }` only when the env
+ * var is set; otherwise `{}`, so the option keeps its native no-default parsing
+ * (a bare `--skill` still yields `''`, which validation relies on).
+ */
+export function wizardEnvDefault(name: string): { default?: string } {
+  const value = optionEnv(name);
+  return value === undefined ? {} : { default: value };
+}
+
+/**
+ * `WIZARD_<NAME>` as a yargs boolean-option default. Falls back to `fallback`
+ * when unset; otherwise anything but `0`/`false`/`no` is truthy.
+ */
+export function wizardEnvBool(name: string, fallback: boolean): boolean {
+  const value = optionEnv(name);
+  if (value == null) return fallback;
+  const norm = value.toLowerCase();
+  return norm !== '0' && norm !== 'false' && norm !== 'no';
 }

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -986,6 +986,9 @@ export async function runAgent(
           ...process.env,
           // Prevent user's Anthropic API key from overriding the wizard's OAuth token
           ANTHROPIC_API_KEY: undefined,
+          // Likewise drop a stray POSTHOG_API_KEY so the agent/MCP authenticate
+          // with the wizard's OAuth credentials, not a key from the user's shell.
+          POSTHOG_API_KEY: undefined,
           // Defer MCP tool schemas to avoid bloating the system prompt.
           // The posthog-wizard MCP exposes many query tools with large schemas;
           // without deferral these consume ~113k tokens upfront, leaving

--- a/src/lib/agent/mcp-prompt-streaming.ts
+++ b/src/lib/agent/mcp-prompt-streaming.ts
@@ -347,6 +347,9 @@ export async function* runMcpPromptViaSdk(args: {
           // the PostHog LLM gateway — defeats quota tracking and the
           // OAuth flow even though our other env vars are correct.
           ANTHROPIC_API_KEY: undefined,
+          // Likewise drop a stray POSTHOG_API_KEY so the MCP authenticates
+          // with the wizard's OAuth credentials, not a key from the user's shell.
+          POSTHOG_API_KEY: undefined,
           // Defer MCP tool schemas to avoid bloating the system prompt.
           // posthog-wizard exposes many query tools with large schemas;
           // without deferral these consume ~113k tokens upfront, which

--- a/src/lib/middleware/config.ts
+++ b/src/lib/middleware/config.ts
@@ -52,7 +52,7 @@ const DEFAULT_CONFIG: BenchmarkConfig = {
 
 export function loadBenchmarkConfig(installDir: string): BenchmarkConfig {
   const configPath =
-    runtimeEnv('POSTHOG_WIZARD_BENCHMARK_CONFIG') ??
+    runtimeEnv('WIZARD_BENCHMARK_CONFIG') ??
     path.join(installDir, '.benchmark-config.json');
   try {
     const raw = fs.readFileSync(configPath, 'utf-8');
@@ -63,11 +63,11 @@ export function loadBenchmarkConfig(installDir: string): BenchmarkConfig {
     };
 
     // Env var overrides for parallel runs
-    const benchFile = runtimeEnv('POSTHOG_WIZARD_BENCHMARK_FILE');
+    const benchFile = runtimeEnv('WIZARD_BENCHMARK_FILE');
     if (benchFile) {
       config.output.benchmarkPath = benchFile;
     }
-    const logDir = runtimeEnv('POSTHOG_WIZARD_LOG_DIR');
+    const logDir = runtimeEnv('WIZARD_LOG_DIR');
     if (logDir) {
       config.output.logPath = path.join(logDir, 'posthog-wizard.log');
     }
@@ -84,11 +84,11 @@ export function loadBenchmarkConfig(installDir: string): BenchmarkConfig {
     const config = structuredClone(DEFAULT_CONFIG);
 
     // Env var overrides
-    const benchFile2 = runtimeEnv('POSTHOG_WIZARD_BENCHMARK_FILE');
+    const benchFile2 = runtimeEnv('WIZARD_BENCHMARK_FILE');
     if (benchFile2) {
       config.output.benchmarkPath = benchFile2;
     }
-    const logDir2 = runtimeEnv('POSTHOG_WIZARD_LOG_DIR');
+    const logDir2 = runtimeEnv('WIZARD_LOG_DIR');
     if (logDir2) {
       config.output.logPath = path.join(logDir2, 'posthog-wizard.log');
     }

--- a/src/lib/runners/resolve-no-telemetry.ts
+++ b/src/lib/runners/resolve-no-telemetry.ts
@@ -1,11 +1,15 @@
+import { IS_PRODUCTION_BUILD } from '@env';
+
 /**
- * `--no-telemetry` flips `telemetry: false` via yargs negation;
- * `POSTHOG_WIZARD_NO_TELEMETRY` is honoured separately so the env-var
- * form documented in the README keeps working.
+ * `--no-telemetry` flips `telemetry: false` via yargs negation; the
+ * `WIZARD_NO_TELEMETRY` env var is honoured separately as a dev/CI-only form.
+ * The env var is ignored in published builds (`IS_PRODUCTION_BUILD`) — in the
+ * shipped CLI, `--no-telemetry` is the way to opt out.
  */
 export function resolveNoTelemetry(options: Record<string, unknown>): boolean {
   if (options.telemetry === false) return true;
-  const env = process.env.POSTHOG_WIZARD_NO_TELEMETRY;
+  if (IS_PRODUCTION_BUILD) return false;
+  const env = process.env.WIZARD_NO_TELEMETRY;
   if (env == null || env === '') return false;
   const norm = env.toLowerCase();
   return norm !== '0' && norm !== 'false';

--- a/src/lib/runners/run-wizard.ts
+++ b/src/lib/runners/run-wizard.ts
@@ -147,7 +147,7 @@ export function runWizard(
       activeTui.unmount();
       process.exit(0);
     } catch (err) {
-      if (runtimeEnv('DEBUG') || runtimeEnv('POSTHOG_WIZARD_DEBUG')) {
+      if (runtimeEnv('DEBUG') || runtimeEnv('WIZARD_DEBUG')) {
         // eslint-disable-next-line no-console
         console.error('TUI init failed:', err);
       }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -31,7 +31,7 @@ export function configureLogFile(opts: {
 }
 
 export function configureLogFileFromEnvironment(): void {
-  const dir = runtimeEnv('POSTHOG_WIZARD_LOG_DIR');
+  const dir = runtimeEnv('WIZARD_LOG_DIR');
   if (dir) {
     configureLogFile({ path: path.join(dir, 'posthog-wizard.log') });
   }

--- a/src/utils/env-api-key.ts
+++ b/src/utils/env-api-key.ts
@@ -1,17 +1,24 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { IS_PRODUCTION_BUILD } from '@env';
 
 /**
- * Read POSTHOG_PERSONAL_API_KEY from .env.local or .env in the current
- * working directory. Returns undefined when no key is found.
+ * Read `WIZARD_API_KEY` from .env.local or .env in the current working
+ * directory. Returns undefined when no key is found.
+ *
+ * This is the same `WIZARD_API_KEY` the `--api-key` flag reads from the
+ * environment in dev/CI — one name for the wizard's API key. It's a dev/CI-only
+ * convenience: published builds ignore it (`IS_PRODUCTION_BUILD`) so the shipped
+ * CLI is driven by the `--api-key` flag rather than the environment.
  */
 export function readApiKeyFromEnv(): string | undefined {
+  if (IS_PRODUCTION_BUILD) return undefined;
   const envFiles = ['.env.local', '.env'];
   for (const envFile of envFiles) {
     const envPath = path.join(process.cwd(), envFile);
     if (fs.existsSync(envPath)) {
       const content = fs.readFileSync(envPath, 'utf8');
-      const match = content.match(/^POSTHOG_PERSONAL_API_KEY=(.+)$/m);
+      const match = content.match(/^WIZARD_API_KEY=(.+)$/m);
       if (match) {
         return match[1].trim();
       }

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -1,55 +1,61 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import type { Argv } from 'yargs';
-import { IS_PRODUCTION_BUILD } from '@env';
+import { IS_PRODUCTION_BUILD, wizardEnvBool, wizardEnvDefault } from '@env';
 import { toCommandModule, type Command } from './commands/command';
 
 /**
- * Global yargs options applied to every command. These are read from the
- * `POSTHOG_WIZARD` env prefix as well as flags.
+ * Global yargs options applied to every command. In dev/CI each can also be set
+ * via a `WIZARD_<NAME>` env var (wired as the option's `default`, e.g.
+ * `WIZARD_API_KEY` backs `--api-key`); `wizardEnvDefault`/`wizardEnvBool` return
+ * undefined/the fallback in published builds, so the shipped package is driven
+ * through flags only. The `env:` lines below document the dev/CI env-var form.
  */
 export const GLOBAL_OPTIONS = {
   debug: {
-    default: false,
-    describe: 'Enable verbose logging\nenv: POSTHOG_WIZARD_DEBUG',
+    default: wizardEnvBool('DEBUG', false),
+    describe: 'Enable verbose logging\nenv: WIZARD_DEBUG',
     type: 'boolean' as const,
   },
   region: {
-    describe: 'PostHog cloud region\nenv: POSTHOG_WIZARD_REGION',
+    ...wizardEnvDefault('REGION'),
+    describe: 'PostHog cloud region\nenv: WIZARD_REGION',
     choices: ['us', 'eu'] as const,
     type: 'string' as const,
   },
   signup: {
-    default: false,
-    describe:
-      'Create a new PostHog account during setup\nenv: POSTHOG_WIZARD_SIGNUP',
+    default: wizardEnvBool('SIGNUP', false),
+    describe: 'Create a new PostHog account during setup\nenv: WIZARD_SIGNUP',
     type: 'boolean' as const,
   },
   'local-mcp': {
-    default: false,
+    default: wizardEnvBool('LOCAL_MCP', false),
     describe:
-      'Use local MCP server at http://localhost:8787/mcp\nenv: POSTHOG_WIZARD_LOCAL_MCP',
+      'Use local MCP server at http://localhost:8787/mcp\nenv: WIZARD_LOCAL_MCP',
     type: 'boolean' as const,
   },
   telemetry: {
-    default: true,
+    default: wizardEnvBool('TELEMETRY', true),
     describe:
-      'Send wizard run state to PostHog (pass --no-telemetry to disable)\nenv: POSTHOG_WIZARD_TELEMETRY',
+      'Send wizard run state to PostHog (pass --no-telemetry to disable)\nenv: WIZARD_TELEMETRY',
     type: 'boolean' as const,
   },
   'api-key': {
+    ...wizardEnvDefault('API_KEY'),
     describe:
-      'PostHog personal API key (phx_xxx) for authentication\nenv: POSTHOG_WIZARD_API_KEY',
+      'PostHog personal API key (phx_xxx) for authentication\nenv: WIZARD_API_KEY',
     type: 'string' as const,
   },
   'project-id': {
+    ...wizardEnvDefault('PROJECT_ID'),
     describe:
-      'PostHog project ID to use (optional; when not set, uses default from API key or OAuth)\nenv: POSTHOG_WIZARD_PROJECT_ID',
+      'PostHog project ID to use (optional; when not set, uses default from API key or OAuth)\nenv: WIZARD_PROJECT_ID',
     type: 'string' as const,
   },
   email: {
+    ...wizardEnvDefault('EMAIL'),
     describe:
-      'Email address for signup (used with --signup)\nenv: POSTHOG_WIZARD_EMAIL',
+      'Email address for signup (used with --signup)\nenv: WIZARD_EMAIL',
     type: 'string' as const,
   },
 };
@@ -58,19 +64,20 @@ export class Wizard {
   private cli: Argv;
 
   private constructor() {
-    let cli = yargs(hideBin(process.argv))
-      .env('POSTHOG_WIZARD')
-      .options(GLOBAL_OPTIONS);
+    let cli = yargs(hideBin(process.argv)).options(GLOBAL_OPTIONS);
 
-    // CI mode (--ci) is only supported in dev/test. It is left undeclared in
-    // published builds (NODE_ENV==='production'), so .strictOptions() rejects
-    // it there as an unknown argument — exactly like any other unrecognized
-    // flag. init() additionally detects it up front to print a clearer message.
+    // `--ci` is dev/CI-only and left out of published builds
+    // (NODE_ENV==='production') because CI mode isn't supported there. Without
+    // the option declared, .strictOptions() rejects `--ci` as an unknown
+    // argument — exactly like any other unrecognized flag. init() additionally
+    // detects it up front to print a clearer message. The `WIZARD_*` env
+    // overrides are wired per-option via `default` (see GLOBAL_OPTIONS and the
+    // command options), not yargs' `.env()` prefix — see src/env.ts for why.
     if (!IS_PRODUCTION_BUILD) {
       cli = cli.option('ci', {
-        default: false,
+        default: wizardEnvBool('CI', false),
         describe:
-          'Enable CI mode for non-interactive execution\nenv: POSTHOG_WIZARD_CI',
+          'Enable CI mode for non-interactive execution\nenv: WIZARD_CI',
         type: 'boolean',
       });
     }
@@ -108,17 +115,16 @@ export class Wizard {
   init(): void {
     // In published builds, `--ci` is undeclared, so yargs would reject it as
     // an unknown argument — accurate but unhelpful, since --help doesn't list
-    // --ci either and the user has no path forward. POSTHOG_WIZARD_CI silently
-    // no-ops for the same reason (yargs only resolves env vars for declared
-    // options). Detect both up front and exit with a message that explains why.
+    // --ci either and the user has no path forward. WIZARD_CI silently no-ops
+    // for the same reason (its `default` helper returns false in published
+    // builds). Detect both up front and exit with a message that explains why.
     if (IS_PRODUCTION_BUILD) {
       const args = process.argv.slice(2);
       const argvHasCI = args.some(
         (a) => a === '--ci' || a === '--no-ci' || a.startsWith('--ci='),
       );
       const envHasCI =
-        process.env.POSTHOG_WIZARD_CI != null &&
-        process.env.POSTHOG_WIZARD_CI !== '';
+        process.env.WIZARD_CI != null && process.env.WIZARD_CI !== '';
       if (argvHasCI || envHasCI) {
         process.stderr.write(
           `\n\x1b[1;91m✖ CI mode is not currently supported in published builds.\x1b[0m\n\n`,


### PR DESCRIPTION
## Problem

<!-- Who is affected and why does this matter? -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- What changed and why this approach. -->

## Test plan

<!-- How was this tested? Steps to verify, commands run, or "covered by CI". -->

<!-- ## LLM context -->

<!-- If an LLM agent co-authored this PR, uncomment and leave relevant context about the session or tools used. -->
