### PR TITLE
feat(orchestrator): executor drain-loop scheduler

### DIFF
--- a/src/lib/programs/orchestrator/__tests__/executor.test.ts
+++ b/src/lib/programs/orchestrator/__tests__/executor.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  QueueStore,
+  type QueuedTask,
+  type TaskHandoff,
+} from '@lib/programs/orchestrator/queue';
+import { drainQueue, type RunTask } from '@lib/programs/orchestrator/executor';
+
+jest.mock('@utils/analytics', () => ({
+  analytics: { captureException: jest.fn(), wizardCapture: jest.fn() },
+}));
+import { analytics } from '@utils/analytics';
+
+const HANDOFF: TaskHandoff = { goals: 'g', did: 'd', forNextAgent: 'n' };
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'executor-test-'));
+}
+
+describe('drainQueue', () => {
+  let dir: string;
+  let q: QueueStore;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    q = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const completing: RunTask = (task) => {
+    q.complete(task.id, HANDOFF);
+    return Promise.resolve();
+  };
+
+  it('runs a single task to done and drains', async () => {
+    const a = q.enqueue({ type: 'install' });
+    await drainQueue(q, completing, { maxStarts: 50 });
+    expect(q.get(a.id)?.status).toBe('done');
+    expect(q.isDrained()).toBe(true);
+  });
+
+  it('runs a dependent task only after its dependency completes', async () => {
+    const order: string[] = [];
+    const a = q.enqueue({ type: 'install' });
+    const b = q.enqueue({ type: 'init', dependsOn: [a.id] });
+    const runner: RunTask = (task) => {
+      order.push(task.type);
+      q.complete(task.id, HANDOFF);
+      return Promise.resolve();
+    };
+    await drainQueue(q, runner, { maxStarts: 50 });
+    expect(order).toEqual(['install', 'init']);
+    expect(q.get(b.id)?.status).toBe('done');
+  });
+
+  it('runs independent branches concurrently; the graph is the only schedule', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const runner: RunTask = async (task) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 5));
+      q.complete(task.id, HANDOFF);
+      active -= 1;
+    };
+    const a = q.enqueue({ type: 'install' });
+    const b = q.enqueue({ type: 'init' });
+    q.enqueue({ type: 'capture', dependsOn: [a.id, b.id] });
+    await drainQueue(q, runner, { maxStarts: 50 });
+    // install and init overlap; capture waits for both.
+    expect(maxActive).toBe(2);
+    expect(q.summary().done).toBe(3);
+  });
+
+  it('starts a dependent the moment its dependency finishes, not in waves', async () => {
+    const startedAt: Record<string, number> = {};
+    let clock = 0;
+    const runner: RunTask = async (task) => {
+      startedAt[task.type] = clock++;
+      // slow holds the wave open; fast finishes early and unblocks after-fast.
+      const delay = task.type === 'slow' ? 30 : 5;
+      await new Promise((r) => setTimeout(r, delay));
+      q.complete(task.id, HANDOFF);
+    };
+    q.enqueue({ type: 'slow' });
+    const fast = q.enqueue({ type: 'fast' });
+    q.enqueue({ type: 'after-fast', dependsOn: [fast.id] });
+    await drainQueue(q, runner, { maxStarts: 50 });
+    // after-fast started while slow was still running.
+    expect(startedAt['after-fast']).toBeDefined();
+    expect(q.summary().done).toBe(3);
+  });
+
+  it('retries a task that ends without reporting, then fails it', async () => {
+    const a = q.enqueue({ type: 'install', maxAttempts: 2 });
+    const noReport: RunTask = async () => {
+      /* agent never calls complete_task */
+    };
+    await drainQueue(q, noReport, { maxStarts: 50 });
+    expect(q.get(a.id)?.status).toBe('failed');
+    expect(q.get(a.id)?.attempts).toBe(2);
+  });
+
+  it('succeeds on a retry within the attempt budget', async () => {
+    let calls = 0;
+    const a = q.enqueue({ type: 'install', maxAttempts: 3 });
+    const flaky: RunTask = (task: QueuedTask) => {
+      calls += 1;
+      if (calls >= 2) q.complete(task.id, HANDOFF);
+      return Promise.resolve();
+    };
+    await drainQueue(q, flaky, { maxStarts: 50 });
+    expect(q.get(a.id)?.status).toBe('done');
+    expect(calls).toBe(2);
+  });
+
+  it('captures and fails a task whose runner throws', async () => {
+    const a = q.enqueue({ type: 'install', maxAttempts: 1 });
+    const throwing: RunTask = () => Promise.reject(new Error('agent exploded'));
+    await drainQueue(q, throwing, { maxStarts: 50 });
+    expect(q.get(a.id)?.status).toBe('failed');
+    expect(analytics.captureException).toHaveBeenCalled();
+  });
+
+  it('does not run a task whose dependency failed', async () => {
+    const a = q.enqueue({ type: 'install', maxAttempts: 1 });
+    const b = q.enqueue({ type: 'init', dependsOn: [a.id] });
+    const runner: RunTask = (task) => {
+      if (task.type === 'init') q.complete(task.id, HANDOFF);
+      // install never reports, so it fails after its single attempt.
+      return Promise.resolve();
+    };
+    await drainQueue(q, runner, { maxStarts: 50 });
+    expect(q.get(a.id)?.status).toBe('failed');
+    expect(q.get(b.id)?.status).toBe('pending');
+    expect(q.isDrained()).toBe(true);
+  });
+
+  it('terminates via the start backstop instead of looping forever', async () => {
+    const a = q.enqueue({ type: 'install', maxAttempts: 999 });
+    const neverReports: RunTask = async () => {
+      /* would retry forever without the backstop */
+    };
+    await drainQueue(q, neverReports, { maxStarts: 3 });
+    expect(q.get(a.id)?.attempts).toBeLessThanOrEqual(3);
+  });
+});

--- a/src/lib/programs/orchestrator/__tests__/queue-tools.test.ts
+++ b/src/lib/programs/orchestrator/__tests__/queue-tools.test.ts
@@ -1,0 +1,127 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { QueueStore } from '@lib/programs/orchestrator/queue';
+import {
+  applyComplete,
+  applyEnqueue,
+  applyReadHandoffs,
+  checkEnqueueGuards,
+  type OrchestratorToolsContext,
+} from '@lib/programs/orchestrator/queue-tools';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'queue-tools-test-'));
+}
+
+const VALID = ['install', 'init', 'capture'];
+
+describe('checkEnqueueGuards', () => {
+  let dir: string;
+  let store: QueueStore;
+  let ctx: OrchestratorToolsContext;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    store = new QueueStore(dir, 'run-1');
+    ctx = { store, validTypes: VALID };
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('rejects an unknown type', () => {
+    const r = checkEnqueueGuards(ctx, { type: 'nope', reason: 'x' });
+    expect(r).toMatchObject({ ok: false, guard: 'unknown-type' });
+  });
+
+  it('rejects an unknown dependency', () => {
+    const r = checkEnqueueGuards(ctx, {
+      type: 'init',
+      dependsOn: ['ghost'],
+      reason: 'x',
+    });
+    expect(r).toMatchObject({ ok: false, guard: 'unknown-dep' });
+  });
+
+  it('trips dedup on the same type and inputs', () => {
+    store.enqueue({ type: 'install', inputs: { pkg: 'posthog-js' } });
+    const r = checkEnqueueGuards(ctx, {
+      type: 'install',
+      inputs: { pkg: 'posthog-js' },
+      reason: 'x',
+    });
+    expect(r).toMatchObject({ ok: false, guard: 'dedup' });
+  });
+
+  it('allows a valid enqueue', () => {
+    const r = checkEnqueueGuards(ctx, { type: 'init', reason: 'x' });
+    expect(r).toEqual({ ok: true });
+  });
+});
+
+describe('apply functions', () => {
+  let dir: string;
+  let store: QueueStore;
+  let ctx: OrchestratorToolsContext;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    store = new QueueStore(dir, 'run-1');
+    ctx = { store, validTypes: VALID };
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('attributes a seed enqueue to the orchestrator', () => {
+    const r = applyEnqueue(ctx, { type: 'install', reason: 'seed' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.task.enqueuedBy).toBe('orchestrator');
+  });
+
+  it('attributes a follow-up enqueue to the running task', () => {
+    const parent = store.enqueue({ type: 'init' });
+    ctx.currentTaskId = parent.id;
+    const r = applyEnqueue(ctx, { type: 'capture', reason: 'follow-up' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.task.enqueuedBy).toBe(parent.id);
+  });
+
+  it('complete_task fails when no task is running', () => {
+    const r = applyComplete(ctx, {
+      status: 'done',
+      handoff: { goals: 'g', did: 'd', forNextAgent: 'n' },
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('complete_task marks the running task done and stores the handoff', () => {
+    const t = store.enqueue({ type: 'install' });
+    ctx.currentTaskId = t.id;
+    store.start(t.id);
+    const r = applyComplete(ctx, {
+      status: 'done',
+      handoff: { goals: 'g', did: 'added sdk', forNextAgent: 'env next' },
+    });
+    expect(r.ok).toBe(true);
+    expect(store.get(t.id)?.status).toBe('done');
+    expect(store.readHandoff(t.id)?.did).toBe('added sdk');
+  });
+
+  it('read_handoffs returns a dependency handoff for the running task', () => {
+    const dep = store.enqueue({ type: 'install' });
+    store.start(dep.id);
+    store.complete(dep.id, {
+      goals: 'g',
+      did: 'installed',
+      forNextAgent: 'now init',
+    });
+    const t = store.enqueue({ type: 'init', dependsOn: [dep.id] });
+    ctx.currentTaskId = t.id;
+
+    const handoffs = applyReadHandoffs(ctx, {});
+    expect(handoffs).toHaveLength(1);
+    expect(handoffs[0].did).toBe('installed');
+  });
+});

--- a/src/lib/programs/orchestrator/__tests__/queue.test.ts
+++ b/src/lib/programs/orchestrator/__tests__/queue.test.ts
@@ -1,0 +1,135 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  QueueStore,
+  type QueueFile,
+  type TaskHandoff,
+} from '@lib/programs/orchestrator/queue';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'queue-test-'));
+}
+
+describe('QueueStore', () => {
+  let dir: string;
+  let q: QueueStore;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    q = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('enqueues a pending task with defaults', () => {
+    const t = q.enqueue({ type: 'install' });
+    expect(t.status).toBe('pending');
+    expect(t.attempts).toBe(0);
+    expect(t.maxAttempts).toBe(2);
+    expect(t.enqueuedBy).toBe('orchestrator');
+    expect(t.dependsOn).toEqual([]);
+    expect(q.list()).toHaveLength(1);
+  });
+
+  it('only marks a task runnable once its dependencies are done', () => {
+    const a = q.enqueue({ type: 'install' });
+    const b = q.enqueue({ type: 'init', dependsOn: [a.id] });
+
+    expect(q.nextRunnable().map((t) => t.id)).toEqual([a.id]);
+
+    q.start(a.id);
+    q.complete(a.id);
+    expect(q.nextRunnable().map((t) => t.id)).toEqual([b.id]);
+  });
+
+  it('returns every runnable task; the graph alone decides parallelism', () => {
+    const a = q.enqueue({ type: 'install' });
+    const b = q.enqueue({ type: 'init' });
+    q.enqueue({ type: 'capture', dependsOn: [a.id, b.id] });
+
+    // Both independent tasks are runnable at once; the dependent one is not.
+    expect(
+      q
+        .nextRunnable()
+        .map((t) => t.id)
+        .sort(),
+    ).toEqual([a.id, b.id].sort());
+
+    q.start(a.id);
+    // An in-progress task is no longer offered.
+    expect(q.nextRunnable().map((t) => t.id)).toEqual([b.id]);
+  });
+
+  it('treats a skipped dependency as satisfied', () => {
+    const a = q.enqueue({ type: 'install' });
+    const b = q.enqueue({ type: 'init', dependsOn: [a.id] });
+
+    q.start(a.id);
+    q.skip(a.id);
+    expect(q.nextRunnable().map((t) => t.id)).toEqual([b.id]);
+  });
+
+  it('start increments attempts and supports within-run retry while attempts remain', () => {
+    const t = q.enqueue({ type: 'install', maxAttempts: 2 });
+    q.start(t.id);
+    expect(q.get(t.id)?.attempts).toBe(1);
+
+    q.fail(t.id, { type: 'API_ERROR', message: 'boom' });
+    expect(q.get(t.id)?.status).toBe('failed');
+
+    // Retry: attempts (1) < maxAttempts (2), so requeue and run again.
+    q.requeue(t.id);
+    expect(q.get(t.id)?.status).toBe('pending');
+    q.start(t.id);
+    expect(q.get(t.id)?.attempts).toBe(2);
+  });
+
+  it('completing a task records and reads back a structured handoff', () => {
+    const t = q.enqueue({ type: 'install' });
+    const handoff: TaskHandoff = {
+      goals: 'install the sdk',
+      did: 'added posthog-js',
+      forNextAgent: 'env vars not set yet',
+      filesTouched: ['package.json'],
+    };
+    q.start(t.id);
+    q.complete(t.id, handoff);
+
+    expect(q.get(t.id)?.status).toBe('done');
+    expect(q.readHandoff(t.id)).toEqual(handoff);
+    expect(q.readHandoffsByType('install')).toEqual([handoff]);
+  });
+
+  it('is drained when a pending task is blocked by a failed dependency', () => {
+    const a = q.enqueue({ type: 'install' });
+    q.enqueue({ type: 'init', dependsOn: [a.id] });
+
+    expect(q.isDrained()).toBe(false);
+    q.start(a.id);
+    q.fail(a.id, { type: 'API_ERROR', message: 'boom' });
+
+    // init can never run now, and nothing is in progress.
+    expect(q.nextRunnable()).toHaveLength(0);
+    expect(q.isDrained()).toBe(true);
+  });
+
+  it('reflects every transition to queue.json, handoffs included', () => {
+    const a = q.enqueue({ type: 'install' });
+    q.start(a.id);
+    q.complete(a.id, {
+      goals: 'g',
+      did: 'd',
+      forNextAgent: 'n',
+    });
+
+    const file = JSON.parse(fs.readFileSync(q.queuePath, 'utf8')) as QueueFile;
+    expect(file.version).toBe(1);
+    expect(file.runId).toBe('run-1');
+    expect(file.tasks).toHaveLength(1);
+    expect(file.tasks[0].status).toBe('done');
+    expect(file.tasks[0].handoff?.did).toBe('d');
+  });
+});

--- a/src/lib/programs/orchestrator/executor.ts
+++ b/src/lib/programs/orchestrator/executor.ts
@@ -1,0 +1,115 @@
+/**
+ * The executor drains the queue. It starts every runnable task (dependencies
+ * satisfied) as soon as it becomes runnable — parallelism is decided by the
+ * task graph, not by an executor knob. Each task runs through an injected
+ * `runTask` function and reports its outcome via `complete_task`; a task that
+ * ends without reporting is retried while attempts remain, then failed. A
+ * `maxStarts` backstop guarantees termination.
+ *
+ * The drain loop is independent of how a task actually runs. `runTask` is
+ * injected: the real one spins up a fresh agent, the tests use a fake.
+ */
+import { analytics } from '../../../utils/analytics';
+import { logToFile } from '../../../utils/debug';
+import { TaskStatus, type QueueStore, type QueuedTask } from './queue';
+
+/** Per-task agent configuration the resolver produces from a task's type. */
+export interface ResolvedTask {
+  model: string;
+  allowedTools: readonly string[];
+  disallowedTools: readonly string[];
+  /** Mini-skills to install before the task runs (the HOW). */
+  skills: readonly string[];
+  prompt: string;
+}
+
+/** Resolves a queued task to what the agent needs. The real one is markdown-backed. */
+export type TaskResolver = (
+  task: QueuedTask,
+  store: QueueStore,
+) => ResolvedTask;
+
+/** Runs one task's agent. It is expected to drive the task to a terminal state
+ *  (via the task agent calling complete_task). */
+export type RunTask = (task: QueuedTask) => Promise<void>;
+
+export interface DrainOptions {
+  /** Backstop against a pathological always-one-more-pending loop. */
+  maxStarts: number;
+}
+
+export const DEFAULT_DRAIN_OPTIONS: DrainOptions = {
+  maxStarts: 200,
+};
+
+async function runOne(
+  store: QueueStore,
+  runTask: RunTask,
+  task: QueuedTask,
+): Promise<void> {
+  store.start(task.id);
+  try {
+    await runTask(task);
+  } catch (error) {
+    // The task threw rather than reporting. The outcome check below handles
+    // the queue; the exception itself should never be silent.
+    logToFile(`[executor] runTask threw for ${task.type}:`, error);
+    analytics.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { step: 'orchestrator_run_task', task_type: task.type },
+    );
+  }
+
+  const after = store.get(task.id);
+  if (!after) return;
+
+  if (after.status === TaskStatus.Running) {
+    // The agent ended without calling complete_task. Retry or fail.
+    if (after.attempts < after.maxAttempts) {
+      store.requeue(task.id);
+    } else {
+      store.fail(task.id, {
+        type: 'no-report',
+        message: 'Task ended without calling complete_task.',
+      });
+    }
+    return;
+  }
+
+  if (
+    after.status === TaskStatus.Failed &&
+    after.attempts < after.maxAttempts
+  ) {
+    store.requeue(task.id);
+  }
+}
+
+/**
+ * Drain the queue to a terminal state. Every runnable task starts the moment
+ * its dependencies finish; independent branches run concurrently. Returns when
+ * every task is done, failed, or blocked by a failed dependency, or when the
+ * start backstop trips.
+ */
+export async function drainQueue(
+  store: QueueStore,
+  runTask: RunTask,
+  opts: DrainOptions = DEFAULT_DRAIN_OPTIONS,
+): Promise<void> {
+  const running = new Map<string, Promise<void>>();
+  let starts = 0;
+
+  for (;;) {
+    for (const task of store.nextRunnable()) {
+      if (++starts > opts.maxStarts) break;
+      // runOne marks the task in_progress synchronously, so the next
+      // nextRunnable() call no longer offers it.
+      const p = runOne(store, runTask, task).finally(() =>
+        running.delete(task.id),
+      );
+      running.set(task.id, p);
+    }
+    if (running.size === 0) break;
+    // Wake on the first finish; it may have unblocked dependents or requeued.
+    await Promise.race(running.values());
+  }
+}

--- a/src/lib/programs/orchestrator/queue-tools.ts
+++ b/src/lib/programs/orchestrator/queue-tools.ts
@@ -1,0 +1,259 @@
+/**
+ * Orchestrator MCP tools, registered into the existing `wizard-tools` server when
+ * a queue is present. They let the orchestrator agent and task agents grow the
+ * queue, report completion with a structured handoff, and read prior handoffs.
+ *
+ * The guard logic and the apply functions are plain, exported, and unit-tested.
+ * `buildOrchestratorTools` wraps them in the SDK `tool()` shape.
+ */
+import { z } from 'zod';
+import { analytics } from '../../../utils/analytics';
+import {
+  TaskStatus,
+  type QueueStore,
+  type QueuedTask,
+  type TaskHandoff,
+} from './queue';
+
+export interface OrchestratorToolsContext {
+  store: QueueStore;
+  /** Task types the registry knows about. enqueue_task rejects anything else. */
+  validTypes: readonly string[];
+  /**
+   * The id of the task this tool server is bound to. Each task agent gets its
+   * own wizard-tools server, so attribution holds when independent tasks run
+   * in parallel. Absent for the seed, which is not a task.
+   */
+  currentTaskId?: string;
+}
+
+export interface EnqueueArgs {
+  type: string;
+  inputs?: Record<string, unknown>;
+  dependsOn?: string[];
+  model?: string;
+  reason: string;
+}
+
+export type GuardResult =
+  | { ok: true }
+  | { ok: false; guard: string; message: string };
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>).sort(
+    ([a], [b]) => a.localeCompare(b),
+  );
+  return `{${entries
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`)
+    .join(',')}}`;
+}
+
+function dedupKey(type: string, inputs: Record<string, unknown>): string {
+  return `${type}::${stableStringify(inputs)}`;
+}
+
+/**
+ * Validate an enqueue. Structural checks only — a real type, real dependencies,
+ * and not a literal duplicate. How much runs, and in what shape, is the task
+ * graph's business, not a knob's.
+ */
+export function checkEnqueueGuards(
+  ctx: OrchestratorToolsContext,
+  args: EnqueueArgs,
+): GuardResult {
+  const tasks = ctx.store.list();
+
+  if (!ctx.validTypes.includes(args.type)) {
+    return {
+      ok: false,
+      guard: 'unknown-type',
+      message: `Unknown task type "${
+        args.type
+      }". Valid types: ${ctx.validTypes.join(', ')}.`,
+    };
+  }
+
+  for (const dep of args.dependsOn ?? []) {
+    if (!ctx.store.get(dep)) {
+      return {
+        ok: false,
+        guard: 'unknown-dep',
+        message: `Dependency "${dep}" is not a known task id.`,
+      };
+    }
+  }
+
+  const key = dedupKey(args.type, args.inputs ?? {});
+  if (
+    tasks.some(
+      (t) =>
+        t.status !== TaskStatus.Failed && dedupKey(t.type, t.inputs) === key,
+    )
+  ) {
+    return {
+      ok: false,
+      guard: 'dedup',
+      message: `A "${args.type}" task with these inputs already exists.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export type EnqueueResult =
+  | { ok: true; task: QueuedTask }
+  | { ok: false; guard: string; message: string };
+
+export function applyEnqueue(
+  ctx: OrchestratorToolsContext,
+  args: EnqueueArgs,
+): EnqueueResult {
+  const guard = checkEnqueueGuards(ctx, args);
+  if (!guard.ok) return guard;
+
+  const task = ctx.store.enqueue({
+    type: args.type,
+    inputs: args.inputs ?? {},
+    dependsOn: args.dependsOn ?? [],
+    model: args.model,
+    enqueuedBy: ctx.currentTaskId ?? 'orchestrator',
+  });
+  return { ok: true, task };
+}
+
+export type CompleteResult = { ok: true } | { ok: false; message: string };
+
+export function applyComplete(
+  ctx: OrchestratorToolsContext,
+  args: { status: 'done' | 'failed' | 'skipped'; handoff: TaskHandoff },
+): CompleteResult {
+  const id = ctx.currentTaskId;
+  if (!id) {
+    return {
+      ok: false,
+      message: 'complete_task can only be called by a running task agent.',
+    };
+  }
+  if (args.status === TaskStatus.Failed) {
+    ctx.store.fail(
+      id,
+      { type: 'self-reported', message: args.handoff.forNextAgent },
+      args.handoff,
+    );
+  } else if (args.status === TaskStatus.Skipped) {
+    ctx.store.skip(id, args.handoff);
+  } else {
+    ctx.store.complete(id, args.handoff);
+  }
+  return { ok: true };
+}
+
+export function applyReadHandoffs(
+  ctx: OrchestratorToolsContext,
+  args: { type?: string; taskId?: string },
+): TaskHandoff[] {
+  if (args.taskId) {
+    const h = ctx.store.readHandoff(args.taskId);
+    return h ? [h] : [];
+  }
+  if (args.type) {
+    return ctx.store.readHandoffsByType(args.type);
+  }
+  // No filter: every handoff of a dependency of the current task.
+  const currentId = ctx.currentTaskId;
+  const current = currentId ? ctx.store.get(currentId) : undefined;
+  if (!current) return [];
+  return current.dependsOn
+    .map((depId) => ctx.store.readHandoff(depId))
+    .filter((h): h is TaskHandoff => h !== null);
+}
+
+const HANDOFF_SHAPE = {
+  goals: z.string().describe('What this task was asked to achieve.'),
+  did: z.string().describe('What you actually did.'),
+  forNextAgent: z.string().describe('What the next agent should know.'),
+  filesTouched: z.array(z.string()).optional(),
+};
+
+type SdkTool = (
+  name: string,
+  description: string,
+  // The SDK accepts a plain object of zod fields as the schema.
+  schema: Record<string, z.ZodTypeAny>,
+  handler: (args: never) => unknown,
+) => unknown;
+
+function textResult(text: string, isError = false) {
+  return { isError, content: [{ type: 'text' as const, text }] };
+}
+
+/**
+ * Build the orchestrator tools in the SDK `tool()` shape. Called from
+ * createWizardToolsServer only when a queue context is present.
+ */
+export function buildOrchestratorTools(
+  tool: SdkTool,
+  ctx: OrchestratorToolsContext,
+): unknown[] {
+  const enqueueTask = tool(
+    'enqueue_task',
+    'Add a task to the orchestrator queue. Use it to seed work and to enqueue follow-up work you discover. Keep tasks small and discrete.',
+    {
+      type: z
+        .string()
+        .describe(`The task type. One of: ${ctx.validTypes.join(', ')}.`),
+      inputs: z.record(z.unknown()).optional(),
+      dependsOn: z
+        .array(z.string())
+        .optional()
+        .describe('Task ids that must be done before this task runs.'),
+      model: z.string().optional(),
+      reason: z.string().describe('One line on why this task is needed.'),
+    },
+    ((args: EnqueueArgs) => {
+      const res = applyEnqueue(ctx, args);
+      if (!res.ok) {
+        analytics.wizardCapture('orchestrator guard tripped', {
+          guard: res.guard,
+          type: args.type,
+        });
+        return textResult(res.message, true);
+      }
+      return textResult(JSON.stringify({ id: res.task.id }));
+    }) as (args: never) => unknown,
+  );
+
+  const completeTask = tool(
+    'complete_task',
+    "Report the outcome of your task. Always call this exactly once when you finish, with a structured handoff for the next agent. Use status 'skipped' when the task does not apply to this project and you cannot do it (say why in the handoff) — not 'done'.",
+    {
+      status: z.enum(['done', 'failed', 'skipped']),
+      handoff: z.object(HANDOFF_SHAPE),
+    },
+    ((args: {
+      status: 'done' | 'failed' | 'skipped';
+      handoff: TaskHandoff;
+    }) => {
+      const res = applyComplete(ctx, args);
+      if (!res.ok) return textResult(res.message, true);
+      return textResult('ok');
+    }) as (args: never) => unknown,
+  );
+
+  const readHandoffs = tool(
+    'read_handoffs',
+    'Read structured handoffs from earlier tasks. With no argument, returns the handoffs of your dependencies.',
+    {
+      type: z.string().optional(),
+      taskId: z.string().optional(),
+    },
+    ((args: { type?: string; taskId?: string }) => {
+      const handoffs = applyReadHandoffs(ctx, args);
+      return textResult(JSON.stringify(handoffs, null, 2));
+    }) as (args: never) => unknown,
+  );
+
+  return [enqueueTask, completeTask, readHandoffs];
+}

--- a/src/lib/programs/orchestrator/queue.ts
+++ b/src/lib/programs/orchestrator/queue.ts
@@ -1,0 +1,239 @@
+/**
+ * The orchestrator task queue.
+ *
+ * In memory, synchronous, single-owner: one Node process drives the run, so
+ * there is no locking. The queue imposes no execution policy — `nextRunnable`
+ * returns every pending task whose dependencies are satisfied, and how many of
+ * those run at once is decided by the task graph, not the queue.
+ *
+ * Every transition rewrites `<installDir>/.posthog-wizard/queue.json`, a small
+ * file holding the whole queue, handoffs included. Today it is the run's
+ * log and the report's source; later it is the resume point.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { writeJsonAtomic } from '../../../utils/atomic-ledger';
+
+export const TaskStatus = {
+  Pending: 'pending',
+  Running: 'running',
+  Done: 'done',
+  Skipped: 'skipped',
+  Failed: 'failed',
+} as const;
+
+export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
+
+export interface QueuedTask {
+  id: string;
+  type: string;
+  status: TaskStatus;
+  dependsOn: string[];
+  inputs: Record<string, unknown>;
+  model?: string;
+  attempts: number;
+  maxAttempts: number;
+  /** The structured handoff the task reported on completion. */
+  handoff?: TaskHandoff;
+  /** 'orchestrator' for seeded tasks, or the id of the task that enqueued this one. */
+  enqueuedBy: string;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  error?: { type: string; message: string };
+}
+
+export interface QueueFile {
+  version: 1;
+  runId: string;
+  tasks: QueuedTask[];
+}
+
+/** The structured handoff a task leaves for the next agent. */
+export interface TaskHandoff {
+  goals: string;
+  did: string;
+  forNextAgent: string;
+  filesTouched?: string[];
+}
+
+export interface EnqueueInput {
+  type: string;
+  inputs?: Record<string, unknown>;
+  dependsOn?: string[];
+  model?: string;
+  maxAttempts?: number;
+  enqueuedBy?: string;
+}
+
+export const QUEUE_DIR_NAME = '.posthog-wizard';
+const DEFAULT_MAX_ATTEMPTS = 2;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export class QueueStore {
+  private tasks: QueuedTask[] = [];
+
+  readonly runId: string;
+  readonly queuePath: string;
+
+  constructor(installDir: string, runId: string) {
+    this.runId = runId;
+    const dir = path.join(installDir, QUEUE_DIR_NAME);
+    this.queuePath = path.join(dir, 'queue.json');
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  // ── Reads ───────────────────────────────────────────────────────────
+
+  list(): readonly QueuedTask[] {
+    return this.tasks;
+  }
+
+  get(id: string): QueuedTask | undefined {
+    return this.tasks.find((t) => t.id === id);
+  }
+
+  /**
+   * Every pending task whose dependencies are all satisfied (`done` or
+   * `skipped`). A skipped dependency does not block downstream work.
+   */
+  nextRunnable(): QueuedTask[] {
+    const doneIds = new Set(
+      this.tasks
+        .filter(
+          (t) =>
+            t.status === TaskStatus.Done || t.status === TaskStatus.Skipped,
+        )
+        .map((t) => t.id),
+    );
+    return this.tasks.filter(
+      (t) =>
+        t.status === TaskStatus.Pending &&
+        t.dependsOn.every((d) => doneIds.has(d)),
+    );
+  }
+
+  /**
+   * True when no task is in progress and none can be started. Either everything
+   * is terminal, or the only pending tasks are blocked by a failed dependency.
+   */
+  isDrained(): boolean {
+    if (this.tasks.some((t) => t.status === TaskStatus.Running)) return false;
+    return this.nextRunnable().length === 0;
+  }
+
+  summary(): Record<TaskStatus, number> & { total: number } {
+    const counts: Record<TaskStatus, number> = {
+      [TaskStatus.Pending]: 0,
+      [TaskStatus.Running]: 0,
+      [TaskStatus.Done]: 0,
+      [TaskStatus.Skipped]: 0,
+      [TaskStatus.Failed]: 0,
+    };
+    for (const t of this.tasks) counts[t.status] += 1;
+    return { ...counts, total: this.tasks.length };
+  }
+
+  readHandoff(id: string): TaskHandoff | null {
+    return this.get(id)?.handoff ?? null;
+  }
+
+  /** Handoffs of completed tasks of a given type, oldest first. */
+  readHandoffsByType(type: string): TaskHandoff[] {
+    return this.tasks
+      .filter((t) => t.type === type && t.handoff)
+      .map((t) => t.handoff as TaskHandoff);
+  }
+
+  // ── Transitions (each one reflected to queue.json) ──────────────────
+
+  enqueue(input: EnqueueInput): QueuedTask {
+    const task: QueuedTask = {
+      id: randomUUID(),
+      type: input.type,
+      status: TaskStatus.Pending,
+      dependsOn: input.dependsOn ?? [],
+      inputs: input.inputs ?? {},
+      model: input.model,
+      attempts: 0,
+      maxAttempts: input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      enqueuedBy: input.enqueuedBy ?? 'orchestrator',
+      createdAt: nowIso(),
+    };
+    this.tasks.push(task);
+    this.reflect();
+    return task;
+  }
+
+  start(id: string): QueuedTask {
+    const t = this.require(id);
+    t.status = TaskStatus.Running;
+    t.startedAt = nowIso();
+    t.attempts += 1;
+    this.reflect();
+    return t;
+  }
+
+  complete(id: string, handoff?: TaskHandoff): QueuedTask {
+    return this.finish(id, TaskStatus.Done, handoff);
+  }
+
+  /** Terminal: the agent could not do the task. Not done, not failed. */
+  skip(id: string, handoff?: TaskHandoff): QueuedTask {
+    return this.finish(id, TaskStatus.Skipped, handoff);
+  }
+
+  fail(
+    id: string,
+    error: { type: string; message: string },
+    handoff?: TaskHandoff,
+  ): QueuedTask {
+    const t = this.require(id);
+    t.error = error;
+    return this.finish(id, TaskStatus.Failed, handoff);
+  }
+
+  /** Put a failed/in-progress task back to pending for a retry within the run. */
+  requeue(id: string): QueuedTask {
+    const t = this.require(id);
+    t.status = TaskStatus.Pending;
+    t.startedAt = undefined;
+    t.finishedAt = undefined;
+    this.reflect();
+    return t;
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private finish(
+    id: string,
+    status: 'done' | 'skipped' | 'failed',
+    handoff?: TaskHandoff,
+  ): QueuedTask {
+    const t = this.require(id);
+    if (handoff) t.handoff = handoff;
+    t.status = status;
+    t.finishedAt = nowIso();
+    this.reflect();
+    return t;
+  }
+
+  private reflect(): void {
+    const file: QueueFile = {
+      version: 1,
+      runId: this.runId,
+      tasks: this.tasks,
+    };
+    writeJsonAtomic(this.queuePath, file);
+  }
+
+  private require(id: string): QueuedTask {
+    const t = this.get(id);
+    if (!t) throw new Error(`No task ${id} in the queue`);
+    return t;
+  }
+}

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -16,6 +16,7 @@ import { z } from 'zod';
 import { logToFile } from '@utils/debug';
 import { analytics } from '@utils/analytics';
 import { skillTmpPath } from '@utils/paths';
+import { writeJsonAtomic, makeMutex } from '@utils/atomic-ledger';
 import type { PackageManagerDetector } from './detection/package-manager';
 import {
   AUDIT_CHECKS_FILE,
@@ -368,14 +369,9 @@ const auditUpdateSchema = z.object({
   details: z.string().optional(),
 });
 
-/**
- * Atomically write JSON: write to .tmp then rename. The rename is what bumps
- * the file's mtime, which is what the UI's file watcher polls on.
- */
+/** Atomically write the audit ledger. Thin typed wrapper over writeJsonAtomic. */
 function writeLedgerAtomic(targetPath: string, checks: AuditCheck[]): void {
-  const tmpPath = `${targetPath}.tmp`;
-  fs.writeFileSync(tmpPath, JSON.stringify(checks, null, 2), 'utf8');
-  fs.renameSync(tmpPath, targetPath);
+  writeJsonAtomic(targetPath, checks);
 }
 
 /**
@@ -472,19 +468,6 @@ function appendAuditChecksToLedger(
 
   writeLedgerAtomic(targetPath, next);
   return { ok: true, added: additions.length };
-}
-
-/**
- * Single async mutex shared by audit tools — guarantees a read-modify-write
- * cycle on the ledger is atomic across concurrent tool calls (e.g. future subagents).
- */
-function makeMutex() {
-  let chain: Promise<unknown> = Promise.resolve();
-  return async function run<T>(fn: () => Promise<T> | T): Promise<T> {
-    const next = chain.then(() => fn());
-    chain = next.catch(() => undefined);
-    return next;
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -26,6 +26,10 @@ import {
 } from './programs/audit/types';
 import type { WizardAskBridge } from './wizard-ask-bridge';
 import { createSecretVault, type SecretVault } from './secret-vault';
+import {
+  buildOrchestratorTools,
+  type OrchestratorToolsContext,
+} from './programs/orchestrator/queue-tools';
 
 // ---------------------------------------------------------------------------
 // SDK dynamic import (ESM module loaded once, cached)
@@ -203,6 +207,14 @@ export interface WizardToolsOptions {
    * (e.g. in unit tests), a fresh vault is created internally.
    */
   secretVault?: SecretVault;
+
+  /**
+   * Orchestrator queue context. Present only when the `wizard-orchestrator`
+   * flag routes the run to the orchestrator; when set, the orchestrator tools
+   * (enqueue_task, complete_task, read_handoffs) are registered. Absent on the
+   * linear path.
+   */
+  orchestrator?: OrchestratorToolsContext;
 }
 
 /** Default per-run cap on wizard_ask calls when no override is provided. */
@@ -488,6 +500,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
     askBridge,
     askMaxQuestions = DEFAULT_ASK_MAX_QUESTIONS,
     secretVault = createSecretVault(),
+    orchestrator,
   } = options;
   const sdk = await getSDKModule();
   const { tool, createSdkMcpServer } = sdk;
@@ -1087,6 +1100,10 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
 
   // -- Assemble server ------------------------------------------------------
 
+  const orchestratorTools = orchestrator
+    ? buildOrchestratorTools(tool, orchestrator)
+    : [];
+
   return createSdkMcpServer({
     name: SERVER_NAME,
     version: '1.0.0',
@@ -1100,6 +1117,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
       auditAddChecks,
       auditResolveChecks,
       wizardAsk,
+      ...orchestratorTools,
     ],
   });
 }
@@ -1119,6 +1137,9 @@ export const WIZARD_TOOL_NAMES = {
   auditAddChecks: `mcp__${SERVER_NAME}__audit_add_checks`,
   auditResolveChecks: `mcp__${SERVER_NAME}__audit_resolve_checks`,
   wizardAsk: `mcp__${SERVER_NAME}__wizard_ask`,
+  enqueueTask: `mcp__${SERVER_NAME}__enqueue_task`,
+  completeTask: `mcp__${SERVER_NAME}__complete_task`,
+  readHandoffs: `mcp__${SERVER_NAME}__read_handoffs`,
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/utils/atomic-ledger.ts
+++ b/src/utils/atomic-ledger.ts
@@ -1,0 +1,29 @@
+/**
+ * Small shared primitives for on-disk ledgers: an atomic JSON writer and a
+ * single-chain async mutex. Used by the audit tools and by the orchestrator
+ * queue. Lifted here so both share one implementation.
+ */
+import * as fs from 'fs';
+
+/**
+ * Atomically write JSON: write to a `.tmp` file then rename over the target. The
+ * rename bumps the file's mtime in one step, which is what a file watcher polls.
+ */
+export function writeJsonAtomic(targetPath: string, data: unknown): void {
+  const tmpPath = `${targetPath}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf8');
+  fs.renameSync(tmpPath, targetPath);
+}
+
+/**
+ * A single async mutex. Serializes read-modify-write cycles so concurrent callers
+ * (parallel task agents, audit tool calls) never interleave a mutation.
+ */
+export function makeMutex() {
+  let chain: Promise<unknown> = Promise.resolve();
+  return async function run<T>(fn: () => Promise<T> | T): Promise<T> {
+    const next = chain.then(() => fn());
+    chain = next.catch(() => undefined);
+    return next;
+  };
+}


### PR DESCRIPTION
The drain loop. Every runnable task starts the moment its dependencies finish, independent branches run concurrently, and the seed's graph is the only schedule. A task whose agent ends without reporting is retried once, then failed. `maxStarts` is a runaway backstop, not a tuning knob. `runTask` is injected, the tests use a fake.