### PR TITLE
feat(agent): detect all gateway-auth overrides and make the 401 actionable

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^25.3.0",
     "husky": "^9.1.7",
+    "ink-testing-library": "^4.0.0",
     "jest": "^29.5.0",
     "lint-staged": "^15.5.1",
     "msw": "^2.10.4",
@@ -118,7 +119,8 @@
     "try": "tsx bin.ts",
     "dev": "pnpm build && pnpm link --global && pnpm build:watch",
     "test:watch": "jest --watch",
-    "prepare": "husky"
+    "prepare": "husky",
+    "screens:check": "tsx scripts/check-screens.tsx"
   },
   "jest": {
     "collectCoverage": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      ink-testing-library:
+        specifier: ^4.0.0
+        version: 4.0.0(@types/react@19.2.14)
       jest:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@18.19.76)(ts-node@10.9.2(@types/node@18.19.76)(typescript@5.7.3))
@@ -2615,6 +2618,15 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ink-testing-library@4.0.0:
+    resolution: {integrity: sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   ink@6.8.0:
     resolution: {integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==}
@@ -6764,6 +6776,10 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ink-testing-library@4.0.0(@types/react@19.2.14):
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   ink@6.8.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:

--- a/scripts/check-screens.tsx
+++ b/scripts/check-screens.tsx
@@ -1,0 +1,124 @@
+/**
+ * Renders the settings-conflict / auth-error screens with real Ink (via
+ * ink-testing-library) and asserts each one names the offending file and key.
+ *
+ * Jest globally mocks `ink` to no-op stubs, so it can't verify what these
+ * screens actually draw. This harness renders them for real and fails on a
+ * regression. Run with `pnpm screens:check`.
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { AuthErrorScreen } from '@ui/tui/screens/AuthErrorScreen';
+import { ManagedSettingsScreen } from '@ui/tui/screens/ManagedSettingsScreen';
+import { SettingsOverrideScreen } from '@ui/tui/screens/SettingsOverrideScreen';
+import type { SettingsConflict } from '@lib/agent/agent-interface';
+
+function fakeStore(session: Record<string, unknown>): any {
+  return {
+    session,
+    subscribe: () => () => undefined,
+    getSnapshot: () => session,
+    backupAndFixSettingsOverride: () => true,
+  };
+}
+
+const userConflict: SettingsConflict = {
+  source: 'user',
+  path: '/home/dev/.claude/settings.json',
+  keys: ['apiKeyHelper'],
+  writable: false,
+};
+const projectConflict: SettingsConflict = {
+  source: 'project',
+  path: '/home/dev/app/.claude/settings.json',
+  keys: ['ANTHROPIC_BASE_URL'],
+  writable: true,
+};
+const managedConflict: SettingsConflict = {
+  source: 'managed',
+  path: '/Library/Application Support/ClaudeCode/managed-settings.json',
+  keys: ['ANTHROPIC_AUTH_TOKEN'],
+  writable: false,
+};
+
+let failures = 0;
+
+function check(
+  label: string,
+  el: React.ReactElement,
+  expected: string[],
+  forbidden: string[] = [],
+): void {
+  const { lastFrame } = render(el);
+  const frame = lastFrame() ?? '';
+  const missing = expected.filter((s) => !frame.includes(s));
+  const present = forbidden.filter((s) => frame.includes(s));
+  const ok = missing.length === 0 && present.length === 0;
+  console.log(`\n===== ${label} ${ok ? 'OK' : 'FAILED'} =====`);
+  console.log(frame);
+  if (missing.length) console.log(`  MISSING: ${missing.join(' | ')}`);
+  if (present.length)
+    console.log(`  SHOULD NOT CONTAIN: ${present.join(' | ')}`);
+  if (!ok) failures++;
+}
+
+check(
+  'AuthErrorScreen — global conflict names file + key + fix',
+  <AuthErrorScreen
+    store={fakeStore({
+      authErrorDetail: {
+        hasSettingsConflict: true,
+        conflicts: [userConflict],
+        logFilePath: '/tmp/posthog-wizard.log',
+      },
+    })}
+  />,
+  ['/home/dev/.claude/settings.json', 'apiKeyHelper', 'claude auth logout'],
+);
+
+check(
+  'AuthErrorScreen — no conflict falls back to key guidance',
+  <AuthErrorScreen
+    store={fakeStore({
+      authErrorDetail: {
+        hasSettingsConflict: false,
+        conflicts: [],
+        logFilePath: '/tmp/posthog-wizard.log',
+      },
+    })}
+  />,
+  ['llm_gateway:read', 'Region mismatch'],
+);
+
+check(
+  'ManagedSettingsScreen — user/global gets self-fix copy, not IT',
+  <ManagedSettingsScreen
+    store={fakeStore({ settingsConflicts: [userConflict] })}
+  />,
+  ['Your global Claude Code settings', userConflict.path, 'Remove these keys'],
+  ['IT administrator'],
+);
+
+check(
+  'ManagedSettingsScreen — managed points at IT',
+  <ManagedSettingsScreen
+    store={fakeStore({ settingsConflicts: [managedConflict] })}
+  />,
+  ['Organization-managed settings', managedConflict.path, 'IT administrator'],
+);
+
+check(
+  'SettingsOverrideScreen — writable project offers backup with full path',
+  <SettingsOverrideScreen
+    store={fakeStore({ settingsConflicts: [projectConflict] })}
+  />,
+  [projectConflict.path, 'ANTHROPIC_BASE_URL', 'Backup & continue'],
+);
+
+if (failures > 0) {
+  console.error(`\n${failures} screen check(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll screen checks passed');
+process.exit(0);

--- a/src/lib/agent/__tests__/settings-conflicts.test.ts
+++ b/src/lib/agent/__tests__/settings-conflicts.test.ts
@@ -1,0 +1,159 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.mock('@utils/analytics', () => ({
+  analytics: { captureException: jest.fn(), wizardCapture: jest.fn() },
+}));
+
+import {
+  checkAllSettingsConflicts,
+  buildAuthErrorContext,
+} from '@lib/agent/agent-interface';
+
+const OVERRIDE = JSON.stringify({ apiKeyHelper: 'echo sk-x' });
+const ENV_OVERRIDE = JSON.stringify({
+  env: { ANTHROPIC_BASE_URL: 'https://example.com' },
+});
+
+let home: string;
+let project: string;
+
+function write(dir: string, name: string, contents: string): void {
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, name), contents);
+}
+
+beforeEach(() => {
+  // A temp home keeps a real global ~/.claude config off the test machine
+  // out of the result; pass it explicitly so detection is deterministic.
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'wizard-home-'));
+  project = fs.mkdtempSync(path.join(os.tmpdir(), 'wizard-proj-'));
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+  fs.rmSync(project, { recursive: true, force: true });
+});
+
+describe('checkAllSettingsConflicts', () => {
+  it('returns nothing when no settings files exist', () => {
+    expect(checkAllSettingsConflicts(project, home)).toEqual([]);
+  });
+
+  it('detects a writable project settings.json override with its path', () => {
+    write(project, 'settings.json', OVERRIDE);
+
+    const conflicts = checkAllSettingsConflicts(project, home);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({
+      source: 'project',
+      writable: true,
+      keys: ['apiKeyHelper'],
+      path: path.join(project, '.claude', 'settings.json'),
+    });
+  });
+
+  it('detects a gitignored project-local override as read-only', () => {
+    write(project, 'settings.local.json', ENV_OVERRIDE);
+
+    const conflicts = checkAllSettingsConflicts(project, home);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]).toMatchObject({
+      source: 'project-local',
+      writable: false,
+      keys: ['ANTHROPIC_BASE_URL'],
+      path: path.join(project, '.claude', 'settings.local.json'),
+    });
+  });
+
+  it('detects the user global ~/.claude/settings.json as read-only', () => {
+    write(home, 'settings.json', OVERRIDE);
+
+    const conflicts = checkAllSettingsConflicts(project, home);
+
+    expect(conflicts).toContainEqual(
+      expect.objectContaining({
+        source: 'user',
+        writable: false,
+        path: path.join(home, '.claude', 'settings.json'),
+      }),
+    );
+  });
+
+  it('detects the user global settings.local.json', () => {
+    write(home, 'settings.local.json', OVERRIDE);
+
+    const conflicts = checkAllSettingsConflicts(project, home);
+
+    expect(conflicts).toContainEqual(
+      expect.objectContaining({
+        source: 'user',
+        path: path.join(home, '.claude', 'settings.local.json'),
+      }),
+    );
+  });
+
+  it('reports conflicts from several sources at once', () => {
+    write(home, 'settings.json', OVERRIDE);
+    write(project, 'settings.json', ENV_OVERRIDE);
+
+    const sources = checkAllSettingsConflicts(project, home).map(
+      (c) => c.source,
+    );
+
+    expect(sources).toEqual(expect.arrayContaining(['user', 'project']));
+  });
+});
+
+describe('buildAuthErrorContext', () => {
+  it('reports no conflict and a default region when nothing overrides auth', () => {
+    const ctx = buildAuthErrorContext(
+      project,
+      'https://gateway.us.posthog.com/wizard',
+      home,
+    );
+
+    expect(ctx.hasSettingsConflict).toBe(false);
+    expect(ctx.conflicts).toEqual([]);
+    expect(ctx.conflictSources).toEqual([]);
+    expect(ctx.conflictKeys).toEqual([]);
+    expect(ctx.region).toBe('us');
+  });
+
+  it('summarises conflicts and dedupes keys for telemetry', () => {
+    write(home, 'settings.json', JSON.stringify({ apiKeyHelper: 'x' }));
+    write(project, 'settings.json', JSON.stringify({ apiKeyHelper: 'y' }));
+
+    const ctx = buildAuthErrorContext(
+      project,
+      'https://gateway.eu.posthog.com/wizard',
+      home,
+    );
+
+    expect(ctx.hasSettingsConflict).toBe(true);
+    expect(ctx.conflictSources).toEqual(
+      expect.arrayContaining(['user', 'project']),
+    );
+    expect(ctx.conflictKeys).toEqual(['apiKeyHelper']);
+    expect(ctx.region).toBe('eu');
+  });
+
+  it('derives the region from the gateway url', () => {
+    expect(
+      buildAuthErrorContext(
+        project,
+        'https://gateway.eu.posthog.com/wizard',
+        home,
+      ).region,
+    ).toBe('eu');
+    expect(
+      buildAuthErrorContext(project, 'http://localhost:3308/wizard', home)
+        .region,
+    ).toBe('local');
+    expect(buildAuthErrorContext(project, '', home).region).toBe('us');
+  });
+});

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -5,6 +5,7 @@
 
 import path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import { getUI, type SpinnerHandle } from '@ui';
 import { debug, logToFile, initLogFile, getLogFilePath } from '@utils/debug';
 import type { WizardRunOptions } from '@utils/types';
@@ -73,15 +74,26 @@ const BLOCKING_ENV_KEYS = [
 const BLOCKING_SETTINGS_KEYS = ['apiKeyHelper'];
 
 /** Where a settings conflict was found. */
-export type SettingsConflictSource = 'project' | 'managed';
+export type SettingsConflictSource =
+  | 'project'
+  | 'project-local'
+  | 'user'
+  | 'managed';
 
 /** A single settings conflict detected during startup. */
 export interface SettingsConflict {
   /** Where the conflict was found. */
   source: SettingsConflictSource;
+  /** Absolute path of the file holding the override. */
+  path: string;
   /** The blocking keys found (e.g. 'ANTHROPIC_BASE_URL', 'apiKeyHelper'). */
   keys: string[];
-  /** Whether the wizard can back up / remove this file. Managed settings are read-only. */
+  /**
+   * Whether the wizard can back up / remove this file. Only the project
+   * `settings.json` is writable: managed settings are root-owned, and the
+   * user's global config and gitignored `*.local.json` are left untouched so
+   * we never mutate config outside the project we were pointed at.
+   */
   writable: boolean;
 }
 
@@ -146,13 +158,18 @@ const MANAGED_SETTINGS_PATH =
   '/Library/Application Support/ClaudeCode/managed-settings.json';
 
 /**
- * Check project and org-managed settings for blocking keys that conflict
- * with the wizard's proxy auth.
+ * Check every settings file Claude Code reads for blocking keys that conflict
+ * with the wizard's gateway auth: org-managed, the user's global config, the
+ * project config, and the gitignored project-local override. Each is a place
+ * an `apiKeyHelper` or `ANTHROPIC_*` override commonly lives, and any of them
+ * can outrank the env the wizard sets and make every agent call 401.
  */
 export function checkAllSettingsConflicts(
   workingDirectory: string,
+  homeDir: string = os.homedir(),
 ): SettingsConflict[] {
   const conflicts: SettingsConflict[] = [];
+  const home = homeDir;
 
   const sources: {
     source: SettingsConflictSource;
@@ -165,6 +182,14 @@ export function checkAllSettingsConflicts(
       writable: false,
     },
     {
+      source: 'user',
+      paths: [
+        path.join(home, '.claude', 'settings.json'),
+        path.join(home, '.claude', 'settings.local.json'),
+      ],
+      writable: false,
+    },
+    {
       source: 'project',
       paths: [
         path.join(workingDirectory, '.claude', 'settings.json'),
@@ -172,19 +197,65 @@ export function checkAllSettingsConflicts(
       ],
       writable: true,
     },
+    {
+      source: 'project-local',
+      paths: [path.join(workingDirectory, '.claude', 'settings.local.json')],
+      writable: false,
+    },
   ];
 
   for (const { source, paths, writable } of sources) {
     for (const filePath of paths) {
       const keys = checkSettingsFile(filePath);
       if (keys.length > 0) {
-        conflicts.push({ source, keys, writable });
+        conflicts.push({ source, path: filePath, keys, writable });
         break; // Only one conflict per source (settings.json vs settings fallback)
       }
     }
   }
 
   return conflicts;
+}
+
+/** Region implied by the resolved gateway URL, for telemetry and display. */
+function regionFromGatewayUrl(gatewayUrl: string): 'eu' | 'us' | 'local' {
+  if (gatewayUrl.includes('localhost')) return 'local';
+  return gatewayUrl.includes('gateway.eu.') ? 'eu' : 'us';
+}
+
+/**
+ * Diagnostic context for a gateway 401, used by the auth-error screen and the
+ * captured exception.
+ *
+ * A bare "Authentication failed" can't be triaged: the 401 could be a settings
+ * file overriding the credential, a region mismatch, or a rejected key. This
+ * records which, so the screen can name an actionable next step and telemetry
+ * can tell the causes apart. Absolute conflict paths stay out of the telemetry
+ * payload (they contain the user's home dir) — only sources/keys are reported.
+ */
+export interface AuthErrorContext {
+  hasSettingsConflict: boolean;
+  conflicts: SettingsConflict[];
+  conflictSources: SettingsConflictSource[];
+  conflictKeys: string[];
+  gatewayUrl: string;
+  region: 'eu' | 'us' | 'local';
+}
+
+export function buildAuthErrorContext(
+  workingDirectory: string,
+  gatewayUrl: string,
+  homeDir: string = os.homedir(),
+): AuthErrorContext {
+  const conflicts = checkAllSettingsConflicts(workingDirectory, homeDir);
+  return {
+    hasSettingsConflict: conflicts.length > 0,
+    conflicts,
+    conflictSources: conflicts.map((c) => c.source),
+    conflictKeys: [...new Set(conflicts.flatMap((c) => c.keys))],
+    gatewayUrl,
+    region: regionFromGatewayUrl(gatewayUrl),
+  };
 }
 
 /**
@@ -1125,19 +1196,25 @@ export async function runAgent(
         // of a 401, distinct from bad PAT / wrong region / expired key.
         // Only the conflict case warrants telling the user to log out of
         // Claude Code.
-        const conflicts = checkAllSettingsConflicts(options.installDir);
-        const hasSettingsConflict = conflicts.length > 0;
-        logToFile('Agent error: 401, showing auth error screen', {
-          hasSettingsConflict,
-          conflicts,
-        });
+        const authError = buildAuthErrorContext(
+          options.installDir,
+          process.env.ANTHROPIC_BASE_URL ?? '',
+        );
+        logToFile('Agent error: 401, showing auth error screen', authError);
         getUI().showAuthError({
-          hasSettingsConflict,
+          hasSettingsConflict: authError.hasSettingsConflict,
+          conflicts: authError.conflicts,
           logFilePath: getLogFilePath(),
         });
         await wizardAbort({
           message: 'Authentication failed (401)',
-          error: new WizardError('Authentication failed'),
+          error: new WizardError('Authentication failed', {
+            hasSettingsConflict: authError.hasSettingsConflict,
+            conflictSources: authError.conflictSources,
+            conflictKeys: authError.conflictKeys,
+            gatewayUrl: authError.gatewayUrl,
+            region: authError.region,
+          }),
         });
       }
 

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -222,6 +222,7 @@ export interface WizardSession {
   settingsConflicts: SettingsConflict[] | null;
   authErrorDetail: {
     hasSettingsConflict: boolean;
+    conflicts?: SettingsConflict[];
     logFilePath: string;
   } | null;
   portConflictProcess: {

--- a/src/ui/tui/screens/AuthErrorScreen.tsx
+++ b/src/ui/tui/screens/AuthErrorScreen.tsx
@@ -29,6 +29,7 @@ export const AuthErrorScreen = ({ store }: AuthErrorScreenProps) => {
 
   const detail = store.session.authErrorDetail;
   const hasSettingsConflict = detail?.hasSettingsConflict ?? true;
+  const conflicts = detail?.conflicts ?? [];
   const logFilePath = detail?.logFilePath;
 
   return (
@@ -42,15 +43,25 @@ export const AuthErrorScreen = ({ store }: AuthErrorScreenProps) => {
           <Box flexDirection="column" marginTop={1}>
             <Text>
               The Wizard couldn't connect to the PostHog LLM Gateway. Claude
-              Code settings on this machine are overriding the Wizard's
-              credentials.
+              Code settings on this machine override the Wizard's credentials.
             </Text>
           </Box>
 
+          {conflicts.length > 0 && (
+            <Box flexDirection="column" marginTop={1} paddingLeft={2}>
+              {conflicts.map((conflict) => (
+                <Text key={conflict.path}>
+                  {'•'} <Text bold>{conflict.path}</Text> sets{' '}
+                  <Text color="yellow">{conflict.keys.join(', ')}</Text>
+                </Text>
+              ))}
+            </Box>
+          )}
+
           <Box marginTop={1}>
             <Text dimColor>
-              Try logging out of Claude Code temporarily and re-running the
-              Wizard:
+              Remove those keys from the file(s) above, or log out of Claude
+              Code, then re-run the Wizard:
             </Text>
           </Box>
 

--- a/src/ui/tui/screens/ManagedSettingsScreen.tsx
+++ b/src/ui/tui/screens/ManagedSettingsScreen.tsx
@@ -1,9 +1,12 @@
 /**
- * ManagedSettingsScreen — Modal when IT/org-managed settings contain overrides
- * that block the Wizard from reaching the PostHog LLM Gateway.
+ * ManagedSettingsScreen — Modal for read-only settings conflicts that block
+ * the Wizard from reaching the PostHog LLM Gateway: org-managed settings, the
+ * user's global `~/.claude` config, and gitignored project-local overrides.
  *
- * Unlike SettingsOverrideScreen, the wizard cannot back up or modify these files.
- * The user must contact their IT administrator to resolve the conflict.
+ * Unlike SettingsOverrideScreen, the wizard cannot safely back up or remove
+ * these files for the user, so it names the exact file and key and asks the
+ * user to fix it and re-run. Managed (root-owned) files need an IT admin; the
+ * rest the user can edit themselves.
  */
 
 import { Box, Text } from 'ink';
@@ -16,9 +19,11 @@ import type { SettingsConflict } from '@lib/agent/agent-interface';
 function sourceLabel(source: SettingsConflict['source']): string {
   switch (source) {
     case 'managed':
-      return 'Managed settings (IT/org-managed)';
-    case 'project':
-      return '.claude/settings.json';
+      return 'Organization-managed settings';
+    case 'user':
+      return 'Your global Claude Code settings';
+    case 'project-local':
+      return 'Project-local settings';
     default:
       return source;
   }
@@ -43,14 +48,16 @@ export const ManagedSettingsScreen = ({
     return null;
   }
 
+  const hasManaged = readOnlyConflicts.some((c) => c.source === 'managed');
+
   return (
     <ModalOverlay
       borderColor="red"
-      title={`${Icons.warning} Organization settings conflict`}
-      width={68}
+      title={`${Icons.warning} Settings conflict`}
+      width={72}
       footer={
         <ConfirmationInput
-          message="Contact your IT administrator to resolve this."
+          message="Fix the file(s) above, then re-run the Wizard."
           confirmLabel=""
           cancelLabel="Exit [Esc]"
           onConfirm={() => process.exit(1)}
@@ -59,12 +66,13 @@ export const ManagedSettingsScreen = ({
       }
     >
       <Text dimColor>
-        Your organization&apos;s managed settings contain overrides that prevent
-        the Wizard from reaching the PostHog LLM Gateway.
+        These Claude Code settings override credentials and prevent the Wizard
+        from reaching the PostHog LLM Gateway.
       </Text>
       {readOnlyConflicts.map((conflict) => (
-        <Box key={conflict.source} flexDirection="column" marginTop={1}>
+        <Box key={conflict.path} flexDirection="column" marginTop={1}>
           <Text bold>{sourceLabel(conflict.source)}</Text>
+          <Text dimColor>{conflict.path}</Text>
           <Box flexDirection="column" paddingLeft={2}>
             {conflict.keys.map((key) => (
               <Text key={key}>
@@ -79,8 +87,9 @@ export const ManagedSettingsScreen = ({
       ))}
       <Box marginTop={1}>
         <Text dimColor>
-          Try running "claude auth logout" or contact your IT administrator to
-          resolve this.
+          {hasManaged
+            ? 'Remove these keys (or run "claude auth logout"). Managed files are root-owned — ask your IT administrator.'
+            : 'Remove these keys, or run "claude auth logout", then re-run the Wizard.'}
         </Text>
       </Box>
     </ModalOverlay>

--- a/src/ui/tui/screens/SettingsOverrideScreen.tsx
+++ b/src/ui/tui/screens/SettingsOverrideScreen.tsx
@@ -3,18 +3,6 @@ import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { ConfirmationInput, ModalOverlay } from '@ui/tui/primitives/index';
 import { Icons } from '@ui/tui/styles';
-import type { SettingsConflictSource } from '@lib/agent/agent-interface';
-
-function sourcePath(source: SettingsConflictSource): string {
-  switch (source) {
-    case 'project':
-      return '.claude/settings.json';
-    case 'managed':
-      return '/Library/Application Support/ClaudeCode/managed-settings.json';
-    default:
-      return source;
-  }
-}
 
 interface SettingsOverrideScreenProps {
   store: WizardStore;
@@ -57,10 +45,9 @@ export const SettingsOverrideScreen = ({
       }
     >
       {conflicts.map((conflict) => (
-        <Box key={conflict.source} flexDirection="column" marginBottom={1}>
+        <Box key={conflict.path} flexDirection="column" marginBottom={1}>
           <Text>
-            Your settings file at{' '}
-            <Text bold>{sourcePath(conflict.source)}</Text> sets:
+            Your settings file at <Text bold>{conflict.path}</Text> sets:
           </Text>
           <Box flexDirection="column" paddingLeft={2}>
             {conflict.keys.map((key) => (

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -36,15 +36,16 @@ export interface SpinnerHandle {
 /**
  * Context passed to `showAuthError` so the screen can pick the right copy.
  *
- * `hasSettingsConflict` is true when a Claude Code settings.json /
- * managed-settings file actually overrides the LLM Gateway auth — the
- * Wizard's pre-flight check missed it or it appeared after startup.
- * When false, the 401 has a different cause (bad PAT prefix, missing
- * scope, expired key, region mismatch) and we should not advise the
- * user to log out of Claude Code.
+ * `hasSettingsConflict` is true when a Claude Code settings file (project,
+ * project-local, the user's global config, or managed) actually overrides the
+ * LLM Gateway auth. `conflicts` carries the exact files and keys so the screen
+ * can name them. When there is no conflict, the 401 has a different cause (bad
+ * PAT prefix, missing scope, expired key, region mismatch) and we should not
+ * advise the user to log out of Claude Code.
  */
 export interface AuthErrorDetail {
   hasSettingsConflict: boolean;
+  conflicts?: SettingsConflict[];
   logFilePath: string;
 }
 


### PR DESCRIPTION
## Problem

Closes #613.

A gateway 401 surfaced as a bare "Authentication failed" with generic "bad key / wrong region" copy, even when the real cause was a Claude Code settings file overriding the wizard's credential. Detection only looked at the project `.claude/settings.json` and managed settings, so the most common override spots — the user's global `~/.claude` config and gitignored `*.local.json` — went unseen. The #598 reporter retried for hours with no usable signal, and telemetry couldn't tell a settings override from a region mismatch or a rejected key.

## Changes

- **`checkAllSettingsConflicts`**: also scan `~/.claude/settings.json`, `~/.claude/settings.local.json`, and project `.claude/settings.local.json`; record the matched file `path` on each `SettingsConflict`. Only the project `settings.json` stays writable (auto-backup) — the rest are surfaced for manual fixing so the wizard never mutates config outside the project it was pointed at. A `homeDir` param makes detection testable.
- **`buildAuthErrorContext`** (new): resolves conflicts + region (from the gateway URL) into one payload, attached to the auth-error screen and to the captured `WizardError` (sources / keys / region / gatewayUrl). Absolute paths stay out of telemetry since they contain the home dir.
- **`AuthErrorScreen` / `ManagedSettingsScreen`**: name the exact file(s) and key(s). Managed (root-owned) files point at IT; the user's own files tell them to remove the keys (or `claude auth logout`) and re-run. Read-only conflicts (global/local) now get a correct pre-run heads-up instead of the old "contact your IT administrator" copy.

## Test plan

- `src/lib/agent/__tests__/settings-conflicts.test.ts` (9 cases): detection across project / project-local / user-global sources with correct `writable` + `path`, multi-source reporting, and `buildAuthErrorContext` (conflict summary, key dedup, region derivation eu/us/local).
- `pnpm screens:check` (new): renders the real screen components with Ink (via ink-testing-library, since jest globally mocks `ink`) and asserts each conflict screen names the offending file + key with the right remediation — including negative cases (no-conflict 401 falls back to key guidance; a user/global conflict tells the user to self-fix rather than "contact IT", which only managed files do).
- `pnpm typecheck`, `pnpm test` (820 pass), `pnpm lint` (0 errors) green.

Not run: a live gateway 401 over the network. The published binary requires an interactive TTY and `--ci` mode is disabled in published builds, so a full live run needs the wizard-workbench env (which mocks the gateway). Follow-ups noted in #613 (live `ANTHROPIC_*` env detection; fail-fast pre-run prompt).

## LLM context

Authored by Claude Code while debugging #598. Pairs with #614 (settings backup/restore resilience); both touch `agent-interface.ts`, so the second to merge needs a trivial rebase.