### PR TITLE
feat(cli): replace --skill flag with skill command

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -40,6 +40,7 @@ import { migrateCommand } from './src/commands/migrate';
 import { eventsAuditCommand } from './src/commands/events-audit';
 import { revenueCommand } from './src/commands/revenue';
 import { uploadSourcemapsCommand } from './src/commands/upload-sourcemaps';
+import { skillCommand } from './src/commands/skill';
 
 Wizard.use(basicIntegrationCommand)
   .use(mcpCommand)
@@ -51,4 +52,5 @@ Wizard.use(basicIntegrationCommand)
   .use(eventsAuditCommand)
   .use(revenueCommand)
   .use(uploadSourcemapsCommand)
+  .use(skillCommand)
   .init();

--- a/src/__tests__/basic-integration-cli.test.ts
+++ b/src/__tests__/basic-integration-cli.test.ts
@@ -17,32 +17,6 @@ describe('basic-integration parsing (end-to-end yargs)', () => {
     ).rejects.toThrow(/--playground cannot be combined/i);
   });
 
-  test('rejects --playground with --skill', async () => {
-    await expect(
-      parseCommand(basicIntegrationCommand, '--playground --skill revenue'),
-    ).rejects.toThrow(/--playground cannot be combined/i);
-  });
-
-  test('accepts --ci with --skill (run a skill headlessly)', async () => {
-    const argv = await parseCommand(
-      basicIntegrationCommand,
-      '--ci --skill revenue',
-    );
-    expect(argv.ci).toBe(true);
-    expect(argv.skill).toBe('revenue');
-  });
-
-  test('rejects --skill with no skill id', async () => {
-    await expect(
-      parseCommand(basicIntegrationCommand, '--skill'),
-    ).rejects.toThrow(/--skill needs a skill id/i);
-  });
-
-  test('accepts --skill with an id', async () => {
-    const argv = await parseCommand(basicIntegrationCommand, '--skill revenue');
-    expect(argv.skill).toBe('revenue');
-  });
-
   // Default boolean values (ci/playground default false) must not register as
   // a spurious conflict when only one mode flag is actually passed.
   test.each(['', '--ci --api-key phx_x --install-dir /tmp', '--playground'])(

--- a/src/__tests__/skill-cli.test.ts
+++ b/src/__tests__/skill-cli.test.ts
@@ -1,0 +1,29 @@
+import { skillCommand } from '../commands/skill';
+import { parseCommand } from './helpers/parse-command.no-jest';
+
+describe('skill command parsing (end-to-end yargs)', () => {
+  test('parses the skill name positional', async () => {
+    const argv = await parseCommand(skillCommand, 'skill audit-events');
+    expect(argv.skillName).toBe('audit-events');
+  });
+
+  test('accepts --ci for a headless run', async () => {
+    const argv = await parseCommand(skillCommand, 'skill audit-events --ci');
+    expect(argv.skillName).toBe('audit-events');
+    expect(argv.ci).toBe(true);
+  });
+
+  test('accepts --install-dir', async () => {
+    const argv = await parseCommand(
+      skillCommand,
+      'skill audit-events --install-dir /tmp/app',
+    );
+    expect(argv.installDir).toBe('/tmp/app');
+  });
+
+  test('rejects a bare `skill` with no skill name', async () => {
+    await expect(parseCommand(skillCommand, 'skill')).rejects.toThrow(
+      /not enough non-option arguments/i,
+    );
+  });
+});

--- a/src/__tests__/skill-cli.test.ts
+++ b/src/__tests__/skill-cli.test.ts
@@ -1,5 +1,16 @@
+import type { Arguments } from 'yargs';
+
+jest.mock('../commands/basic-integration/skill', () => ({
+  runSkillMode: jest.fn(),
+}));
+
+import { runSkillMode } from '../commands/basic-integration/skill';
 import { skillCommand } from '../commands/skill';
 import { parseCommand } from './helpers/parse-command.no-jest';
+
+function makeArgv(extra: Record<string, unknown> = {}): Arguments {
+  return { _: [], $0: 'wizard', ...extra } as Arguments;
+}
 
 describe('skill command parsing (end-to-end yargs)', () => {
   test('parses the skill name positional', async () => {
@@ -23,7 +34,38 @@ describe('skill command parsing (end-to-end yargs)', () => {
 
   test('rejects a bare `skill` with no skill name', async () => {
     await expect(parseCommand(skillCommand, 'skill')).rejects.toThrow(
-      /not enough non-option arguments/i,
+      /not enough non-option arguments|skill name/i,
     );
+  });
+});
+
+describe('skill command validation', () => {
+  test('rejects an empty / whitespace skill name', () => {
+    expect(() => skillCommand.check!(makeArgv({ skillName: '   ' }))).toThrow(
+      /skill name/i,
+    );
+  });
+
+  test('accepts a non-empty skill name', () => {
+    expect(skillCommand.check!(makeArgv({ skillName: 'audit-events' }))).toBe(
+      true,
+    );
+  });
+});
+
+describe('skill command handler', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('bridges the positional onto runSkillMode as the skill id', () => {
+    skillCommand.handler!(makeArgv({ skillName: 'audit-events', ci: false }));
+    expect(runSkillMode).toHaveBeenCalledTimes(1);
+    const passed = (runSkillMode as jest.Mock).mock.calls[0][0];
+    expect(passed.skill).toBe('audit-events');
+  });
+
+  test('trims surrounding whitespace from the skill id', () => {
+    skillCommand.handler!(makeArgv({ skillName: '  audit-events  ' }));
+    const passed = (runSkillMode as jest.Mock).mock.calls[0][0];
+    expect(passed.skill).toBe('audit-events');
   });
 });

--- a/src/commands/basic-integration/index.ts
+++ b/src/commands/basic-integration/index.ts
@@ -32,11 +32,6 @@ export const basicIntegrationCommand: Command = {
       type: 'boolean',
       hidden: true,
     },
-    skill: {
-      describe:
-        'Run a specific context-mill skill by ID\nenv: POSTHOG_WIZARD_SKILL',
-      type: 'string',
-    },
     name: {
       describe:
         'Name for account creation with --ci --signup\nenv: POSTHOG_WIZARD_NAME',
@@ -44,27 +39,16 @@ export const basicIntegrationCommand: Command = {
     },
   },
   check: (argv) => {
-    // --playground is the standalone TUI demo; it can't combine with the other
-    // run modes. (--ci + --skill IS valid — run a skill headlessly.)
-    if (argv.playground && (argv.ci || argv.skill)) {
-      throw new Error('--playground cannot be combined with --ci or --skill.');
-    }
-    // --skill with no ID would otherwise fall through to the interactive flow.
-    if (typeof argv.skill === 'string' && argv.skill.trim() === '') {
-      throw new Error('--skill needs a skill ID, e.g. --skill="foo"');
+    // --playground is the standalone TUI demo; it can't combine with --ci.
+    if (argv.playground && argv.ci) {
+      throw new Error('--playground cannot be combined with --ci.');
     }
     return true;
   },
   handler: (argv) => {
     // Each mode file is loaded only when its branch is taken, so a plain
-    // `npx @posthog/wizard` never pulls in the CI, playground, or skill paths.
+    // `npx @posthog/wizard` never pulls in the CI or playground paths.
     void (async () => {
-      // --ci --skill runs the skill headlessly (skill takes precedence over the
-      // default CI integration); --ci alone runs the integration.
-      if (argv.ci && argv.skill) {
-        const { runSkillMode } = await import('./skill');
-        return runSkillMode(argv);
-      }
       if (argv.ci) {
         const { runCIInstall } = await import('./ci-install');
         return runCIInstall(argv);
@@ -76,10 +60,6 @@ export const basicIntegrationCommand: Command = {
       if (argv.playground) {
         const { runPlayground } = await import('./playground');
         return runPlayground();
-      }
-      if (argv.skill) {
-        const { runSkillMode } = await import('./skill');
-        return runSkillMode(argv);
       }
       const { runInteractive } = await import('./interactive');
       runInteractive(argv);

--- a/src/commands/basic-integration/skill.ts
+++ b/src/commands/basic-integration/skill.ts
@@ -3,7 +3,7 @@ import { POSTHOG_DOCS_URL } from '@lib/constants';
 import { runWizard, runWizardCI } from '@lib/runners';
 import { createSkillProgram } from '@lib/programs/agent-skill/index';
 
-/** Run an arbitrary context-mill skill by id (`--skill <id>`, headless with `--ci`). */
+/** Run an arbitrary context-mill skill by id (`wizard skill <id>`, headless with `--ci`). */
 export function runSkillMode(argv: Arguments): void {
   const skillId = argv.skill as string;
   const config = createSkillProgram({

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,0 +1,23 @@
+import { runSkillMode } from './basic-integration/skill';
+import { skillProgramOptions } from './skill-program-options';
+import type { Command } from './command';
+
+/**
+ * `wizard skill <skill-name>` — run a single context-mill skill by id.
+ *
+ * Replaces the old `--skill=<id>` flag on the default command. The skill id
+ * is fetched from context-mill's release at runtime (same mechanism the flag
+ * used), so any published skill id works. Pass `--ci` to run headlessly.
+ */
+export const skillCommand: Command = {
+  name: 'skill <skill-name>',
+  description: 'Run a specific context-mill skill by name',
+  options: {
+    ...skillProgramOptions,
+  },
+  handler: (argv) => {
+    const skillName = String(argv.skillName ?? argv['skill-name'] ?? '').trim();
+    // runSkillMode reads `argv.skill`; bridge the positional onto it.
+    runSkillMode({ ...argv, skill: skillName });
+  },
+};

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -1,6 +1,12 @@
+import type { Arguments } from 'yargs';
 import { runSkillMode } from './basic-integration/skill';
 import { skillProgramOptions } from './skill-program-options';
 import type { Command } from './command';
+
+/** Read the `<skill-name>` positional (yargs camelCases the hyphenated key). */
+function readSkillName(argv: Arguments): string {
+  return String(argv.skillName ?? argv['skill-name'] ?? '').trim();
+}
 
 /**
  * `wizard skill <skill-name>` — run a single context-mill skill by id.
@@ -15,9 +21,19 @@ export const skillCommand: Command = {
   options: {
     ...skillProgramOptions,
   },
+  // yargs already requires the positional, but an explicitly-empty value
+  // (`wizard skill ""`) would otherwise slip through to a broken run with no
+  // skill id. Reject it with the same friendly message the old flag gave.
+  check: (argv) => {
+    if (!readSkillName(argv)) {
+      throw new Error(
+        'skill needs a skill name, e.g. `wizard skill audit-events`',
+      );
+    }
+    return true;
+  },
   handler: (argv) => {
-    const skillName = String(argv.skillName ?? argv['skill-name'] ?? '').trim();
     // runSkillMode reads `argv.skill`; bridge the positional onto it.
-    runSkillMode({ ...argv, skill: skillName });
+    runSkillMode({ ...argv, skill: readSkillName(argv) });
   },
 };

--- a/src/ui/tui/screens/RunScreen.tsx
+++ b/src/ui/tui/screens/RunScreen.tsx
@@ -79,8 +79,8 @@ export const RunScreen = ({ store }: RunScreenProps) => {
 
   // Each program owns its content deck (program/content/index.tsx)
   // and wires it onto its ProgramConfig.getContentBlocks. Fall back to the
-  // agent-skill deck for runtime-created configs (e.g. `--skill <id>`) that
-  // aren't in the static registry.
+  // agent-skill deck for runtime-created configs (e.g. `wizard skill <id>`)
+  // that aren't in the static registry.
   const activeProgram = store.router.activeProgram;
   const learnBlocks = useMemo(() => {
     const getBlocks =


### PR DESCRIPTION
instead of running a single skill using `--skill=<id>` flag, promote it to a `wizard skill <skill-name>` subcommand

## changes

> BREAKING CHANGEEEEEEE 🛑  `wizard --skill=foo` no longer works. Use `wizard skill foo` instead
(headless: `wizard skill foo --ci`)

- New `wizard skill <skill-name>` command: a thin wrapper over the existing
  `runSkillMode` engine, so behavior is unchanged
- Removed the `--skill` flag from the default command, along with its `check`
  rules and handler branches
- Swapped the CLI parsing tests: dropped the old `--skill` flag tests, added
  coverage for the new command'

## testing
- `pnpm build && pnpm test && pnpm lint` all green. Manually confirmed
- `wizard skill <name>` registers in `--help`