### PR TITLE
fix: upload source maps command

### DIFF
--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -10,6 +10,7 @@ import type { Arguments } from 'yargs';
 import { integrateCommand } from '../commands/integrate';
 import { auditCommand } from '../commands/audit';
 import { migrateCommand } from '../commands/migrate';
+import { uploadSourcemapsCommand } from '../commands/upload-sourcemaps';
 import { parseCommand } from './helpers/parse-command.no-jest';
 
 function makeArgv(extra: Record<string, unknown> = {}): Arguments {
@@ -92,5 +93,18 @@ describe('program commands', () => {
       'audit web-analytics --install-dir /tmp/app',
     );
     expect(argv.installDir).toBe('/tmp/app');
+  });
+
+  test('accepts upload-source-maps and legacy upload-sourcemaps alias', async () => {
+    const canonical = await parseCommand(
+      uploadSourcemapsCommand,
+      'upload-source-maps --region eu',
+    );
+    const legacy = await parseCommand(
+      uploadSourcemapsCommand,
+      'upload-sourcemaps --region eu',
+    );
+    expect(canonical.region).toBe('eu');
+    expect(legacy.region).toBe('eu');
   });
 });

--- a/src/commands/upload-sourcemaps.ts
+++ b/src/commands/upload-sourcemaps.ts
@@ -4,7 +4,8 @@ import { skillProgramOptions } from './skill-program-options';
 import type { Command } from './command';
 
 export const uploadSourcemapsCommand: Command = {
-  name: 'upload-sourcemaps',
+  // Must match ProgramConfig.command; legacy alias kept for #489 regression.
+  name: [errorTrackingUploadSourceMapsConfig.command!, 'upload-sourcemaps'],
   description: errorTrackingUploadSourceMapsConfig.description,
   options: {
     ...skillProgramOptions,


### PR DESCRIPTION
Default command
```
npx -y @posthog/wizard@latest upload-source-maps --region eu
```

Doesn't work again due to [some changes](https://github.com/PostHog/wizard/pull/489) in the wizard. Fixing it