### PR TITLE
feat(privacy): consolidate disclosure into Privacy & data usage panel

### DIFF
--- a/src/frameworks/android/android-wizard-agent.ts
+++ b/src/frameworks/android/android-wizard-agent.ts
@@ -20,7 +20,6 @@ export const ANDROID_AGENT_CONFIG: FrameworkConfig<AndroidContext> = {
   metadata: {
     name: 'Android (Kotlin)',
     integration: Integration.android,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/android',
     gatherContext: (options: WizardRunOptions) => {
       const kotlinVersion = getKotlinVersion(options);

--- a/src/frameworks/django/django-wizard-agent.ts
+++ b/src/frameworks/django/django-wizard-agent.ts
@@ -25,7 +25,6 @@ export const DJANGO_AGENT_CONFIG: FrameworkConfig<DjangoContext> = {
   metadata: {
     name: 'Django',
     integration: Integration.django,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/django',
     unsupportedVersionDocsUrl: 'https://posthog.com/docs/libraries/python',
     gatherContext: async (options: WizardRunOptions) => {

--- a/src/frameworks/flask/flask-wizard-agent.ts
+++ b/src/frameworks/flask/flask-wizard-agent.ts
@@ -25,7 +25,6 @@ export const FLASK_AGENT_CONFIG: FrameworkConfig<FlaskContext> = {
   metadata: {
     name: 'Flask',
     integration: Integration.flask,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/python',
     unsupportedVersionDocsUrl: 'https://posthog.com/docs/libraries/python',
     gatherContext: async (options: WizardRunOptions) => {

--- a/src/frameworks/javascript-node/javascript-node-wizard-agent.ts
+++ b/src/frameworks/javascript-node/javascript-node-wizard-agent.ts
@@ -11,7 +11,6 @@ export const JAVASCRIPT_NODE_AGENT_CONFIG: FrameworkConfig<JavaScriptNodeContext
     metadata: {
       name: 'Node.js',
       integration: Integration.javascriptNode,
-      beta: true,
       docsUrl: 'https://posthog.com/docs/libraries/node',
     },
 

--- a/src/frameworks/javascript-web/javascript-web-wizard-agent.ts
+++ b/src/frameworks/javascript-web/javascript-web-wizard-agent.ts
@@ -19,7 +19,6 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
   metadata: {
     name: 'JavaScript (Web)',
     integration: Integration.javascript_web,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/js',
     gatherContext: (options: WizardRunOptions) => {
       const packageManagerName = detectJsPackageManager(options);

--- a/src/frameworks/laravel/laravel-wizard-agent.ts
+++ b/src/frameworks/laravel/laravel-wizard-agent.ts
@@ -28,7 +28,6 @@ export const LARAVEL_AGENT_CONFIG: FrameworkConfig<LaravelContext> = {
   metadata: {
     name: 'Laravel',
     integration: Integration.laravel,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/php',
     unsupportedVersionDocsUrl: 'https://posthog.com/docs/libraries/php',
     gatherContext: async (options: WizardRunOptions) => {

--- a/src/frameworks/nuxt/nuxt-wizard-agent.ts
+++ b/src/frameworks/nuxt/nuxt-wizard-agent.ts
@@ -23,7 +23,6 @@ export const NUXT_AGENT_CONFIG: FrameworkConfig<NuxtContext> = {
     name: 'Nuxt',
     integration: Integration.nuxt,
     docsUrl: 'https://posthog.com/docs/libraries/nuxt',
-    beta: true,
     gatherContext: async (options: WizardRunOptions) => {
       const packageJson = await tryGetPackageJson(options);
       if (!packageJson) return {};

--- a/src/frameworks/python/python-wizard-agent.ts
+++ b/src/frameworks/python/python-wizard-agent.ts
@@ -23,7 +23,6 @@ export const PYTHON_AGENT_CONFIG: FrameworkConfig<PythonContext> = {
   metadata: {
     name: 'Python Language',
     integration: Integration.python,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/python',
     gatherContext: async (options: WizardRunOptions) => {
       const packageManager = await detectPackageManager(options);

--- a/src/frameworks/rails/rails-wizard-agent.ts
+++ b/src/frameworks/rails/rails-wizard-agent.ts
@@ -22,7 +22,6 @@ export const RAILS_AGENT_CONFIG: FrameworkConfig<RailsContext> = {
   metadata: {
     name: 'Ruby on Rails',
     integration: Integration.rails,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/ruby-on-rails',
     unsupportedVersionDocsUrl: 'https://posthog.com/docs/libraries/ruby',
     gatherContext: (options: WizardRunOptions) => {

--- a/src/frameworks/ruby/ruby-wizard-agent.ts
+++ b/src/frameworks/ruby/ruby-wizard-agent.ts
@@ -20,7 +20,6 @@ export const RUBY_AGENT_CONFIG: FrameworkConfig<RubyContext> = {
   metadata: {
     name: 'Ruby',
     integration: Integration.ruby,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/ruby',
     gatherContext: (options: WizardRunOptions) => {
       const packageManager = detectPackageManager(options);

--- a/src/frameworks/svelte/svelte-wizard-agent.ts
+++ b/src/frameworks/svelte/svelte-wizard-agent.ts
@@ -16,7 +16,6 @@ export const SVELTEKIT_AGENT_CONFIG: FrameworkConfig<SvelteKitContext> = {
     name: 'SvelteKit',
     integration: Integration.sveltekit,
     docsUrl: 'https://posthog.com/docs/libraries/svelte',
-    beta: true,
     additionalMcpServers: {
       svelte: { url: 'https://mcp.svelte.dev/mcp' },
     },

--- a/src/frameworks/swift/swift-wizard-agent.ts
+++ b/src/frameworks/swift/swift-wizard-agent.ts
@@ -20,7 +20,6 @@ export const SWIFT_AGENT_CONFIG: FrameworkConfig<SwiftContext> = {
   metadata: {
     name: 'Swift (iOS/macOS)',
     integration: Integration.swift,
-    beta: true,
     docsUrl: 'https://posthog.com/docs/libraries/ios',
     preRunNotice:
       'Please close the Xcode project before proceeding. Xcode may overwrite changes the wizard makes to project files.',

--- a/src/frameworks/vue/vue-wizard-agent.ts
+++ b/src/frameworks/vue/vue-wizard-agent.ts
@@ -20,7 +20,6 @@ export const VUE_AGENT_CONFIG: FrameworkConfig<VueContext> = {
     name: 'Vue',
     integration: Integration.vue,
     docsUrl: 'https://posthog.com/docs/libraries/vue',
-    beta: true,
   },
 
   detection: {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -57,6 +57,15 @@ export const DEFAULT_HOST_URL = IS_DEV
   : 'https://us.i.posthog.com';
 export const ISSUES_URL = 'https://github.com/posthog/wizard/issues';
 export const CONTEXT_MILL_URL = 'https://github.com/PostHog/context-mill';
+/**
+ * Latest context-mill release page — the BYOAI download link shown in
+ * the privacy panel. Deliberately the release PAGE, not a direct asset
+ * URL: asset URLs are ~89 chars and hard-wrap inside the 64-col panel,
+ * which corrupts terminal copy/paste with a mid-URL line break. This
+ * stays under one line; the panel names the exact asset to grab.
+ */
+export const CONTEXT_MILL_RELEASES_URL =
+  'https://github.com/PostHog/context-mill/releases/latest';
 export const POSTHOG_DOCS_URL = 'https://posthog.com/docs';
 export const POSTHOG_WIZARD_REPO_URL = 'https://github.com/PostHog/wizard';
 export const POSTHOG_TERMS_URL = 'https://posthog.com/terms';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -58,6 +58,10 @@ export const DEFAULT_HOST_URL = IS_DEV
 export const ISSUES_URL = 'https://github.com/posthog/wizard/issues';
 export const CONTEXT_MILL_URL = 'https://github.com/PostHog/context-mill';
 export const POSTHOG_DOCS_URL = 'https://posthog.com/docs';
+export const POSTHOG_WIZARD_REPO_URL = 'https://github.com/PostHog/wizard';
+export const POSTHOG_TERMS_URL = 'https://posthog.com/terms';
+export const POSTHOG_PRIVACY_URL = 'https://posthog.com/privacy';
+export const WIZARD_CONTACT_EMAIL = 'wizard@posthog.com';
 
 /** Remote base URL for fetching the skill menu + downloading skills. */
 export const REMOTE_SKILLS_BASE_URL =

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -57,10 +57,14 @@ export const DEFAULT_HOST_URL = IS_DEV
   : 'https://us.i.posthog.com';
 export const ISSUES_URL = 'https://github.com/posthog/wizard/issues';
 export const CONTEXT_MILL_URL = 'https://github.com/PostHog/context-mill';
+export const CONTEXT_MILL_RELEASE_URL =
+  'https://github.com/PostHog/context-mill/releases';
 export const POSTHOG_DOCS_URL = 'https://posthog.com/docs';
 export const POSTHOG_WIZARD_REPO_URL = 'https://github.com/PostHog/wizard';
 export const POSTHOG_TERMS_URL = 'https://posthog.com/terms';
 export const POSTHOG_PRIVACY_URL = 'https://posthog.com/privacy';
+export const POSTHOG_ORG_AI_SETTINGS_URL =
+  'https://app.posthog.com/settings/organization-details#setting=organization-ai-consent';
 export const WIZARD_CONTACT_EMAIL = 'wizard@posthog.com';
 
 /** Remote base URL for fetching the skill menu + downloading skills. */

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -22,6 +22,7 @@ export const errorTrackingUploadSourceMapsConfig: ProgramConfig = {
   command: 'upload-source-maps',
   description: 'Upload source maps to PostHog Error Tracking',
   id: 'error-tracking-upload-source-maps',
+  requiresAi: false,
   steps: ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM,
   reportFile: REPORT_FILE,
   getContentBlocks,

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -22,7 +22,7 @@ export const errorTrackingUploadSourceMapsConfig: ProgramConfig = {
   command: 'upload-source-maps',
   description: 'Upload source maps to PostHog Error Tracking',
   id: 'error-tracking-upload-source-maps',
-  requiresAi: false,
+  requiresAi: true,
   steps: ERROR_TRACKING_UPLOAD_SOURCE_MAPS_PROGRAM,
   reportFile: REPORT_FILE,
   getContentBlocks,

--- a/src/lib/programs/mcp/index.ts
+++ b/src/lib/programs/mcp/index.ts
@@ -13,6 +13,7 @@ import { McpOutcome } from '@lib/wizard-session';
 
 export const mcpAddConfig: ProgramConfig = {
   id: 'mcp-add',
+  requiresAi: false,
   description: 'Add PostHog MCP server to supported clients',
   steps: [
     {
@@ -60,6 +61,7 @@ export const mcpAddConfig: ProgramConfig = {
  */
 export const mcpRemoveConfig: ProgramConfig = {
   id: 'mcp-remove',
+  requiresAi: false,
   description: 'Remove PostHog MCP server from supported clients',
   steps: [
     {
@@ -83,6 +85,7 @@ export const mcpRemoveConfig: ProgramConfig = {
  */
 export const mcpTutorialConfig: ProgramConfig = {
   id: 'mcp-tutorial',
+  requiresAi: false,
   description: 'Try the PostHog MCP with your agent — no install needed',
   steps: [
     {

--- a/src/lib/programs/mcp/index.ts
+++ b/src/lib/programs/mcp/index.ts
@@ -13,6 +13,7 @@ import { McpOutcome } from '@lib/wizard-session';
 
 export const mcpAddConfig: ProgramConfig = {
   id: 'mcp-add',
+  requiresAi: false,
   description: 'Add PostHog MCP server to supported clients',
   steps: [
     {
@@ -50,6 +51,7 @@ export const mcpAddConfig: ProgramConfig = {
  */
 export const mcpRemoveConfig: ProgramConfig = {
   id: 'mcp-remove',
+  requiresAi: false,
   description: 'Remove PostHog MCP server from supported clients',
   steps: [
     {
@@ -73,6 +75,7 @@ export const mcpRemoveConfig: ProgramConfig = {
  */
 export const mcpTutorialConfig: ProgramConfig = {
   id: 'mcp-tutorial',
+  requiresAi: false,
   description: 'Try the PostHog MCP with your agent — no install needed',
   steps: [
     {

--- a/src/lib/programs/posthog-doctor/index.ts
+++ b/src/lib/programs/posthog-doctor/index.ts
@@ -7,6 +7,7 @@ export const posthogDoctorConfig: ProgramConfig = {
   description:
     'Diagnose your PostHog project for configuration issues and setup warnings',
   id: 'posthog-doctor',
+  requiresAi: false,
   steps: POSTHOG_DOCTOR_PROGRAM,
   allowedTools: ['Agent'],
   disallowedTools: [WIZARD_TOOL_NAMES.wizardAsk],

--- a/src/lib/programs/posthog-integration/detect.ts
+++ b/src/lib/programs/posthog-integration/detect.ts
@@ -49,7 +49,11 @@ export async function detectPostHogIntegration(
     }
 
     ctx.setFrameworkConfig(detectedIntegration, config);
-    session.skillId = detectedIntegration;
+    // Must go through the store setter: setFrameworkConfig (above) calls
+    // nanostore setKey, which replaces the session with a shallow copy —
+    // a direct `session.skillId = ...` here would write to the stale
+    // pre-copy object and the live session would never see it.
+    ctx.setSkillId(detectedIntegration);
 
     if (!session.detectedFrameworkLabel) {
       ctx.setDetectedFramework(config.metadata.name);

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -122,6 +122,19 @@ export interface ProgramConfig {
   /** Unique program id — matches the Program enum value */
   id: string;
   /**
+   * Whether this program's agent run requires third-party AI services.
+   *
+   * When true (the default), the wizard checks
+   * `apiUser.organization.is_ai_data_processing_approved` after auth and
+   * renders `AiOptInRequiredScreen` if the org has not opted in. Matches
+   * Max's strict reading: only literal `true` proceeds.
+   *
+   * Opt out (set to `false`) for programs that don't run the agent —
+   * doctor, mcp install/remove/tutorial, source-map upload. The safe
+   * default is `true` so future programs gate by declaration.
+   */
+  requiresAi?: boolean;
+  /**
    * Context-mill skill ID this program installs and runs. When present,
    * bin.ts seeds `session.skillId` with this value before the TUI renders
    * so intro screens can resolve skill metadata without waiting for the

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -123,6 +123,19 @@ export interface ProgramConfig {
   /** Unique program id — matches the Program enum value */
   id: string;
   /**
+   * Whether this program's agent run requires third-party AI services.
+   *
+   * When true (the default), the wizard checks
+   * `apiUser.organization.is_ai_data_processing_approved` after auth and
+   * renders `AiOptInRequiredScreen` if the org has not opted in. Matches
+   * Max's strict reading: only literal `true` proceeds.
+   *
+   * Opt out (set to `false`) for programs that don't run the agent —
+   * doctor, mcp install/remove/tutorial, source-map upload. The safe
+   * default is `true` so future programs gate by declaration.
+   */
+  requiresAi?: boolean;
+  /**
    * Context-mill skill ID this program installs and runs. When present,
    * bin.ts seeds `session.skillId` with this value before the TUI renders
    * so intro screens can resolve skill metadata without waiting for the

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -43,6 +43,7 @@ export interface ProgramReadyContext {
     config: FrameworkConfig,
   ) => void;
   readonly setDetectedFramework: (label: string) => void;
+  readonly setSkillId: (skillId: string | null) => void;
   readonly setUnsupportedVersion: (info: {
     current: string;
     minimum: string;

--- a/src/lib/runners/run-wizard-ci.ts
+++ b/src/lib/runners/run-wizard-ci.ts
@@ -97,6 +97,11 @@ export function runWizardCI(
           },
           setFrameworkConfig: () => undefined,
           setDetectedFramework: () => undefined,
+          // CI session is a plain object (no nanostore copy-on-write),
+          // so direct assignment is safe here.
+          setSkillId: (skillId: string | null) => {
+            session.skillId = skillId;
+          },
           setUnsupportedVersion: () => undefined,
           addDiscoveredFeature: () => undefined,
           setDetectionComplete: () => undefined,

--- a/src/lib/runners/run-wizard-ci.ts
+++ b/src/lib/runners/run-wizard-ci.ts
@@ -93,6 +93,11 @@ export function runWizardCI(
           },
           setFrameworkConfig: () => undefined,
           setDetectedFramework: () => undefined,
+          // CI session is a plain object (no nanostore copy-on-write),
+          // so direct assignment is safe here.
+          setSkillId: (skillId: string | null) => {
+            session.skillId = skillId;
+          },
           setUnsupportedVersion: () => undefined,
           addDiscoveredFeature: () => undefined,
           setDetectionComplete: () => undefined,

--- a/src/ui/tui/__tests__/skill-entry.test.ts
+++ b/src/ui/tui/__tests__/skill-entry.test.ts
@@ -1,0 +1,38 @@
+import { resolveSkillEntry } from '@ui/tui/screens/SkillSourceInfo';
+import type { SkillEntry } from '@lib/wizard-tools';
+
+const entry = (id: string): SkillEntry =>
+  ({ id, downloadUrl: `https://example.com/${id}.tar.gz` } as SkillEntry);
+
+const MENU: SkillEntry[] = [
+  entry('audit'),
+  entry('integration-python'),
+  entry('integration-django'),
+  entry('integration-nextjs-app-router'),
+  entry('integration-nextjs-pages-router'),
+  entry('integration-vue-3'),
+];
+
+describe('resolveSkillEntry', () => {
+  it('matches exact ids (named programs like audit)', () => {
+    expect(resolveSkillEntry(MENU, 'audit')?.id).toBe('audit');
+  });
+
+  it('matches raw integration ids against integration-<id> entries', () => {
+    expect(resolveSkillEntry(MENU, 'python')?.id).toBe('integration-python');
+  });
+
+  it('matches a unique integration-<id>-* variant', () => {
+    expect(resolveSkillEntry(MENU, 'vue')?.id).toBe('integration-vue-3');
+  });
+
+  it('returns null for ambiguous variants rather than guessing', () => {
+    // nextjs has app-router and pages-router variants — which one is
+    // right depends on the project, so don't pick arbitrarily.
+    expect(resolveSkillEntry(MENU, 'nextjs')).toBeNull();
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(resolveSkillEntry(MENU, 'cobol')).toBeNull();
+  });
+});

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -47,8 +47,9 @@ export const PrivacyPanel = ({
 
       <Box marginTop={1}>
         <Text>
-          Telemetry is enabled by default. You can disable it by passing
-          <Text color="green">--no-telemetry</Text>.
+          We collect anonymous usage metrics (run count, errors, cost) — never
+          your source code or prompts, and nothing is used for AI training. Pass{' '}
+          <Text color="green">--no-telemetry</Text> to opt out.
         </Text>
       </Box>
 

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -5,12 +5,12 @@
  * identically from the intro screen ("Privacy & data usage" menu option)
  * and as an overlay from the auth screen ([I] keystroke).
  *
- * Compact layout — must fit in a default-sized macOS Terminal (~24
- * rows) without scrolling. Sections are visually grouped with bold
- * headers and a single blank line between them; no nested margin boxes.
+ * Must fit in a default-sized macOS Terminal (~24 rows) with no
+ * scrolling. Compact paragraph form is preferred over multi-section
+ * bullet layouts — users who want the full legal text follow the Terms
+ * / Privacy links to their browser.
  */
 
-import type { ReactNode } from 'react';
 import { Box, Text } from 'ink';
 import {
   POSTHOG_PRIVACY_URL,
@@ -22,7 +22,6 @@ import {
   SkillSourceInfo,
   useSkillEntry,
 } from '@ui/tui/screens/SkillSourceInfo';
-import { Divider } from '@ui/tui/primitives/index';
 
 interface PrivacyPanelProps {
   /** Reflects session.noTelemetry — controls the telemetry status line. */
@@ -47,15 +46,13 @@ export const PrivacyPanel = ({
         <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>
       </Text>
 
-      <Section title="Leaves your machine">
-        <Bullet>Source files → Anthropic Claude (AI context)</Bullet>
-        <Bullet>Run metadata → PostHog telemetry</Bullet>
-      </Section>
-
-      <Section title="Stays on your machine">
-        <Bullet>.env* files and secrets</Bullet>
-        <Bullet>Anything matched by the security scanner</Bullet>
-      </Section>
+      <Box marginTop={1}>
+        <Text>
+          We use <Text bold>Anthropic Claude</Text> to read your source files as
+          AI context. <Text bold>.env*</Text> files, secrets, and anything
+          matched by the security scanner stay on your machine.
+        </Text>
+      </Box>
 
       <Box marginTop={1}>
         <Text>
@@ -73,46 +70,22 @@ export const PrivacyPanel = ({
         </Text>
       </Box>
 
-      <Section title="Prefer your own AI?">
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>Prefer your own AI? Download the skill:</Text>
         <SkillSourceInfo
           skillId={skillId}
           skillEntry={skillEntry}
           fetchFailed={fetchFailed}
         />
-      </Section>
+      </Box>
 
       <Box marginTop={1}>
         <Text dimColor>
-          Terms: <Text color="cyan">{POSTHOG_TERMS_URL}</Text> · Privacy:{' '}
-          <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text>
+          <Text color="cyan">{POSTHOG_TERMS_URL}</Text> ·{' '}
+          <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text> ·{' '}
+          <Text color="cyan">{WIZARD_CONTACT_EMAIL}</Text>
         </Text>
-      </Box>
-      <Text dimColor>
-        Contact: <Text color="cyan">{WIZARD_CONTACT_EMAIL}</Text>
-      </Text>
-
-      <Box marginTop={1}>
-        <Divider />
       </Box>
     </Box>
   );
 };
-
-const Section = ({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) => (
-  <Box flexDirection="column" marginTop={1}>
-    <Text bold>{title}</Text>
-    {children}
-  </Box>
-);
-
-const Bullet = ({ children }: { children: ReactNode }) => (
-  <Text>
-    {'•'} {children}
-  </Text>
-);

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -33,7 +33,7 @@ interface PrivacyPanelProps {
 }
 
 export const PrivacyPanel = ({
-  noTelemetry,
+  noTelemetry: _noTelemetry,
   skillId,
   localMcp,
 }: PrivacyPanelProps) => {
@@ -42,19 +42,24 @@ export const PrivacyPanel = ({
   return (
     <Box flexDirection="column" width={64} flexShrink={0}>
       <Text>
-        We use <Text bold>Anthropic Claude</Text> to read your source files as
-        AI context. <Text bold>.env*</Text> files, secrets, and anything matched
-        by the security scanner stay on your machine. Telemetry is{' '}
-        {noTelemetry ? (
-          <Text color="green">DISABLED</Text>
-        ) : (
-          <Text color="yellow">ENABLED</Text>
-        )}{' '}
-        — pass <Text color="cyan">--no-telemetry</Text>
-        {noTelemetry ? '' : ' to disable'}. The wizard is open source (
-        <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>); prefer your own
-        AI? Download the skill below and run it in your own agent.
+        We use Anthropic's Claude via the PostHog LLM gateway to read your
+        source files as AI context. .env* files, secrets, and anything matched
+        by the security scanner stay on your machine. The wizard is open source
+        (<Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>).
       </Text>
+
+      <Box marginTop={1}>
+        <Text>
+          Telemetry is enabled by default. You can disable it by passing
+          `--no-telemetry`.
+        </Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text>
+          Prefer your own AI? Download the skill and run it in your own agent.
+        </Text>
+      </Box>
 
       <Box marginTop={1}>
         <SkillSourceInfo

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -5,71 +5,44 @@
  * identically from the intro screen ("Privacy & data usage" menu option)
  * and as an overlay from the auth screen ([I] keystroke).
  *
- * Must fit in a default-sized macOS Terminal (~24 rows). One condensed
- * paragraph carries the top-level disclosure; the dynamic skill block
- * and link footer follow. Users who want the full legal text follow
- * the Terms / Privacy URLs to their browser.
+ * Must fit in a default-sized macOS Terminal (~24 rows). Two condensed
+ * paragraphs carry the top-level disclosure; the link footer follows.
+ * Users who want the full legal text follow the Terms / Privacy URLs to
+ * their browser.
  */
 
 import { Box, Text } from 'ink';
 import {
-  CONTEXT_MILL_URL,
+  POSTHOG_ORG_AI_SETTINGS_URL,
   POSTHOG_PRIVACY_URL,
   POSTHOG_TERMS_URL,
-  POSTHOG_WIZARD_REPO_URL,
-  WIZARD_CONTACT_EMAIL,
 } from '@lib/constants';
-import { useSkillEntry } from '@ui/tui/screens/SkillSourceInfo';
 
-interface PrivacyPanelProps {
-  /** Program's skill id, for the BYOAI escape-hatch section. */
-  skillId: string | null;
-  /** Session's localMcp flag — picks remote vs local skill base URL. */
-  localMcp: boolean;
-}
-
-export const PrivacyPanel = ({ skillId, localMcp }: PrivacyPanelProps) => {
-  const { skillEntry, fetchFailed } = useSkillEntry(skillId, localMcp);
-
+export const PrivacyPanel = () => {
   return (
     <Box flexDirection="column" width={64} flexShrink={0}>
       <Text>
         We use Anthropic's Claude via the PostHog LLM gateway to read your
         source files as AI context. .env* files, secrets, and anything matched
-        by the security scanner stay on your machine. The wizard is open source:{' '}
-        <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>.
+        by the security scanner stay on your machine.
       </Text>
 
       <Box marginTop={1}>
         <Text>
-          We collect anonymous usage metrics (run count, errors, cost) — never
-          your source code or prompts, and nothing is used for AI training. Pass{' '}
-          <Text color="green">--no-telemetry</Text> to opt out.
-        </Text>
-      </Box>
-
-      {/* Fallback to the skills repo when the menu lookup can't resolve a
-          single skill (ambiguous framework variants, menu fetch failure) —
-          a browseable link beats rendering "unavailable". */}
-      <Box marginTop={1}>
-        <Text>
-          Prefer your own AI? Download the skill and run it in your own agent:{' '}
-          <Text color="cyan">
-            {skillEntry?.downloadUrl ??
-              (fetchFailed ? CONTEXT_MILL_URL : 'Loading...')}
-          </Text>
+          To use the wizard, AI features must be enabled in your organization's
+          settings.
         </Text>
       </Box>
 
       <Box marginTop={1} flexDirection="column">
-        <Text dimColor>
+        <Text>
           Terms: <Text color="cyan">{POSTHOG_TERMS_URL}</Text>
         </Text>
-        <Text dimColor>
+        <Text>
           Privacy: <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text>
         </Text>
-        <Text dimColor>
-          Contact: <Text color="cyan">{WIZARD_CONTACT_EMAIL}</Text>
+        <Text>
+          AI settings: <Text color="cyan">{POSTHOG_ORG_AI_SETTINGS_URL}</Text>
         </Text>
       </Box>
     </Box>

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -1,0 +1,123 @@
+/**
+ * PrivacyPanel — Shared disclosure component.
+ *
+ * Single source of truth for the wizard's privacy disclosure, rendered
+ * identically from the intro screen ("Privacy & data usage" menu option)
+ * and as an overlay from the auth screen ([I] keystroke).
+ *
+ * Sections:
+ *   - Open source         (trust signal)
+ *   - Leaves your machine (source files → Claude, run metadata → telemetry)
+ *   - Stays on your machine (.env*, secrets, anything matched by YARA)
+ *   - Telemetry status    (reflects session.noTelemetry)
+ *   - BYOAI escape        (SkillSourceInfo — the strongest privacy out)
+ *   - Terms / Privacy / Contact
+ */
+
+import type { ReactNode } from 'react';
+import { Box, Text } from 'ink';
+import {
+  POSTHOG_PRIVACY_URL,
+  POSTHOG_TERMS_URL,
+  POSTHOG_WIZARD_REPO_URL,
+  WIZARD_CONTACT_EMAIL,
+} from '@lib/constants';
+import {
+  SkillSourceInfo,
+  useSkillEntry,
+} from '@ui/tui/screens/SkillSourceInfo';
+
+interface PrivacyPanelProps {
+  /** Reflects session.noTelemetry — controls the telemetry status line. */
+  noTelemetry: boolean;
+  /** Program's skill id, for the BYOAI escape-hatch section. */
+  skillId: string | null;
+  /** Session's localMcp flag — picks remote vs local skill base URL. */
+  localMcp: boolean;
+}
+
+export const PrivacyPanel = ({
+  noTelemetry,
+  skillId,
+  localMcp,
+}: PrivacyPanelProps) => {
+  const { skillEntry, fetchFailed } = useSkillEntry(skillId, localMcp);
+
+  return (
+    <Box flexDirection="column" width={64} flexShrink={0}>
+      <Section title="Open source">
+        <Text>
+          The wizard's code is open:{' '}
+          <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>
+        </Text>
+      </Section>
+
+      <Section title="Leaves your machine">
+        <Bullet>Source files → Anthropic Claude (AI context)</Bullet>
+        <Bullet>Run metadata → PostHog telemetry</Bullet>
+      </Section>
+
+      <Section title="Stays on your machine">
+        <Bullet>.env* files and secrets</Bullet>
+        <Bullet>Anything matched by the security scanner</Bullet>
+      </Section>
+
+      <Section title="Telemetry">
+        {noTelemetry ? (
+          <Text>
+            <Text color="green">DISABLED</Text> (via --no-telemetry)
+          </Text>
+        ) : (
+          <Text>
+            <Text color="yellow">ENABLED</Text> — run with{' '}
+            <Text color="cyan">--no-telemetry</Text> to disable
+          </Text>
+        )}
+      </Section>
+
+      <Section title="Prefer your own AI?">
+        <Text>Download the skill and run it in your own agent:</Text>
+        <Box marginTop={1}>
+          <SkillSourceInfo
+            skillId={skillId}
+            skillEntry={skillEntry}
+            fetchFailed={fetchFailed}
+          />
+        </Box>
+      </Section>
+
+      <Section title="More info">
+        <Text>
+          Terms: <Text color="cyan">{POSTHOG_TERMS_URL}</Text>
+        </Text>
+        <Text>
+          Privacy: <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text>
+        </Text>
+        <Text>
+          Contact: <Text color="cyan">{WIZARD_CONTACT_EMAIL}</Text>
+        </Text>
+      </Section>
+    </Box>
+  );
+};
+
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) => (
+  <Box flexDirection="column" marginTop={1}>
+    <Text bold>{title}</Text>
+    <Box flexDirection="column" marginTop={0}>
+      {children}
+    </Box>
+  </Box>
+);
+
+const Bullet = ({ children }: { children: ReactNode }) => (
+  <Text>
+    {'•'} {children}
+  </Text>
+);

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -13,6 +13,7 @@
 
 import { Box, Text } from 'ink';
 import {
+  CONTEXT_MILL_URL,
   POSTHOG_PRIVACY_URL,
   POSTHOG_TERMS_URL,
   POSTHOG_WIZARD_REPO_URL,
@@ -47,12 +48,15 @@ export const PrivacyPanel = ({ skillId, localMcp }: PrivacyPanelProps) => {
         </Text>
       </Box>
 
+      {/* Fallback to the skills repo when the menu lookup can't resolve a
+          single skill (ambiguous framework variants, menu fetch failure) —
+          a browseable link beats rendering "unavailable". */}
       <Box marginTop={1}>
         <Text>
           Prefer your own AI? Download the skill and run it in your own agent:{' '}
           <Text color="cyan">
             {skillEntry?.downloadUrl ??
-              (fetchFailed ? 'unavailable' : 'Loading...')}
+              (fetchFailed ? CONTEXT_MILL_URL : 'Loading...')}
           </Text>
         </Text>
       </Box>

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -5,13 +5,9 @@
  * identically from the intro screen ("Privacy & data usage" menu option)
  * and as an overlay from the auth screen ([I] keystroke).
  *
- * Sections:
- *   - Open source         (trust signal)
- *   - Leaves your machine (source files → Claude, run metadata → telemetry)
- *   - Stays on your machine (.env*, secrets, anything matched by YARA)
- *   - Telemetry status    (reflects session.noTelemetry)
- *   - BYOAI escape        (SkillSourceInfo — the strongest privacy out)
- *   - Terms / Privacy / Contact
+ * Compact layout — must fit in a default-sized macOS Terminal (~24
+ * rows) without scrolling. Sections are visually grouped with bold
+ * headers and a single blank line between them; no nested margin boxes.
  */
 
 import type { ReactNode } from 'react';
@@ -26,6 +22,7 @@ import {
   SkillSourceInfo,
   useSkillEntry,
 } from '@ui/tui/screens/SkillSourceInfo';
+import { Divider } from '@ui/tui/primitives/index';
 
 interface PrivacyPanelProps {
   /** Reflects session.noTelemetry — controls the telemetry status line. */
@@ -45,12 +42,10 @@ export const PrivacyPanel = ({
 
   return (
     <Box flexDirection="column" width={64} flexShrink={0}>
-      <Section title="Open source">
-        <Text>
-          The wizard's code is open:{' '}
-          <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>
-        </Text>
-      </Section>
+      <Text>
+        Wizard is open source —{' '}
+        <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>
+      </Text>
 
       <Section title="Leaves your machine">
         <Bullet>Source files → Anthropic Claude (AI context)</Bullet>
@@ -62,41 +57,43 @@ export const PrivacyPanel = ({
         <Bullet>Anything matched by the security scanner</Bullet>
       </Section>
 
-      <Section title="Telemetry">
-        {noTelemetry ? (
-          <Text>
-            <Text color="green">DISABLED</Text> (via --no-telemetry)
-          </Text>
-        ) : (
-          <Text>
-            <Text color="yellow">ENABLED</Text> — run with{' '}
-            <Text color="cyan">--no-telemetry</Text> to disable
-          </Text>
-        )}
-      </Section>
+      <Box marginTop={1}>
+        <Text>
+          <Text bold>Telemetry:</Text>{' '}
+          {noTelemetry ? (
+            <>
+              <Text color="green">DISABLED</Text> (via --no-telemetry)
+            </>
+          ) : (
+            <>
+              <Text color="yellow">ENABLED</Text> — run with{' '}
+              <Text color="cyan">--no-telemetry</Text> to disable
+            </>
+          )}
+        </Text>
+      </Box>
 
       <Section title="Prefer your own AI?">
-        <Text>Download the skill and run it in your own agent:</Text>
-        <Box marginTop={1}>
-          <SkillSourceInfo
-            skillId={skillId}
-            skillEntry={skillEntry}
-            fetchFailed={fetchFailed}
-          />
-        </Box>
+        <SkillSourceInfo
+          skillId={skillId}
+          skillEntry={skillEntry}
+          fetchFailed={fetchFailed}
+        />
       </Section>
 
-      <Section title="More info">
-        <Text>
-          Terms: <Text color="cyan">{POSTHOG_TERMS_URL}</Text>
+      <Box marginTop={1}>
+        <Text dimColor>
+          Terms: <Text color="cyan">{POSTHOG_TERMS_URL}</Text> · Privacy:{' '}
+          <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text>
         </Text>
-        <Text>
-          Privacy: <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text>
-        </Text>
-        <Text>
-          Contact: <Text color="cyan">{WIZARD_CONTACT_EMAIL}</Text>
-        </Text>
-      </Section>
+      </Box>
+      <Text dimColor>
+        Contact: <Text color="cyan">{WIZARD_CONTACT_EMAIL}</Text>
+      </Text>
+
+      <Box marginTop={1}>
+        <Divider />
+      </Box>
     </Box>
   );
 };
@@ -110,9 +107,7 @@ const Section = ({
 }) => (
   <Box flexDirection="column" marginTop={1}>
     <Text bold>{title}</Text>
-    <Box flexDirection="column" marginTop={0}>
-      {children}
-    </Box>
+    {children}
   </Box>
 );
 

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -36,8 +36,8 @@ export const PrivacyPanel = ({ skillId, localMcp }: PrivacyPanelProps) => {
       <Text>
         We use Anthropic's Claude via the PostHog LLM gateway to read your
         source files as AI context. .env* files, secrets, and anything matched
-        by the security scanner stay on your machine. The wizard is open source:{' '}
-        <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>.
+        by the local security scanner stay on your machine. The wizard is open
+        source: <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>.
       </Text>
 
       <Box marginTop={1}>

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -48,19 +48,13 @@ export const PrivacyPanel = ({
       <Box marginTop={1}>
         <Text>
           Telemetry is enabled by default. You can disable it by passing
-          `--no-telemetry`.
+          <Text color="green">--no-telemetry</Text>.
         </Text>
       </Box>
 
       <Box marginTop={1}>
         <Text>
-          Prefer your own AI? Download the skill and run it in your own agent.
-        </Text>
-      </Box>
-
-      <Box marginTop={1}>
-        <Text>
-          Skill:{' '}
+          Prefer your own AI? Download the skill and run it in your own agent:{' '}
           <Text color="cyan">
             {skillEntry?.downloadUrl ??
               (fetchFailed ? 'unavailable' : 'Loading...')}

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -5,10 +5,10 @@
  * identically from the intro screen ("Privacy & data usage" menu option)
  * and as an overlay from the auth screen ([I] keystroke).
  *
- * Must fit in a default-sized macOS Terminal (~24 rows) with no
- * scrolling. Compact paragraph form is preferred over multi-section
- * bullet layouts — users who want the full legal text follow the Terms
- * / Privacy links to their browser.
+ * Must fit in a default-sized macOS Terminal (~24 rows). One condensed
+ * paragraph carries the top-level disclosure; the dynamic skill block
+ * and link footer follow. Users who want the full legal text follow
+ * the Terms / Privacy URLs to their browser.
  */
 
 import { Box, Text } from 'ink';
@@ -42,36 +42,21 @@ export const PrivacyPanel = ({
   return (
     <Box flexDirection="column" width={64} flexShrink={0}>
       <Text>
-        Wizard is open source —{' '}
-        <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>
+        We use <Text bold>Anthropic Claude</Text> to read your source files as
+        AI context. <Text bold>.env*</Text> files, secrets, and anything matched
+        by the security scanner stay on your machine. Telemetry is{' '}
+        {noTelemetry ? (
+          <Text color="green">DISABLED</Text>
+        ) : (
+          <Text color="yellow">ENABLED</Text>
+        )}{' '}
+        — pass <Text color="cyan">--no-telemetry</Text>
+        {noTelemetry ? '' : ' to disable'}. The wizard is open source (
+        <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>); prefer your own
+        AI? Download the skill below and run it in your own agent.
       </Text>
 
       <Box marginTop={1}>
-        <Text>
-          We use <Text bold>Anthropic Claude</Text> to read your source files as
-          AI context. <Text bold>.env*</Text> files, secrets, and anything
-          matched by the security scanner stay on your machine.
-        </Text>
-      </Box>
-
-      <Box marginTop={1}>
-        <Text>
-          <Text bold>Telemetry:</Text>{' '}
-          {noTelemetry ? (
-            <>
-              <Text color="green">DISABLED</Text> (via --no-telemetry)
-            </>
-          ) : (
-            <>
-              <Text color="yellow">ENABLED</Text> — run with{' '}
-              <Text color="cyan">--no-telemetry</Text> to disable
-            </>
-          )}
-        </Text>
-      </Box>
-
-      <Box marginTop={1} flexDirection="column">
-        <Text bold>Prefer your own AI? Download the skill:</Text>
         <SkillSourceInfo
           skillId={skillId}
           skillEntry={skillEntry}
@@ -79,11 +64,15 @@ export const PrivacyPanel = ({
         />
       </Box>
 
-      <Box marginTop={1}>
+      <Box marginTop={1} flexDirection="column">
         <Text dimColor>
-          <Text color="cyan">{POSTHOG_TERMS_URL}</Text> ·{' '}
-          <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text> ·{' '}
-          <Text color="cyan">{WIZARD_CONTACT_EMAIL}</Text>
+          Terms: <Text color="cyan">{POSTHOG_TERMS_URL}</Text>
+        </Text>
+        <Text dimColor>
+          Privacy: <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text>
+        </Text>
+        <Text dimColor>
+          Contact: <Text color="cyan">{WIZARD_CONTACT_EMAIL}</Text>
         </Text>
       </Box>
     </Box>

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -21,19 +21,13 @@ import {
 import { useSkillEntry } from '@ui/tui/screens/SkillSourceInfo';
 
 interface PrivacyPanelProps {
-  /** Reflects session.noTelemetry — controls the telemetry status line. */
-  noTelemetry: boolean;
   /** Program's skill id, for the BYOAI escape-hatch section. */
   skillId: string | null;
   /** Session's localMcp flag — picks remote vs local skill base URL. */
   localMcp: boolean;
 }
 
-export const PrivacyPanel = ({
-  noTelemetry: _noTelemetry,
-  skillId,
-  localMcp,
-}: PrivacyPanelProps) => {
+export const PrivacyPanel = ({ skillId, localMcp }: PrivacyPanelProps) => {
   const { skillEntry, fetchFailed } = useSkillEntry(skillId, localMcp);
 
   return (

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -18,10 +18,7 @@ import {
   POSTHOG_WIZARD_REPO_URL,
   WIZARD_CONTACT_EMAIL,
 } from '@lib/constants';
-import {
-  SkillSourceInfo,
-  useSkillEntry,
-} from '@ui/tui/screens/SkillSourceInfo';
+import { useSkillEntry } from '@ui/tui/screens/SkillSourceInfo';
 
 interface PrivacyPanelProps {
   /** Reflects session.noTelemetry — controls the telemetry status line. */
@@ -44,8 +41,8 @@ export const PrivacyPanel = ({
       <Text>
         We use Anthropic's Claude via the PostHog LLM gateway to read your
         source files as AI context. .env* files, secrets, and anything matched
-        by the security scanner stay on your machine. The wizard is open source
-        (<Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>).
+        by the security scanner stay on your machine. The wizard is open source:{' '}
+        <Text color="cyan">{POSTHOG_WIZARD_REPO_URL}</Text>.
       </Text>
 
       <Box marginTop={1}>
@@ -62,11 +59,13 @@ export const PrivacyPanel = ({
       </Box>
 
       <Box marginTop={1}>
-        <SkillSourceInfo
-          skillId={skillId}
-          skillEntry={skillEntry}
-          fetchFailed={fetchFailed}
-        />
+        <Text>
+          Skill:{' '}
+          <Text color="cyan">
+            {skillEntry?.downloadUrl ??
+              (fetchFailed ? 'unavailable' : 'Loading...')}
+          </Text>
+        </Text>
       </Box>
 
       <Box marginTop={1} flexDirection="column">

--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -13,7 +13,7 @@
 
 import { Box, Text } from 'ink';
 import {
-  CONTEXT_MILL_URL,
+  CONTEXT_MILL_RELEASES_URL,
   POSTHOG_PRIVACY_URL,
   POSTHOG_TERMS_URL,
   POSTHOG_WIZARD_REPO_URL,
@@ -29,7 +29,7 @@ interface PrivacyPanelProps {
 }
 
 export const PrivacyPanel = ({ skillId, localMcp }: PrivacyPanelProps) => {
-  const { skillEntry, fetchFailed } = useSkillEntry(skillId, localMcp);
+  const { skillEntry } = useSkillEntry(skillId, localMcp);
 
   return (
     <Box flexDirection="column" width={64} flexShrink={0}>
@@ -48,17 +48,25 @@ export const PrivacyPanel = ({ skillId, localMcp }: PrivacyPanelProps) => {
         </Text>
       </Box>
 
-      {/* Fallback to the skills repo when the menu lookup can't resolve a
-          single skill (ambiguous framework variants, menu fetch failure) —
-          a browseable link beats rendering "unavailable". */}
-      <Box marginTop={1}>
+      {/* Always link the release PAGE, never the direct asset URL — asset
+          URLs are ~89 chars and hard-wrap inside this 64-col panel, which
+          corrupts copy/paste with a mid-URL line break. The resolved skill
+          entry names the exact asset to grab; when the lookup can't pin one
+          (ambiguous framework variants, menu fetch failure) the sentence
+          stays generic. */}
+      <Box marginTop={1} flexDirection="column">
         <Text>
-          Prefer your own AI? Download the skill and run it in your own agent:{' '}
-          <Text color="cyan">
-            {skillEntry?.downloadUrl ??
-              (fetchFailed ? CONTEXT_MILL_URL : 'Loading...')}
-          </Text>
+          Prefer your own AI? Download{' '}
+          {skillEntry ? (
+            <>
+              the <Text bold>{skillEntry.id}</Text> skill
+            </>
+          ) : (
+            'the skill for your framework'
+          )}{' '}
+          and run it in your own agent:
         </Text>
+        <Text color="cyan">{CONTEXT_MILL_RELEASES_URL}</Text>
       </Box>
 
       <Box marginTop={1} flexDirection="column">

--- a/src/ui/tui/screens/AuthScreen.tsx
+++ b/src/ui/tui/screens/AuthScreen.tsx
@@ -15,7 +15,7 @@ import type { WizardStore } from '@ui/tui/store';
 import { LoadingBox } from '@ui/tui/primitives/index';
 import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
 import { IntroScreenLayout } from '@ui/tui/screens/IntroScreenLayout';
-import { useKeyBindings } from '@ui/tui/hooks/useKeyBindings';
+import { useKeyBindings, type KeyBinding } from '@ui/tui/hooks/useKeyBindings';
 import { Colors } from '@ui/tui/styles';
 
 interface AuthScreenProps {
@@ -36,29 +36,26 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
   // the browser can't reach the local callback server.
   const canPasteCode = Boolean(session.loginUrl);
 
-  useKeyBindings(
-    'auth',
-    showPrivacy
-      ? []
-      : [
-          ...(canPasteCode
-            ? [
-                {
-                  match: ['p', 'P'],
-                  label: 'P',
-                  action: 'paste auth code',
-                  handler: () => store.showManualAuthCode(),
-                },
-              ]
-            : []),
-          {
-            match: ['i', 'I'],
-            label: 'I',
-            action: 'privacy info',
-            handler: () => setShowPrivacy(true),
-          },
-        ],
-  );
+  // Build bindings imperatively: while the privacy view is open, the
+  // screen registers NO bindings (IntroScreenLayout's menu owns input).
+  const bindings: KeyBinding[] = [];
+  if (!showPrivacy) {
+    if (canPasteCode) {
+      bindings.push({
+        match: ['p', 'P'],
+        label: 'P',
+        action: 'paste auth code',
+        handler: () => store.showManualAuthCode(),
+      });
+    }
+    bindings.push({
+      match: ['i', 'I'],
+      label: 'I',
+      action: 'privacy info',
+      handler: () => setShowPrivacy(true),
+    });
+  }
+  useKeyBindings('auth', bindings);
 
   if (showPrivacy) {
     return (

--- a/src/ui/tui/screens/AuthScreen.tsx
+++ b/src/ui/tui/screens/AuthScreen.tsx
@@ -67,9 +67,7 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
         title="Wizard privacy & usage"
         showSubtitle={false}
         showDetection={false}
-        body={
-          <PrivacyPanel skillId={session.skillId} localMcp={session.localMcp} />
-        }
+        body={<PrivacyPanel />}
         menuOptions={[{ label: 'Back', value: 'back' }]}
         menuAlign="left"
         onSelect={() => setShowPrivacy(false)}
@@ -112,25 +110,16 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
       </Box>
 
       <Box flexDirection="column" marginBottom={1}>
-        <Text bold>How does the wizard use your data?</Text>
+        <Text bold dimColor>
+          How does the wizard use your data?
+        </Text>
         <Text dimColor>
           {'•'} Source files are read by Claude for AI context
         </Text>
         <Text dimColor>{'•'} .env* and secrets stay on your machine</Text>
         <Text dimColor>
-          {'•'} Usage data{' '}
-          {session.noTelemetry ? (
-            <Text color="green">disabled</Text>
-          ) : (
-            <>
-              <Text color="yellow">enabled by default</Text>, pass{' '}
-              <Text color="cyan">--no-telemetry</Text> to disable
-            </>
-          )}
-        </Text>
-        <Text dimColor>
-          Press <Text color={Colors.accent}>[I]</Text> for full privacy & usage
-          info
+          {'•'} Press <Text color={Colors.accent}>[I]</Text> for full privacy &
+          usage info
         </Text>
       </Box>
 

--- a/src/ui/tui/screens/AuthScreen.tsx
+++ b/src/ui/tui/screens/AuthScreen.tsx
@@ -68,11 +68,7 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
         showSubtitle={false}
         showDetection={false}
         body={
-          <PrivacyPanel
-            noTelemetry={session.noTelemetry}
-            skillId={session.skillId}
-            localMcp={session.localMcp}
-          />
+          <PrivacyPanel skillId={session.skillId} localMcp={session.localMcp} />
         }
         menuOptions={[{ label: 'Back', value: 'back' }]}
         menuAlign="left"
@@ -99,6 +95,10 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
           </Text>
         )}
 
+        {/* Dead path today — every framework went GA, so no config has
+            metadata.beta = true. Kept intentionally for the next time we
+            ship a framework integration in beta. Set `beta: true` on the
+            framework's config and this rendering re-activates. */}
         {config?.metadata.beta && (
           <Text color="yellow">
             [BETA] The {config.metadata.name} wizard is in beta. Questions or

--- a/src/ui/tui/screens/AuthScreen.tsx
+++ b/src/ui/tui/screens/AuthScreen.tsx
@@ -1,15 +1,23 @@
 /**
  * AuthScreen — Shown while waiting for OAuth authentication.
  *
- * Displays framework detection results, beta/disclosure notices,
- * a waiting spinner, and the login URL when available.
+ * Displays framework detection, a compressed privacy summary, a waiting
+ * spinner, and the login URL when available. [I] opens the full
+ * PrivacyPanel as an overlay. [P] (when loginUrl is set) lets the user
+ * paste the callback URL by hand.
+ *
  * The router resolves past this screen once session.credentials is set.
  */
 
 import { Box, Text } from 'ink';
-import { useSyncExternalStore } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
-import { LoadingBox } from '@ui/tui/primitives/index';
+import {
+  ConfirmationInput,
+  LoadingBox,
+  ModalOverlay,
+} from '@ui/tui/primitives/index';
+import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
 import { useKeyBindings } from '@ui/tui/hooks/useKeyBindings';
 import { Colors } from '@ui/tui/styles';
 
@@ -23,25 +31,63 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
     () => store.getSnapshot(),
   );
 
+  const [showPrivacy, setShowPrivacy] = useState(false);
   const { session } = store;
 
   // While the OAuth flow is waiting (loginUrl set), let the user paste the
   // callback URL/code by hand — the fallback for headless/remote shells where
   // the browser can't reach the local callback server.
   const canPasteCode = Boolean(session.loginUrl);
+
   useKeyBindings(
     'auth',
-    canPasteCode
-      ? [
+    showPrivacy
+      ? []
+      : [
+          ...(canPasteCode
+            ? [
+                {
+                  match: ['p', 'P'],
+                  label: 'P',
+                  action: 'paste auth code',
+                  handler: () => store.showManualAuthCode(),
+                },
+              ]
+            : []),
           {
-            match: ['p', 'P'],
-            label: 'P',
-            action: 'paste auth code',
-            handler: () => store.showManualAuthCode(),
+            match: ['i', 'I'],
+            label: 'I',
+            action: 'privacy info',
+            handler: () => setShowPrivacy(true),
           },
-        ]
-      : [],
+        ],
   );
+
+  if (showPrivacy) {
+    return (
+      <ModalOverlay
+        borderColor="cyan"
+        title="Privacy & data usage"
+        width={72}
+        footer={
+          <ConfirmationInput
+            message=""
+            confirmLabel=""
+            cancelLabel="Back [Esc]"
+            onConfirm={() => setShowPrivacy(false)}
+            onCancel={() => setShowPrivacy(false)}
+          />
+        }
+      >
+        <PrivacyPanel
+          noTelemetry={session.noTelemetry}
+          skillId={session.skillId}
+          localMcp={session.localMcp}
+        />
+      </ModalOverlay>
+    );
+  }
+
   const config = session.frameworkConfig;
   const frameworkLabel =
     session.detectedFrameworkLabel ?? config?.metadata.name;
@@ -55,7 +101,7 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
 
         {frameworkLabel && (
           <Text>
-            <Text color="green">{'\u2714'} </Text>
+            <Text color="green">{'✔'} </Text>
             <Text>Framework: {frameworkLabel}</Text>
           </Text>
         )}
@@ -70,6 +116,29 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
         {config?.metadata.preRunNotice && (
           <Text color="yellow">{config.metadata.preRunNotice}</Text>
         )}
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold>Privacy at a glance</Text>
+        <Text dimColor>
+          {'•'} Source files {'→'} Anthropic Claude (AI context)
+        </Text>
+        <Text dimColor>{'•'} .env* files and secrets stay on your machine</Text>
+        <Text dimColor>
+          {'•'} Telemetry:{' '}
+          {session.noTelemetry ? (
+            <Text color="green">DISABLED</Text>
+          ) : (
+            <>
+              <Text color="yellow">ENABLED</Text> (
+              <Text color="cyan">--no-telemetry</Text> to disable)
+            </>
+          )}
+        </Text>
+        <Text dimColor>
+          Press <Text color={Colors.accent}>[I]</Text> for full privacy & data
+          usage info
+        </Text>
       </Box>
 
       <LoadingBox message="Waiting for authentication..." />

--- a/src/ui/tui/screens/AuthScreen.tsx
+++ b/src/ui/tui/screens/AuthScreen.tsx
@@ -12,12 +12,9 @@
 import { Box, Text } from 'ink';
 import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
-import {
-  ConfirmationInput,
-  LoadingBox,
-  ModalOverlay,
-} from '@ui/tui/primitives/index';
+import { LoadingBox } from '@ui/tui/primitives/index';
 import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
+import { IntroScreenLayout } from '@ui/tui/screens/IntroScreenLayout';
 import { useKeyBindings } from '@ui/tui/hooks/useKeyBindings';
 import { Colors } from '@ui/tui/styles';
 
@@ -65,26 +62,22 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
 
   if (showPrivacy) {
     return (
-      <ModalOverlay
-        borderColor="cyan"
-        title="Privacy & data usage"
-        width={72}
-        footer={
-          <ConfirmationInput
-            message=""
-            confirmLabel=""
-            cancelLabel="Back [Esc]"
-            onConfirm={() => setShowPrivacy(false)}
-            onCancel={() => setShowPrivacy(false)}
+      <IntroScreenLayout
+        installDir={session.installDir}
+        title="Wizard privacy & usage"
+        showSubtitle={false}
+        showDetection={false}
+        body={
+          <PrivacyPanel
+            noTelemetry={session.noTelemetry}
+            skillId={session.skillId}
+            localMcp={session.localMcp}
           />
         }
-      >
-        <PrivacyPanel
-          noTelemetry={session.noTelemetry}
-          skillId={session.skillId}
-          localMcp={session.localMcp}
-        />
-      </ModalOverlay>
+        menuOptions={[{ label: 'Back', value: 'back' }]}
+        menuAlign="left"
+        onSelect={() => setShowPrivacy(false)}
+      />
     );
   }
 
@@ -119,25 +112,25 @@ export const AuthScreen = ({ store }: AuthScreenProps) => {
       </Box>
 
       <Box flexDirection="column" marginBottom={1}>
-        <Text bold>Privacy at a glance</Text>
+        <Text bold>How does the wizard use your data?</Text>
         <Text dimColor>
-          {'•'} Source files {'→'} Anthropic Claude (AI context)
+          {'•'} Source files are read by Claude for AI context
         </Text>
-        <Text dimColor>{'•'} .env* files and secrets stay on your machine</Text>
+        <Text dimColor>{'•'} .env* and secrets stay on your machine</Text>
         <Text dimColor>
-          {'•'} Telemetry:{' '}
+          {'•'} Usage data{' '}
           {session.noTelemetry ? (
-            <Text color="green">DISABLED</Text>
+            <Text color="green">disabled</Text>
           ) : (
             <>
-              <Text color="yellow">ENABLED</Text> (
-              <Text color="cyan">--no-telemetry</Text> to disable)
+              <Text color="yellow">enabled by default</Text>, pass{' '}
+              <Text color="cyan">--no-telemetry</Text> to disable
             </>
           )}
         </Text>
         <Text dimColor>
-          Press <Text color={Colors.accent}>[I]</Text> for full privacy & data
-          usage info
+          Press <Text color={Colors.accent}>[I]</Text> for full privacy & usage
+          info
         </Text>
       </Box>
 

--- a/src/ui/tui/screens/IntroScreenLayout.tsx
+++ b/src/ui/tui/screens/IntroScreenLayout.tsx
@@ -120,11 +120,13 @@ export const IntroScreenLayout = ({
           {showSubtitle && (
             <Box flexDirection="column" alignItems="center" marginTop={1}>
               <Text dimColor>
-                We'll use AI to analyze your project and complete work.
+                We'll use Anthropic Claude to analyze your project and complete
+                work.
               </Text>
               <Text dimColor>
-                .env* file contents will not leave your machine.
+                .env* files and secrets stay on your machine.
               </Text>
+              <Text dimColor>Details under "Privacy & data usage" below.</Text>
             </Box>
           )}
 

--- a/src/ui/tui/screens/IntroScreenLayout.tsx
+++ b/src/ui/tui/screens/IntroScreenLayout.tsx
@@ -46,6 +46,13 @@ interface IntroScreenLayoutProps {
   /** Menu options. Pass null to hide the menu entirely. */
   menuOptions?: { label: string; value: string }[] | null;
 
+  /**
+   * Menu alignment. 'center' (default) matches the wizard's standard
+   * intro menu. 'left' is for views like the privacy panel where the
+   * menu should align with the panel content rather than viewport center.
+   */
+  menuAlign?: 'center' | 'left';
+
   /** Called when the user picks a menu option */
   onSelect?: (value: string) => void;
 
@@ -76,6 +83,7 @@ export const IntroScreenLayout = ({
   detectionRows,
   children,
   menuOptions,
+  menuAlign = 'center',
   onSelect,
   programLabel,
   skillId,
@@ -120,13 +128,11 @@ export const IntroScreenLayout = ({
           {showSubtitle && (
             <Box flexDirection="column" alignItems="center" marginTop={1}>
               <Text dimColor>
-                We'll use Anthropic Claude to analyze your project and complete
-                work.
+                We'll use AI to analyze your project and complete work.
               </Text>
               <Text dimColor>
-                .env* files and secrets stay on your machine.
+                .env* file contents will not leave your machine.
               </Text>
-              <Text dimColor>Details under "Privacy & data usage" below.</Text>
             </Box>
           )}
 
@@ -179,9 +185,11 @@ export const IntroScreenLayout = ({
           </Box>
         )}
 
-        <Box width={24}>
+        <Box width={menuAlign === 'left' ? 64 : 24} marginTop={1}>
           {resolvedMenuOptions && onSelect && (
-            <Box justifyContent="center">
+            <Box
+              justifyContent={menuAlign === 'left' ? 'flex-start' : 'center'}
+            >
               <PickerMenu
                 key={resolvedMenuOptions.map((o) => o.value).join(',')}
                 options={resolvedMenuOptions}

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -156,7 +156,7 @@ export const PostHogIntegrationIntroScreen = ({
     );
   } else if (view === 'more-info') {
     body = (
-      <Box flexDirection="column" width={56} flexShrink={0}>
+      <Box flexDirection="column" width={64} flexShrink={0}>
         <Text>
           The wizard is an agent that executes PostHog tasks. Its code is open
           source: <Text color="cyan">https://github.com/PostHog/wizard</Text>

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -113,7 +113,12 @@ export const PostHogIntegrationIntroScreen = ({
 
   // ── Title ──────────────────────────────────────────────────────────
 
-  const title = detecting ? 'PostHog Wizard starting up' : 'PostHog Wizard 🦔';
+  const title =
+    view === 'more-info'
+      ? 'Wizard privacy & usage'
+      : detecting
+      ? 'PostHog Wizard starting up'
+      : 'PostHog Wizard 🦔';
 
   // ── Description ────────────────────────────────────────────────────
 

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -16,6 +16,7 @@ import type { WizardStore } from '@ui/tui/store';
 import { Integration, WIZARD_TOOLS_MENU_FLAG_KEY } from '@lib/constants';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
+import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
 import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
 import { releaseTerminal } from '@ui/tui/start-tui';
 import { analytics } from '@utils/analytics';
@@ -24,7 +25,7 @@ const TOOLS = [
   { label: 'Troubleshoot Integration', command: 'doctor' },
 ] as const;
 
-type View = 'default' | 'more-info' | 'tools';
+type View = 'default' | 'more-info' | 'privacy' | 'tools';
 
 function launchTool(command: string, installDir: string): never {
   releaseTerminal();
@@ -100,6 +101,10 @@ export const PostHogIntegrationIntroScreen = ({
   const config = session.frameworkConfig;
   const frameworkLabel =
     session.detectedFrameworkLabel ?? config?.metadata.name;
+  const { skillEntry, fetchFailed } = useSkillEntry(
+    session.skillId,
+    session.localMcp,
+  );
   const detecting = !session.detectionComplete;
   const needsFrameworkPick =
     session.detectionComplete && !session.frameworkConfig;
@@ -114,7 +119,7 @@ export const PostHogIntegrationIntroScreen = ({
   // ── Title ──────────────────────────────────────────────────────────
 
   const title =
-    view === 'more-info'
+    view === 'privacy'
       ? 'Wizard privacy & usage'
       : detecting
       ? 'PostHog Wizard starting up'
@@ -151,8 +156,41 @@ export const PostHogIntegrationIntroScreen = ({
     );
   } else if (view === 'more-info') {
     body = (
-      <PrivacyPanel skillId={session.skillId} localMcp={session.localMcp} />
+      <Box flexDirection="column" width={56} flexShrink={0}>
+        <Text>
+          The wizard is an agent that executes PostHog tasks. Its code is open
+          source: <Text color="cyan">https://github.com/PostHog/wizard</Text>
+        </Text>
+        <Box flexDirection="column" marginTop={1}>
+          <Text>
+            The{' '}
+            <Text italic color="cyan">
+              {session.programLabel}
+            </Text>{' '}
+            program installs the PostHog SDKs, instruments event tracking, and
+            integrates the following dev tools for your application:
+          </Text>
+        </Box>
+        <Box flexDirection="column" marginTop={1} paddingLeft={4}>
+          <Text>{`•`} Product Analytics</Text>
+          <Text>{`•`} Web Analytics</Text>
+          <Text>{`•`} Session Replay</Text>
+          <Text>{`•`} Error Tracking</Text>
+        </Box>
+        <Box flexDirection="column" marginTop={1}>
+          <Text>If you prefer your own AI setup, download the skill:</Text>
+          <Box marginTop={1}>
+            <SkillSourceInfo
+              skillId={session.skillId}
+              skillEntry={skillEntry}
+              fetchFailed={fetchFailed}
+            />
+          </Box>
+        </Box>
+      </Box>
     );
+  } else if (view === 'privacy') {
+    body = <PrivacyPanel />;
   } else if (showContinue) {
     body = (
       <>
@@ -230,13 +268,18 @@ export const PostHogIntegrationIntroScreen = ({
       { label: 'Back', value: 'back' },
     ];
   } else if (view === 'more-info') {
+    menuOptions = [
+      { label: 'Back', value: 'back' },
+      { label: 'Privacy & data usage', value: 'privacy' },
+    ];
+  } else if (view === 'privacy') {
     menuOptions = [{ label: 'Back', value: 'back' }];
   } else if (showContinue) {
     menuOptions = [
       { label: 'Continue', value: 'continue' },
       { label: 'Change framework', value: 'framework' },
       ...(toolsEnabled ? [{ label: 'Tools', value: 'tools' }] : []),
-      { label: 'Privacy & data usage', value: 'more-info' },
+      { label: 'More info', value: 'more-info' },
       { label: 'Cancel', value: 'cancel' },
     ];
   }
@@ -254,10 +297,12 @@ export const PostHogIntegrationIntroScreen = ({
       setManuallySelected(true);
     } else if (value === 'more-info') {
       setView('more-info');
+    } else if (value === 'privacy') {
+      setView('privacy');
     } else if (value === 'tools') {
       setView('tools');
     } else if (value === 'back') {
-      setView('default');
+      setView(view === 'privacy' ? 'more-info' : 'default');
     } else {
       store.completeSetup();
     }
@@ -274,7 +319,7 @@ export const PostHogIntegrationIntroScreen = ({
       showDetection={showContinue}
       detectionRows={detectionRows}
       menuOptions={unsupported ? null : menuOptions}
-      menuAlign={view === 'more-info' ? 'left' : 'center'}
+      menuAlign="center"
       onSelect={handleSelect}
       programLabel={session.programLabel}
       skillId={session.skillId}

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -16,7 +16,7 @@ import type { WizardStore } from '@ui/tui/store';
 import { Integration, WIZARD_TOOLS_MENU_FLAG_KEY } from '@lib/constants';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
-import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
+import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
 import { releaseTerminal } from '@ui/tui/start-tui';
 import { analytics } from '@utils/analytics';
 
@@ -100,10 +100,6 @@ export const PostHogIntegrationIntroScreen = ({
   const config = session.frameworkConfig;
   const frameworkLabel =
     session.detectedFrameworkLabel ?? config?.metadata.name;
-  const { skillEntry, fetchFailed } = useSkillEntry(
-    session.skillId,
-    session.localMcp,
-  );
   const detecting = !session.detectionComplete;
   const needsFrameworkPick =
     session.detectionComplete && !session.frameworkConfig;
@@ -150,38 +146,11 @@ export const PostHogIntegrationIntroScreen = ({
     );
   } else if (view === 'more-info') {
     body = (
-      <Box flexDirection="column" width={56} flexShrink={0}>
-        <Text>
-          The wizard is an agent that executes PostHog tasks. Its code is open
-          source: <Text color="cyan">https://github.com/PostHog/wizard</Text>
-        </Text>
-        <Box flexDirection="column" marginTop={1}>
-          <Text>
-            The{' '}
-            <Text italic color="cyan">
-              {session.programLabel}
-            </Text>{' '}
-            program installs the PostHog SDKs, instruments event tracking, and
-            integrates the following dev tools for your application:
-          </Text>
-        </Box>
-        <Box flexDirection="column" marginTop={1} paddingLeft={4}>
-          <Text>{`\u2022`} Product Analytics</Text>
-          <Text>{`\u2022`} Web Analytics</Text>
-          <Text>{`\u2022`} Session Replay</Text>
-          <Text>{`\u2022`} Error Tracking</Text>
-        </Box>
-        <Box flexDirection="column" marginTop={1}>
-          <Text>If you prefer your own AI setup, download the skill:</Text>
-          <Box marginTop={1}>
-            <SkillSourceInfo
-              skillId={session.skillId}
-              skillEntry={skillEntry}
-              fetchFailed={fetchFailed}
-            />
-          </Box>
-        </Box>
-      </Box>
+      <PrivacyPanel
+        noTelemetry={session.noTelemetry}
+        skillId={session.skillId}
+        localMcp={session.localMcp}
+      />
     );
   } else if (showContinue) {
     body = (
@@ -264,7 +233,7 @@ export const PostHogIntegrationIntroScreen = ({
       { label: 'Continue', value: 'continue' },
       { label: 'Change framework', value: 'framework' },
       ...(toolsEnabled ? [{ label: 'Tools', value: 'tools' }] : []),
-      { label: 'More info', value: 'more-info' },
+      { label: 'Privacy & data usage', value: 'more-info' },
       { label: 'Cancel', value: 'cancel' },
     ];
   }

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -151,11 +151,7 @@ export const PostHogIntegrationIntroScreen = ({
     );
   } else if (view === 'more-info') {
     body = (
-      <PrivacyPanel
-        noTelemetry={session.noTelemetry}
-        skillId={session.skillId}
-        localMcp={session.localMcp}
-      />
+      <PrivacyPanel skillId={session.skillId} localMcp={session.localMcp} />
     );
   } else if (showContinue) {
     body = (
@@ -173,6 +169,8 @@ export const PostHogIntegrationIntroScreen = ({
   if (frameworkLabel) {
     const suffixParts: string[] = [];
     if (!manuallySelected) suffixParts.push('(detected)');
+    // Dead path today — every framework went GA. Kept for re-activation
+    // when the next beta framework lands (set `beta: true` on its config).
     if (config?.metadata.beta) suffixParts.push('[BETA]');
 
     detectionRows.push({

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -271,6 +271,7 @@ export const PostHogIntegrationIntroScreen = ({
       showDetection={showContinue}
       detectionRows={detectionRows}
       menuOptions={unsupported ? null : menuOptions}
+      menuAlign={view === 'more-info' ? 'left' : 'center'}
       onSelect={handleSelect}
       programLabel={session.programLabel}
       skillId={session.skillId}

--- a/src/ui/tui/screens/SkillSourceInfo.tsx
+++ b/src/ui/tui/screens/SkillSourceInfo.tsx
@@ -16,6 +16,34 @@ import { useEffect, useState } from 'react';
 import { fetchSkillMenu, type SkillEntry } from '@lib/wizard-tools';
 import { getSkillsBaseUrl } from '@lib/constants';
 
+/**
+ * Resolve a session skillId against the skill-menu entries.
+ *
+ * `session.skillId` is seeded with the raw integration id during
+ * detection (e.g. 'python'), but the menu publishes integration skills
+ * under prefixed ids ('integration-python'); frameworks with variants
+ * publish several ('integration-nextjs-app-router', '-pages-router').
+ * Match chain: exact id → `integration-<id>` → unique
+ * `integration-<id>-*` prefix. Ambiguous variants (≥2 prefix matches)
+ * return null — the caller should point at the skills repo instead of
+ * guessing the wrong variant.
+ */
+export function resolveSkillEntry(
+  entries: SkillEntry[],
+  skillId: string,
+): SkillEntry | null {
+  const exact = entries.find((s) => s.id === skillId);
+  if (exact) return exact;
+
+  const prefixed = entries.find((s) => s.id === `integration-${skillId}`);
+  if (prefixed) return prefixed;
+
+  const variants = entries.filter((s) =>
+    s.id.startsWith(`integration-${skillId}-`),
+  );
+  return variants.length === 1 ? variants[0] : null;
+}
+
 export function useSkillEntry(
   skillId: string | null,
   local: boolean,
@@ -37,9 +65,10 @@ export function useSkillEntry(
         setFetchFailed(true);
         return;
       }
-      const match = Object.values(menu.categories)
-        .flat()
-        .find((s) => s.id === skillId);
+      const match = resolveSkillEntry(
+        Object.values(menu.categories).flat(),
+        skillId,
+      );
       if (match) setSkillEntry(match);
       else setFetchFailed(true);
     });

--- a/src/ui/tui/screens/SkillSourceInfo.tsx
+++ b/src/ui/tui/screens/SkillSourceInfo.tsx
@@ -14,7 +14,7 @@
 import { Box, Text } from 'ink';
 import { useEffect, useState } from 'react';
 import { fetchSkillMenu, type SkillEntry } from '@lib/wizard-tools';
-import { getSkillsBaseUrl } from '@lib/constants';
+import { CONTEXT_MILL_RELEASE_URL, getSkillsBaseUrl } from '@lib/constants';
 
 /**
  * Resolve a session skillId against the skill-menu entries.
@@ -102,7 +102,7 @@ export const SkillSourceInfo = ({
       URL:{' '}
       <Text color="cyan">
         {skillEntry?.downloadUrl ??
-          (fetchFailed ? 'unavailable' : 'Loading...')}
+          (fetchFailed ? CONTEXT_MILL_RELEASE_URL : 'Loading...')}
       </Text>
     </Text>
   </Box>

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -178,6 +178,7 @@ export class WizardStore {
       setFrameworkContext: (k, v) => this.setFrameworkContext(k, v),
       setFrameworkConfig: (i, c) => this.setFrameworkConfig(i, c),
       setDetectedFramework: (l) => this.setDetectedFramework(l),
+      setSkillId: (id) => this.setSkillId(id),
       setUnsupportedVersion: (info) => this.setUnsupportedVersion(info),
       addDiscoveredFeature: (f) => this.addDiscoveredFeature(f),
       setDetectionComplete: () => this.setDetectionComplete(),
@@ -315,6 +316,11 @@ export class WizardStore {
 
   setDetectedFramework(label: string): void {
     this.$session.setKey('detectedFrameworkLabel', label);
+    this.emitChange();
+  }
+
+  setSkillId(skillId: string | null): void {
+    this.$session.setKey('skillId', skillId);
     this.emitChange();
   }
 

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -173,6 +173,7 @@ export class WizardStore {
       setFrameworkContext: (k, v) => this.setFrameworkContext(k, v),
       setFrameworkConfig: (i, c) => this.setFrameworkConfig(i, c),
       setDetectedFramework: (l) => this.setDetectedFramework(l),
+      setSkillId: (id) => this.setSkillId(id),
       setUnsupportedVersion: (info) => this.setUnsupportedVersion(info),
       addDiscoveredFeature: (f) => this.addDiscoveredFeature(f),
       setDetectionComplete: () => this.setDetectionComplete(),
@@ -310,6 +311,11 @@ export class WizardStore {
 
   setDetectedFramework(label: string): void {
     this.$session.setKey('detectedFrameworkLabel', label);
+    this.emitChange();
+  }
+
+  setSkillId(skillId: string | null): void {
+    this.$session.setKey('skillId', skillId);
     this.emitChange();
   }
 


### PR DESCRIPTION
review in graphite if easier: https://app.graphite.com/github/pr/PostHog/wizard/644/feat(privacy)-consolidate-disclosure-into-Privacy-%26-data-usage-panel

replaces "more info" tab with "privacy & data usage" screen. the more info tab had some privacy stuff mixed in, but it really deserves to be a more explicit privacy page

tried to highlight the top things to care about: what info is sent to the LLM gateway, what stays on your machine, and what we collect usage data on. links to website for broader terms and privacy

demo video:

https://github.com/user-attachments/assets/c8876591-a04e-4bcc-aba4-7915461ccfee



