### PR TITLE
feat: Slack connect follow-ups from #640 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ When creating your personal API key, ensure it has the following scopes enabled:
 - `dashboard:write` - Required to create dashboards
 - `insight:write` - Required to create insights
 
+### OAuth app scope ceiling
+
+The wizard's OAuth app on the PostHog side caps the scopes its tokens may
+carry (`OAuthApplication.scopes`). Any scope requested in this repo (see
+`src/lib/oauth/program-scopes.ts`) must be present in that list. Current
+ceiling, for bookkeeping:
+
+```
+user:read,project:read,llm_gateway:read,dashboard:read,dashboard:write,insight:read,insight:write,query:read,notebook:read,notebook:write,health_issue:read,wizard_session:read,wizard_session:write,feature_flag:read,experiment:read,experiment_saved_metric:read,survey:read,session_recording:read,error_tracking:read,web_analytics:read,llm_analytics:read,cohort:read,person:read,annotation:read,annotation:write,activity_log:read,property_definition:read,event_definition:read,action:read,warehouse_table:read,warehouse_view:read,alert:read,subscription:read,feature_flag:write,integration:read
+```
+
 # Steal this code
 
 While the wizard works great on its own, we also find the approach used by this

--- a/src/lib/agent/agent-runner.ts
+++ b/src/lib/agent/agent-runner.ts
@@ -191,7 +191,12 @@ export async function runProgram(
 
   const skillsBaseUrl = getSkillsBaseUrl(session.localMcp);
 
-  // 2. Health check (guarded — skip if TUI already ran it)
+  // 2. Health check (guarded — skip if TUI already ran it). Only
+  // programs that declare a health-check screen get pre-flight checks;
+  // for everything else the checks never fire and never block.
+  const hasHealthCheckScreen = programConfig.steps.some(
+    (s) => s.screenId === 'health-check',
+  );
   if (session.readinessResult) {
     logToFile(
       `[agent-runner] readiness pre-computed by TUI: decision=${session.readinessResult.decision}` +
@@ -200,7 +205,7 @@ export async function runProgram(
         } — skipping re-check`,
     );
   }
-  if (!session.readinessResult) {
+  if (hasHealthCheckScreen && !session.readinessResult) {
     logToFile('[agent-runner] evaluating wizard readiness');
     const readinessConfig = session.signup
       ? SIGNUP_WIZARD_READINESS_CONFIG

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -222,34 +222,30 @@ const IntegrationsResponseSchema = z.object({
 });
 
 /**
- * Best-effort check for whether the project already has a Slack integration
- * connected. Returns false on any error (missing scope, network failure,
- * unexpected shape) so callers can treat "unknown" as "not connected" and
- * show the connect nudge rather than a hard failure.
+ * Check whether the project already has a Slack integration connected.
+ * Requires the `integration:read` scope. Throws on failure — callers
+ * (including the SlackConnectScreen poll) decide how to degrade and
+ * are responsible for capturing the error exactly once.
  */
 export async function fetchSlackConnected(
   accessToken: string,
   projectId: number,
   baseUrl: string,
+  signal?: AbortSignal,
 ): Promise<boolean> {
-  try {
-    const response = await axios.get(
-      `${baseUrl}/api/projects/${projectId}/integrations/`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'User-Agent': WIZARD_USER_AGENT,
-        },
-        // Short timeout — best-effort probe, not a critical path.
-        timeout: 4000,
+  const response = await axios.get(
+    `${baseUrl}/api/projects/${projectId}/integrations/`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'User-Agent': WIZARD_USER_AGENT,
       },
-    );
-    const parsed = IntegrationsResponseSchema.safeParse(response.data);
-    if (!parsed.success) return false;
-    return parsed.data.results.some((i) => i.kind === 'slack');
-  } catch {
-    return false;
-  }
+      signal,
+    },
+  );
+  const parsed = IntegrationsResponseSchema.safeParse(response.data);
+  if (!parsed.success) return false;
+  return parsed.data.results.some((i) => i.kind === 'slack');
 }
 
 export function handleApiError(error: unknown, operation: string): ApiError {

--- a/src/lib/mcp-role-prompts.copy.json
+++ b/src/lib/mcp-role-prompts.copy.json
@@ -1,5 +1,4 @@
 {
-  "$schema-note": "All copy for the MCP tutorial picker, greeting, follow-ups, and cross-sells. Edit this file to update prompts without touching TypeScript. Every prompt is either (a) a read query on any PostHog product, or (b) a write on dashboards, insights, notebooks, or annotations — the four 'persistence' surfaces. No prompt should ask the agent to ship a flag, run an experiment, send a survey, or create an alert. See prompt-tree.md §5 for the scope reality.",
 
   "pinnedFirstPrompt": {
     "prompt": "Show me my top 5 events from the last 7 days",
@@ -508,7 +507,6 @@
     { "product": "Error Tracking", "prompt": "List the top errors my users hit this week.", "description": "Built-in error tracking — no separate tool." }
   ],
 
-  "slackApp-note": "Presentation copy for the 'Take PostHog to Slack' surfaces (Goodbye card + dedicated step). These strings are shown to the user, NOT sent to the agent — so the read/persistence prompt-scope rule above does not apply. The two capabilities describe the Slack agent itself, not role-specific examples. Connecting Slack is a manual OAuth step in the PostHog app, so we link out to setupUrl rather than wiring it up.",
   "slackApp": {
     "learnMoreUrl": "https://posthog.com/slack-app",
     "setupUrl": "https://app.posthog.com/settings/project-integrations#integration-slack",

--- a/src/lib/mcp-role-prompts.ts
+++ b/src/lib/mcp-role-prompts.ts
@@ -5,6 +5,13 @@
  * edited without touching TypeScript. This file holds the types,
  * the lookup functions, and the framework-family mapping.
  *
+ * Editing rule for the JSON (which can't carry comments itself): every
+ * prompt is either (a) a read query on any PostHog product, or (b) a
+ * write on dashboards, insights, notebooks, or annotations — the four
+ * "persistence" surfaces. No prompt should ask the agent to ship a
+ * flag, run an experiment, send a survey, or create an alert. See
+ * prompt-tree.md §5 for the scope reality.
+ *
  * The wizard surfaces these on the McpSuggestedPromptsScreen after
  * MCP install. Picking strategy for the kit:
  *   1. Known role + known framework → role kit with family overrides.
@@ -144,6 +151,12 @@ const CROSS_SELL_BY_ROLE = copyData.crossSellByRole as Record<
   PromptOption[]
 >;
 const NEUTRAL_CROSS_SELL = copyData.neutralCrossSell as PromptOption[];
+// Presentation copy for the "Take PostHog to Slack" surfaces (Goodbye
+// card + dedicated step). Shown to the user, never sent to the agent —
+// so the read/persistence prompt-scope rule above does not apply. The
+// capabilities describe the Slack agent itself, not role-specific
+// examples. Connecting Slack is a manual OAuth step in the PostHog app,
+// so we link out to `setupUrl` rather than wiring it up.
 const SLACK_APP = copyData.slackApp as {
   learnMoreUrl: string;
   setupUrl: string;

--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -35,11 +35,11 @@ import { WIZARD_OAUTH_SCOPES } from '@lib/constants';
 /**
  * Extra scopes the MCP tutorial needs on top of `WIZARD_OAUTH_SCOPES`.
  *
- * Mirrors the wizard partner's full OAuth ceiling on the PostHog side
- * (see the comma-delimited list in the wizard OAuth app's
- * `OAuthApplication.scopes`). The tutorial's prompts and follow-ups
- * touch most of the read surface, plus annotation write for the
- * "PostHog wizard install" verify-prompt.
+ * Every scope requested here must stay within the wizard OAuth app's
+ * ceiling on the PostHog side (`OAuthApplication.scopes`) — the full
+ * list lives in the README under "OAuth app scope ceiling". The
+ * tutorial's prompts and follow-ups touch most of the read surface,
+ * plus annotation write for the "PostHog wizard install" verify-prompt.
  *
  * Already in the base `WIZARD_OAUTH_SCOPES` (and therefore not
  * repeated here):
@@ -98,10 +98,6 @@ export const MCP_TUTORIAL_SCOPE_ADDITIONS = [
   // alert on this metric?").
   'alert:read',
   'subscription:read',
-
-  // Integration read — lets the tutorial detect whether Slack is already
-  // connected so the Connect-Slack surfaces can adapt their copy (confirm
-  // it's on vs. nudge to connect). Read-only; we never write integrations.
   'integration:read',
 ] as const;
 

--- a/src/lib/programs/posthog-integration/steps.ts
+++ b/src/lib/programs/posthog-integration/steps.ts
@@ -66,6 +66,13 @@ export const POSTHOG_INTEGRATION_PROGRAM: ProgramStep[] = [
     isComplete: (session) => session.mcpComplete,
   },
   {
+    id: 'slack-connect',
+    label: 'Connect Slack',
+    screenId: 'slack-connect',
+    // Always shown — the user declines via Skip/esc, never bypassed.
+    isComplete: (session) => session.slackStepDismissed,
+  },
+  {
     id: 'outro',
     label: 'Done',
     screenId: 'outro',

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -18,8 +18,8 @@ import type { WizardStore } from '@ui/tui/store';
  * Other programs (e.g. revenue analytics) register a different step list.
  */
 /**
- * Context passed to onInit callbacks — fires during store construction,
- * before bin.ts has assigned the real session.
+ * Context passed to onInit callbacks — fires when the TUI starts
+ * rendering, before bin.ts has assigned the real session.
  */
 export interface StoreInitContext {
   readonly session: WizardSession;
@@ -85,10 +85,11 @@ export interface ProgramStep {
   gate?: (session: WizardSession) => boolean;
 
   /**
-   * Called once during store construction, with the default session.
-   * Use for session-independent fire-and-forget work that should start
-   * as early as possible (e.g. health check kicked off while the user
-   * is still reading the intro screen).
+   * Called once when the TUI starts rendering, with the default
+   * session. Use for session-independent fire-and-forget work that
+   * should start as early as possible (e.g. health check kicked off
+   * while the user is still reading the intro screen). Never fires for
+   * a store that isn't rendering screens (tests, playground).
    */
   onInit?: (ctx: StoreInitContext) => void;
 

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -215,9 +215,10 @@ export interface WizardSession {
   /** True once the user has acted on (opened or skipped) the Connect-Slack step. */
   slackStepDismissed: boolean;
   /**
-   * Whether the project already has a Slack integration connected. `null`
-   * until detected (post-login, best-effort) — treated as "not connected"
-   * by the UI, which shows the connect nudge rather than the confirmation.
+   * Whether the project already has a Slack integration connected.
+   * `null` until detected. Prefetched by the tutorial screen as soon as
+   * credentials exist so the Connect-Slack step renders the right
+   * variant immediately instead of flashing the nudge first.
    */
   slackConnected: boolean | null;
   skillsComplete: boolean;

--- a/src/ui/tui/__tests__/router.test.ts
+++ b/src/ui/tui/__tests__/router.test.ts
@@ -70,6 +70,7 @@ describe('WizardRouter', () => {
       };
       session.runPhase = RunPhase.Completed;
       session.mcpComplete = true;
+      session.slackStepDismissed = true;
 
       expect(router.resolve(session)).toBe(ScreenId.Outro);
     });

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -452,6 +452,7 @@ describe('WizardStore', () => {
       });
       store.setRunPhase(RunPhase.Completed);
       store.setMcpComplete();
+      store.setSlackStepDismissed();
       expect(store.currentScreen).toBe(ScreenId.Outro);
     });
 
@@ -471,6 +472,7 @@ describe('WizardStore', () => {
       });
       store.setRunPhase(RunPhase.Completed);
       store.setMcpComplete();
+      store.setSlackStepDismissed();
       store.setOutroDismissed();
       expect(store.currentScreen).toBe(ScreenId.KeepSkills);
     });
@@ -1092,14 +1094,18 @@ describe('WizardStore', () => {
 
       // Step 5: Complete MCP
       store.setMcpComplete();
+      expect(store.currentScreen).toBe(ScreenId.SlackConnect);
+
+      // Step 6: Dismiss the Connect-Slack step
+      store.setSlackStepDismissed();
       expect(store.currentScreen).toBe(ScreenId.Outro);
 
-      // Step 6: Dismiss outro
+      // Step 7: Dismiss outro
       store.setOutroDismissed();
       expect(store.currentScreen).toBe(ScreenId.KeepSkills);
 
       // Verify version was bumped for each setter call
-      expect(store.getVersion()).toBe(7);
+      expect(store.getVersion()).toBe(8);
     });
 
     it('walks through the revenue analytics flow correctly', () => {
@@ -1196,6 +1202,7 @@ describe('WizardStore', () => {
       });
 
       const store = createStore();
+      store.runInitHooks();
       let resolved = false;
 
       void store.getGate('health-check').then(() => {
@@ -1220,6 +1227,7 @@ describe('WizardStore', () => {
       });
 
       const store = createStore();
+      store.runInitHooks();
       let resolved = false;
 
       void store.getGate('health-check').then(() => {

--- a/src/ui/tui/primitives/PickerMenu.tsx
+++ b/src/ui/tui/primitives/PickerMenu.tsx
@@ -139,7 +139,7 @@ const SinglePickerMenu = <T,>({
     if (focused >= options.length || options[focused]?.disabled) {
       setFocused(firstEnabled(options));
     }
-  });
+  }, [options, focused]);
 
   const bindings: KeyBinding[] = [
     {
@@ -277,7 +277,7 @@ const MultiPickerMenu = <T,>({
     if (focused >= options.length || options[focused]?.disabled) {
       setFocused(firstEnabled(options));
     }
-  });
+  }, [options, focused]);
 
   const bindings: KeyBinding[] = [
     {

--- a/src/ui/tui/primitives/PickerMenu.tsx
+++ b/src/ui/tui/primitives/PickerMenu.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Box, Text } from 'ink';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Icons, Colors } from '@ui/tui/styles';
 import { PromptLabel } from './PromptLabel.js';
 import {
@@ -21,6 +21,11 @@ interface PickerOption<T> {
   label: string;
   value: T;
   hint?: string;
+  /** Glyph rendered before the label, in its own color — unaffected by
+   *  focus and disabled styling. */
+  icon?: { glyph: string; color?: string };
+  /** Dimmed and unselectable; navigation skips over it. */
+  disabled?: boolean;
   /**
    * Multi-select only: marks this option mutually exclusive with every other
    * option. Selecting it clears all other picks; selecting any non-exclusive
@@ -28,6 +33,35 @@ interface PickerOption<T> {
    * installed alongside local editors.
    */
   exclusive?: boolean;
+}
+
+/**
+ * Step through a column's options in `dir`, wrapping, until an enabled
+ * option is found. Returns `from` unchanged if the column is entirely
+ * disabled.
+ */
+function stepEnabled<T>(
+  options: PickerOption<T>[],
+  rows: number,
+  from: number,
+  dir: 1 | -1,
+): number {
+  const col = Math.floor(from / rows);
+  const colStart = col * rows;
+  const colLen = Math.min(rows, options.length - colStart);
+  let row = from % rows;
+  for (let i = 0; i < colLen; i++) {
+    row = (row + dir + colLen) % colLen;
+    const idx = colStart + row;
+    if (!options[idx]?.disabled) return idx;
+  }
+  return from;
+}
+
+/** Index of the first enabled option, for the initial focus. */
+function firstEnabled<T>(options: PickerOption<T>[]): number {
+  const idx = options.findIndex((o) => !o.disabled);
+  return idx === -1 ? 0 : idx;
 }
 
 interface PickerMenuProps<T> {
@@ -95,8 +129,17 @@ const SinglePickerMenu = <T,>({
   optionMarginBottom?: number;
   onSelect: (value: T | T[]) => void;
 }) => {
-  const [focused, setFocused] = useState(0);
+  const [focused, setFocused] = useState(() => firstEnabled(options));
   const rows = Math.ceil(options.length / columns);
+
+  // Re-validate focus when the options change while mounted \u2014 a list
+  // that shrinks or disables entries can leave `focused` pointing at a
+  // missing or disabled option, which would make enter a no-op.
+  useEffect(() => {
+    if (focused >= options.length || options[focused]?.disabled) {
+      setFocused(firstEnabled(options));
+    }
+  });
 
   const bindings: KeyBinding[] = [
     {
@@ -104,23 +147,11 @@ const SinglePickerMenu = <T,>({
       label: '\u2191\u2193',
       action: 'navigate',
       handler: (_input, key) => {
-        const col = Math.floor(focused / rows);
-        const row = focused % rows;
-
         if (key.upArrow) {
-          if (row > 0) {
-            setFocused(col * rows + row - 1);
-          } else {
-            setFocused(Math.min(col * rows + rows - 1, options.length - 1));
-          }
+          setFocused(stepEnabled(options, rows, focused, -1));
         }
         if (key.downArrow) {
-          const next = col * rows + row + 1;
-          if (next < options.length && row + 1 < rows) {
-            setFocused(next);
-          } else {
-            setFocused(col * rows);
-          }
+          setFocused(stepEnabled(options, rows, focused, 1));
         }
       },
     },
@@ -130,7 +161,7 @@ const SinglePickerMenu = <T,>({
       action: 'select',
       handler: () => {
         const selected = options[focused];
-        if (selected) {
+        if (selected && !selected.disabled) {
           onSelect(selected.value);
         }
       },
@@ -146,14 +177,21 @@ const SinglePickerMenu = <T,>({
         const col = Math.floor(focused / rows);
         const row = focused % rows;
 
+        let next = focused;
         if (key.leftArrow) {
           const prevCol = col > 0 ? col - 1 : columns - 1;
-          setFocused(Math.min(prevCol * rows + row, options.length - 1));
+          next = Math.min(prevCol * rows + row, options.length - 1);
         }
         if (key.rightArrow) {
           const nextCol = col < columns - 1 ? col + 1 : 0;
-          setFocused(Math.min(nextCol * rows + row, options.length - 1));
+          next = Math.min(nextCol * rows + row, options.length - 1);
         }
+        // Landing on a disabled option slides to the column's nearest
+        // enabled one.
+        if (options[next]?.disabled) {
+          next = stepEnabled(options, rows, next, 1);
+        }
+        setFocused(next);
       },
     });
   }
@@ -186,10 +224,19 @@ const SinglePickerMenu = <T,>({
                   >
                     {isFocused ? Icons.triangleSmallRight : ' '}
                   </Text>
+                  {opt.icon && (
+                    <Text color={opt.icon.color}>{opt.icon.glyph}</Text>
+                  )}
                   <Text
-                    color={isFocused ? Colors.accent : undefined}
-                    bold={isFocused}
-                    dimColor={!isFocused}
+                    color={
+                      opt.disabled
+                        ? Colors.muted
+                        : isFocused
+                        ? Colors.accent
+                        : undefined
+                    }
+                    bold={isFocused && !opt.disabled}
+                    dimColor={!isFocused || opt.disabled}
                   >
                     {label}
                   </Text>
@@ -219,9 +266,18 @@ const MultiPickerMenu = <T,>({
   optionMarginBottom?: number;
   onSelect: (value: T | T[]) => void;
 }) => {
-  const [focused, setFocused] = useState(0);
+  const [focused, setFocused] = useState(() => firstEnabled(options));
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const rows = Math.ceil(options.length / columns);
+
+  // Re-validate focus when the options change while mounted — a list
+  // that shrinks or disables entries can leave `focused` pointing at a
+  // missing or disabled option, which would make enter a no-op.
+  useEffect(() => {
+    if (focused >= options.length || options[focused]?.disabled) {
+      setFocused(firstEnabled(options));
+    }
+  });
 
   const bindings: KeyBinding[] = [
     {
@@ -229,23 +285,11 @@ const MultiPickerMenu = <T,>({
       label: '\u2191\u2193',
       action: 'navigate',
       handler: (_input, key) => {
-        const col = Math.floor(focused / rows);
-        const row = focused % rows;
-
         if (key.upArrow) {
-          if (row > 0) {
-            setFocused(col * rows + row - 1);
-          } else {
-            setFocused(Math.min(col * rows + rows - 1, options.length - 1));
-          }
+          setFocused(stepEnabled(options, rows, focused, -1));
         }
         if (key.downArrow) {
-          const next = col * rows + row + 1;
-          if (next < options.length && row + 1 < rows) {
-            setFocused(next);
-          } else {
-            setFocused(col * rows);
-          }
+          setFocused(stepEnabled(options, rows, focused, 1));
         }
       },
     },
@@ -254,6 +298,7 @@ const MultiPickerMenu = <T,>({
       label: 'space',
       action: 'toggle',
       handler: () => {
+        if (options[focused]?.disabled) return;
         setSelected((prev) => {
           const next = new Set(prev);
           if (next.has(focused)) {
@@ -282,7 +327,7 @@ const MultiPickerMenu = <T,>({
       handler: () => {
         if (selected.size === 0) {
           const hovered = options[focused];
-          if (hovered) {
+          if (hovered && !hovered.disabled) {
             onSelect(hovered.value);
           }
         } else {
@@ -302,14 +347,21 @@ const MultiPickerMenu = <T,>({
         const col = Math.floor(focused / rows);
         const row = focused % rows;
 
+        let next = focused;
         if (key.leftArrow) {
           const prevCol = col > 0 ? col - 1 : columns - 1;
-          setFocused(Math.min(prevCol * rows + row, options.length - 1));
+          next = Math.min(prevCol * rows + row, options.length - 1);
         }
         if (key.rightArrow) {
           const nextCol = col < columns - 1 ? col + 1 : 0;
-          setFocused(Math.min(nextCol * rows + row, options.length - 1));
+          next = Math.min(nextCol * rows + row, options.length - 1);
         }
+        // Landing on a disabled option slides to the column's nearest
+        // enabled one.
+        if (options[next]?.disabled) {
+          next = stepEnabled(options, rows, next, 1);
+        }
+        setFocused(next);
       },
     });
   }
@@ -348,10 +400,19 @@ const MultiPickerMenu = <T,>({
                   >
                     {checkbox}
                   </Text>
+                  {opt.icon && (
+                    <Text color={opt.icon.color}>{opt.icon.glyph}</Text>
+                  )}
                   <Text
-                    color={isFocused ? Colors.accent : undefined}
-                    bold={isFocused}
-                    dimColor={!isFocused}
+                    color={
+                      opt.disabled
+                        ? Colors.muted
+                        : isFocused
+                        ? Colors.accent
+                        : undefined
+                    }
+                    bold={isFocused && !opt.disabled}
+                    dimColor={!isFocused || opt.disabled}
                   >
                     {label}
                   </Text>

--- a/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
+++ b/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
@@ -130,8 +130,19 @@ export const McpSuggestedPromptsScreen = ({
     [session.roleAtOrganization],
   );
 
-  const [phase, setPhase] = useState<Phase>(Phase.Choose);
+  // Auth runs up front: the whole flow (Choose-phase Slack option, the
+  // Connect-Slack step after) needs credentials to know whether Slack
+  // is already connected, so without them we go straight into the
+  // OAuth dance and land on Choose informed. Esc cancels back to
+  // Choose for users who don't want to log in.
+  const [phase, setPhase] = useState<Phase>(() =>
+    store.session.credentials ? Phase.Choose : Phase.Authenticating,
+  );
   const [loginError, setLoginError] = useState<string | null>(null);
+  // Whether the user picked "Start MCP tutorial" — decides where a
+  // successful login lands: Greeting for a started tutorial, Choose
+  // for the up-front auth.
+  const startedTutorialRef = useRef(false);
   const [runningPrompt, setRunningPrompt] = useState<string | null>(null);
   const [runChunks, setRunChunks] = useState<AgentChunk[]>([]);
   const [runStartedAt, setRunStartedAt] = useState<number | null>(null);
@@ -179,20 +190,7 @@ export const McpSuggestedPromptsScreen = ({
         store.setRoleAtOrganization(roleAtOrganization);
         store.setApiUser(user);
         store.setLoginUrl(null);
-        setPhase(Phase.Greeting);
-
-        // Fire-and-forget: detect whether Slack is already connected so the
-        // Goodbye card and the dedicated Connect-Slack step can adapt their
-        // copy (confirm it's on vs. nudge to connect). Best-effort — on
-        // failure `slackConnected` stays null and renders as "not connected".
-        void services
-          .checkSlackConnected(credentials)
-          .then((connected) => {
-            if (!cancelled) store.setSlackConnected(connected);
-          })
-          .catch(() => {
-            /* best-effort; leave slackConnected unknown */
-          });
+        setPhase(startedTutorialRef.current ? Phase.Greeting : Phase.Choose);
       } catch (err) {
         if (cancelled) return;
         const message = err instanceof Error ? err.message : String(err);
@@ -207,6 +205,36 @@ export const McpSuggestedPromptsScreen = ({
       cancelled = true;
     };
   }, [phase, services, store]);
+
+  // Detect whether Slack is already connected, as soon as credentials
+  // are available — pre-seeded by the install flow, or set by the login
+  // above. Stored in the session so the Connect-Slack step that follows
+  // renders the right variant immediately. Drives the Choose-phase
+  // "Connect Slack now" option here. On failure `slackConnected` stays
+  // null and renders as "not connected".
+  const credentials = session.credentials;
+  const slackConnected = session.slackConnected;
+  useEffect(() => {
+    if (!credentials || slackConnected !== null) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    void services
+      .checkSlackConnected(credentials, controller.signal)
+      .then((connected) => {
+        if (!cancelled) store.setSlackConnected(connected);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        analytics.captureException(
+          err instanceof Error ? err : new Error(String(err)),
+          { step: 'slack_connected_check' },
+        );
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [credentials, slackConnected, services, store]);
 
   // Stream the chosen prompt against the agent. On terminal chunks
   // ('done' or 'error') we schedule a short delay before swapping into
@@ -309,13 +337,6 @@ export const McpSuggestedPromptsScreen = ({
   // move on.
   const enterGoodbye = (): void => {
     runAbortRef.current?.abort();
-    // The Goodbye phase also surfaces the "Take PostHog to Slack" card —
-    // capture the impression here (the single entry-point into Goodbye)
-    // rather than in render, which would re-fire on every re-render.
-    analytics.wizardCapture('mcp suggested prompts slack shown', {
-      role: session.roleAtOrganization,
-      engaged: branchHistory.length > 0,
-    });
     setPhase(Phase.Goodbye);
   };
 
@@ -333,7 +354,9 @@ export const McpSuggestedPromptsScreen = ({
       analytics.wizardCapture('mcp suggested prompts choose', {
         choice: 'login',
       });
-      setPhase(Phase.Authenticating);
+      startedTutorialRef.current = true;
+      // Already authenticated by the up-front login — skip straight in.
+      setPhase(session.credentials ? Phase.Greeting : Phase.Authenticating);
     } else if (choice === ChoiceValue.ConnectSlack) {
       analytics.wizardCapture('mcp suggested prompts choose', {
         choice: 'connect-slack',
@@ -398,10 +421,19 @@ export const McpSuggestedPromptsScreen = ({
     {
       match: KeyMatch.Escape,
       label: 'esc',
-      action: phase === Phase.Goodbye ? 'close' : 'exit',
+      action:
+        phase === Phase.Goodbye
+          ? 'close'
+          : phase === Phase.Authenticating
+          ? 'cancel'
+          : 'exit',
       handler: () => {
         if (phase === Phase.Goodbye) {
           closeWizard();
+        } else if (phase === Phase.Authenticating) {
+          // Cancel the OAuth dance — the login effect's cleanup discards
+          // the in-flight result. Choose still works without credentials.
+          setPhase(Phase.Choose);
         } else if (
           phase === Phase.Running ||
           phase === Phase.PromptPicker ||
@@ -451,7 +483,11 @@ export const McpSuggestedPromptsScreen = ({
     <Box flexDirection="column" flexGrow={1}>
       <Box marginTop={1} flexDirection="column">
         {phase === Phase.Choose && (
-          <ChoosePhase error={loginError} onSelect={handleChoice} />
+          <ChoosePhase
+            error={loginError}
+            slackConnected={slackConnected}
+            onSelect={handleChoice}
+          />
         )}
 
         {phase === Phase.Authenticating && (
@@ -527,7 +563,6 @@ export const McpSuggestedPromptsScreen = ({
             role={session.roleAtOrganization}
             integration={session.integration}
             engaged={branchHistory.length > 0}
-            slackConnected={session.slackConnected}
             onClose={closeWizard}
           />
         )}
@@ -540,10 +575,11 @@ export const McpSuggestedPromptsScreen = ({
 
 interface ChoosePhaseProps {
   error: string | null;
+  slackConnected: boolean | null;
   onSelect: (value: ChoiceValue | ChoiceValue[]) => void;
 }
 
-const ChoosePhase = ({ error, onSelect }: ChoosePhaseProps) => {
+const ChoosePhase = ({ error, slackConnected, onSelect }: ChoosePhaseProps) => {
   return (
     <Box flexDirection="column">
       <Text bold color={Colors.accent}>
@@ -576,10 +612,18 @@ const ChoosePhase = ({ error, onSelect }: ChoosePhaseProps) => {
       </Box>
 
       <Box marginTop={1} flexDirection="column">
-        <Text>
-          You can also connect PostHog to Slack, so you can analyze data and
-          ship product changes there by tagging <Text bold>@PostHog</Text>.
-        </Text>
+        {slackConnected ? (
+          <Text>
+            <Text color={Colors.success}>{Icons.check}</Text> Slack is connected
+            — analyze data and ship product changes there by tagging{' '}
+            <Text bold>@PostHog</Text>.
+          </Text>
+        ) : (
+          <Text>
+            You can also connect PostHog to Slack, so you can analyze data and
+            ship product changes there by tagging <Text bold>@PostHog</Text>.
+          </Text>
+        )}
       </Box>
 
       <Box marginTop={1}>
@@ -590,7 +634,14 @@ const ChoosePhase = ({ error, onSelect }: ChoosePhaseProps) => {
         <PickerMenu
           options={[
             { label: 'Start MCP tutorial', value: ChoiceValue.Login },
-            { label: 'Connect Slack now', value: ChoiceValue.ConnectSlack },
+            slackConnected
+              ? {
+                  label: 'Already connected to Slack',
+                  value: ChoiceValue.ConnectSlack,
+                  icon: { glyph: Icons.check, color: Colors.success },
+                  disabled: true,
+                }
+              : { label: 'Connect Slack now', value: ChoiceValue.ConnectSlack },
             { label: 'Exit', value: ChoiceValue.Exit },
           ]}
           onSelect={onSelect}
@@ -1014,8 +1065,6 @@ interface GoodbyePhaseProps {
   integration: Integration | null;
   /** True if the user actually ran at least one prompt this session. */
   engaged: boolean;
-  /** Whether Slack is already connected (null = unknown → treat as not). */
-  slackConnected: boolean | null;
   onClose: () => void;
 }
 
@@ -1024,33 +1073,12 @@ const GoodbyePhase = ({
   role,
   integration,
   engaged,
-  slackConnected,
   onClose,
 }: GoodbyePhaseProps) => {
   // Take 3 starter prompts from the role-tailored kit. These act as
   // "next time you open your IDE, try this" reminders.
   const kit = getRolePrompts(role, integration);
   const samples = kit.slice(0, 3);
-  const slack = getSlackAppCard();
-
-  // "Close" always dismisses; "Connect PostHog Slack agent" also opens the
-  // integration settings first. Only offered when Slack isn't already
-  // connected — connected users just get "Close".
-  const handleGoodbye = (value: string | string[]): void => {
-    const choice = Array.isArray(value) ? value[0] : value;
-    if (choice === 'connect-slack') {
-      analytics.wizardCapture('slack connect opened', {
-        role,
-        surface: 'goodbye',
-      });
-      if (process.env.NODE_ENV !== 'test') {
-        opn(slack.setupUrl, { wait: false }).catch(() => {
-          // No browser available.
-        });
-      }
-    }
-    onClose();
-  };
 
   const headline = engaged
     ? 'Nice work. You can keep talking to PostHog anytime.'
@@ -1092,43 +1120,6 @@ const GoodbyePhase = ({
         ))}
       </Box>
 
-      {/* "Take PostHog to Slack" — describe the Slack agent's two
-          capabilities. When already connected we confirm it and drop the
-          connect option; otherwise the "Connect PostHog Slack agent" menu
-          entry opens the integration settings (a manual OAuth step — we
-          never wire it up ourselves). */}
-      <Box marginBottom={1} flexDirection="column">
-        {slackConnected ? (
-          <Text bold color={Colors.success}>
-            {Icons.check} Slack connected
-          </Text>
-        ) : (
-          <Text bold color={Colors.accent}>
-            {slack.headline}
-          </Text>
-        )}
-        <Box marginTop={1}>
-          <Text dimColor>
-            {slackConnected
-              ? "Slack is connected — here's what you can do:"
-              : slack.pitch}
-          </Text>
-        </Box>
-        <Box marginTop={1} flexDirection="column">
-          {slack.capabilities.map((capability, i) => (
-            // Marker + copy in one <Text> so the (long) line wraps as a
-            // single flow. Separate row-Box siblings drop the marker on
-            // wrapped bullets — see TipsCard for the same pattern.
-            <Box key={i} marginTop={i === 0 ? 0 : 1}>
-              <Text dimColor>
-                <Text color={Colors.primary}>{Icons.triangleSmallRight} </Text>
-                {capability}
-              </Text>
-            </Box>
-          ))}
-        </Box>
-      </Box>
-
       <Box marginBottom={1}>
         <Text dimColor>
           Re-run this tutorial anytime with{' '}
@@ -1137,18 +1128,8 @@ const GoodbyePhase = ({
       </Box>
 
       <PickerMenu
-        options={
-          slackConnected
-            ? [{ label: 'Close', value: 'close' }]
-            : [
-                {
-                  label: 'Connect PostHog Slack agent',
-                  value: 'connect-slack',
-                },
-                { label: 'Close', value: 'close' },
-              ]
-        }
-        onSelect={handleGoodbye}
+        options={[{ label: 'Close', value: 'close' }]}
+        onSelect={() => onClose()}
       />
     </Box>
   );

--- a/src/ui/tui/screens/SlackConnectScreen.tsx
+++ b/src/ui/tui/screens/SlackConnectScreen.tsx
@@ -4,19 +4,20 @@
  * (`wizard mcp add`).
  *
  * Presents the PostHog Slack app plus role-tailored use-cases. The copy
- * adapts to whether Slack is already connected (`session.slackConnected`,
- * detected post-login):
+ * adapts to whether Slack is already connected (polled while the screen
+ * is up, held as local state):
  *   • not connected (or unknown) — nudge + "Open Slack setup", which
- *     launches the browser at the integration settings page. We link
- *     rather than wire it up: connecting Slack is a manual OAuth step.
+ *     launches the browser at the integration settings page and keeps
+ *     the screen alive; the poll flips it to connected once the user
+ *     finishes the manual OAuth step in the browser.
  *   • already connected — confirm it and skip the connect CTA, so users
  *     who already have it aren't nagged.
- * Either path dismisses the step (`slackStepDismissed`) and lets the
- * router advance to exit.
+ * "Skip" / "Done" / esc dismiss the step (`slackStepDismissed`) and let
+ * the router advance to exit.
  */
 
 import { Box, Text } from 'ink';
-import { useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import opn from 'opn';
 
 import type { WizardStore } from '@ui/tui/store';
@@ -24,6 +25,7 @@ import { Colors, Icons } from '@ui/tui/styles';
 import { PickerMenu } from '@ui/tui/primitives/index';
 import { useKeyBindings, KeyMatch } from '@ui/tui/hooks/useKeyBindings';
 import { getSlackAppCard } from '@lib/mcp-role-prompts';
+import { fetchSlackConnected } from '@lib/api';
 import { analytics } from '@utils/analytics';
 
 interface SlackConnectScreenProps {
@@ -35,6 +37,8 @@ enum ChoiceValue {
   Skip = 'skip',
 }
 
+const POLL_INTERVAL_MS = 3000;
+
 export const SlackConnectScreen = ({ store }: SlackConnectScreenProps) => {
   useSyncExternalStore(
     (cb) => store.subscribe(cb),
@@ -43,28 +47,82 @@ export const SlackConnectScreen = ({ store }: SlackConnectScreenProps) => {
 
   const role = store.session.roleAtOrganization;
   const slack = getSlackAppCard();
-  const connected = store.session.slackConnected === true;
 
-  const dismiss = (choice: ChoiceValue): void => {
-    if (choice === ChoiceValue.Open) {
-      analytics.wizardCapture('slack connect opened', { role });
-      // Fire-and-forget. opn throws in environments without a browser
-      // (headless/remote) — the setup URL is printed on screen as a
-      // fallback, so swallow the error.
-      if (process.env.NODE_ENV !== 'test') {
-        opn(slack.setupUrl, { wait: false }).catch(() => {
-          // No browser available — the printed URL is the fallback.
+  // Impression — once per mount, not per render.
+  useEffect(() => {
+    analytics.wizardCapture('slack connect shown', { role });
+  }, []);
+
+  // Seeded by the tutorial screen's prefetch (session.slackConnected),
+  // so the first render already shows the right variant. While not
+  // connected, poll: connecting Slack is a manual OAuth step in the
+  // browser, so the poll is what flips the screen to the connected
+  // state when the user comes back. Without credentials (user skipped
+  // login) it renders the connect nudge.
+  const connected = store.session.slackConnected === true;
+  const credentials = store.session.credentials;
+  useEffect(() => {
+    if (!credentials || connected) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const controller = new AbortController();
+    const check = (): void => {
+      fetchSlackConnected(
+        credentials.accessToken,
+        credentials.projectId,
+        credentials.host,
+        controller.signal,
+      )
+        .then((isConnected) => {
+          if (cancelled) return;
+          if (isConnected) {
+            store.setSlackConnected(true);
+          } else {
+            timer = setTimeout(check, POLL_INTERVAL_MS);
+          }
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          // Capture once and stop polling — repeating a failing call
+          // every tick would spam error tracking. The nudge copy is
+          // the fallback either way.
+          analytics.captureException(
+            err instanceof Error ? err : new Error(String(err)),
+            { step: 'slack_connected_check' },
+          );
         });
-      }
-    } else {
-      analytics.wizardCapture('slack connect skipped', { role, connected });
-    }
+    };
+    check();
+    return () => {
+      // Tear down fully on exit: no new ticks (cancelled), no pending
+      // tick (clearTimeout), no in-flight request (abort).
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      controller.abort();
+    };
+  }, [credentials, connected, store]);
+
+  const dismiss = (): void => {
+    analytics.wizardCapture('slack connect skipped', { role, connected });
     store.setSlackStepDismissed();
   };
 
   const handleSelect = (value: ChoiceValue | ChoiceValue[]): void => {
     const choice = Array.isArray(value) ? value[0] : value;
-    dismiss(choice);
+    if (choice === ChoiceValue.Open) {
+      analytics.wizardCapture('slack connect opened', { role });
+      // Fire-and-forget. opn throws in environments without a browser
+      // (headless/remote) — the setup URL is printed on screen as a
+      // fallback, so swallow the error. The screen stays up; the poll
+      // flips it to connected once the OAuth step completes.
+      if (process.env.NODE_ENV !== 'test') {
+        opn(slack.setupUrl, { wait: false }).catch(() => {
+          // No browser available — the printed URL is the fallback.
+        });
+      }
+      return;
+    }
+    dismiss();
   };
 
   useKeyBindings('slack-connect', [
@@ -72,7 +130,7 @@ export const SlackConnectScreen = ({ store }: SlackConnectScreenProps) => {
       match: KeyMatch.Escape,
       label: 'esc',
       action: connected ? 'done' : 'skip',
-      handler: () => dismiss(ChoiceValue.Skip),
+      handler: () => dismiss(),
     },
   ]);
 

--- a/src/ui/tui/services/mcp-suggested-prompts-services.ts
+++ b/src/ui/tui/services/mcp-suggested-prompts-services.ts
@@ -49,13 +49,16 @@ export interface McpSuggestedPromptsServices {
   }>;
 
   /**
-   * Best-effort check for whether the project already has a Slack
-   * integration connected. Drives the Connect-Slack copy (confirm vs.
-   * nudge). Resolves false on any failure — callers treat "unknown" as
-   * "not connected". Production hits the PostHog integrations API; the
-   * playground returns a canned value.
+   * Check whether the project already has a Slack integration
+   * connected. Drives the Goodbye card copy (confirm vs. nudge).
+   * Rejects on failure — callers treat that as "not connected".
+   * Production hits the PostHog integrations API; the playground
+   * returns a canned value.
    */
-  checkSlackConnected(credentials: Credentials): Promise<boolean>;
+  checkSlackConnected(
+    credentials: Credentials,
+    signal?: AbortSignal,
+  ): Promise<boolean>;
 
   /**
    * Run a prompt against Claude with the PostHog MCP server available
@@ -115,12 +118,13 @@ export function createMcpSuggestedPromptsServices(
       };
     },
 
-    checkSlackConnected: async (credentials) => {
+    checkSlackConnected: async (credentials, signal) => {
       const { fetchSlackConnected } = await import('@lib/api');
       return fetchSlackConnected(
         credentials.accessToken,
         credentials.projectId,
         credentials.host,
+        signal,
       );
     },
 

--- a/src/ui/tui/start-tui.ts
+++ b/src/ui/tui/start-tui.ts
@@ -65,7 +65,21 @@ export function startTUI(
   const inkUI = new InkUI(store);
   setUI(inkUI);
 
-  const { unmount: inkUnmount } = render(createElement(App, { store }));
+  const { unmount: inkUnmount, waitUntilExit } = render(
+    createElement(App, { store }),
+  );
+
+  // Fire the program steps' init work (e.g. the health-check pre-flight)
+  // now that the screens are rendering — store construction alone must
+  // not trigger it.
+  store.runInitHooks();
+
+  // Tearing down raw mode with a TTY read still pending surfaces a
+  // benign 'read EIO' on stdin (macOS); without a handler Node treats
+  // it as an uncaught exception and prints a stack over the exit line.
+  process.stdin.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code !== 'EIO') throw err;
+  });
 
   // On exit: unmount Ink, leave alt screen (restores previous content),
   // then print exit summary line into the main buffer.
@@ -84,6 +98,15 @@ export function startTUI(
     process.stdout.write(getExitLine(store) + '\n');
   };
   process.on('exit', cleanup);
+
+  // Ink unmounts itself on ctrl+c (exitOnCtrlC) but that alone doesn't
+  // end the process — background handles (e.g. the OAuth callback
+  // server) keep the event loop alive, leaving a zombie wizard with no
+  // UI. Follow the app teardown with a real exit.
+  void waitUntilExit().then(() => {
+    cleanup();
+    process.exit(process.exitCode ?? 0);
+  });
 
   return {
     unmount: cleanup,

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -121,8 +121,7 @@ export class WizardStore {
   }
 
   /**
-   * Scan program steps for gate predicates and onInit callbacks.
-   * Creates gate promises and fires init work.
+   * Scan program steps for gate predicates and create gate promises.
    */
   private _initFromProgram(program: ProgramId): void {
     const steps = getProgramConfig(program).steps;
@@ -142,10 +141,16 @@ export class WizardStore {
         });
       }
     }
+  }
 
-    // Run onInit callbacks with a minimal context interface.
-    // Arrow functions capture `this` from _initFromProgram so we don't
-    // need to alias it.
+  /**
+   * Run the program steps' onInit callbacks. startTUI calls this once
+   * the screens are actually rendering — constructing a store alone
+   * (tests, playground) must not fire init work like the health-check
+   * pre-flight, whose probes belong only to flows that show its screen.
+   */
+  runInitHooks(): void {
+    const steps = getProgramConfig(this.router.activeProgram).steps;
     const getSession = (): WizardSession => this.session;
     const ctx: StoreInitContext = {
       get session() {


### PR DESCRIPTION
Follow-ups to #640. I merged that PR before this work was pushed, my mistake — the review fixes and everything below were sitting uncommitted in a local worktree while the original branch went in.

What this adds on top of #640:

- Addresses my own review comments: drops the probe timeout, requests `integration:read`, captures check failures to error tracking, removes the JSON note keys in favor of real comments.
- Auth runs up front in the MCP tutorial so the first screen already knows the Slack state. Esc cancels back to Choose.
- `slackConnected` lives in the session, checked once per flow. The Connect-Slack screen seeds from it (no nudge flash) and polls every 3s while open, tearing down timers and in-flight requests on exit.
- PickerMenu supports disabled options with an icon slot. Navigation skips them, focus revalidates when options change. Connected state renders as a green ✔ "Already connected to Slack".
- The main wizard gets the Connect-Slack step between MCP and outro — always shown, declinable.
- The Goodbye card no longer duplicates the Slack card the dedicated step shows right after.
- Ctrl+C exits cleanly: no more `read EIO` stack, no zombie process holding the OAuth callback server.
- Health checks only fire for programs that declare a health-check screen, and onInit hooks fire when the TUI renders rather than at store construction — tests and the playground no longer hit real status endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)