### PR TITLE
feat: detect existing Slack connection at the end of a wizard run

### DIFF
--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -10,13 +10,15 @@
  * not listed in `PROGRAM_SCOPE_ADDITIONS` request the unchanged
  * base set, exactly like before.
  *
- * Today only `McpTutorial` adds anything: read-only on every product
+ * Current additions: `McpTutorial` layers read-only on every product
  * surface (feature flags, experiments, surveys, replays, errors, web
  * analytics, LLM analytics, cohorts, persons) plus read/write on
- * annotations. Persistence writes (dashboard:write, insight:write,
- * notebook:write, query:read) come for free from the base set, so the
- * tutorial's "save as insight / pin to dashboard / add to notebook"
- * follow-ups keep working.
+ * annotations; `AgentSkill` adds feature-flag read/write; the default
+ * `PostHogIntegration` run adds `integration:read` for the
+ * Connect-Slack step. Persistence writes (dashboard:write,
+ * insight:write, notebook:write, query:read) come for free from the
+ * base set, so the tutorial's "save as insight / pin to dashboard /
+ * add to notebook" follow-ups keep working.
  *
  * Add a new program override by extending `PROGRAM_SCOPE_ADDITIONS`
  * below — no other call-site changes required as long as the program's
@@ -118,6 +120,20 @@ export const AGENT_SKILL_SCOPE_ADDITIONS = [
 ] as const;
 
 /**
+ * Extra scope the default wizard run needs on top of `WIZARD_OAUTH_SCOPES`.
+ *
+ * The Connect-Slack step at the end of the run polls
+ * `/api/projects/:id/integrations/` (`fetchSlackConnected`) to render the
+ * already-connected variant and to flip live once the user completes the
+ * Slack OAuth step in the browser. Without `integration:read` the first
+ * poll 403s, the screen stops polling, and an already-connected project
+ * is nagged with the connect nudge.
+ */
+export const POSTHOG_INTEGRATION_SCOPE_ADDITIONS = [
+  'integration:read',
+] as const;
+
+/**
  * Per-program scope additions, layered on top of `WIZARD_OAUTH_SCOPES`.
  *
  * Programs not listed here request the unchanged base set. Use this
@@ -135,6 +151,7 @@ const PROGRAM_SCOPE_ADDITIONS: Partial<Record<ProgramId, readonly string[]>> = {
   // ever changes, this line will fail to type-check.
   'mcp-tutorial': MCP_TUTORIAL_SCOPE_ADDITIONS,
   'agent-skill': AGENT_SKILL_SCOPE_ADDITIONS,
+  'posthog-integration': POSTHOG_INTEGRATION_SCOPE_ADDITIONS,
 };
 
 /**

--- a/src/ui/tui/playground/PlaygroundApp.tsx
+++ b/src/ui/tui/playground/PlaygroundApp.tsx
@@ -21,6 +21,7 @@ import { McpSuggestedPromptsDemo } from './demos/McpSuggestedPromptsDemo.js';
 import { KeyboardHintsDemo } from './demos/KeyboardHintsDemo.js';
 import { AuditChecksDemo } from './demos/AuditChecksDemo.js';
 import { LearnDeckDemo } from './demos/LearnDeckDemo.js';
+import { EndScreensDemo } from './demos/EndScreensDemo.js';
 
 interface PlaygroundAppProps {
   store: WizardStore;
@@ -76,6 +77,11 @@ export const PlaygroundApp = ({ store }: PlaygroundAppProps) => {
       id: 'learn-deck',
       label: 'Learn deck',
       component: <LearnDeckDemo store={store} />,
+    },
+    {
+      id: 'end-screens',
+      label: 'End screens',
+      component: <EndScreensDemo store={store} />,
     },
   ];
 

--- a/src/ui/tui/playground/demos/EndScreensDemo.tsx
+++ b/src/ui/tui/playground/demos/EndScreensDemo.tsx
@@ -1,0 +1,139 @@
+/**
+ * EndScreensDemo — Playground demo for the screens shown at the end of
+ * a wizard run.
+ *
+ * Mounts the real SlackConnectScreen and OutroScreen against the shared
+ * playground store so every variant can be previewed without a run:
+ *
+ *   V   switch view          (slack-connect → outro)
+ *   K   toggle Slack state   (connected ↔ not connected) — simulates the
+ *       poll flipping the screen when the user finishes the browser OAuth
+ *   O   cycle outro kind     (success → error → cancel)
+ *
+ * The playground credentials are re-pointed at a localhost dead-end
+ * while this demo is mounted, so SlackConnectScreen's poll fails fast
+ * without real network traffic; `K` drives `session.slackConnected`
+ * directly, which is the same store key the poll writes.
+ *
+ * KeepSkillsScreen is intentionally absent — it reads the install dir's
+ * .claude/skills/ from disk and calls process.exit() when none are
+ * found, which would kill the playground.
+ */
+
+import { Box, Text, useInput } from 'ink';
+import { useEffect, useState, useSyncExternalStore } from 'react';
+import type { WizardStore } from '@ui/tui/store';
+import { SlackConnectScreen } from '@ui/tui/screens/SlackConnectScreen';
+import { OutroScreen } from '@ui/tui/screens/OutroScreen';
+import { Colors } from '@ui/tui/styles';
+import { OutroKind, type OutroData } from '@lib/wizard-session';
+
+const VIEWS = ['slack-connect', 'outro'] as const;
+type View = (typeof VIEWS)[number];
+
+const OUTRO_KINDS = [OutroKind.Success, OutroKind.Error, OutroKind.Cancel];
+
+const OUTRO_FIXTURES: Record<OutroKind, OutroData> = {
+  [OutroKind.Success]: {
+    kind: OutroKind.Success,
+    message: 'PostHog is set up!',
+    changes: [
+      'Installed posthog-js and wired the provider',
+      'Added pageview + pageleave capture',
+      'Instrumented 4 product events',
+    ],
+    reportFile: 'posthog-setup-report.md',
+    dashboardUrl: 'https://us.posthog.com/project/1/dashboard/42',
+    notebookUrl: 'https://us.posthog.com/project/1/notebooks/demo',
+    docsUrl: 'https://posthog.com/docs/libraries/next-js',
+  },
+  [OutroKind.Error]: {
+    kind: OutroKind.Error,
+    message: 'The agent hit an error',
+    body: 'The integration step failed before any files were changed.\nRe-run the wizard to try again.',
+    docsUrl: 'https://posthog.com/docs/ai-engineering/ai-wizard',
+  },
+  [OutroKind.Cancel]: {
+    kind: OutroKind.Cancel,
+    message: 'Cancelled — no changes were made',
+  },
+};
+
+interface EndScreensDemoProps {
+  store: WizardStore;
+}
+
+export const EndScreensDemo = ({ store }: EndScreensDemoProps) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  const [viewIdx, setViewIdx] = useState(0);
+  const [outroKindIdx, setOutroKindIdx] = useState(0);
+
+  const view: View = VIEWS[viewIdx];
+  const outroKind = OUTRO_KINDS[outroKindIdx];
+
+  // The playground pre-seeds fake credentials pointed at the real
+  // PostHog host, which SlackConnectScreen's poll would hit. Swap the
+  // host for a localhost dead-end while this demo is mounted (restore
+  // on unmount — tab switches unmount). The credentials must stay
+  // non-null: the router derives the active screen from session state,
+  // and nulling them drops the playground out of the 'run' screen,
+  // unmounting the tab bar and resetting it to the first tab.
+  useEffect(() => {
+    const previous = store.session.credentials;
+    store.setCredentials({
+      accessToken: 'playground',
+      projectApiKey: 'playground',
+      host: 'http://127.0.0.1:9',
+      projectId: 0,
+    });
+    return () => {
+      store.setCredentials(previous);
+    };
+  }, [store]);
+
+  // Seed the outro fixture each screen reads. slackConnected starts
+  // null (unknown) so the first paint shows the nudge variant, exactly
+  // like a wizard run before the poll's first response.
+  useEffect(() => {
+    store.setOutroData(OUTRO_FIXTURES[outroKind]);
+  }, [store, outroKind]);
+
+  useInput((input) => {
+    if (input === 'V' || input === 'v') {
+      setViewIdx((i) => (i + 1) % VIEWS.length);
+    } else if (input === 'K' || input === 'k') {
+      store.setSlackConnected(store.session.slackConnected !== true);
+    } else if (input === 'O' || input === 'o') {
+      setOutroKindIdx((i) => (i + 1) % OUTRO_KINDS.length);
+    }
+  });
+
+  const slackState =
+    store.session.slackConnected === true ? 'connected' : 'not-connected';
+
+  return (
+    <Box flexDirection="column" flexGrow={1} paddingX={1}>
+      <Text dimColor>V view · K slack state · O outro kind</Text>
+      <Text dimColor>
+        view={view} · slack={slackState} · outro={outroKind}
+      </Text>
+      <Box marginTop={1} flexDirection="column" flexGrow={1}>
+        {view === 'slack-connect' ? (
+          <SlackConnectScreen store={store} />
+        ) : (
+          <OutroScreen store={store} />
+        )}
+      </Box>
+      <Box marginTop={1}>
+        <Text color={Colors.muted} dimColor>
+          (session-driven previews — the Slack poll points at a localhost
+          dead-end; K flips the same store key the poll writes.)
+        </Text>
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/tui/primitives/TabContainer.tsx
+++ b/src/ui/tui/primitives/TabContainer.tsx
@@ -125,9 +125,10 @@ export const TabContainer = ({
         </Box>
       )}
 
-      {/* Tab bar */}
+      {/* Tab bar — wraps onto extra rows when there are more tabs than
+          fit the terminal width, instead of clipping the overflow. */}
       <Box height={1} />
-      <Box gap={1} paddingX={1}>
+      <Box gap={1} paddingX={1} flexWrap="wrap" flexShrink={0}>
         {tabs.map((tab, i) => (
           <Text
             key={tab.id}


### PR DESCRIPTION
## What

The Connect-Slack step at the end of the default wizard run now actually detects an existing Slack connection — same behavior as the MCP tutorial.

`SlackConnectScreen` already polls `fetchSlackConnected` every 3s, but that endpoint requires the `integration:read` scope, which only the `mcp-tutorial` program requested (#648). In the default `posthog-integration` run the first poll 403s, the catch stops polling, and an already-connected project is nagged with the connect nudge forever. This adds `integration:read` to the program's scope additions (it's already inside the OAuth app ceiling), which makes the existing screen behavior work: already-connected projects flip to the ✓ connected variant on mount, and "Open Slack setup" flips live once the browser OAuth completes.

## Also

- **End-screens playground tab** — mounts the real `SlackConnectScreen` and `OutroScreen` against the shared store. `V` switches view, `K` toggles the Slack state (writes the same store key the poll writes), `O` cycles outro success/error/cancel. The demo swaps the playground's fake credentials for a localhost dead-end while mounted (and restores on unmount) so the poll can't reach a real host — credentials stay non-null because nulling them knocks the router out of the `run` screen and resets the tab bar.
- **Playground tab bar wraps** — `flexWrap="wrap"` on the `TabContainer` tab bar, so the now-14-tab playground stacks onto extra rows instead of clipping.

## Test

- `pnpm build && pnpm test && pnpm fix` — 857 tests pass.
- Drove the playground in a pty to the End screens tab: demo renders the Slack nudge variant and the tab bar wraps at 80 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)