### PR TITLE
feat: utm-tag and track outbound links, fix event attribution

### DIFF
--- a/src/commands/basic-integration/index.ts
+++ b/src/commands/basic-integration/index.ts
@@ -1,4 +1,5 @@
 import { isNonInteractiveEnvironment } from '@utils/environment';
+import { setEntryCommand } from '@utils/links';
 import { provisionCommand } from '../provision';
 import type { Command } from '../command';
 
@@ -46,6 +47,8 @@ export const basicIntegrationCommand: Command = {
     return true;
   },
   handler: (argv) => {
+    // The bare run is the integrate flow.
+    setEntryCommand('integrate');
     // Each mode file is loaded only when its branch is taken, so a plain
     // `npx @posthog/wizard` never pulls in the CI or playground paths.
     void (async () => {

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,4 +1,5 @@
 import type { Arguments, Argv, CommandModule, Options } from 'yargs';
+import { setEntryCommand } from '@utils/links';
 
 export interface Command {
   /** Yargs command name. Use `['$0']` for the default command. */
@@ -37,6 +38,11 @@ export function toCommandModule(
   cmd: Command,
   parentPath: readonly string[],
 ): CommandModule {
+  // `wizard slack` → 'slack', `wizard mcp add` → 'mcp-add'. The default
+  // `$0` resolves to '' and is skipped — its handler reports itself.
+  const entryCommand = [...parentPath, commandKeys(cmd.name)[0]]
+    .filter((key) => key !== '$0')
+    .join('-');
   return {
     command: cmd.name,
     describe: cmd.description,
@@ -55,6 +61,9 @@ export function toCommandModule(
       }
       return next;
     },
-    handler: cmd.handler ?? (() => undefined),
+    handler: (argv: Arguments) => {
+      if (entryCommand) setEntryCommand(entryCommand);
+      cmd.handler?.(argv);
+    },
   };
 }

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -1,4 +1,3 @@
-import opn from 'opn';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
@@ -18,6 +17,7 @@ import { WIZARD_INTERACTION_EVENT_NAME } from '@lib/constants';
 import { getUI } from '@ui/index';
 import { getCloudUrlFromRegion } from '@utils/urls';
 import { requestDeepLink } from '@utils/provisioning';
+import { openTrackedLink, withUtm } from '@utils/links';
 import type { CloudRegion } from '@utils/types';
 import { POSTHOG_INTEGRATION_PROGRAM } from './steps.js';
 import { getContentBlocks } from './content/index.js';
@@ -32,7 +32,10 @@ function resolveContinueUrl(
   if (!sess.signup) return undefined;
   if (typeof deepLink === 'string' && deepLink) return deepLink;
   if (cloudRegion)
-    return `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`;
+    return withUtm(
+      `${getCloudUrlFromRegion(cloudRegion)}/products?source=wizard`,
+      'outro-continue',
+    );
   return undefined;
 }
 
@@ -230,12 +233,11 @@ Important: Use the detect_package_manager tool (from the wizard-tools MCP server
             credentials.host,
           );
           if (deepLink) {
-            sess.frameworkContext[DASHBOARD_DEEP_LINK_KEY] = deepLink;
-            if (process.env.NODE_ENV !== 'test') {
-              opn(deepLink, { wait: false }).catch(() => {
-                // opn throws in environments without a browser
-              });
-            }
+            const taggedDeepLink = withUtm(deepLink, 'dashboard-deeplink');
+            sess.frameworkContext[DASHBOARD_DEEP_LINK_KEY] = taggedDeepLink;
+            openTrackedLink(taggedDeepLink, 'dashboard-deeplink', {
+              auto: true,
+            });
           }
         }
       },

--- a/src/lib/runners/run-wizard-ci.ts
+++ b/src/lib/runners/run-wizard-ci.ts
@@ -2,6 +2,7 @@ import { POSTHOG_DOCS_URL } from '@lib/constants';
 import { getUI, setUI } from '@ui';
 import { LoggingUI } from '@ui/logging-ui';
 import type { ProgramConfig } from '@lib/programs/program-step';
+import { analytics } from '@utils/analytics';
 import { resolveNoTelemetry } from './resolve-no-telemetry';
 
 /**
@@ -39,6 +40,9 @@ export function runWizardCI(
 ): void {
   setUI(new LoggingUI());
   validateCiOptions(options);
+  // Every CI entry point routes through here — upgrade the non-prod
+  // build tag from 'dev' to 'ci'.
+  analytics.setTag('build', 'ci');
 
   void (async () => {
     const path = await import('path');

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-web.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-web.test.ts
@@ -1,10 +1,12 @@
-import opn from 'opn';
 import { ClaudeWebMCPClient } from '@steps/add-mcp-server-to-clients/clients/claude-web';
 import { isBrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+import { openTrackedLink } from '@utils/links';
 
-jest.mock('opn', () => jest.fn(() => Promise.resolve()));
+jest.mock('@utils/links', () => ({
+  openTrackedLink: jest.fn(),
+}));
 
-const opnMock = opn as unknown as jest.Mock;
+const openTrackedLinkMock = openTrackedLink as jest.Mock;
 
 const CONNECTOR_URL = 'https://claude.ai/directory/connectors/posthog';
 
@@ -36,18 +38,17 @@ describe('ClaudeWebMCPClient', () => {
     await expect(client.isServerInstalled()).resolves.toBe(false);
   });
 
-  it('opens the connector page on addServer and reports success', async () => {
+  it('opens the connector page as a tracked link on addServer', async () => {
     await expect(client.addServer()).resolves.toEqual({ success: true });
-    expect(opnMock).toHaveBeenCalledWith(CONNECTOR_URL, { wait: false });
-  });
-
-  it('still reports success when opening the browser fails', async () => {
-    opnMock.mockReturnValueOnce(Promise.reject(new Error('no browser')));
-    await expect(client.addServer()).resolves.toEqual({ success: true });
+    expect(openTrackedLinkMock).toHaveBeenCalledWith(
+      CONNECTOR_URL,
+      'claude-web-connector',
+      { auto: true, skipUtm: true },
+    );
   });
 
   it('removeServer is a no-op that reports nothing removed', async () => {
     await expect(client.removeServer()).resolves.toEqual({ success: false });
-    expect(opnMock).not.toHaveBeenCalled();
+    expect(openTrackedLinkMock).not.toHaveBeenCalled();
   });
 });

--- a/src/steps/add-mcp-server-to-clients/clients/claude-web.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-web.ts
@@ -1,6 +1,6 @@
-import opn from 'opn';
 import { MCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
 import { BrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+import { openTrackedLink } from '@utils/links';
 
 /**
  * Claude Desktop / Claude.ai (web). PostHog ships here as a hosted connector,
@@ -24,9 +24,10 @@ export class ClaudeWebMCPClient extends MCPClient implements BrowserFinishable {
   }
 
   addServer(): Promise<{ success: boolean }> {
-    void opn(this.connectorUrl, { wait: false }).catch(() => {
-      // opn throws in environments without a browser (e.g. CI) — swallow it;
-      // the URL is still surfaced to the user on the Done screen.
+    // Not a PostHog property, so no UTMs — just the tracked open.
+    openTrackedLink(this.connectorUrl, 'claude-web-connector', {
+      auto: true,
+      skipUtm: true,
     });
     return Promise.resolve({ success: true });
   }

--- a/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
+++ b/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
@@ -41,7 +41,6 @@ import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSyncExternalStore } from 'react';
-import opn from 'opn';
 
 import type { WizardStore } from '@ui/tui/store';
 import { Colors, Icons } from '@ui/tui/styles';
@@ -67,6 +66,7 @@ import {
 import type { Integration } from '@lib/constants';
 import { analytics } from '@utils/analytics';
 import { logToFile } from '@utils/debug';
+import { openTrackedLink } from '@utils/links';
 import type {
   AgentChunk,
   McpSuggestedPromptsServices,
@@ -362,15 +362,8 @@ export const McpSuggestedPromptsScreen = ({
         choice: 'connect-slack',
       });
       // Open the Slack integration settings and stay on the Choose screen
-      // so the user can still start the tutorial. opn throws in headless
-      // environments — swallow it; the URL is also printed on screen.
-      if (process.env.NODE_ENV !== 'test') {
-        opn(getSlackAppCard().setupUrl, {
-          wait: false,
-        }).catch(() => {
-          // No browser available.
-        });
-      }
+      // so the user can still start the tutorial.
+      openTrackedLink(getSlackAppCard().setupUrl, 'mcp-prompts-slack-setup');
     } else {
       analytics.wizardCapture('mcp suggested prompts choose', {
         choice: 'exit',

--- a/src/ui/tui/screens/OutroScreen.tsx
+++ b/src/ui/tui/screens/OutroScreen.tsx
@@ -11,6 +11,7 @@ import { useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { OutroKind } from '@lib/wizard-session';
 import { Colors } from '@ui/tui/styles';
+import { withUtm } from '@utils/links';
 
 interface OutroScreenProps {
   store: WizardStore;
@@ -87,7 +88,9 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
             <Box marginTop={1}>
               <Text>
                 We've also made you a dashboard:{' '}
-                <Text color="cyan">{outroData.dashboardUrl}</Text>
+                <Text color="cyan">
+                  {withUtm(outroData.dashboardUrl, 'outro-dashboard')}
+                </Text>
               </Text>
             </Box>
           )}
@@ -96,7 +99,9 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
             <Box marginTop={1}>
               <Text>
                 And uploaded the report to a PostHog notebook:{' '}
-                <Text color="cyan">{outroData.notebookUrl}</Text>
+                <Text color="cyan">
+                  {withUtm(outroData.notebookUrl, 'outro-notebook')}
+                </Text>
               </Text>
             </Box>
           )}
@@ -104,7 +109,10 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
           {outroData.docsUrl && (
             <Box marginTop={1}>
               <Text>
-                Learn more: <Text color="cyan">{outroData.docsUrl}</Text>
+                Learn more:{' '}
+                <Text color="cyan">
+                  {withUtm(outroData.docsUrl, 'outro-docs')}
+                </Text>
               </Text>
             </Box>
           )}
@@ -113,7 +121,9 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
             <Box>
               <Text>
                 Continue onboarding:{' '}
-                <Text color="cyan">{outroData.continueUrl}</Text>
+                <Text color="cyan">
+                  {withUtm(outroData.continueUrl, 'outro-continue')}
+                </Text>
               </Text>
             </Box>
           )}

--- a/src/ui/tui/start-tui.ts
+++ b/src/ui/tui/start-tui.ts
@@ -13,6 +13,7 @@ import { InkUI } from './ink-ui.js';
 import { setUI } from '@ui/index';
 import { App } from './App.js';
 import { OutroKind } from '@lib/wizard-session';
+import { analytics } from '@utils/analytics';
 import { logToFile } from '@utils/debug';
 
 // ANSI escape sequences
@@ -68,6 +69,10 @@ export function startTUI(
   const { unmount: inkUnmount, waitUntilExit } = render(
     createElement(App, { store }),
   );
+
+  // The launch marker — the first event of every TUI run, captured under
+  // the run's anonymous id and merged into the user once they log in.
+  analytics.wizardCapture('started', { program_id: program });
 
   // Fire the program steps' init work (e.g. the health-check pre-flight)
   // now that the screens are rendering — store construction alone must

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -667,6 +667,11 @@ export class WizardStore {
   private _detectTransition(): void {
     const next = this.router.resolve(this.session);
     const prev = this._lastScreen;
+    if (next !== prev) {
+      // Every event carries the active TUI screen, filling the
+      // "URL / Screen" column in PostHog.
+      analytics.setTag('$screen_name', next);
+    }
     if (prev !== null && next !== prev) {
       const hooks = this._enterScreenHooks.get(next);
       if (hooks) {

--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -22,6 +22,7 @@ describe('Analytics', () => {
       capture: jest.fn(),
       captureException: jest.fn(),
       alias: jest.fn(),
+      identify: jest.fn(),
       shutdown: jest.fn().mockResolvedValue(undefined),
     } as any;
 
@@ -43,6 +44,7 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
           ...properties,
         },
       );
@@ -61,6 +63,7 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
           testTag: 'testValue',
           ...properties,
         },
@@ -71,7 +74,7 @@ describe('Analytics', () => {
       const error = new Error('Test error');
       const distinctId = 'user-123';
 
-      analytics.setDistinctId(distinctId);
+      analytics.identifyUser({ distinct_id: distinctId } as unknown as ApiUser);
       analytics.captureException(error);
 
       expect(mockPostHogInstance.captureException).toHaveBeenCalledWith(
@@ -80,6 +83,7 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
         },
       );
     });
@@ -95,6 +99,7 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
         },
       );
     });
@@ -113,6 +118,7 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
           environment: 'test',
           version: '1.0.0',
           integration: 'nextjs',
@@ -134,6 +140,7 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
           integration: 'react',
         },
       );
@@ -150,8 +157,123 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
         },
       );
+    });
+  });
+
+  describe('identifyUser', () => {
+    const user = {
+      distinct_id: 'user-123',
+      email: 'v@posthog.com',
+      first_name: 'Vincent',
+      last_name: null,
+    } as unknown as ApiUser;
+
+    it('identifies the user, then merges the anonymous person in', () => {
+      analytics.identifyUser(user);
+
+      expect(mockPostHogInstance.identify).toHaveBeenCalledWith({
+        distinctId: 'user-123',
+        properties: {
+          $set: { email: 'v@posthog.com', name: 'Vincent' },
+        },
+      });
+      expect(mockPostHogInstance.alias).toHaveBeenCalledWith({
+        distinctId: 'user-123',
+        alias: 'test-uuid',
+      });
+      // Alias only ever fires after identification.
+      expect(
+        (mockPostHogInstance.identify as jest.Mock).mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        (mockPostHogInstance.alias as jest.Mock).mock.invocationCallOrder[0],
+      );
+    });
+
+    it('runs once per user — re-login does not re-identify or re-merge', () => {
+      analytics.identifyUser(user);
+      analytics.identifyUser(user);
+
+      expect(mockPostHogInstance.identify).toHaveBeenCalledTimes(1);
+      expect(mockPostHogInstance.alias).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when the id is the run anonymous id itself', () => {
+      analytics.identifyUser({
+        distinct_id: 'test-uuid',
+      } as unknown as ApiUser);
+
+      expect(mockPostHogInstance.identify).not.toHaveBeenCalled();
+      expect(mockPostHogInstance.alias).not.toHaveBeenCalled();
+    });
+
+    it('omits person properties the user does not have', () => {
+      analytics.identifyUser({
+        distinct_id: 'user-123',
+      } as unknown as ApiUser);
+
+      expect(mockPostHogInstance.identify).toHaveBeenCalledWith({
+        distinctId: 'user-123',
+        properties: { $set: {} },
+      });
+    });
+  });
+
+  describe('exception repair (before_send)', () => {
+    type TestEvent = Record<string, unknown> & {
+      distinctId?: string;
+      properties?: Record<string, unknown>;
+    };
+    type BeforeSendFn = (event: TestEvent | null) => TestEvent | null;
+
+    const getBeforeSend = (): BeforeSendFn =>
+      (MockedPostHog.mock.calls[0][1] as { before_send: BeforeSendFn })
+        .before_send;
+
+    it('reattaches identity and tags to autocaptured exceptions', () => {
+      analytics.setTag('command', 'slack');
+      const beforeSend = getBeforeSend();
+
+      const result = beforeSend({
+        event: '$exception',
+        distinctId: 'random-uuidv7',
+        properties: {
+          $exception_list: [{ type: 'Error' }],
+          $process_person_profile: false,
+        },
+      });
+
+      expect(result?.distinctId).toBe('test-uuid');
+      expect(result?.properties).toEqual({
+        $app_name: 'wizard',
+        build: 'dev',
+        command: 'slack',
+        $exception_list: [{ type: 'Error' }],
+      });
+    });
+
+    it('uses the real distinct id once set', () => {
+      analytics.identifyUser({ distinct_id: 'user-123' } as unknown as ApiUser);
+      const beforeSend = getBeforeSend();
+
+      const result = beforeSend({
+        event: '$exception',
+        distinctId: 'random-uuidv7',
+        properties: {},
+      });
+
+      expect(result?.distinctId).toBe('user-123');
+    });
+
+    it('leaves non-exception events untouched', () => {
+      const beforeSend = getBeforeSend();
+      const event = { event: 'x', distinctId: 'd', properties: { a: 1 } };
+
+      expect(beforeSend(event)).toBe(event);
+      expect(event.distinctId).toBe('d');
+      expect(event.properties).toEqual({ a: 1 });
     });
   });
 
@@ -288,6 +410,7 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
           integration: 'nextjs',
           localMcp: true,
           debug: false,
@@ -297,11 +420,11 @@ describe('Analytics', () => {
       );
     });
 
-    it('should work correctly with setDistinctId and captureException', () => {
+    it('attributes exceptions to the identified user', () => {
       const error = new Error('Test error');
       const distinctId = 'user-456';
 
-      analytics.setDistinctId(distinctId);
+      analytics.identifyUser({ distinct_id: distinctId } as unknown as ApiUser);
       analytics.setTag('integration', 'svelte');
       analytics.captureException(error);
 
@@ -311,6 +434,7 @@ describe('Analytics', () => {
         {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
+          build: 'dev',
           integration: 'svelte',
         },
       );

--- a/src/utils/__tests__/links.test.ts
+++ b/src/utils/__tests__/links.test.ts
@@ -1,0 +1,33 @@
+import { withUtm } from '../links';
+
+describe('withUtm', () => {
+  it('tags a URL with the wizard UTM params and no campaign', () => {
+    const url = withUtm('https://us.posthog.com/products', 'outro-continue');
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('utm_source')).toBe('wizard');
+    expect(parsed.searchParams.get('utm_medium')).toBe('cli');
+    expect(parsed.searchParams.get('utm_content')).toBe('outro-continue');
+    expect(parsed.searchParams.has('utm_campaign')).toBe(false);
+  });
+
+  it('preserves existing query params and fragments', () => {
+    const url = withUtm(
+      'https://app.posthog.com/settings/project-integrations?a=1#integration-slack',
+      'slack-connect-setup',
+    );
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('a')).toBe('1');
+    expect(parsed.searchParams.get('utm_source')).toBe('wizard');
+    expect(parsed.hash).toBe('#integration-slack');
+  });
+
+  it('does not re-tag a URL that already carries a utm_source', () => {
+    const once = withUtm('https://us.posthog.com/x', 'first');
+    const twice = withUtm(once, 'second');
+    expect(twice).toBe(once);
+  });
+
+  it('returns unparseable input untouched', () => {
+    expect(withUtm('not a url', 'x')).toBe('not a url');
+  });
+});

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -7,6 +7,7 @@ import {
 import type { WizardSession } from '@lib/wizard-session';
 import type { ApiUser } from '@lib/api';
 import { v4 as uuidv4 } from 'uuid';
+import { IS_PRODUCTION_BUILD } from '@env';
 import { debug } from './debug';
 
 /**
@@ -63,22 +64,63 @@ export class Analytics {
       flushInterval: 0,
       enableExceptionAutocapture: true,
       before_send: (event) => {
-        if (event && Object.keys(this.groups).length > 0) {
+        if (!event) return event;
+        if (Object.keys(this.groups).length > 0) {
           event.groups = { ...this.groups, ...event.groups };
+        }
+        // Autocaptured exceptions arrive with a random uuid and
+        // `$process_person_profile: false` — reattach the run's identity
+        // and tags so they land on the same person as everything else.
+        if (event.event === '$exception') {
+          event.distinctId = this.distinctId ?? this.anonymousId;
+          const { $process_person_profile, ...properties } =
+            event.properties ?? {};
+          void $process_person_profile;
+          event.properties = { ...this.tags, ...properties };
         }
         return event;
       },
     });
 
     this.tags = { $app_name: this.appName };
+    // Non-production builds tag every event so they segment out of prod
+    // data. CI runs upgrade the tag to 'ci' (see runWizardCI).
+    if (!IS_PRODUCTION_BUILD) {
+      this.tags.build = 'dev';
+    }
 
     this.anonymousId = uuidv4();
 
     this.distinctId = undefined;
   }
 
-  setDistinctId(distinctId: string) {
+  /**
+   * Associate the run with the logged-in user, once per id: identify them
+   * (email, name), then alias the run's anonymous id onto the identified
+   * person so pre-login events merge in. Alias only ever fires after
+   * identification.
+   */
+  identifyUser(user: ApiUser) {
+    const distinctId = user.distinct_id;
+    if (this.distinctId === distinctId || distinctId === this.anonymousId) {
+      return;
+    }
     this.distinctId = distinctId;
+    this.client.identify({
+      distinctId,
+      properties: {
+        $set: {
+          ...(user.email ? { email: user.email } : {}),
+          ...(user.first_name || user.last_name
+            ? {
+                name: [user.first_name, user.last_name]
+                  .filter(Boolean)
+                  .join(' '),
+              }
+            : {}),
+        },
+      },
+    });
     this.client.alias({
       distinctId,
       alias: this.anonymousId,

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,0 +1,65 @@
+/**
+ * Outbound links: UTM tagging and tracked opens.
+ *
+ * Every URL the wizard sends a user to — auto-opened or printed in the TUI —
+ * carries `utm_source=wizard`, `utm_medium=cli`, `utm_content=<which link>`.
+ * The command dimension rides on every wizard event as the `command` tag.
+ * Opening a link also captures a wizard event.
+ */
+import opn from 'opn';
+import { NODE_ENV } from '@env';
+import { analytics } from './analytics';
+
+/**
+ * Record the CLI command this run was started with (e.g. `integrate`,
+ * `slack`, `mcp-add`). Set once at dispatch; tagged onto every wizard
+ * event so wizard-side events segment by command.
+ */
+export function setEntryCommand(command: string): void {
+  analytics.setTag('command', command);
+}
+
+/**
+ * Tag a URL with the wizard's UTM params. `content` names the specific link
+ * (e.g. `oauth-signup`, `slack-connect-setup`). URLs that already carry a
+ * utm_source — or don't parse — are returned untouched.
+ */
+export function withUtm(url: string, content: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  if (parsed.searchParams.has('utm_source')) return url;
+  parsed.searchParams.set('utm_source', 'wizard');
+  parsed.searchParams.set('utm_medium', 'cli');
+  parsed.searchParams.set('utm_content', content);
+  return parsed.toString();
+}
+
+/**
+ * Open a URL in the user's browser, UTM-tagged (pass `skipUtm` for
+ * destinations that aren't PostHog properties or are already final), and
+ * capture the interaction. `auto` marks opens the wizard initiated itself,
+ * as opposed to a user picking a link on screen. opn throws in headless
+ * environments — the URL is always also printed on screen, so the failure
+ * is swallowed.
+ */
+export function openTrackedLink(
+  url: string,
+  content: string,
+  opts?: { auto?: boolean; skipUtm?: boolean },
+): void {
+  const finalUrl = opts?.skipUtm ? url : withUtm(url, content);
+  analytics.wizardCapture('link opened', {
+    content,
+    url: finalUrl,
+    auto: opts?.auto ?? false,
+  });
+  if (NODE_ENV !== 'test') {
+    opn(finalUrl, { wait: false }).catch(() => {
+      // No browser available — the printed URL is the fallback.
+    });
+  }
+}

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -3,7 +3,6 @@ import * as http from 'node:http';
 import { execSync } from 'node:child_process';
 import axios from 'axios';
 import { logToFile } from './debug';
-import opn from 'opn';
 import { z } from 'zod';
 import { getUI } from '@ui';
 import {
@@ -16,8 +15,8 @@ import {
   POSTHOG_PROXY_CLIENT_ID,
   WIZARD_USER_AGENT,
 } from '@lib/constants';
-import { NODE_ENV } from '@env';
 import { abort } from './setup-utils';
+import { openTrackedLink, withUtm } from './links';
 import { analytics } from './analytics';
 
 const OAUTH_CALLBACK_STYLES = `
@@ -358,10 +357,16 @@ export async function performOAuthFlow(
       authUrl.searchParams.set('scope', config.scopes.join(' '));
       authUrl.searchParams.set('required_access_level', 'project');
 
+      // UTM-tag both kickoff URLs so the journey into the app is
+      // attributable to the wizard command that started it.
+      const taggedAuthUrl = withUtm(authUrl.toString(), 'oauth-authorize');
       const signupUrl = new URL(
-        `${POSTHOG_OAUTH_URL}/signup?next=${encodeURIComponent(
-          authUrl.toString(),
-        )}`,
+        withUtm(
+          `${POSTHOG_OAUTH_URL}/signup?next=${encodeURIComponent(
+            taggedAuthUrl,
+          )}`,
+          'oauth-signup',
+        ),
       );
       const localSignupUrl = getLocalSignupUrl(port);
       const localLoginUrl = getLocalLoginUrl(port);
@@ -373,7 +378,7 @@ export async function performOAuthFlow(
       let waitForCallback: () => Promise<string>;
       try {
         ({ server, waitForCallback } = await startCallbackServer(
-          authUrl.toString(),
+          taggedAuthUrl,
           signupUrl.toString(),
           port,
         ));
@@ -391,14 +396,12 @@ export async function performOAuthFlow(
       // remote/headless box the user opens it from another machine, where
       // localhost:<port> is unreachable.
       getUI().setAuthorizeUrl(
-        config.signup ? signupUrl.toString() : authUrl.toString(),
+        config.signup ? signupUrl.toString() : taggedAuthUrl,
       );
 
-      if (NODE_ENV !== 'test') {
-        opn(urlToOpen, { wait: false }).catch(() => {
-          // opn throws in environments without a browser
-        });
-      }
+      // The localhost proxy URL stays untagged — the PostHog destination
+      // it redirects to carries the UTMs.
+      openTrackedLink(urlToOpen, 'oauth', { auto: true, skipUtm: true });
 
       const loginSpinner = getUI().spinner();
       loginSpinner.start('Waiting for authorization...');

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -430,6 +430,7 @@ export async function getOrAskForProjectData(
     } catch {
       // best-effort
     }
+    if (user) analytics.identifyUser(user);
 
     return {
       host,
@@ -570,7 +571,7 @@ async function askForWizardLogin(options: {
 
   getUI().log.success('Login complete.');
   analytics.setTag('opened-wizard-link', true);
-  analytics.setDistinctId(data.distinctId);
+  analytics.identifyUser(userData);
 
   return data;
 }


### PR DESCRIPTION
Fix identification and add per screen tracking.

You can now follow the entire journey of a user properly. The part before oauth has proper aliasing now.

<img width="1295" height="634" alt="Screenshot 2026-06-12 at 1 12 38 PM" src="https://github.com/user-attachments/assets/bd7bda5d-af4e-4716-814a-a7ae6fc2b0c4" />
<img width="1295" height="634" alt="Screenshot 2026-06-12 at 1 12 33 PM" src="https://github.com/user-attachments/assets/55a6e680-75e5-4742-861c-a6d0effeed96" />

<img width="852" height="288" alt="Screenshot 2026-06-12 at 1 15 55 PM" src="https://github.com/user-attachments/assets/27583767-8be2-457f-89ab-cfc6e974fa6d" />


<img width="1284" height="762" alt="Screenshot 2026-06-12 at 1 25 28 PM" src="https://github.com/user-attachments/assets/5815207e-a6b9-42a7-ab3d-76db051ac3e3" />
<img width="1284" height="762" alt="Screenshot 2026-06-12 at 1 25 24 PM" src="https://github.com/user-attachments/assets/f8f3ab24-3f49-48ce-9aac-4de279545e75" />