### PR TITLE
fix(oauth): time out the login flow at 5 minutes and prompt re-run

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -163,5 +163,13 @@ export const POSTHOG_FLAG_HEADER_PREFIX = 'X-POSTHOG-FLAG-';
 /** Timeout for framework / project detection probes (ms). */
 export const DETECTION_TIMEOUT_MS = 10_000;
 
-/** Timeout for the OAuth authorization flow (ms). */
-export const OAUTH_TIMEOUT_MS = 360_000;
+/**
+ * Timeout for the OAuth authorization flow (ms).
+ *
+ * Mirrors the server-side authorization-code expiry
+ * (`AUTHORIZATION_CODE_EXPIRE_SECONDS`, 5 minutes). Once the code expires the
+ * callback is dead and the token exchange can no longer succeed, so we stop
+ * waiting at the same moment and prompt the user to re-run rather than letting
+ * them complete a login that would fail.
+ */
+export const OAUTH_TIMEOUT_MS = 300_000;

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -242,6 +242,9 @@ export interface WizardSession {
     conflicts?: SettingsConflict[];
     logFilePath: string;
   } | null;
+  /** Minutes after which the login window expired. Set when the OAuth flow
+   *  times out, drives the session-timeout overlay copy. */
+  sessionTimeoutMinutes: number | null;
   portConflictProcess: {
     command: string;
     pid: string;
@@ -329,6 +332,7 @@ export function buildSession(args: {
     settingsOverrideKeys: null,
     settingsConflicts: null,
     authErrorDetail: null,
+    sessionTimeoutMinutes: null,
     portConflictProcess: null,
     outroData: null,
     dashboardUrl: null,

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -242,9 +242,6 @@ export interface WizardSession {
     conflicts?: SettingsConflict[];
     logFilePath: string;
   } | null;
-  /** Minutes after which the login window expired. Set when the OAuth flow
-   *  times out, drives the session-timeout overlay copy. */
-  sessionTimeoutMinutes: number | null;
   portConflictProcess: {
     command: string;
     pid: string;
@@ -332,7 +329,6 @@ export function buildSession(args: {
     settingsOverrideKeys: null,
     settingsConflicts: null,
     authErrorDetail: null,
-    sessionTimeoutMinutes: null,
     portConflictProcess: null,
     outroData: null,
     dashboardUrl: null,

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -12,6 +12,7 @@ import {
 } from './wizard-ui';
 import type { SettingsConflict } from '@lib/agent/claude-settings';
 import type { ApiUser } from '@lib/api';
+import { OAUTH_TIMEOUT_MS } from '@lib/constants';
 import {
   type WizardReadinessResult,
   getBlockingServiceKeys,
@@ -196,7 +197,8 @@ export class LoggingUI implements WizardUI {
     }
   }
 
-  showSessionTimeout(minutes: number): void {
+  showSessionTimeout(): void {
+    const minutes = Math.round(OAUTH_TIMEOUT_MS / 60_000);
     console.log(
       `✖  Login timed out. The OAuth link timed out after ${minutes} minutes.`,
     );

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -196,6 +196,13 @@ export class LoggingUI implements WizardUI {
     }
   }
 
+  showSessionTimeout(minutes: number): void {
+    console.log(
+      `✖  Login timed out. The OAuth link timed out after ${minutes} minutes.`,
+    );
+    console.log(`│  Re-run the wizard to get a fresh link and try again.`);
+  }
+
   startRun(): void {
     // No-op in CI mode
   }

--- a/src/ui/tui/__tests__/router.test.ts
+++ b/src/ui/tui/__tests__/router.test.ts
@@ -87,6 +87,25 @@ describe('WizardRouter', () => {
       router.popOverlay();
       expect(router.resolve(session)).toBe(Overlay.SettingsOverride);
     });
+
+    it('shows the session-timeout overlay over the auth screen that never completes', () => {
+      // On OAuth timeout the user has no credentials, so the auth step's
+      // isComplete gate never passes and resolve() is pinned on Auth. The
+      // overlay must take precedence, otherwise the spinner shows forever.
+      const router = new WizardRouter(Program.PostHogIntegration);
+      const session = baseWizardSession();
+
+      session.setupConfirmed = true;
+      session.readinessResult = {
+        decision: WizardReadiness.Yes,
+        health: {} as never,
+        reasons: [],
+      };
+      expect(router.resolve(session)).toBe(ScreenId.Auth);
+
+      router.pushOverlay(Overlay.SessionTimeout);
+      expect(router.resolve(session)).toBe(Overlay.SessionTimeout);
+    });
   });
 
   describe('activeScreen', () => {

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -147,6 +147,10 @@ export class InkUI implements WizardUI {
     this.store.showAuthError(detail);
   }
 
+  showSessionTimeout(minutes: number): void {
+    this.store.showSessionTimeout(minutes);
+  }
+
   requestQuestion(question: PendingQuestion): Promise<AskAnswers> {
     return this.store.requestQuestion(question);
   }

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -147,8 +147,8 @@ export class InkUI implements WizardUI {
     this.store.showAuthError(detail);
   }
 
-  showSessionTimeout(minutes: number): void {
-    this.store.showSessionTimeout(minutes);
+  showSessionTimeout(): void {
+    this.store.showSessionTimeout();
   }
 
   requestQuestion(question: PendingQuestion): Promise<AskAnswers> {

--- a/src/ui/tui/router.ts
+++ b/src/ui/tui/router.ts
@@ -34,6 +34,7 @@ export enum Overlay {
   PortConflict = 'port-conflict',
   ManualAuthCode = 'manual-auth-code',
   AuthError = 'auth-error',
+  SessionTimeout = 'session-timeout',
   WizardAsk = 'wizard-ask',
 }
 

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -41,6 +41,7 @@ import { KeepSkillsScreen } from './screens/KeepSkillsScreen.js';
 import { OutroScreen } from './screens/OutroScreen.js';
 import { ExitScreen } from './screens/ExitScreen.js';
 import { AuthErrorScreen } from './screens/AuthErrorScreen.js';
+import { SessionTimeoutScreen } from './screens/SessionTimeoutScreen.js';
 import { WizardAskScreen } from './screens/WizardAskScreen.js';
 import { createMcpInstaller } from './services/mcp-installer.js';
 import type { McpInstaller } from './services/mcp-installer.js';
@@ -70,6 +71,7 @@ export function createScreens(
     [Overlay.PortConflict]: <PortConflictScreen store={store} />,
     [Overlay.ManualAuthCode]: <ManualAuthCodeScreen store={store} />,
     [Overlay.AuthError]: <AuthErrorScreen store={store} />,
+    [Overlay.SessionTimeout]: <SessionTimeoutScreen store={store} />,
     [Overlay.WizardAsk]: <WizardAskScreen store={store} />,
 
     // Wizard flow

--- a/src/ui/tui/screens/SessionTimeoutScreen.tsx
+++ b/src/ui/tui/screens/SessionTimeoutScreen.tsx
@@ -11,10 +11,13 @@ import { Box, Text, useInput } from 'ink';
 import { useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { Colors } from '@ui/tui/styles';
+import { OAUTH_TIMEOUT_MS } from '@lib/constants';
 
 interface SessionTimeoutScreenProps {
   store: WizardStore;
 }
+
+const TIMEOUT_MINUTES = Math.round(OAUTH_TIMEOUT_MS / 60_000);
 
 export const SessionTimeoutScreen = ({ store }: SessionTimeoutScreenProps) => {
   useSyncExternalStore(
@@ -26,8 +29,6 @@ export const SessionTimeoutScreen = ({ store }: SessionTimeoutScreenProps) => {
     process.exit(1);
   });
 
-  const minutes = store.session.sessionTimeoutMinutes ?? 5;
-
   return (
     <Box flexDirection="column" flexGrow={1}>
       <Text color="red" bold>
@@ -35,7 +36,7 @@ export const SessionTimeoutScreen = ({ store }: SessionTimeoutScreenProps) => {
       </Text>
 
       <Box marginTop={1}>
-        <Text>The OAuth link timed out after {minutes} minutes.</Text>
+        <Text>The OAuth link timed out after {TIMEOUT_MINUTES} minutes.</Text>
       </Box>
 
       <Box marginTop={1}>

--- a/src/ui/tui/screens/SessionTimeoutScreen.tsx
+++ b/src/ui/tui/screens/SessionTimeoutScreen.tsx
@@ -1,0 +1,50 @@
+/**
+ * SessionTimeoutScreen — shown when the OAuth login window expires before the
+ * user completes authorization.
+ *
+ * Pushed as an overlay so it takes priority over the gated AuthScreen (which
+ * never completes without credentials). Terminal state: any key exits, since
+ * the only way forward is to re-run the wizard for a fresh login window.
+ */
+
+import { Box, Text, useInput } from 'ink';
+import { useSyncExternalStore } from 'react';
+import type { WizardStore } from '@ui/tui/store';
+import { Colors } from '@ui/tui/styles';
+
+interface SessionTimeoutScreenProps {
+  store: WizardStore;
+}
+
+export const SessionTimeoutScreen = ({ store }: SessionTimeoutScreenProps) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  useInput(() => {
+    process.exit(1);
+  });
+
+  const minutes = store.session.sessionTimeoutMinutes ?? 5;
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Text color="red" bold>
+        {'✘'} Login timed out
+      </Text>
+
+      <Box marginTop={1}>
+        <Text>The OAuth link timed out after {minutes} minutes.</Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text>Re-run the wizard to get a fresh link and try again.</Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text color={Colors.muted}>Press any key to exit</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -503,6 +503,12 @@ export class WizardStore {
     this.pushOverlay(Overlay.AuthError);
   }
 
+  /** Push the session-timeout overlay (no dismiss — user must exit). */
+  showSessionTimeout(minutes: number): void {
+    this.$session.setKey('sessionTimeoutMinutes', minutes);
+    this.pushOverlay(Overlay.SessionTimeout);
+  }
+
   addDiscoveredFeature(feature: DiscoveredFeature): void {
     if (!this.session.discoveredFeatures.includes(feature)) {
       this.session.discoveredFeatures.push(feature);

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -510,8 +510,7 @@ export class WizardStore {
   }
 
   /** Push the session-timeout overlay (no dismiss — user must exit). */
-  showSessionTimeout(minutes: number): void {
-    this.$session.setKey('sessionTimeoutMinutes', minutes);
+  showSessionTimeout(): void {
     this.pushOverlay(Overlay.SessionTimeout);
   }
 

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -140,7 +140,7 @@ export interface WizardUI {
   showAuthError(detail?: AuthErrorDetail): void;
 
   /** Show the session-timeout overlay when the OAuth login window expires. */
-  showSessionTimeout(minutes: number): void;
+  showSessionTimeout(): void;
 
   /**
    * Open the wizard_ask overlay and resolve with the user's answers.

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -139,6 +139,9 @@ export interface WizardUI {
   /** Show auth error overlay when Anthropic API returns 401. */
   showAuthError(detail?: AuthErrorDetail): void;
 
+  /** Show the session-timeout overlay when the OAuth login window expires. */
+  showSessionTimeout(minutes: number): void;
+
   /**
    * Open the wizard_ask overlay and resolve with the user's answers.
    * Implementations that can't ask (CI/logging) reject so the bridge can

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -1,4 +1,4 @@
-import { extractOAuthCode } from '@utils/oauth';
+import { extractOAuthCode, isAuthorizationTimeout } from '@utils/oauth';
 
 describe('extractOAuthCode', () => {
   it('extracts the code from a full callback URL', () => {
@@ -44,5 +44,29 @@ describe('extractOAuthCode', () => {
 
   it('returns null for free-form text with whitespace and no code', () => {
     expect(extractOAuthCode('please paste here')).toBeNull();
+  });
+});
+
+describe('isAuthorizationTimeout', () => {
+  it('matches the authorization timeout error', () => {
+    expect(isAuthorizationTimeout(new Error('Authorization timed out'))).toBe(
+      true,
+    );
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(
+      isAuthorizationTimeout(new Error('OAuth error: access_denied')),
+    ).toBe(false);
+    expect(isAuthorizationTimeout(new Error('Unknown error'))).toBe(false);
+  });
+
+  // Guards the regression where `.includes('timeout')` was used to detect the
+  // `'Authorization timed out'` error — it never matched, so timeouts fell
+  // through to the generic "create an issue" message.
+  it('matches a message that the old substring check would have missed', () => {
+    const error = new Error('Authorization timed out');
+    expect(error.message).not.toContain('timeout');
+    expect(isAuthorizationTimeout(error)).toBe(true);
   });
 });

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -455,10 +455,11 @@ export async function performOAuthFlow(
         logToFile('[oauth] flow failed:', error);
 
         if (timedOut) {
+          // Overlay bypasses the auth-step gating (which never completes
+          // without credentials), so the user sees the failure instead of a
+          // spinner that never stops; any key exits.
           const timeoutMinutes = Math.round(OAUTH_TIMEOUT_MS / 60_000);
-          getUI().log.error(
-            `Session timed out. The login window expired after ${timeoutMinutes} minutes for security reasons.\n\nRe-run the wizard to start a new session.`,
-          );
+          getUI().showSessionTimeout(timeoutMinutes);
         } else if (error.message.includes('access_denied')) {
           getUI().log.info(
             `Authorization was cancelled.\n\nYou denied access to PostHog. To use the wizard, you need to authorize access to your PostHog account.\n\nYou can try again by re-running the wizard.`,

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -54,6 +54,15 @@ const OAuthTokenResponseSchema = z.object({
 
 export type OAuthTokenResponse = z.infer<typeof OAuthTokenResponseSchema>;
 
+// Stable marker for the authorization-flow timeout. Detection keys off the exact
+// message rather than a loose substring — `.includes('timeout')` never matched
+// `'timed out'`, which silently routed timeouts to the generic failure message.
+const AUTHORIZATION_TIMEOUT_MESSAGE = 'Authorization timed out';
+
+export function isAuthorizationTimeout(error: Error): boolean {
+  return error.message === AUTHORIZATION_TIMEOUT_MESSAGE;
+}
+
 interface OAuthConfig {
   scopes: string[];
   signup?: boolean;
@@ -416,7 +425,7 @@ export async function performOAuthFlow(
           getUI().waitForManualAuthCode(),
           new Promise<never>((_, reject) =>
             setTimeout(
-              () => reject(new Error('Authorization timed out')),
+              () => reject(new Error(AUTHORIZATION_TIMEOUT_MESSAGE)),
               OAUTH_TIMEOUT_MS,
             ),
           ),
@@ -435,14 +444,21 @@ export async function performOAuthFlow(
 
         return token;
       } catch (e) {
-        loginSpinner.stop('Authorization failed.');
+        const error = e instanceof Error ? e : new Error('Unknown error');
+        const timedOut = isAuthorizationTimeout(error);
+
+        loginSpinner.stop(
+          timedOut ? 'Session timed out.' : 'Authorization failed.',
+        );
         server.close();
 
-        const error = e instanceof Error ? e : new Error('Unknown error');
         logToFile('[oauth] flow failed:', error);
 
-        if (error.message.includes('timeout')) {
-          getUI().log.error('Authorization timed out. Please try again.');
+        if (timedOut) {
+          const timeoutMinutes = Math.round(OAUTH_TIMEOUT_MS / 60_000);
+          getUI().log.error(
+            `Session timed out. The login window expired after ${timeoutMinutes} minutes for security reasons.\n\nRe-run the wizard to start a new session.`,
+          );
         } else if (error.message.includes('access_denied')) {
           getUI().log.info(
             `Authorization was cancelled.\n\nYou denied access to PostHog. To use the wizard, you need to authorize access to your PostHog account.\n\nYou can try again by re-running the wizard.`,
@@ -455,7 +471,7 @@ export async function performOAuthFlow(
 
         const oauthErrorCode = error.message.startsWith('OAuth error: ')
           ? error.message.slice('OAuth error: '.length)
-          : error.message.includes('timeout')
+          : timedOut
           ? 'timeout'
           : 'unknown';
 

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -458,8 +458,7 @@ export async function performOAuthFlow(
           // Overlay bypasses the auth-step gating (which never completes
           // without credentials), so the user sees the failure instead of a
           // spinner that never stops; any key exits.
-          const timeoutMinutes = Math.round(OAUTH_TIMEOUT_MS / 60_000);
-          getUI().showSessionTimeout(timeoutMinutes);
+          getUI().showSessionTimeout();
         } else if (error.message.includes('access_denied')) {
           getUI().log.info(
             `Authorization was cancelled.\n\nYou denied access to PostHog. To use the wizard, you need to authorize access to your PostHog account.\n\nYou can try again by re-running the wizard.`,


### PR DESCRIPTION
## Problem

The wizard's OAuth login waited up to **6 minutes** (`OAUTH_TIMEOUT_MS = 360_000`) for the callback, but PostHog's server-side authorization code expires after **5 minutes** (`AUTHORIZATION_CODE_EXPIRE_SECONDS`). A user who kicked off the login, stepped away, and came back a few minutes later could finish the browser flow into a code that was already dead — the callback URL fails and the paste-URL fallback fails the same way, with no clear explanation of what happened.

## Changes

- Align the client timeout with the server: `OAUTH_TIMEOUT_MS` `360_000 → 300_000`, so the wizard stops waiting at the exact moment the authorization code expires instead of inviting the user to complete a login that can no longer be exchanged.
- On timeout, show a clear **"Session timed out"** message explaining the 5-minute window expired for security and prompting the user to **re-run the wizard** to start a new session (replacing a generic failure message).
- Fix a latent detection bug found along the way: the timeout error message `"Authorization timed out"` was matched with `.includes('timeout')`, which never matches `"timed out"`. Timeouts silently fell through to the generic "create an issue" message and were mis-tagged as `unknown` in analytics. Detection now keys off a shared marker (`isAuthorizationTimeout`).

**Why:** a user reported that the auth flow's callback URL was dead after they started it, filed some bugs, and came back ~7 minutes later to finish — the code had already expired server-side and nothing surfaced that. This makes the wizard fail fast at the real deadline with an actionable next step.


<img width="1236" height="849" alt="Screenshot 2026-06-15 at 11 28 56 AM" src="https://github.com/user-attachments/assets/15e2be41-fe92-4ac9-becf-8c0cbb5e010b" />


## Test plan

- Added unit tests in `src/utils/__tests__/oauth.test.ts` for `isAuthorizationTimeout`, including a regression test asserting the old `.includes('timeout')` substring check would have missed the real message.
- `pnpm build` (typecheck + smoke test), `pnpm test` (oauth suite 12/12 passing), and `pnpm lint` (0 errors) all pass locally.
- I'm an agent (PostHog Slack app) — I did not manually run the end-to-end browser login; the timeout path is covered by the unit tests above.

<!-- LLM context -->
Authored by the PostHog Slack app from a Slack thread. The reporter hit a dead callback after ~7 minutes; we traced it to the 5-minute server auth-code expiry exceeding the wizard's 6-minute local wait, and aligned the two while fixing the timeout message/detection.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1781442337729579?thread_ts=1781442337.729579&cid=C09GTQY5RLZ)*
