### PR TITLE
feat: refresh Slack app copy and update /slack URL

### DIFF
--- a/src/lib/__tests__/mcp-role-prompts.test.ts
+++ b/src/lib/__tests__/mcp-role-prompts.test.ts
@@ -295,7 +295,7 @@ describe('getSlackAppCard', () => {
 
   it('exposes the documented learn-more and setup URLs', () => {
     const card = getSlackAppCard();
-    expect(card.learnMoreUrl).toBe('https://posthog.com/slack-app');
+    expect(card.learnMoreUrl).toBe('https://posthog.com/slack');
     expect(card.setupUrl).toBe(
       'https://app.posthog.com/settings/project-integrations#integration-slack',
     );

--- a/src/lib/mcp-role-prompts.copy.json
+++ b/src/lib/mcp-role-prompts.copy.json
@@ -508,10 +508,10 @@
   ],
 
   "slackApp": {
-    "learnMoreUrl": "https://posthog.com/slack-app",
+    "learnMoreUrl": "https://posthog.com/slack",
     "setupUrl": "https://app.posthog.com/settings/project-integrations#integration-slack",
-    "headline": "Take PostHog to Slack",
-    "pitch": "You can also analyze product data and ship changes.",
+    "headline": "@PostHog in Slack",
+    "pitch": "Analyze product data and ship changes.",
     "capabilities": [
       "Tag @PostHog with a bug, edit, or a feature idea. It will spin up a sandboxed environment, plan, edit files, run tests, and open a draft PR.",
       "Tag @PostHog with any data question. It's the same SQL-writing, statistically-minded assistant as PostHog AI, but it responds where you send work memes."

--- a/src/lib/mcp-role-prompts.copy.json
+++ b/src/lib/mcp-role-prompts.copy.json
@@ -511,7 +511,7 @@
     "learnMoreUrl": "https://posthog.com/slack",
     "setupUrl": "https://app.posthog.com/settings/project-integrations#integration-slack",
     "headline": "@PostHog in Slack",
-    "pitch": "Analyze product data and ship changes.",
+    "pitch": "Ask about your product data, debug issues, and generate PRs without leaving the thread.",
     "capabilities": [
       "Tag @PostHog with a bug, edit, or a feature idea. It will spin up a sandboxed environment, plan, edit files, run tests, and open a draft PR.",
       "Tag @PostHog with any data question. It's the same SQL-writing, statistically-minded assistant as PostHog AI, but it responds where you send work memes."

--- a/src/lib/mcp-role-prompts.ts
+++ b/src/lib/mcp-role-prompts.ts
@@ -94,7 +94,7 @@ export interface SlackAppCard {
   headline: string;
   /** One-line hook covering both analysis and shipping. */
   pitch: string;
-  /** posthog.com/slack-app — "learn more". */
+  /** posthog.com/slack — "learn more". */
   learnMoreUrl: string;
   /** settings/project-integrations#integration-slack — where the user connects Slack. */
   setupUrl: string;

--- a/src/ui/tui/components/TipsCard.tsx
+++ b/src/ui/tui/components/TipsCard.tsx
@@ -54,7 +54,7 @@ const TIPS: Tip[] = [
     title: 'Use PostHog in Slack',
     description:
       'Connect the PostHog Slack app to analyze data and ship product changes — deploy flags, open PRs, run queries — just by tagging @PostHog:',
-    url: 'https://posthog.com/slack-app',
+    url: 'https://posthog.com/slack',
   },
   {
     id: 'stripe',


### PR DESCRIPTION
## Summary

Refreshes the Slack app copy in the wizard based on feedback from the website team, and updates the landing-page URL from `/slack-app` to `/slack`.

- **Headline**: `Take PostHog to Slack` → `@PostHog in Slack` (catchier)
- **Pitch**: dropped the dangling "also" — `You can also analyze product data and ship changes.` → `Analyze product data and ship changes.`
- **URL**: `posthog.com/slack-app` → `posthog.com/slack` across the copy block, its doc comment, the test assertion, and the agent-run `TipsCard` tip

The headline/pitch/URL all flow from the `slackApp` block in `mcp-role-prompts.copy.json` via `getSlackAppCard()`, so the screens pick up the new copy with no component edits.

## Context

This keeps the wizard's Slack copy in sync with the website (`posthog.com/slack`). Longer term it's worth a shared copy source so the two evolve together — flagged for a follow-up.

## Out of scope

`McpSuggestedPromptsScreen.tsx` has its own inline "You can **also** connect PostHog to Slack…" line, where "also" is grammatically correct in context (it follows the MCP tutorial pitch), so it's left unchanged.

## Verification

- `pnpm build` succeeds
- `mcp-role-prompts` tests pass (30/30), including the updated URL assertion
- `pnpm fix` clean
