### PR TITLE
feat(analytics): add run_id to every event and $session_id after login

### DIFF
--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -7,6 +7,21 @@ import type { ApiUser } from '@lib/api';
 jest.mock('posthog-node');
 jest.mock('uuid');
 
+// IS_PRODUCTION_BUILD is read live (property access) in the Analytics
+// constructor, so a getter backed by this mutable flag lets a test flip the
+// build type without re-importing the module. Defaults falsy → 'dev',
+// matching every other test. `var` (not `let`) so the hoisted jest.mock
+// factory can read it at import time without hitting the temporal dead zone;
+// the `mock` prefix satisfies jest's hoisting rule.
+// eslint-disable-next-line no-var
+var mockIsProductionBuild = false;
+jest.mock('@env', () => ({
+  ...jest.requireActual('@env'),
+  get IS_PRODUCTION_BUILD() {
+    return mockIsProductionBuild;
+  },
+}));
+
 const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
 const MockedPostHog = PostHog as jest.MockedClass<typeof PostHog>;
 
@@ -16,6 +31,7 @@ describe('Analytics', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsProductionBuild = false;
     // Each run mints several distinct uuids; mock them to different values
     // so the tests reflect reality (run_id !== $session_id) rather than
     // collapsing them. Call order: anonymousId, runId (both in the
@@ -178,6 +194,31 @@ describe('Analytics', () => {
           run_id: 'run-uuid',
         },
       );
+    });
+  });
+
+  describe('build tag', () => {
+    it("tags dev/test runs as 'dev'", () => {
+      analytics.captureException(new Error('e'));
+
+      expect(
+        (mockPostHogInstance.captureException as jest.Mock).mock.calls.at(
+          -1,
+        )?.[2],
+      ).toMatchObject({ build: 'dev' });
+    });
+
+    it("tags production builds as 'prod'", () => {
+      mockIsProductionBuild = true;
+      const prodAnalytics = new Analytics();
+
+      prodAnalytics.captureException(new Error('e'));
+
+      expect(
+        (mockPostHogInstance.captureException as jest.Mock).mock.calls.at(
+          -1,
+        )?.[2],
+      ).toMatchObject({ build: 'prod' });
     });
   });
 

--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -16,7 +16,17 @@ describe('Analytics', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUuidv4.mockReturnValue('test-uuid' as any);
+    // Each run mints several distinct uuids; mock them to different values
+    // so the tests reflect reality (run_id !== $session_id) rather than
+    // collapsing them. Call order: anonymousId, runId (both in the
+    // constructor), then sessionId (lazily, on first identify).
+    let uuidCall = 0;
+    mockUuidv4.mockImplementation((() => {
+      uuidCall += 1;
+      if (uuidCall === 1) return 'test-uuid'; // anonymousId
+      if (uuidCall === 2) return 'run-uuid'; // runId
+      return 'session-uuid'; // sessionId (first identify)
+    }) as any);
 
     mockPostHogInstance = {
       capture: jest.fn(),
@@ -45,6 +55,7 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
           ...properties,
         },
       );
@@ -64,6 +75,7 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
           testTag: 'testValue',
           ...properties,
         },
@@ -84,6 +96,8 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
+          $session_id: 'session-uuid',
         },
       );
     });
@@ -100,6 +114,7 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
         },
       );
     });
@@ -119,6 +134,7 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
           environment: 'test',
           version: '1.0.0',
           integration: 'nextjs',
@@ -141,6 +157,7 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
           integration: 'react',
         },
       );
@@ -158,6 +175,7 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
         },
       );
     });
@@ -209,6 +227,24 @@ describe('Analytics', () => {
       expect(mockPostHogInstance.alias).not.toHaveBeenCalled();
     });
 
+    it('opens the session ($session_id) only once the user is identified', () => {
+      const error = new Error('e');
+
+      // Pre-login: run_id is present, $session_id is not.
+      analytics.captureException(error);
+      const beforeLogin = (mockPostHogInstance.captureException as jest.Mock)
+        .mock.calls[0][2];
+      expect(beforeLogin).toMatchObject({ run_id: 'run-uuid' });
+      expect(beforeLogin).not.toHaveProperty('$session_id');
+
+      // Post-login: both ids ride along.
+      analytics.identifyUser({ distinct_id: 'user-123' } as unknown as ApiUser);
+      analytics.captureException(error);
+      expect(
+        (mockPostHogInstance.captureException as jest.Mock).mock.calls[1][2],
+      ).toMatchObject({ run_id: 'run-uuid', $session_id: 'session-uuid' });
+    });
+
     it('omits person properties the user does not have', () => {
       analytics.identifyUser({
         distinct_id: 'user-123',
@@ -249,6 +285,7 @@ describe('Analytics', () => {
       expect(result?.properties).toEqual({
         $app_name: 'wizard',
         build: 'dev',
+        run_id: 'run-uuid',
         command: 'slack',
         $exception_list: [{ type: 'Error' }],
       });
@@ -411,6 +448,7 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
           integration: 'nextjs',
           localMcp: true,
           debug: false,
@@ -435,6 +473,8 @@ describe('Analytics', () => {
           team: ANALYTICS_TEAM_TAG,
           $app_name: 'wizard',
           build: 'dev',
+          run_id: 'run-uuid',
+          $session_id: 'session-uuid',
           integration: 'svelte',
         },
       );

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -53,6 +53,8 @@ export class Analytics {
     {};
   private distinctId?: string;
   private anonymousId: string;
+  private runId: string;
+  private sessionId: string | null = null;
   private appName = 'wizard';
   private activeFlags: Record<string, string> | null = null;
   private groups: Record<string, string> = {};
@@ -91,6 +93,16 @@ export class Analytics {
 
     this.anonymousId = uuidv4();
 
+    // One id per process = one id per wizard run, registered in the tag bag
+    // so it rides on every capture, exception, and autocaptured exception
+    // (all of which merge `this.tags`). Lets you separate two runs by the
+    // same logged-in user, who otherwise share one distinct id. Distinct
+    // from `anonymousId`, the pre-login *person* id that gets aliased onto
+    // the real user at login. `$session_id` is intentionally not set here —
+    // it stays null until OAuth completes (see identifyUser).
+    this.runId = uuidv4();
+    this.tags.run_id = this.runId;
+
     this.distinctId = undefined;
   }
 
@@ -106,6 +118,15 @@ export class Analytics {
       return;
     }
     this.distinctId = distinctId;
+    // Open the analytics session on first login. Null until here, so
+    // pre-OAuth events carry only `run_id`; from now on every event also
+    // carries `$session_id` and PostHog groups the authenticated run into a
+    // native Session. Stored in the tag bag so it rides on every subsequent
+    // capture and exception.
+    if (!this.sessionId) {
+      this.sessionId = uuidv4();
+      this.tags.$session_id = this.sessionId;
+    }
     this.client.identify({
       distinctId,
       properties: {
@@ -214,6 +235,10 @@ export class Analytics {
       distinctId: this.distinctId ?? this.anonymousId,
       event: 'setup wizard finished',
       properties: {
+        // Hoisted out of `tags` so the run's terminal event is filterable by
+        // run, and joins the session when one was opened (post-OAuth runs).
+        run_id: this.runId,
+        ...(this.sessionId ? { $session_id: this.sessionId } : {}),
         status,
         tags: this.tags,
       },

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -85,11 +85,11 @@ export class Analytics {
     });
 
     this.tags = { $app_name: this.appName };
-    // Non-production builds tag every event so they segment out of prod
-    // data. CI runs upgrade the tag to 'ci' (see runWizardCI).
-    if (!IS_PRODUCTION_BUILD) {
-      this.tags.build = 'dev';
-    }
+    // Tag every run with its build type so prod / dev / ci segment cleanly
+    // in analytics. tsdown inlines IS_PRODUCTION_BUILD to `true` in published
+    // builds and `false` for dev/tsx/test runs. CI runs (always non-prod
+    // builds) upgrade this to 'ci' in runWizardCI.
+    this.tags.build = IS_PRODUCTION_BUILD ? 'prod' : 'dev';
 
     this.anonymousId = uuidv4();
 


### PR DESCRIPTION
## Problem

Wizard analytics events had no per-run correlation id. Before login the distinct id is a fresh anonymous uuid (unique per run), but OAuth switches the distinct id to the **real user id**, which is shared across all of that user's runs. So two runs by the same person could not be separated, and there was no way to funnel/group the events of a single run.

Separately, production runs carried **no `build` tag at all** — it was only set for non-prod builds — so prod runs were indistinguishable from untagged data.

## Change

All analytics-only — no OAuth or backend plumbing touched. Identifiers ride on every `capture`, `captureException`, and autocaptured exception via the existing `this.tags` bag.

**Per-run correlation**
- **`run_id`** — a per-process uuid minted in the `Analytics` constructor. Always present, so any two runs (even by the same logged-in user) are distinguishable and filterable.
- **`$session_id`** — `null` until OAuth completes. Set lazily on first `identifyUser()`, so pre-login events carry only `run_id`; once authenticated, every event also carries `$session_id` and PostHog groups the run into a native **Session**. The two are independent uuids and will essentially never be equal.
- The `setup wizard finished` shutdown event hoists `run_id` (always) and `$session_id` (when a session was opened) out of the nested `tags` so the terminal event is filterable/groupable like every other capture.

**Build-type tagging**
- `build` is now always set: `'prod'` for published builds (`IS_PRODUCTION_BUILD`), `'dev'` otherwise. CI runs continue to upgrade it to `'ci'` in `runWizardCI`, so **prod / dev / ci** segment cleanly. Previously prod runs were untagged.

## Testing

- `pnpm build` ✅
- `pnpm test` — **896 passed** ✅ (incl. new run/session-id and build-tag tests; uuid mock now returns distinct values so `run_id !== $session_id` is reflected)
- `pnpm lint` ✅ (exit 0; only pre-existing project-wide warnings)