### PR TITLE
fix(agent): don't fail a successful run on a post-completion socket close

### DIFF
--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -279,6 +279,61 @@ describe('runAgent', () => {
       expect(mockUIInstance.log.error).not.toHaveBeenCalled();
     });
 
+    it('should return success when a post-success result carries an API Error', async () => {
+      // The reported failure: after a clean success result, the SDK emits a
+      // second error result whose text is "API Error: socket closed" (the
+      // streaming connection dropping on teardown). That text lands in the
+      // output signals, so the post-loop hasApiError() check would escalate
+      // teardown noise to a fatal API_ERROR. A finished run is finished.
+      function* mockGeneratorWithApiErrorAfterSuccess() {
+        yield {
+          type: 'system',
+          subtype: 'init',
+          model: 'claude-opus-4-5-20251101',
+          tools: [],
+          mcp_servers: [],
+        };
+
+        yield {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          num_turns: 42,
+          result: '[WIZARD-REMARK] Integration completed successfully',
+          session_id: '2ce14bda-6d86-4220-b5bb-ab24f7004290',
+          total_cost_usd: 1.23,
+        };
+
+        yield {
+          type: 'result',
+          subtype: 'error_during_execution',
+          is_error: true,
+          num_turns: 0,
+          result:
+            'API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()',
+          session_id: '2ce14bda-6d86-4220-b5bb-ab24f7004290',
+          total_cost_usd: 0,
+        };
+      }
+
+      mockQuery.mockReturnValue(mockGeneratorWithApiErrorAfterSuccess());
+
+      const result = await runAgent(
+        defaultAgentConfig,
+        'test prompt',
+        defaultOptions,
+        mockSpinner as unknown as SpinnerHandle,
+        {
+          successMessage: 'Test success',
+          errorMessage: 'Test error',
+        },
+      );
+
+      expect(result).toEqual({});
+      expect(mockSpinner.stop).toHaveBeenCalledWith('Test success');
+      expect(mockUIInstance.log.error).not.toHaveBeenCalled();
+    });
+
     it('should ignore abort requests when no abort cases are registered', async () => {
       function* mockGeneratorWithAbortText() {
         yield {

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -1072,6 +1072,16 @@ export async function runAgent(
       return { error: AgentErrorType.RESOURCE_MISSING };
     }
 
+    // A clean success result already arrived. The Claude SDK can emit a second
+    // error result during teardown (e.g. "API Error: The socket connection was
+    // closed unexpectedly" when the streaming connection drops on cleanup),
+    // whose text lands in `signals` — so the API-error checks below would
+    // escalate that teardown noise to a fatal error. A finished run is
+    // finished; mirror the catch-path guard and complete successfully.
+    if (receivedSuccessResult) {
+      return completeWithSuccess();
+    }
+
     // Check for API errors (rate limits, etc.)
     // Surface just the API error line(s), not the entire output
     const apiErrorMessage = signals.apiErrorMessage() ?? 'Unknown API error';


### PR DESCRIPTION
There's a really weird bug we can sometimes have with the Claude agent sdk where it errors on the teardown after succeeding

[posthog-wizard (4).log](https://github.com/user-attachments/files/28967347/posthog-wizard.4.log)

this hopefully fixes it. Doesn't affect prod, only CI mode