### PR TITLE
feat(analytics): instrument privacy panel, intro menu, and settings-conflict screens

### DIFF
--- a/src/ui/tui/components/PrivacyPanel.tsx
+++ b/src/ui/tui/components/PrivacyPanel.tsx
@@ -11,14 +11,22 @@
  * their browser.
  */
 
+import { useEffect } from 'react';
 import { Box, Text } from 'ink';
 import {
   POSTHOG_ORG_AI_SETTINGS_URL,
   POSTHOG_PRIVACY_URL,
   POSTHOG_TERMS_URL,
 } from '@lib/constants';
+import { analytics } from '@utils/analytics';
 
 export const PrivacyPanel = () => {
+  // Rendered from the intro menu and the auth-screen [I] overlay; either way,
+  // count the impression once per mount.
+  useEffect(() => {
+    analytics.wizardCapture('privacy panel shown');
+  }, []);
+
   return (
     <Box flexDirection="column" width={64} flexShrink={0}>
       <Text>

--- a/src/ui/tui/screens/ManagedSettingsScreen.tsx
+++ b/src/ui/tui/screens/ManagedSettingsScreen.tsx
@@ -10,11 +10,12 @@
  */
 
 import { Box, Text } from 'ink';
-import { useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { ConfirmationInput, ModalOverlay } from '@ui/tui/primitives/index';
 import { Icons } from '@ui/tui/styles';
 import type { SettingsConflict } from '@lib/agent/claude-settings';
+import { analytics } from '@utils/analytics';
 
 function sourceLabel(source: SettingsConflict['source']): string {
   switch (source) {
@@ -44,11 +45,25 @@ export const ManagedSettingsScreen = ({
   const conflicts = store.session.settingsConflicts;
   const readOnlyConflicts = conflicts?.filter((c) => !c.writable);
 
+  const hasManaged = Boolean(
+    readOnlyConflicts?.some((c) => c.source === 'managed'),
+  );
+  const hasReadOnly = Boolean(
+    readOnlyConflicts && readOnlyConflicts.length > 0,
+  );
+  useEffect(() => {
+    // Read-only conflict — nothing to accept, so impression only.
+    if (hasReadOnly) {
+      analytics.wizardCapture('settings conflict shown', {
+        kind: 'managed',
+        has_managed: hasManaged,
+      });
+    }
+  }, [hasReadOnly, hasManaged]);
+
   if (!readOnlyConflicts || readOnlyConflicts.length === 0) {
     return null;
   }
-
-  const hasManaged = readOnlyConflicts.some((c) => c.source === 'managed');
 
   return (
     <ModalOverlay

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -285,6 +285,7 @@ export const PostHogIntegrationIntroScreen = ({
   }
 
   const handleSelect = (value: string) => {
+    analytics.wizardCapture('intro menu selected', { value, view });
     if (view === 'tools') {
       if (value === 'back') setView('default');
       else launchTool(value, session.installDir);

--- a/src/ui/tui/screens/SettingsOverrideScreen.tsx
+++ b/src/ui/tui/screens/SettingsOverrideScreen.tsx
@@ -1,8 +1,9 @@
 import { Box, Text } from 'ink';
-import { useState, useSyncExternalStore } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { ConfirmationInput, ModalOverlay } from '@ui/tui/primitives/index';
 import { Icons } from '@ui/tui/styles';
+import { analytics } from '@utils/analytics';
 
 interface SettingsOverrideScreenProps {
   store: WizardStore;
@@ -18,6 +19,13 @@ export const SettingsOverrideScreen = ({
 
   const [feedback, setFeedback] = useState<string | null>(null);
   const conflicts = store.session.settingsConflicts?.filter((c) => c.writable);
+
+  const hasConflicts = Boolean(conflicts && conflicts.length > 0);
+  useEffect(() => {
+    if (hasConflicts) {
+      analytics.wizardCapture('settings conflict shown', { kind: 'override' });
+    }
+  }, [hasConflicts]);
 
   if (!conflicts || conflicts.length === 0) {
     return null;
@@ -35,6 +43,9 @@ export const SettingsOverrideScreen = ({
           confirmLabel="Backup & continue [Enter]"
           cancelLabel="Exit [Esc]"
           onConfirm={() => {
+            analytics.wizardCapture('settings conflict accepted', {
+              kind: 'override',
+            });
             const ok = store.backupAndFixSettingsOverride();
             if (!ok) {
               setFeedback('Could not back up the settings file.');


### PR DESCRIPTION
Additional analytics to see what people are doing inside privacy panel etc.

Btw you can see people interacting with the [optin menu here](https://us.posthog.com/project/2/insights/cfAKHt2l?dashboard=1716223&variables_override=%7B%7D&filters_override=%7B%22date_to%22%3Anull%2C%22date_from%22%3A%222026-06-15T12%3A00%3A00%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22build%22%2C%22type%22%3A%22event%22%2C%22value%22%3A%5B%22ci%22%2C%22dev%22%5D%2C%22operator%22%3A%22is_not%22%7D%5D%2C%22explicitDate%22%3Atrue%7D&tile_filters_override=%7B%7D)