### PR TITLE
fix(mcp): let users select both web and claude code together.

### DIFF
--- a/src/ui/tui/primitives/PickerMenu.tsx
+++ b/src/ui/tui/primitives/PickerMenu.tsx
@@ -209,7 +209,7 @@ const SinglePickerMenu = <T,>({
   return (
     <Box flexDirection="column" alignItems={align}>
       <PromptLabel message={message} />
-      <Box flexDirection="row" gap={4}>
+      <Box flexDirection="row" gap={4} marginTop={message ? 1 : 0}>
         {columnArrays.map((colOpts, colIdx) => (
           <Box key={colIdx} flexDirection="column">
             {colOpts.map((opt, rowIdx) => {

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Box, Text, useInput } from 'ink';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useSyncExternalStore } from 'react';
 import { type WizardStore, McpOutcome } from '@ui/tui/store';
 import {
@@ -101,6 +101,42 @@ export const McpScreen = ({
   const [resultClients, setResultClients] = useState<string[]>([]);
   const [pluginClients, setPluginClients] = useState<string[]>([]);
   const [installMode, setInstallMode] = useState<'all' | 'custom'>('custom');
+  // Clients targeted by the in-flight install step (named on the Working screen).
+  const [installingNames, setInstallingNames] = useState<string[]>([]);
+
+  // A run can install in two steps — local editors first, then the browser
+  // connector on a deliberate "continue" — so results accumulate across calls.
+  const installedRef = useRef<{ mcp: string[]; plugin: string[] }>({
+    mcp: [],
+    plugin: [],
+  });
+  // Features chosen for the local editors; reported on the final Done screen
+  // even though the trailing connector step installs with no feature list.
+  const featuresRef = useRef<string[] | undefined>(undefined);
+
+  const isConnectorName = (name: string): boolean =>
+    Boolean(clients.find((c) => c.name === name)?.finish);
+  const connectorNames = (names: string[]): string[] =>
+    names.filter(isConnectorName);
+  const localNames = (names: string[]): string[] =>
+    names.filter((n) => !isConnectorName(n));
+
+  /**
+   * Install `names`, deferring any browser connector to its own screen so its
+   * page opens after the local editors are configured — not at the same time.
+   */
+  const installLocalsThenConnector = (
+    names: string[],
+    features: string[] | undefined,
+  ) => {
+    const connectors = connectorNames(names);
+    const locals = localNames(names);
+    if (connectors.length > 0 && locals.length > 0) {
+      void doInstall(locals, features, { thenConnector: connectors });
+    } else {
+      void doInstall(names, features);
+    }
+  };
 
   useEffect(() => {
     void (async () => {
@@ -125,28 +161,25 @@ export const McpScreen = ({
     chosenMode: 'all' | 'custom',
   ) => {
     setSelectedClientNames(clientNames);
+    installedRef.current = { mcp: [], plugin: [] };
+    featuresRef.current = undefined;
 
-    // Recommended flow: install everything straight away. Browser connectors
-    // (e.g. Claude Desktop/Web) just open their connector page here, same as
-    // before — no extra screen.
+    // Recommended flow: install everything straight away. A mixed pick still
+    // installs the local editors first and opens the connector after.
     if (chosenMode === 'all') {
-      void doInstall(clientNames, [...ALL_FEATURE_VALUES]);
+      installLocalsThenConnector(clientNames, [...ALL_FEATURE_VALUES]);
       return;
     }
     if (store.session.mcpFeatures) {
-      void doInstall(clientNames, store.session.mcpFeatures);
+      installLocalsThenConnector(clientNames, store.session.mcpFeatures);
       return;
     }
 
-    // Customize flow: local editors get the feature picker. A browser connector
-    // configures its tools in Claude's UI, so it ignores the feature list — but
-    // a mixed selection still routes through the feature picker (doInstall opens
-    // the connector page alongside writing local configs). Only a connector-only
-    // selection skips straight to the connector screen.
-    const hasLocalClient = clientNames.some(
-      (name) => !clients.find((c) => c.name === name)?.finish,
-    );
-    if (!hasLocalClient) {
+    // Customize flow: local editors go through the feature picker; a browser
+    // connector configures its tools in Claude's UI, so it opens on its own
+    // screen. A connector-only pick goes straight there; a mixed pick installs
+    // the local editors first (feature picker), then hands off to the connector.
+    if (localNames(clientNames).length === 0) {
       setPhase(Phase.Connector);
       return;
     }
@@ -180,7 +213,12 @@ export const McpScreen = ({
     markDone(store, McpOutcome.Skipped);
   };
 
-  const doInstall = async (names: string[], features?: string[]) => {
+  const doInstall = async (
+    names: string[],
+    features?: string[],
+    opts?: { thenConnector?: string[] },
+  ) => {
+    setInstallingNames(names);
     setPhase(Phase.Working);
     let mcpResult: string[] = [];
     let pluginResult: string[] = [];
@@ -222,22 +260,33 @@ export const McpScreen = ({
       }
     }
 
-    setResultClients(mcpResult);
-    setPluginClients(pluginResult);
+    // Accumulate across the local-then-connector steps.
+    installedRef.current = {
+      mcp: [...installedRef.current.mcp, ...mcpResult],
+      plugin: [...installedRef.current.plugin, ...pluginResult],
+    };
+    setResultClients(installedRef.current.mcp);
+    setPluginClients(installedRef.current.plugin);
+
+    // Mixed pick: locals are done — hand off to the connector screen so its
+    // page opens on a deliberate "continue", not at the same time as this.
+    if (opts?.thenConnector && opts.thenConnector.length > 0) {
+      featuresRef.current = features;
+      setPhase(Phase.Connector);
+      return;
+    }
+
     setPhase(Phase.Done);
-    const succeeded = mcpResult.length + pluginResult.length > 0;
-    const outcome = succeeded ? McpOutcome.Installed : McpOutcome.Failed;
-    const featuresReport = reportFeatures(features ?? [...ALL_FEATURE_VALUES]);
-    setTimeout(
-      () =>
-        markDone(
-          store,
-          outcome,
-          [...mcpResult, ...pluginResult],
-          featuresReport,
-        ),
-      2000,
+    const installed = [
+      ...installedRef.current.mcp,
+      ...installedRef.current.plugin,
+    ];
+    const outcome =
+      installed.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
+    const featuresReport = reportFeatures(
+      featuresRef.current ?? features ?? [...ALL_FEATURE_VALUES],
     );
+    setTimeout(() => markDone(store, outcome, installed, featuresReport), 2000);
   };
 
   const doRemove = async () => {
@@ -384,28 +433,49 @@ export const McpScreen = ({
             groups={AVAILABLE_FEATURES}
             initialSelected={[]}
             onSelect={(features) => {
-              void doInstall(selectedClientNames, features);
+              installLocalsThenConnector(selectedClientNames, features);
             }}
           />
         )}
 
         {phase === Phase.Connector && (
           <Box flexDirection="column">
-            <Box marginBottom={1}>
+            {/* In a mixed pick the local editors are already done — confirm that
+                before handing off, so the browser step reads as "what's next". */}
+            {installedNow.length > 0 && (
+              <Box marginBottom={1}>
+                <Text color={Colors.success}>
+                  {Icons.check} MCP installed for {installedNow.join(', ')}
+                </Text>
+              </Box>
+            )}
+            <Text bold color={Colors.accent}>
+              {installedNow.length > 0 ? 'Next: connect ' : 'Connect '}
+              {connectorNames(selectedClientNames).join(' & ')}
+            </Text>
+            <Box marginTop={1} marginBottom={1}>
               <Text dimColor>
-                You&apos;ll choose which features and tools to enable in
-                Claude&apos;s UI after connecting.
+                This opens in your browser. You&apos;ll choose which features
+                and tools to enable in Claude&apos;s UI after connecting.
               </Text>
             </Box>
             <ConnectorContinue
-              onContinue={() => void doInstall(selectedClientNames, [])}
+              onContinue={() =>
+                void doInstall(connectorNames(selectedClientNames), [])
+              }
             />
           </Box>
         )}
 
         {phase === Phase.Working && (
           <Text dimColor>
-            {isRemove ? 'Removing' : 'Installing'} MCP server...
+            {isRemove
+              ? 'Removing MCP server...'
+              : installingNames.length > 0 &&
+                connectorNames(installingNames).length ===
+                  installingNames.length
+              ? `Opening ${installingNames.join(', ')}...`
+              : `Installing MCP for ${installingNames.join(', ')}...`}
           </Text>
         )}
 

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -45,6 +45,8 @@ enum Phase {
   Pick = 'pick',
   FeatureSelect = 'feature-select',
   Connector = 'connector',
+  /** Connector page opened; waiting for the user to finish in the browser. */
+  ConnectorFinish = 'connector-finish',
   Working = 'working',
   Done = 'done',
   None = 'none',
@@ -66,7 +68,13 @@ const reportFeatures = (features: string[]): 'all' | string[] =>
  * Connector step prompt — Enter continues (opens the connector page). There's
  * no skip: picking the connector commits to opening it.
  */
-const ConnectorContinue = ({ onContinue }: { onContinue: () => void }) => {
+const ConnectorContinue = ({
+  onContinue,
+  label = 'continue',
+}: {
+  onContinue: () => void;
+  label?: string;
+}) => {
   useInput((_input, key) => {
     if (key.return) {
       onContinue();
@@ -74,7 +82,7 @@ const ConnectorContinue = ({ onContinue }: { onContinue: () => void }) => {
   });
   return (
     <Text color={Colors.primary}>
-      Press enter to continue {Icons.triangleRight}
+      Press enter to {label} {Icons.triangleRight}
     </Text>
   );
 };
@@ -131,11 +139,14 @@ export const McpScreen = ({
   ) => {
     const connectors = connectorNames(names);
     const locals = localNames(names);
-    if (connectors.length > 0 && locals.length > 0) {
-      void doInstall(locals, features, { thenConnector: connectors });
-    } else {
-      void doInstall(names, features);
+    if (locals.length === 0) {
+      // Connector-only — its own screen opens the page and waits for the user.
+      setPhase(Phase.Connector);
+      return;
     }
+    void doInstall(locals, features, {
+      thenConnector: connectors.length > 0 ? connectors : undefined,
+    });
   };
 
   useEffect(() => {
@@ -287,6 +298,48 @@ export const McpScreen = ({
       featuresRef.current ?? features ?? [...ALL_FEATURE_VALUES],
     );
     setTimeout(() => markDone(store, outcome, installed, featuresReport), 2000);
+  };
+
+  /**
+   * Open the browser connector, then wait. The connector finishes in the
+   * browser (sign in, click Connect), so we hand off and pause on
+   * ConnectorFinish rather than auto-advancing — the user presses enter when
+   * they're done.
+   */
+  const openConnector = async () => {
+    const connectors = connectorNames(selectedClientNames);
+    setInstallingNames(connectors);
+    setPhase(Phase.Working);
+    let result: string[] = [];
+    try {
+      result = await installer.install(connectors, [], store.session.apiKey);
+    } catch {
+      // result stays []
+    }
+    installedRef.current = {
+      ...installedRef.current,
+      mcp: [...installedRef.current.mcp, ...result],
+    };
+    setResultClients(installedRef.current.mcp);
+    setPhase(Phase.ConnectorFinish);
+  };
+
+  /**
+   * After the user confirms they finished connecting in the browser, show the
+   * Done summary (what landed) before the flow advances on to the tutorial.
+   */
+  const finishRun = () => {
+    setPhase(Phase.Done);
+    const installed = [
+      ...installedRef.current.mcp,
+      ...installedRef.current.plugin,
+    ];
+    const outcome =
+      installed.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
+    const featuresReport = reportFeatures(
+      featuresRef.current ?? [...ALL_FEATURE_VALUES],
+    );
+    setTimeout(() => markDone(store, outcome, installed, featuresReport), 2500);
   };
 
   const doRemove = async () => {
@@ -460,10 +513,48 @@ export const McpScreen = ({
               </Text>
             </Box>
             <ConnectorContinue
-              onContinue={() =>
-                void doInstall(connectorNames(selectedClientNames), [])
-              }
+              onContinue={() => void openConnector()}
+              label="open it in your browser"
             />
+          </Box>
+        )}
+
+        {phase === Phase.ConnectorFinish && (
+          <Box flexDirection="column">
+            {installedNow.length > 0 && (
+              <Box marginBottom={1}>
+                <Text color={Colors.success}>
+                  {Icons.check} MCP installed for {installedNow.join(', ')}
+                </Text>
+              </Box>
+            )}
+            {finishNotes.map((note) => (
+              <Box key={note.name} flexDirection="column">
+                <Text color={Colors.success}>
+                  {Icons.check} Opened {note.name} in your browser
+                </Text>
+                <Box
+                  flexDirection="column"
+                  marginTop={1}
+                  marginBottom={1}
+                  paddingLeft={2}
+                >
+                  <Text color="cyan">{note.url}</Text>
+                  <Box marginTop={1}>
+                    <Text dimColor>{note.instruction}</Text>
+                  </Box>
+                  <Text dimColor>
+                    (If it didn&apos;t open, paste the URL above.)
+                  </Text>
+                </Box>
+              </Box>
+            ))}
+            <Box marginTop={1}>
+              <ConnectorContinue
+                onContinue={finishRun}
+                label="continue once you've connected"
+              />
+            </Box>
           </Box>
         )}
 

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -138,14 +138,15 @@ export const McpScreen = ({
       return;
     }
 
-    // Customize flow: a browser connector configures its tools and features in
-    // Claude's UI, not through the wizard's feature picker. The picker keeps it
-    // mutually exclusive from local editors, so a connector selection is
-    // connector-only — show its own screen instead of the feature picker.
-    const isConnector = clientNames.some(
-      (name) => clients.find((c) => c.name === name)?.finish,
+    // Customize flow: local editors get the feature picker. A browser connector
+    // configures its tools in Claude's UI, so it ignores the feature list — but
+    // a mixed selection still routes through the feature picker (doInstall opens
+    // the connector page alongside writing local configs). Only a connector-only
+    // selection skips straight to the connector screen.
+    const hasLocalClient = clientNames.some(
+      (name) => !clients.find((c) => c.name === name)?.finish,
     );
-    if (isConnector) {
+    if (!hasLocalClient) {
       setPhase(Phase.Connector);
       return;
     }
@@ -358,9 +359,6 @@ export const McpScreen = ({
             options={clients.map((c) => ({
               label: c.name,
               value: c.name,
-              // Browser connectors can't be installed alongside local editors
-              // and are configured on their own screen, not the feature picker.
-              exclusive: Boolean(c.finish),
               // Hints only show in the recommended flow; the customize flow
               // keeps the list clean.
               hint:

--- a/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
+++ b/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
@@ -37,7 +37,7 @@
  * Running useEffect against a state-machine bug.
  */
 
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSyncExternalStore } from 'react';
@@ -80,6 +80,8 @@ interface McpSuggestedPromptsScreenProps {
 enum Phase {
   Choose = 'choose',
   Authenticating = 'authenticating',
+  /** Brief "signed in" confirmation between auth and the tutorial. */
+  SignedIn = 'signed-in',
   Greeting = 'greeting',
   PromptPicker = 'prompt-picker',
   Running = 'running',
@@ -176,6 +178,10 @@ export const McpSuggestedPromptsScreen = ({
   // user returns to PromptPicker — that's a fresh conversation.
   const currentSessionIdRef = useRef<string | null>(null);
 
+  // Where to go after the "signed in" confirmation (Greeting if the user
+  // started the tutorial, else back to Choose).
+  const postAuthPhaseRef = useRef<Phase>(Phase.Choose);
+
   // Run OAuth when entering Authenticating phase.
   useEffect(() => {
     if (phase !== Phase.Authenticating) return;
@@ -190,7 +196,10 @@ export const McpSuggestedPromptsScreen = ({
         store.setRoleAtOrganization(roleAtOrganization);
         store.setApiUser(user);
         store.setLoginUrl(null);
-        setPhase(startedTutorialRef.current ? Phase.Greeting : Phase.Choose);
+        postAuthPhaseRef.current = startedTutorialRef.current
+          ? Phase.Greeting
+          : Phase.Choose;
+        setPhase(Phase.SignedIn);
       } catch (err) {
         if (cancelled) return;
         const message = err instanceof Error ? err.message : String(err);
@@ -487,6 +496,15 @@ export const McpSuggestedPromptsScreen = ({
           <AuthenticatingPhase loginUrl={session.loginUrl} />
         )}
 
+        {phase === Phase.SignedIn && (
+          <SignedInPhase
+            userDisplayName={
+              session.apiUser?.first_name || session.apiUser?.email || null
+            }
+            onContinue={() => setPhase(postAuthPhaseRef.current)}
+          />
+        )}
+
         {phase === Phase.Greeting && (
           <GreetingPhase
             greeting={greeting}
@@ -657,6 +675,13 @@ interface AuthenticatingPhaseProps {
 
 const AuthenticatingPhase = ({ loginUrl }: AuthenticatingPhaseProps) => (
   <Box flexDirection="column">
+    <Box marginBottom={1} flexDirection="column">
+      <Text>We&apos;ve opened your browser to sign in to PostHog.</Text>
+      <Text dimColor>
+        Authorize the wizard there — this screen continues automatically once
+        you do.
+      </Text>
+    </Box>
     <LoadingBox message="Waiting for authentication..." />
     {loginUrl && (
       <Box marginTop={1} marginBottom={1} flexDirection="column">
@@ -667,8 +692,37 @@ const AuthenticatingPhase = ({ loginUrl }: AuthenticatingPhaseProps) => (
         </Text>
       </Box>
     )}
+    <Box marginTop={1}>
+      <Text dimColor>
+        Press <Text color={Colors.accent}>[esc]</Text> to cancel.
+      </Text>
+    </Box>
   </Box>
 );
+
+interface SignedInPhaseProps {
+  userDisplayName: string | null;
+  onContinue: () => void;
+}
+
+const SignedInPhase = ({ userDisplayName, onContinue }: SignedInPhaseProps) => {
+  useInput((_input, key) => {
+    if (key.return) onContinue();
+  });
+  return (
+    <Box flexDirection="column">
+      <Text color={Colors.success} bold>
+        {Icons.check} Signed in to PostHog
+        {userDisplayName ? ` as ${userDisplayName}` : ''}
+      </Text>
+      <Box marginTop={1}>
+        <Text color={Colors.primary}>
+          Press enter to continue {Icons.triangleRight}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
 
 // ── Greeting phase ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

Right now, you can only select Claude Web vs Claude Code. 

Not a technical constraint — an accidental regression from #442.

- **#517** ("add Claude Desktop/Web to mcp add") introduced the browser connector with a free `mode="multi"` picker. Mixed picks worked: the post-pick logic (`anyNeedsFeatures = clientNames.some(name => !info?.finish)`) routed any selection containing a local editor through the feature picker, and connector-only selections installed directly. Selecting the web connector alongside a local editor was fine.
- **#442** ("granular feature selection with plugin/MCP decoupling") reworked the flow and added a dedicated `Phase.Connector` screen. As part of that it added `exclusive: Boolean(c.finish)` to the picker and replaced `anyNeedsFeatures` with `isConnector → Phase.Connector`, which doesn't handle a mix. The commit comment frames the connector as "connector-only … show its own screen" — a code convenience to avoid threading a mixed selection through the new screen, not a real conflict. (The PR also noted the manual TUI walkthrough was "still owed before merge.")

So a multi-select silently became single-select for the connector: picking Claude Desktop/Web cleared every other client (and vice-versa), with no label or disabled state explaining why.

## Fix


https://github.com/user-attachments/assets/e9cf267b-6419-4902-8384-a802c1b1f77c



Both post-pick phases already `doInstall` the full selection (`Phase.FeatureSelect` with features, `Phase.Connector` with `[]`), so a mixed install needs no new plumbing — the connector just ignores the feature list. So:

- Drop `exclusive` from the picker option (free multi-select again).
- Route a mixed pick through `Phase.FeatureSelect` (installs local editors with chosen features and opens the connector page).
- Reserve `Phase.Connector` for a connector-only selection.

Effectively restores the pre-#442 "mixed picks route through the feature picker" behavior, adapted to the new phase structure.