### PR TITLE
feat: promote programs via post-install "Recommended next" screen

### DIFF
--- a/src/lib/discovered-features.ts
+++ b/src/lib/discovered-features.ts
@@ -1,0 +1,23 @@
+/**
+ * `DiscoveredFeature` lives in its own dependency-free leaf module on purpose.
+ *
+ * Program configs reference these enum values at module-init time (e.g.
+ * `promotable: { feature: DiscoveredFeature.Stripe }` in a program's
+ * `index.ts`). If the enum were defined in `wizard-session.ts` — which sits
+ * inside the import graph that the program registry pulls in — those
+ * init-time references could resolve to `undefined` mid-cycle under bundlers
+ * or test transforms that don't erase `import type`. A leaf module with zero
+ * imports is always fully initialized the instant it's imported, so the value
+ * can never be observed half-built.
+ *
+ * `wizard-session.ts` re-exports this enum, so existing
+ * `import { DiscoveredFeature } from '@lib/wizard-session'` consumers keep
+ * working. New code that references it at module-init (program configs) should
+ * import it from here directly to stay clear of the cycle.
+ */
+
+/** A signal the `detect` step found, marking the project a fit for a program. */
+export enum DiscoveredFeature {
+  Stripe = 'stripe',
+  LLM = 'llm',
+}

--- a/src/lib/programs/__tests__/promotable.test.ts
+++ b/src/lib/programs/__tests__/promotable.test.ts
@@ -1,0 +1,40 @@
+import { getPromotableRecommendations } from '@lib/programs/promotable';
+import { buildSession, DiscoveredFeature } from '@lib/wizard-session';
+import { Program } from '@lib/programs/program-registry';
+
+describe('getPromotableRecommendations', () => {
+  it('returns no recommendations when nothing was detected', () => {
+    const session = buildSession({ installDir: '/tmp/nope' });
+    expect(getPromotableRecommendations(session)).toEqual([]);
+  });
+
+  it('recommends revenue analytics when Stripe is detected', () => {
+    const session = buildSession({ installDir: '/tmp/nope' });
+    session.discoveredFeatures = [DiscoveredFeature.Stripe];
+
+    const ids = getPromotableRecommendations(session).map((c) => c.id);
+
+    expect(ids).toContain(Program.RevenueAnalyticsSetup);
+  });
+
+  it('does not recommend a program whose feature was not detected', () => {
+    const session = buildSession({ installDir: '/tmp/nope' });
+    session.discoveredFeatures = [DiscoveredFeature.LLM];
+
+    const ids = getPromotableRecommendations(session).map((c) => c.id);
+
+    expect(ids).not.toContain(Program.RevenueAnalyticsSetup);
+  });
+
+  it('only ever returns programs that declared promotable metadata', () => {
+    const session = buildSession({ installDir: '/tmp/nope' });
+    session.discoveredFeatures = [
+      DiscoveredFeature.Stripe,
+      DiscoveredFeature.LLM,
+    ];
+
+    for (const config of getPromotableRecommendations(session)) {
+      expect(config.promotable).toBeDefined();
+    }
+  });
+});

--- a/src/lib/programs/posthog-integration/steps.ts
+++ b/src/lib/programs/posthog-integration/steps.ts
@@ -79,6 +79,17 @@ export const POSTHOG_INTEGRATION_PROGRAM: ProgramStep[] = [
     isComplete: (session) => session.outroDismissed,
   },
   {
+    id: 'recommended-next',
+    label: 'Recommended next',
+    screenId: 'recommended-next',
+    // Only shown when the project is a good fit for another program. When no
+    // candidates were detected the router skips this screen entirely.
+    // `promotableCandidates` is computed by the store (steps can't import the
+    // program registry without a module load cycle).
+    show: (session) => session.promotableCandidates.length > 0,
+    isComplete: (session) => session.recommendedNextDismissed,
+  },
+  {
     id: 'keep-skills',
     label: 'Keep Skills',
     screenId: 'keep-skills',

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -1,4 +1,5 @@
-import type { WizardSession, DiscoveredFeature } from '@lib/wizard-session';
+import type { WizardSession } from '@lib/wizard-session';
+import type { DiscoveredFeature } from '@lib/discovered-features';
 import type { WizardReadinessResult } from '@lib/health-checks/readiness';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { Integration } from '@lib/constants';
@@ -156,6 +157,21 @@ export interface ProgramConfig {
   ciPreRun?: (session: WizardSession) => Promise<void>;
   /** Prerequisites: other program ids that must have run first */
   requires?: string[];
+  /**
+   * Discoverability metadata. When set, this program can be promoted on the
+   * post-install "Recommended next" screen — but only if its `feature` signal
+   * was found during the integration flow's `detect` step (i.e. it's in
+   * `session.discoveredFeatures`). Adding a promotable program is one registry
+   * entry: the screen iterates the registry and stays product-agnostic.
+   */
+  promotable?: {
+    /** Detection signal that makes this program a good fit for the project. */
+    feature: DiscoveredFeature;
+    /** Display name on the recommendation screen, e.g. "Revenue analytics". */
+    label: string;
+    /** One-line "why you're a fit" shown next to the label. */
+    description: string;
+  };
   /**
    * Path (relative to installDir) of the report file the program writes.
    * Mirrors `run.reportFile` but lifted to the top level so UI screens can

--- a/src/lib/programs/promotable.ts
+++ b/src/lib/programs/promotable.ts
@@ -1,0 +1,29 @@
+/**
+ * Promotable-program discovery — the producer side of post-install
+ * discoverability.
+ *
+ * A program opts in by declaring `promotable` on its config (see
+ * `ProgramConfig.promotable`). This module answers one product-agnostic
+ * question: given what the `detect` step found, which registered programs
+ * should we recommend? The "Recommended next" screen and its `show` predicate
+ * are the only callers — they hold no product knowledge, they just iterate.
+ *
+ * The user's picks land in `session.recommendedFollowUps`, which is the seam a
+ * future orchestrator/queue consumes. Today the seam is rendered as copy-paste
+ * `npx` commands on exit (see `exit-line.ts`).
+ */
+
+import type { WizardSession } from '@lib/wizard-session';
+import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
+import type { ProgramConfig } from '@lib/programs/program-step';
+
+/** Registered programs whose `promotable.feature` was detected on the project. */
+export function getPromotableRecommendations(
+  session: WizardSession,
+): ProgramConfig[] {
+  return PROGRAM_REGISTRY.filter(
+    (config) =>
+      config.promotable != null &&
+      session.discoveredFeatures.includes(config.promotable.feature),
+  );
+}

--- a/src/lib/programs/revenue-analytics/index.ts
+++ b/src/lib/programs/revenue-analytics/index.ts
@@ -1,4 +1,7 @@
 import type { ProgramConfig } from '@lib/programs/program-step';
+// Import from the leaf module (not @lib/wizard-session): this value is read at
+// module-init, and the leaf is dependency-free so it can't be mid-cycle.
+import { DiscoveredFeature } from '@lib/discovered-features';
 import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { REVENUE_ANALYTICS_PROGRAM } from './steps.js';
 import { REVENUE_ABORT_CASES } from './detect.js';
@@ -24,6 +27,11 @@ export const revenueAnalyticsConfig: ProgramConfig = {
     abortCases: REVENUE_ABORT_CASES,
   },
   requires: ['posthog-integration'],
+  promotable: {
+    feature: DiscoveredFeature.Stripe,
+    label: 'Revenue analytics',
+    description: 'connect Stripe to track revenue in PostHog',
+  },
 };
 
 export { REVENUE_ANALYTICS_PROGRAM } from './steps.js';

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -15,6 +15,11 @@ import type { FrameworkConfig } from './framework-config';
 import type { WizardReadinessResult } from './health-checks/readiness';
 import type { SettingsConflict } from './agent/claude-settings';
 import type { ApiUser } from './api';
+// Type-only — erased at compile time, so no runtime cycle with program-registry.
+import type { ProgramId } from './programs/program-registry';
+// Local type-only binding for use within this file; the runtime value is
+// re-exported below.
+import type { DiscoveredFeature } from './discovered-features';
 
 export interface Credentials {
   accessToken: string;
@@ -44,10 +49,11 @@ export enum RunPhase {
 }
 
 /** Features discovered by the feature-discovery subagent */
-export enum DiscoveredFeature {
-  Stripe = 'stripe',
-  LLM = 'llm',
-}
+// `DiscoveredFeature` is defined in a dependency-free leaf module (see
+// discovered-features.ts) so program configs can reference its values at
+// module-init without risking a mid-cycle `undefined`. Re-exported here so
+// existing `@lib/wizard-session` consumers are unaffected.
+export { DiscoveredFeature } from './discovered-features';
 
 /** Additional features the agent can integrate after the main setup */
 export enum AdditionalFeature {
@@ -213,6 +219,14 @@ export interface WizardSession {
 
   // Feature discovery
   discoveredFeatures: DiscoveredFeature[];
+  /**
+   * Registered programs the project is a good fit for, derived from
+   * `discoveredFeatures` + each program's `promotable` metadata. Computed by
+   * the store as features are discovered (the store can import the program
+   * registry; the integration program's steps can't, without a load cycle).
+   * The "Recommended next" step's `show` predicate reads this.
+   */
+  promotableCandidates: ProgramId[];
   llmOptIn: boolean;
 
   // ScreenId completion
@@ -231,6 +245,9 @@ export interface WizardSession {
   slackConnected: boolean | null;
   skillsComplete: boolean;
   outroDismissed: boolean;
+  /** True once the user has acted on (confirmed or skipped) the
+   *  post-install "Recommended next" screen. */
+  recommendedNextDismissed: boolean;
 
   // Runtime
   readinessResult: WizardReadinessResult | null;
@@ -254,6 +271,14 @@ export interface WizardSession {
 
   // Additional features queue (drained via stop hook after main integration)
   additionalFeatureQueue: AdditionalFeature[];
+
+  /**
+   * Standalone programs the user picked on the "Recommended next" screen.
+   * The modular seam: today these are printed as `npx` commands on exit
+   * (exit-line.ts); a future orchestrator/queue will drain this array to run
+   * each program in-process. Empty when nothing was detected/picked.
+   */
+  recommendedFollowUps: ProgramId[];
 
   // Program metadata (set by runWizard in bin.ts)
   programLabel: string | null;
@@ -310,6 +335,7 @@ export function buildSession(args: {
 
     runPhase: RunPhase.Idle,
     discoveredFeatures: [],
+    promotableCandidates: [],
     llmOptIn: false,
     mcpComplete: false,
     mcpOutcome: null,
@@ -319,6 +345,7 @@ export function buildSession(args: {
     slackConnected: null,
     skillsComplete: false,
     outroDismissed: false,
+    recommendedNextDismissed: false,
     loginUrl: null,
     authorizeUrl: null,
     credentials: null,
@@ -334,6 +361,7 @@ export function buildSession(args: {
     dashboardUrl: null,
     notebookUrl: null,
     additionalFeatureQueue: [],
+    recommendedFollowUps: [],
     programLabel: null,
     skillId: null,
     frameworkConfig: null,

--- a/src/ui/tui/__tests__/exit-line.test.ts
+++ b/src/ui/tui/__tests__/exit-line.test.ts
@@ -87,4 +87,30 @@ describe('getExitLine', () => {
     expect(line).toMatch(/exited\.$/);
     expect(line).not.toContain('coding agent');
   });
+
+  it('prints npx commands for recommended follow-up programs', () => {
+    const store = storeWithOutro({
+      kind: OutroKind.Success,
+      message: 'Successfully installed PostHog!',
+    });
+    store.setRecommendedFollowUps([Program.RevenueAnalyticsSetup]);
+
+    const line = stripAnsi(getExitLine(store));
+
+    expect(line).toContain('Recommended next');
+    expect(line).toContain('npx @posthog/wizard revenue');
+  });
+
+  it('omits the follow-up block when nothing was picked', () => {
+    const store = storeWithOutro({
+      kind: OutroKind.Success,
+      message: 'Successfully installed PostHog!',
+    });
+    store.setRecommendedFollowUps([]);
+
+    const line = stripAnsi(getExitLine(store));
+
+    expect(line).not.toContain('Recommended next');
+    expect(line).not.toContain('npx @posthog/wizard');
+  });
 });

--- a/src/ui/tui/exit-line.ts
+++ b/src/ui/tui/exit-line.ts
@@ -15,11 +15,32 @@
 
 import type { WizardStore } from './store.js';
 import { OutroKind } from '@lib/wizard-session';
+import { getProgramConfig } from '@lib/programs/program-registry';
 
 const RESET_ATTRS = '\x1b[0m';
 const GREEN = '\x1b[32m';
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
+
+/**
+ * Interim "recommended next" block — the picks made on the RecommendedNext
+ * screen, rendered as copy-paste `npx` commands. This is the throwaway
+ * consumer of `session.recommendedFollowUps`; a future orchestrator/queue
+ * will run these in-process instead. Returns '' when nothing was picked.
+ */
+function getFollowUpBlock(store: WizardStore): string {
+  const commands = store.session.recommendedFollowUps
+    .map((id) => getProgramConfig(id).command)
+    .filter((command): command is string => command != null)
+    .map((command) => `  npx @posthog/wizard ${command}`);
+
+  if (commands.length === 0) return '';
+
+  return (
+    `\n\n${DIM}Recommended next — run these to set up more:${RESET_ATTRS}\n` +
+    commands.join('\n')
+  );
+}
 
 export function getExitLine(store: WizardStore): string {
   const outro = store.session.outroData;
@@ -32,15 +53,17 @@ export function getExitLine(store: WizardStore): string {
         ? ` Check ./${outro.reportFile} for details.`
         : '';
     const headline = `${GREEN}${BOLD}✔${RESET_ATTRS} ${message}${reportSuffix}`;
+    const followUps = getFollowUpBlock(store);
 
     if (outro.handoffPrompt) {
       return (
         `${headline}\n\n` +
         `${DIM}Hand this to your coding agent to finish up (triple-click to select):${RESET_ATTRS}\n` +
-        outro.handoffPrompt
+        outro.handoffPrompt +
+        followUps
       );
     }
-    return headline;
+    return headline + followUps;
   }
 
   return `${DIM}${label} exited.${RESET_ATTRS}`;

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -38,6 +38,7 @@ import { RunScreen } from './screens/RunScreen.js';
 import { McpScreen } from './screens/McpScreen.js';
 import { McpSuggestedPromptsScreen } from './screens/McpSuggestedPromptsScreen.js';
 import { SlackConnectScreen } from './screens/SlackConnectScreen.js';
+import { RecommendedNextScreen } from './screens/RecommendedNextScreen.js';
 import { KeepSkillsScreen } from './screens/KeepSkillsScreen.js';
 import { OutroScreen } from './screens/OutroScreen.js';
 import { ExitScreen } from './screens/ExitScreen.js';
@@ -105,6 +106,7 @@ export function createScreens(
       />
     ),
     [ScreenId.SlackConnect]: <SlackConnectScreen store={store} />,
+    [ScreenId.RecommendedNext]: <RecommendedNextScreen store={store} />,
     [ScreenId.KeepSkills]: <KeepSkillsScreen store={store} />,
     [ScreenId.Outro]: <OutroScreen store={store} />,
     [ScreenId.Exit]: <ExitScreen />,

--- a/src/ui/tui/screen-sequences.ts
+++ b/src/ui/tui/screen-sequences.ts
@@ -37,6 +37,7 @@ export enum ScreenId {
   Mcp = 'mcp',
   McpSuggestedPrompts = 'mcp-suggested-prompts',
   SlackConnect = 'slack-connect',
+  RecommendedNext = 'recommended-next',
   KeepSkills = 'keep-skills',
   Outro = 'outro',
   Exit = 'exit',

--- a/src/ui/tui/screens/RecommendedNextScreen.tsx
+++ b/src/ui/tui/screens/RecommendedNextScreen.tsx
@@ -1,0 +1,79 @@
+/**
+ * RecommendedNextScreen — post-install discoverability for other PostHog
+ * programs the project looks like a good fit for (e.g. revenue analytics when
+ * Stripe is present).
+ *
+ * Product-agnostic: it renders whatever `getPromotableRecommendations` returns
+ * from the registry. Good fits are pre-selected. Confirming writes the picks to
+ * `session.recommendedFollowUps` (the modular seam); skipping writes an empty
+ * list. Either way the screen completes and the flow advances. On exit those
+ * picks are printed as `npx` commands (see exit-line.ts).
+ *
+ * This screen only sets state — the router advances to the next step. It never
+ * exits the process itself.
+ */
+
+import { Box, Text } from 'ink';
+import { useSyncExternalStore } from 'react';
+
+import type { WizardStore } from '@ui/tui/store';
+import { getPromotableRecommendations } from '@lib/programs/promotable';
+import { GroupedPickerMenu } from '@ui/tui/primitives/index';
+import { useKeyBindings, KeyMatch } from '@ui/tui/hooks/useKeyBindings';
+import { Colors } from '@ui/tui/styles';
+
+interface RecommendedNextScreenProps {
+  store: WizardStore;
+}
+
+export const RecommendedNextScreen = ({
+  store,
+}: RecommendedNextScreenProps) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  const recommendations = getPromotableRecommendations(store.session);
+
+  // Esc skips everything — the router's `show` predicate keeps this screen out
+  // of the flow entirely when there are no recommendations, so this handler
+  // only runs when there's something to skip.
+  useKeyBindings('recommended-next', [
+    {
+      match: KeyMatch.Escape,
+      label: 'esc',
+      action: 'skip',
+      handler: () => store.setRecommendedFollowUps([]),
+    },
+  ]);
+
+  const options = recommendations.map((config) => ({
+    value: config.id,
+    label: config.promotable!.label,
+    hint: config.promotable!.description,
+  }));
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Text bold color={Colors.accent}>
+        Recommended next
+      </Text>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text dimColor>
+          Based on your project, you might also want to set these up. We&apos;ll
+          print the commands to run when the wizard exits.
+        </Text>
+
+        <Box marginTop={1}>
+          <GroupedPickerMenu
+            groups={{ 'Set up with PostHog': options }}
+            initialSelected={recommendations.map((config) => config.id)}
+            onSelect={(values) => store.setRecommendedFollowUps(values)}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -43,6 +43,7 @@ import type {
   ProgramReadyContext,
 } from '@lib/programs/program-step';
 import { getProgramConfig } from '@lib/programs/program-registry';
+import { getPromotableRecommendations } from '@lib/programs/promotable';
 import { withAiOptInGate } from '@lib/programs/ai-opt-in-gate';
 import { EXPANDED_COUNT } from '@ui/tui/constants';
 
@@ -524,6 +525,13 @@ export class WizardStore {
   addDiscoveredFeature(feature: DiscoveredFeature): void {
     if (!this.session.discoveredFeatures.includes(feature)) {
       this.session.discoveredFeatures.push(feature);
+      // Recompute which registered programs are now promotable. Done here
+      // (not in the integration steps) because the store can import the
+      // program registry without a module load cycle.
+      this.$session.setKey(
+        'promotableCandidates',
+        getPromotableRecommendations(this.session).map((config) => config.id),
+      );
       this.emitChange();
     }
   }
@@ -591,6 +599,21 @@ export class WizardStore {
 
   setOutroDismissed(): void {
     this.$session.setKey('outroDismissed', true);
+    this.emitChange();
+  }
+
+  /**
+   * Record the user's picks on the "Recommended next" screen and mark the
+   * screen done. `ids` may be empty (the user skipped). The picks are the
+   * modular seam consumed by exit-line.ts today and a future queue later.
+   */
+  setRecommendedFollowUps(ids: ProgramId[]): void {
+    this.$session.setKey('recommendedFollowUps', ids);
+    this.$session.setKey('recommendedNextDismissed', true);
+    analytics.wizardCapture('recommended next dismissed', {
+      recommended_follow_ups: ids,
+      ...sessionProperties(this.session),
+    });
     this.emitChange();
   }
 


### PR DESCRIPTION
## Summary

Keeps the **main wizard flow install-only** and surfaces other programs (revenue analytics today; data-warehouse / LLM-analytics next) as **discoverable follow-ups** once install succeeds. No flow or UI overhaul — this is the interim, modular discoverability layer agreed in Slack while the new TUI / orchestrator is sidelined for self-driving product.

Per Edwin's steer: keep programs separate, just add discoverability now; merge into the orchestrator later.

## How it works

- **`ProgramConfig.promotable` metadata** — a program opts into promotion by declaring its detection `feature`, `label`, and `description` in one registry entry. The screen holds no product knowledge; it just iterates the registry.
- **`promotable.ts`** — the producer side: given what the `detect` step found, which registered programs should we recommend?
- **`RecommendedNextScreen`** — a new post-install, `show`-gated step. Renders detected candidates; when none are detected the router skips it entirely. The user's picks land in **`session.recommendedFollowUps`** — the modular seam a future orchestrator/queue consumes unchanged.
- **Interim action** — the seam renders as copy-paste `npx @posthog/wizard <cmd>` lines on exit (`exit-line.ts`). No queue/orchestration yet; that's a deliberate fast-follow.

## Notable

- `DiscoveredFeature` is extracted into a **dependency-free leaf module** (`discovered-features.ts`) so program configs can reference its enum values at module-init without a module-load cycle. It's re-exported from `wizard-session` so every existing `@lib/wizard-session` consumer is unaffected.

## Testing

- `pnpm build` (incl. smoke test) ✓
- `pnpm jest` — new `promotable.test.ts` + extended `exit-line.test.ts` pass; only failure is the pre-existing order-dependent `provision-cli` flake (fails on clean `main` too) ✓
- `pnpm lint` — 0 errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)