### PR TITLE
fix: health-check-retry

### DIFF
--- a/src/lib/health-checks/__tests__/health-checks.test.ts
+++ b/src/lib/health-checks/__tests__/health-checks.test.ts
@@ -735,7 +735,7 @@ describe('health-checks', () => {
       expect(result.error).toBe('HTTP 502');
     });
 
-    it('returns down on DNS resolution failure', async () => {
+    it('returns no-connection on DNS resolution failure (no status-page corroboration)', async () => {
       (global.fetch as jest.Mock).mockImplementation(
         overrideFetch({
           [URLS.llmGatewayLiveness]: () =>
@@ -745,11 +745,11 @@ describe('health-checks', () => {
         }),
       );
       const result = await checkLlmGatewayHealth();
-      expect(result.status).toBe(ServiceHealthStatus.Down);
+      expect(result.status).toBe(ServiceHealthStatus.NoConnection);
       expect(result.error).toBe('getaddrinfo ENOTFOUND gateway.us.posthog.com');
     });
 
-    it('returns down on timeout (AbortError)', async () => {
+    it('returns no-connection on timeout (AbortError)', async () => {
       const abortError = new Error('The operation was aborted.');
       abortError.name = 'AbortError';
       (global.fetch as jest.Mock).mockImplementation(
@@ -758,8 +758,46 @@ describe('health-checks', () => {
         }),
       );
       const result = await checkLlmGatewayHealth();
-      expect(result.status).toBe(ServiceHealthStatus.Down);
+      expect(result.status).toBe(ServiceHealthStatus.NoConnection);
       expect(result.error).toBe('Request timed out after 5000ms');
+    });
+
+    it('retries on network errors and recovers if a later attempt succeeds', async () => {
+      let calls = 0;
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.llmGatewayLiveness]: () => {
+            calls++;
+            if (calls < 3) {
+              return Promise.reject(new Error('ECONNRESET'));
+            }
+            return Promise.resolve(
+              new Response(LLM_GATEWAY_LIVENESS_BODY, { status: 200 }),
+            );
+          },
+        }),
+      );
+      const result = await checkLlmGatewayHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Healthy);
+      expect(result.rawIndicator).toContain('attempts=3');
+      expect(calls).toBe(3);
+    });
+
+    it('does not retry on explicit HTTP errors (single attempt)', async () => {
+      let calls = 0;
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.llmGatewayLiveness]: () => {
+            calls++;
+            return Promise.resolve(
+              new Response('Service Unavailable', { status: 503 }),
+            );
+          },
+        }),
+      );
+      const result = await checkLlmGatewayHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Down);
+      expect(calls).toBe(1);
     });
   });
 
@@ -832,14 +870,14 @@ describe('health-checks', () => {
       expect(result.error).toBe('HTTP 522');
     });
 
-    it('returns down on network failure', async () => {
+    it('returns no-connection on network failure', async () => {
       (global.fetch as jest.Mock).mockImplementation(
         overrideFetch({
           [URLS.mcpLanding]: () => Promise.reject(new Error('fetch failed')),
         }),
       );
       const result = await checkMcpHealth();
-      expect(result.status).toBe(ServiceHealthStatus.Down);
+      expect(result.status).toBe(ServiceHealthStatus.NoConnection);
       expect(result.error).toBe('fetch failed');
     });
   });
@@ -899,6 +937,56 @@ describe('health-checks', () => {
       for (const val of Object.values(health)) {
         expect(val.status).toBe(ServiceHealthStatus.Healthy);
       }
+    });
+
+    it('upgrades NoConnection llmGateway/mcp to Down when status page reports an outage', async () => {
+      const incidentBody = {
+        ...POSTHOG_INCIDENTIO_HEALTHY,
+        ongoing_incidents: [
+          {
+            id: 'inc1',
+            name: 'Major outage',
+            status: 'identified',
+            current_worst_impact: 'full_outage',
+            affected_components: [],
+            url: 'https://www.posthogstatus.com/incidents/test',
+            last_update_at: '2026-04-22T00:00:00Z',
+            last_update_message: 'Investigating',
+          },
+        ],
+      };
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.posthogIncidentIo]: () =>
+            Promise.resolve(
+              new Response(JSON.stringify(incidentBody), { status: 200 }),
+            ),
+          [URLS.llmGatewayLiveness]: () =>
+            Promise.reject(new Error('ECONNRESET')),
+          [URLS.mcpLanding]: () => Promise.reject(new Error('ECONNRESET')),
+        }),
+      );
+
+      const health = await checkAllExternalServices();
+      expect(health.posthogOverall.status).toBe(ServiceHealthStatus.Down);
+      expect(health.llmGateway.status).toBe(ServiceHealthStatus.Down);
+      expect(health.llmGateway.error).toContain('corroborated by status page');
+      expect(health.mcp.status).toBe(ServiceHealthStatus.Down);
+    });
+
+    it('keeps llmGateway/mcp as NoConnection when status page reports no incident', async () => {
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.llmGatewayLiveness]: () =>
+            Promise.reject(new Error('ETIMEDOUT')),
+          [URLS.mcpLanding]: () => Promise.reject(new Error('ETIMEDOUT')),
+        }),
+      );
+
+      const health = await checkAllExternalServices();
+      expect(health.posthogOverall.status).toBe(ServiceHealthStatus.Healthy);
+      expect(health.llmGateway.status).toBe(ServiceHealthStatus.NoConnection);
+      expect(health.mcp.status).toBe(ServiceHealthStatus.NoConnection);
     });
 
     it('fires all fetch calls in parallel', async () => {

--- a/src/lib/health-checks/__tests__/health-checks.test.ts
+++ b/src/lib/health-checks/__tests__/health-checks.test.ts
@@ -455,6 +455,40 @@ describe('health-checks', () => {
       expect(result.status).toBe(ServiceHealthStatus.Down);
     });
 
+    it('returns NoConnection when posthogstatus.com fetch fails with a network error', async () => {
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.posthogIncidentIo]: () =>
+            Promise.reject(new Error('getaddrinfo ENOTFOUND')),
+        }),
+      );
+      const result = await checkPosthogOverallHealth();
+      expect(result.status).toBe(ServiceHealthStatus.NoConnection);
+    });
+
+    it('returns NoConnection when posthogstatus.com fetch times out', async () => {
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.posthogIncidentIo]: () => Promise.reject(abortError),
+        }),
+      );
+      const result = await checkPosthogOverallHealth();
+      expect(result.status).toBe(ServiceHealthStatus.NoConnection);
+    });
+
+    it('returns Down when posthogstatus.com returns an HTTP error', async () => {
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.posthogIncidentIo]: () =>
+            Promise.resolve(new Response('Bad Gateway', { status: 502 })),
+        }),
+      );
+      const result = await checkPosthogOverallHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Down);
+    });
+
     it('returns degraded when an incident has partial_outage impact', async () => {
       const body = {
         ...POSTHOG_INCIDENTIO_HEALTHY,
@@ -1015,6 +1049,31 @@ describe('health-checks', () => {
       expect(health.llmGateway.status).toBe(ServiceHealthStatus.Down);
       expect(health.llmGateway.error).toContain('corroborated by status page');
       expect(health.mcp.status).toBe(ServiceHealthStatus.Down);
+    });
+
+    it('keeps llmGateway/mcp as NoConnection when posthogstatus.com itself is unreachable (the bug-fix scenario)', async () => {
+      // User on flaky wifi: every PostHog-owned URL fetch fails at the
+      // network layer, including posthogstatus.com. Previously
+      // incidentio.ts returned Degraded for fetch failures, which
+      // tricked reconciliation into upgrading the gateway probe to Down
+      // and showing the red "Ongoing service disruptions" screen — the
+      // exact false positive this PR fixes.
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.posthogIncidentIo]: () =>
+            Promise.reject(new Error('ECONNRESET')),
+          [URLS.llmGatewayLiveness]: () =>
+            Promise.reject(new Error('ECONNRESET')),
+          [URLS.mcpLanding]: () => Promise.reject(new Error('ECONNRESET')),
+        }),
+      );
+
+      const health = await checkAllExternalServices();
+      expect(health.posthogOverall.status).toBe(
+        ServiceHealthStatus.NoConnection,
+      );
+      expect(health.llmGateway.status).toBe(ServiceHealthStatus.NoConnection);
+      expect(health.mcp.status).toBe(ServiceHealthStatus.NoConnection);
     });
 
     it('keeps llmGateway/mcp as NoConnection when status page reports no incident', async () => {

--- a/src/lib/health-checks/__tests__/health-checks.test.ts
+++ b/src/lib/health-checks/__tests__/health-checks.test.ts
@@ -706,7 +706,7 @@ describe('health-checks', () => {
       );
       const result = await checkLlmGatewayHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(result.error).toBe('HTTP 302');
+      expect(result.error).toContain('HTTP 302');
     });
 
     it('returns down when gateway responds 503 (e.g. deploying)', async () => {
@@ -720,7 +720,7 @@ describe('health-checks', () => {
       );
       const result = await checkLlmGatewayHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(result.error).toBe('HTTP 503');
+      expect(result.error).toContain('HTTP 503');
     });
 
     it('returns down when gateway responds 502 (bad gateway)', async () => {
@@ -732,7 +732,7 @@ describe('health-checks', () => {
       );
       const result = await checkLlmGatewayHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(result.error).toBe('HTTP 502');
+      expect(result.error).toContain('HTTP 502');
     });
 
     it('returns no-connection on DNS resolution failure (no status-page corroboration)', async () => {
@@ -783,7 +783,7 @@ describe('health-checks', () => {
       expect(calls).toBe(3);
     });
 
-    it('does not retry on explicit HTTP errors (single attempt)', async () => {
+    it('retries on persistent HTTP errors and stays Down after all attempts fail', async () => {
       let calls = 0;
       (global.fetch as jest.Mock).mockImplementation(
         overrideFetch({
@@ -797,7 +797,50 @@ describe('health-checks', () => {
       );
       const result = await checkLlmGatewayHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(calls).toBe(1);
+      expect(calls).toBe(3);
+      expect(result.error).toContain('HTTP 503');
+      expect(result.error).toContain('attempts=3');
+    });
+
+    it('retries on transient 5xx and recovers if a later attempt succeeds', async () => {
+      let calls = 0;
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.llmGatewayLiveness]: () => {
+            calls++;
+            if (calls < 3) {
+              return Promise.resolve(
+                new Response('Bad Gateway', { status: 502 }),
+              );
+            }
+            return Promise.resolve(
+              new Response(LLM_GATEWAY_LIVENESS_BODY, { status: 200 }),
+            );
+          },
+        }),
+      );
+      const result = await checkLlmGatewayHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Healthy);
+      expect(result.rawIndicator).toContain('attempts=3');
+      expect(calls).toBe(3);
+    });
+
+    it('returns Down (not NoConnection) when last attempt got an HTTP response after earlier network errors', async () => {
+      let calls = 0;
+      (global.fetch as jest.Mock).mockImplementation(
+        overrideFetch({
+          [URLS.llmGatewayLiveness]: () => {
+            calls++;
+            if (calls < 3) return Promise.reject(new Error('ECONNRESET'));
+            return Promise.resolve(
+              new Response('Bad Gateway', { status: 502 }),
+            );
+          },
+        }),
+      );
+      const result = await checkLlmGatewayHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Down);
+      expect(result.error).toContain('HTTP 502');
     });
   });
 
@@ -841,7 +884,7 @@ describe('health-checks', () => {
       );
       const result = await checkMcpHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(result.error).toBe('HTTP 400');
+      expect(result.error).toContain('HTTP 400');
     });
 
     it('returns down when worker responds 500', async () => {
@@ -855,7 +898,7 @@ describe('health-checks', () => {
       );
       const result = await checkMcpHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(result.error).toBe('HTTP 500');
+      expect(result.error).toContain('HTTP 500');
     });
 
     it('returns down when Cloudflare returns 522 (connection timed out)', async () => {
@@ -867,7 +910,7 @@ describe('health-checks', () => {
       );
       const result = await checkMcpHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(result.error).toBe('HTTP 522');
+      expect(result.error).toContain('HTTP 522');
     });
 
     it('returns no-connection on network failure', async () => {
@@ -906,7 +949,7 @@ describe('health-checks', () => {
       );
       const result = await checkGithubReleasesHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(result.error).toBe('HTTP 404');
+      expect(result.error).toContain('HTTP 404');
     });
   });
 

--- a/src/lib/health-checks/endpoints.ts
+++ b/src/lib/health-checks/endpoints.ts
@@ -6,7 +6,12 @@ import { ServiceHealthStatus, type BaseHealthResult } from './types';
 // Direct endpoint health checks
 //
 // These ping PostHog-owned services directly (no Statuspage intermediary).
-// A non-expected HTTP status or any network error is treated as Down.
+// Result taxonomy:
+//   - HTTP 2xx-3xx (per `isExpectedStatus`)        → Healthy
+//   - HTTP 4xx / 5xx                                → Down (confirmed)
+//   - Network error / DNS / timeout (after retries) → NoConnection
+// NoConnection means we don't know whose fault it is; readiness reconciles
+// against the status page before deciding how to surface it to the user.
 //
 // LLM Gateway – FastAPI service
 //   Source: posthog/services/llm-gateway/src/llm_gateway/api/health.py
@@ -17,8 +22,44 @@ import { ServiceHealthStatus, type BaseHealthResult } from './types';
 //   GET / → 302 to posthog.com docs. The redirect proves the worker is up.
 // ---------------------------------------------------------------------------
 
+function noConnectionResult(error: string, attempts: number): BaseHealthResult {
+  return {
+    status: ServiceHealthStatus.NoConnection,
+    error,
+    rawIndicator: attempts > 1 ? `attempts=${attempts}` : undefined,
+  };
+}
+
 function downResult(error: string): BaseHealthResult {
   return { status: ServiceHealthStatus.Down, error };
+}
+
+// Backoffs sized to cover typical wifi flakiness — a single dropped
+// packet recovers via the 500ms retry; a wifi access point reconnect
+// or wifi↔LTE handoff (2-5s) is caught by the 2000ms retry. Tighter
+// schedules miss multi-second blips because all retries land in the
+// same dead window.
+const RETRY_BACKOFFS_MS = [500, 2000];
+
+async function attemptFetch(
+  url: string,
+  timeoutMs: number,
+  redirect: 'follow' | 'manual' | 'error',
+): Promise<
+  | { kind: 'response'; res: Response }
+  | { kind: 'error'; error: Error; timedOut: boolean }
+> {
+  const controller = new AbortController();
+  const tid = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal, redirect });
+    clearTimeout(tid);
+    return { kind: 'response', res };
+  } catch (e) {
+    clearTimeout(tid);
+    const err = e instanceof Error ? e : new Error('Unknown error');
+    return { kind: 'error', error: err, timedOut: err.name === 'AbortError' };
+  }
 }
 
 async function fetchEndpointHealth(
@@ -27,34 +68,52 @@ async function fetchEndpointHealth(
   isExpectedStatus: (status: number) => boolean = (s) => s === 200,
   redirect: 'follow' | 'manual' | 'error' = 'follow',
 ): Promise<BaseHealthResult> {
-  const result = await (async (): Promise<BaseHealthResult> => {
-    try {
-      const controller = new AbortController();
-      const tid = setTimeout(() => controller.abort(), timeoutMs);
-      const res = await fetch(url, {
-        signal: controller.signal,
-        redirect,
-      });
-      clearTimeout(tid);
+  // Total attempts = 1 initial + RETRY_BACKOFFS_MS.length retries. Only
+  // network/timeout errors trigger a retry — explicit HTTP responses are
+  // deterministic so retrying them is wasted time and a worse spinner.
+  let lastError = 'Unknown error';
+  let attempts = 0;
 
-      if (isExpectedStatus(res.status)) {
-        return {
-          status: ServiceHealthStatus.Healthy,
-          rawIndicator: `HTTP ${res.status}`,
-        };
-      }
-      return downResult(`HTTP ${res.status}`);
-    } catch (e) {
-      if (e instanceof Error && e.name === 'AbortError')
-        return downResult(`Request timed out after ${timeoutMs}ms`);
-      return downResult(e instanceof Error ? e.message : 'Unknown error');
+  for (let i = 0; i <= RETRY_BACKOFFS_MS.length; i++) {
+    if (i > 0) {
+      const wait = RETRY_BACKOFFS_MS[i - 1];
+      logToFile(
+        `[health-checks] retry ${i}/${RETRY_BACKOFFS_MS.length} for ${url} in ${wait}ms`,
+      );
+      await new Promise((r) => setTimeout(r, wait));
     }
-  })();
+    attempts++;
 
+    const outcome = await attemptFetch(url, timeoutMs, redirect);
+
+    if (outcome.kind === 'response') {
+      const res = outcome.res;
+      const result: BaseHealthResult = isExpectedStatus(res.status)
+        ? {
+            status: ServiceHealthStatus.Healthy,
+            rawIndicator:
+              attempts > 1
+                ? `HTTP ${res.status} (attempts=${attempts})`
+                : `HTTP ${res.status}`,
+          }
+        : downResult(`HTTP ${res.status}`);
+      logToFile(
+        `[health-checks] GET ${url} -> ${result.status}` +
+          `${result.rawIndicator ? ` (${result.rawIndicator})` : ''}` +
+          `${result.error ? ` (${result.error})` : ''}`,
+      );
+      return result;
+    }
+
+    lastError = outcome.timedOut
+      ? `Request timed out after ${timeoutMs}ms`
+      : outcome.error.message;
+  }
+
+  const result = noConnectionResult(lastError, attempts);
   logToFile(
     `[health-checks] GET ${url} -> ${result.status}` +
-      `${result.rawIndicator ? ` (${result.rawIndicator})` : ''}` +
-      `${result.error ? ` (${result.error})` : ''}`,
+      ` (attempts=${attempts}, ${result.error})`,
   );
   return result;
 }

--- a/src/lib/health-checks/endpoints.ts
+++ b/src/lib/health-checks/endpoints.ts
@@ -68,9 +68,17 @@ async function fetchEndpointHealth(
   isExpectedStatus: (status: number) => boolean = (s) => s === 200,
   redirect: 'follow' | 'manual' | 'error' = 'follow',
 ): Promise<BaseHealthResult> {
-  // Total attempts = 1 initial + RETRY_BACKOFFS_MS.length retries. Only
-  // network/timeout errors trigger a retry — explicit HTTP responses are
-  // deterministic so retrying them is wasted time and a worse spinner.
+  // Total attempts = 1 initial + RETRY_BACKOFFS_MS.length retries. Both
+  // unexpected HTTP statuses (4xx/5xx) and network errors trigger a retry:
+  // transient 5xx and Cloudflare edge blips often recover on a retry, and
+  // even nominally deterministic 4xx can be transient (CDN propagation
+  // lag after a release, token rotation, rate-limit window resets). GETs
+  // are idempotent so retrying is safe.
+  //
+  // Final status if every attempt fails:
+  //   - At least one HTTP response observed → `Down` (server-side evidence)
+  //   - Only network errors observed         → `NoConnection`
+  let lastHttpStatus: number | null = null;
   let lastError = 'Unknown error';
   let attempts = 0;
 
@@ -78,7 +86,7 @@ async function fetchEndpointHealth(
     if (i > 0) {
       const wait = RETRY_BACKOFFS_MS[i - 1];
       logToFile(
-        `[health-checks] retry ${i}/${RETRY_BACKOFFS_MS.length} for ${url} in ${wait}ms`,
+        `[health-checks] retry ${i}/${RETRY_BACKOFFS_MS.length} for ${url} in ${wait}ms (last: ${lastError})`,
       );
       await new Promise((r) => setTimeout(r, wait));
     }
@@ -88,21 +96,23 @@ async function fetchEndpointHealth(
 
     if (outcome.kind === 'response') {
       const res = outcome.res;
-      const result: BaseHealthResult = isExpectedStatus(res.status)
-        ? {
-            status: ServiceHealthStatus.Healthy,
-            rawIndicator:
-              attempts > 1
-                ? `HTTP ${res.status} (attempts=${attempts})`
-                : `HTTP ${res.status}`,
-          }
-        : downResult(`HTTP ${res.status}`);
-      logToFile(
-        `[health-checks] GET ${url} -> ${result.status}` +
-          `${result.rawIndicator ? ` (${result.rawIndicator})` : ''}` +
-          `${result.error ? ` (${result.error})` : ''}`,
-      );
-      return result;
+      if (isExpectedStatus(res.status)) {
+        const result: BaseHealthResult = {
+          status: ServiceHealthStatus.Healthy,
+          rawIndicator:
+            attempts > 1
+              ? `HTTP ${res.status} (attempts=${attempts})`
+              : `HTTP ${res.status}`,
+        };
+        logToFile(
+          `[health-checks] GET ${url} -> ${result.status}` +
+            ` (${result.rawIndicator})`,
+        );
+        return result;
+      }
+      lastHttpStatus = res.status;
+      lastError = `HTTP ${res.status}`;
+      continue;
     }
 
     lastError = outcome.timedOut
@@ -110,7 +120,10 @@ async function fetchEndpointHealth(
       : outcome.error.message;
   }
 
-  const result = noConnectionResult(lastError, attempts);
+  const result =
+    lastHttpStatus !== null
+      ? downResult(`HTTP ${lastHttpStatus} (attempts=${attempts})`)
+      : noConnectionResult(lastError, attempts);
   logToFile(
     `[health-checks] GET ${url} -> ${result.status}` +
       ` (attempts=${attempts}, ${result.error})`,

--- a/src/lib/health-checks/incidentio.ts
+++ b/src/lib/health-checks/incidentio.ts
@@ -51,8 +51,28 @@ function mapComponentStatus(status: string): ServiceHealthStatus {
   }
 }
 
-function errResult(error: string): BaseHealthResult {
-  return { status: ServiceHealthStatus.Degraded, error };
+/**
+ * Build an error result for fetch failures. The kind matters for
+ * downstream reconciliation:
+ *
+ *   - 'http' (incident.io returned a bad status code) → `Down`. We
+ *     reached the status page but it told us something is wrong on
+ *     its side. We have a definitive response.
+ *   - 'network' (timeout, DNS failure, TCP/TLS failure) → `NoConnection`.
+ *     We never reached the status page. Treating this as `Degraded`
+ *     (the previous behavior) silently flipped the reconciliation in
+ *     `readiness.ts` from "soft" to "confirmed outage" whenever the
+ *     user's own network was flaky — exactly the false positive this
+ *     module is meant to help diagnose.
+ */
+function errResult(error: string, kind: 'http' | 'network'): BaseHealthResult {
+  return {
+    status:
+      kind === 'http'
+        ? ServiceHealthStatus.Down
+        : ServiceHealthStatus.NoConnection,
+    error,
+  };
 }
 
 const POSTHOG_STATUS_URL = 'https://www.posthogstatus.com/api/v1/summary';
@@ -67,7 +87,7 @@ async function fetchPosthogStatus(
     clearTimeout(tid);
 
     if (!res.ok) {
-      const err = errResult(`HTTP ${res.status}`);
+      const err = errResult(`HTTP ${res.status}`, 'http');
       return { overall: err, components: err };
     }
 
@@ -114,10 +134,13 @@ async function fetchPosthogStatus(
     };
   } catch (e) {
     if (e instanceof Error && e.name === 'AbortError') {
-      const err = errResult('Request timed out');
+      const err = errResult('Request timed out', 'network');
       return { overall: err, components: err };
     }
-    const err = errResult(e instanceof Error ? e.message : 'Unknown error');
+    const err = errResult(
+      e instanceof Error ? e.message : 'Unknown error',
+      'network',
+    );
     return { overall: err, components: err };
   }
 }

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -109,7 +109,7 @@ export async function checkAllExternalServices(): Promise<AllServicesHealth> {
     checkGithubReleasesHealth(),
   ]);
 
-  return {
+  const health: AllServicesHealth = {
     anthropic,
     posthogOverall,
     posthogComponents,
@@ -121,6 +121,50 @@ export async function checkAllExternalServices(): Promise<AllServicesHealth> {
     llmGateway,
     mcp,
     githubReleases,
+  };
+  return reconcilePosthogReachability(health);
+}
+
+/**
+ * When a PostHog-owned endpoint probe returns `NoConnection`, decide
+ * whether it's a real outage or a likely-local issue by checking the
+ * official status page (`posthogstatus.com`):
+ *
+ *   - Status page says PostHog is `Down` / `Degraded` → upgrade
+ *     llmGateway / mcp to `Down`. The status page corroborates.
+ *   - Status page is `Healthy` → keep `NoConnection`. The status page
+ *     contradicts; this is probably the user's network.
+ *   - Status page is also `NoConnection` → keep `NoConnection`. User
+ *     can't reach two independent PostHog properties; almost
+ *     certainly their network.
+ *
+ * Mutates a copy of `health` and returns it.
+ */
+export function reconcilePosthogReachability(
+  health: AllServicesHealth,
+): AllServicesHealth {
+  const posthogStatus = health.posthogOverall.status;
+  const corroboratesOutage =
+    posthogStatus === ServiceHealthStatus.Down ||
+    posthogStatus === ServiceHealthStatus.Degraded;
+
+  if (!corroboratesOutage) return health;
+
+  const upgrade = (r: BaseHealthResult): BaseHealthResult =>
+    r.status === ServiceHealthStatus.NoConnection
+      ? {
+          ...r,
+          status: ServiceHealthStatus.Down,
+          error: r.error
+            ? `${r.error} (corroborated by status page)`
+            : 'corroborated by status page',
+        }
+      : r;
+
+  return {
+    ...health,
+    llmGateway: upgrade(health.llmGateway),
+    mcp: upgrade(health.mcp),
   };
 }
 
@@ -163,7 +207,11 @@ function describeComponents(label: string, h: ComponentHealthResult): string {
   return `${label} components impacted: ${shown.join(', ')}${suffix}`;
 }
 
-const READINESS_TIMEOUT_MS = 10_000;
+// Each probe can take up to one base timeout + two retries with the
+// 500ms / 2000ms backoffs in endpoints.ts (worst case ~17.5s for a
+// network failure that exhausts retries). Probes run in parallel so
+// the aggregate ceiling is one probe, not the sum.
+const READINESS_TIMEOUT_MS = 20_000;
 
 export async function evaluateWizardReadiness(
   config: WizardReadinessConfig = DEFAULT_WIZARD_READINESS_CONFIG,
@@ -237,6 +285,11 @@ const COMPONENT_KEYS: HealthCheckKey[] = [
 
 /**
  * Get the keys of services that would block a wizard run per the given config.
+ *
+ * `NoConnection` blocks the same services as `Down` — the wizard genuinely
+ * can't continue if it can't reach the gateway. The screen shows softer
+ * framing in that case (HealthCheckScreen) so we don't falsely accuse
+ * PostHog of an outage when the user's network is the likely cause.
  */
 export function getBlockingServiceKeys(
   health: AllServicesHealth,
@@ -247,7 +300,8 @@ export function getBlockingServiceKeys(
     const result = health[key];
     if (
       config.downBlocksRun.includes(key) &&
-      result.status === ServiceHealthStatus.Down
+      (result.status === ServiceHealthStatus.Down ||
+        result.status === ServiceHealthStatus.NoConnection)
     ) {
       return true;
     }

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -136,7 +136,23 @@ export async function checkAllExternalServices(): Promise<AllServicesHealth> {
  *     contradicts; this is probably the user's network.
  *   - Status page is also `NoConnection` → keep `NoConnection`. User
  *     can't reach two independent PostHog properties; almost
- *     certainly their network.
+ *     certainly their network. (This case relies on incidentio.ts
+ *     correctly emitting `NoConnection` for fetch failures rather
+ *     than the previous `Degraded`, which used to silently flip the
+ *     reconciliation into a false positive.)
+ *
+ * Why `Degraded` corroborates: a `Degraded` reading here only fires
+ * when incident.io's API parsed successfully and reported a real
+ * `partial_outage` or `degraded_performance` for some component. That's
+ * PostHog acknowledging an issue, even if narrower than a full outage.
+ * If our gateway probe is also failing, those two signals together
+ * justify pointing at PostHog rather than the user.
+ *
+ * A narrower variant — only corroborate when the affected component is
+ * gateway-related (LLM, US/EU Cloud, app) — would be more precise. We
+ * have the data in `posthogComponents` but don't use it here. If the
+ * analytics show false positives concentrated in this case, it's a
+ * cheap follow-up.
  *
  * Mutates a copy of `health` and returns it.
  */

--- a/src/lib/health-checks/types.ts
+++ b/src/lib/health-checks/types.ts
@@ -2,6 +2,14 @@ export enum ServiceHealthStatus {
   Healthy = 'healthy',
   Degraded = 'degraded',
   Down = 'down',
+  /**
+   * Probe failed (network error, timeout, DNS failure) AND we have no
+   * corroborating status-page incident. The service may be fine — the
+   * user's network is the likely culprit. Distinct from `Down`, which
+   * is confirmed (HTTP 5xx or status-page incident). User-facing label:
+   * "No connection".
+   */
+  NoConnection = 'no-connection',
 }
 
 export interface BaseHealthResult {

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -40,6 +40,7 @@ jest.mock('../../../lib/health-checks/readiness.js', () => ({
     YesWithWarnings: 'yes-with-warnings',
   },
   SERVICE_LABELS: {},
+  getBlockingServiceKeys: jest.fn(() => []),
 }));
 
 function createStore(program?: ProgramId): WizardStore {

--- a/src/ui/tui/components/ServiceHealthList.tsx
+++ b/src/ui/tui/components/ServiceHealthList.tsx
@@ -38,6 +38,8 @@ function statusIcon(status: ServiceHealthStatus): {
       return { icon: Icons.squareFilled, color: 'red' };
     case ServiceHealthStatus.Degraded:
       return { icon: Icons.squareFilled, color: '#DC9300' };
+    case ServiceHealthStatus.NoConnection:
+      return { icon: Icons.squareFilled, color: 'gray' };
     case ServiceHealthStatus.Healthy:
       return { icon: Icons.check, color: 'green' };
   }

--- a/src/ui/tui/playground/demos/HealthCheckDemo.tsx
+++ b/src/ui/tui/playground/demos/HealthCheckDemo.tsx
@@ -1,9 +1,12 @@
 /**
  * HealthCheckDemo — Playground demo for health check UI components.
  *
- * Shows the ModalOverlay with ServiceHealthList, cycling through states:
- *   1. Checking (spinner) — 2 seconds
- *   2. Blocking outage modal (Anthropic down, npm degraded)
+ * Cycles through three states (2s checking spinner → 5s confirmed-outage
+ * red modal → 5s no-connection yellow modal, then loops):
+ *   1. Checking (spinner)
+ *   2. Confirmed outage (status page corroborates → red framing)
+ *   3. No connection only (no status-page incident → yellow "couldn't
+ *      reach PostHog" framing)
  *
  * Renders components directly (not HealthCheckScreen) to avoid useInput
  * conflicts with TabContainer's key handling.
@@ -20,7 +23,7 @@ import type { AllServicesHealth } from '@lib/health-checks/types';
 
 const HEALTHY = { status: ServiceHealthStatus.Healthy } as const;
 
-const MOCK_HEALTH: AllServicesHealth = {
+const MOCK_CONFIRMED_OUTAGE: AllServicesHealth = {
   anthropic: { status: ServiceHealthStatus.Down, rawIndicator: 'major' },
   posthogOverall: HEALTHY,
   posthogComponents: { status: ServiceHealthStatus.Healthy },
@@ -46,15 +49,43 @@ const MOCK_HEALTH: AllServicesHealth = {
   githubReleases: HEALTHY,
 };
 
+const MOCK_NO_CONNECTION: AllServicesHealth = {
+  anthropic: HEALTHY,
+  posthogOverall: HEALTHY,
+  posthogComponents: { status: ServiceHealthStatus.Healthy },
+  github: HEALTHY,
+  npmOverall: HEALTHY,
+  npmComponents: { status: ServiceHealthStatus.Healthy },
+  cloudflareOverall: HEALTHY,
+  cloudflareComponents: { status: ServiceHealthStatus.Healthy },
+  llmGateway: {
+    status: ServiceHealthStatus.NoConnection,
+    error: 'getaddrinfo ENOTFOUND gateway.us.posthog.com',
+  },
+  mcp: {
+    status: ServiceHealthStatus.NoConnection,
+    error: 'fetch failed',
+  },
+  githubReleases: HEALTHY,
+};
+
+type Phase = 'checking' | 'confirmed' | 'no-connection';
+
 export const HealthCheckDemo = () => {
-  const [showOutage, setShowOutage] = useState(false);
+  const [phase, setPhase] = useState<Phase>('checking');
 
   useEffect(() => {
-    const timer = setTimeout(() => setShowOutage(true), 2000);
-    return () => clearTimeout(timer);
-  }, []);
+    const t1 = setTimeout(() => setPhase('confirmed'), 2000);
+    const t2 = setTimeout(() => setPhase('no-connection'), 7000);
+    const t3 = setTimeout(() => setPhase('checking'), 12000);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [phase]);
 
-  if (!showOutage) {
+  if (phase === 'checking') {
     return (
       <Box
         flexDirection="column"
@@ -67,12 +98,19 @@ export const HealthCheckDemo = () => {
     );
   }
 
-  const blockingKeys = getBlockingServiceKeys(MOCK_HEALTH);
+  const health =
+    phase === 'confirmed' ? MOCK_CONFIRMED_OUTAGE : MOCK_NO_CONNECTION;
+  const blockingKeys = getBlockingServiceKeys(health);
+  const isNoConnection = phase === 'no-connection';
 
   return (
     <ModalOverlay
-      borderColor="red"
-      title={`${Icons.warning} Ongoing service disruptions`}
+      borderColor={isNoConnection ? 'yellow' : 'red'}
+      title={
+        isNoConnection
+          ? "Couldn't reach PostHog"
+          : `${Icons.warning} Ongoing service disruptions`
+      }
       width={72}
       footer={
         <Box marginLeft={2}>
@@ -88,19 +126,23 @@ export const HealthCheckDemo = () => {
             <Text color="red">{Icons.squareFilled}</Text>
             <Text dimColor> Down </Text>
             <Text color="#DC9300">{Icons.squareFilled}</Text>
-            <Text dimColor> Degraded</Text>
+            <Text dimColor> Degraded </Text>
+            <Text color="gray">{Icons.squareFilled}</Text>
+            <Text dimColor> No connection</Text>
           </Text>
         </Box>
 
         <ServiceHealthList
-          health={MOCK_HEALTH}
+          health={health}
           filterKeys={blockingKeys}
           showHealthy={false}
         />
       </Box>
 
       <Text dimColor>
-        The wizard may not work reliably while services are affected.
+        {isNoConnection
+          ? "We couldn't reach these services. PostHog's status page shows no incidents, likely a network issue (VPN, firewall, captive portal, or Wi-Fi)."
+          : 'The wizard may not work reliably while services are affected.'}
       </Text>
     </ModalOverlay>
   );

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -114,13 +114,30 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
     result.health.githubReleases.status === ServiceHealthStatus.Healthy;
   const integration = store.session.integration;
 
-  const title = hasHardBlock
+  // If every blocking row is `NoConnection` (probe failed, no status-page
+  // corroboration), reframe the screen to point at the user's network
+  // instead of accusing PostHog of an outage. Mixed Down + NoConnection
+  // falls through to the confirmed-outage framing because there's still
+  // a real incident underneath.
+  const allBlockingHaveNoConnection =
+    hasHardBlock &&
+    displayKeys.every(
+      (k) => result.health[k].status === ServiceHealthStatus.NoConnection,
+    );
+
+  const title = isGithubReleasesDown
+    ? 'Ongoing service disruptions'
+    : allBlockingHaveNoConnection
+    ? "Couldn't reach PostHog"
+    : hasHardBlock
     ? 'Ongoing service disruptions'
     : 'Service disruption detected';
 
   const docsUrl = store.session.frameworkConfig?.metadata.docsUrl;
   const description = isGithubReleasesDown
     ? "The Wizard can't download necessary skills from GitHub Releases right now."
+    : allBlockingHaveNoConnection
+    ? "We couldn't reach these services from this machine. PostHog's status page shows no incidents, so this is most likely a network issue — VPN, firewall, captive portal, or flaky Wi-Fi."
     : hasHardBlock
     ? 'The Wizard cannot start while these services are down.'
     : 'Some services are degraded. You can continue, but parts of the wizard may not work reliably.';
@@ -155,7 +172,9 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
 
   return (
     <ModalOverlay
-      borderColor={hasHardBlock ? 'red' : 'yellow'}
+      borderColor={
+        hasHardBlock && !allBlockingHaveNoConnection ? 'red' : 'yellow'
+      }
       title={title}
       width={72}
       footer={
@@ -188,7 +207,9 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
             <Text color="red">{Icons.squareFilled}</Text>
             <Text dimColor> Down </Text>
             <Text color="#DC9300">{Icons.squareFilled}</Text>
-            <Text dimColor> Degraded</Text>
+            <Text dimColor> Degraded </Text>
+            <Text color="gray">{Icons.squareFilled}</Text>
+            <Text dimColor> No connection</Text>
           </Text>
         </Box>
 

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -28,7 +28,12 @@ import {
   buildSession,
 } from '@lib/wizard-session';
 import type { SettingsConflict } from '@lib/agent/claude-settings';
-import type { WizardReadinessResult } from '@lib/health-checks/readiness';
+import {
+  WizardReadiness,
+  getBlockingServiceKeys,
+  type WizardReadinessResult,
+} from '@lib/health-checks/readiness';
+import { ServiceHealthStatus } from '@lib/health-checks/types';
 import {
   WizardRouter,
   type ScreenName,
@@ -75,6 +80,60 @@ interface GateEntry {
  * the cap is tied to the window it feeds.
  */
 const MAX_STATUS_MESSAGES = EXPANDED_COUNT;
+
+/**
+ * Fired once per blocked readiness result, so we can quantify how often
+ * the wizard refuses to start and — crucially — split that between
+ * confirmed PostHog outages and probe-level reachability failures that
+ * are most likely the user's network. Helps us decide whether the
+ * health-check UX is over-firing.
+ */
+function captureHealthCheckBlocked(result: WizardReadinessResult): void {
+  try {
+    const health = result.health;
+    const blockingKeys = getBlockingServiceKeys(health);
+    const blockingStatuses = blockingKeys.map((k) => health[k]?.status);
+
+    const allNoConnection =
+      blockingStatuses.length > 0 &&
+      blockingStatuses.every((s) => s === ServiceHealthStatus.NoConnection);
+    const onlyGithubReleases =
+      blockingKeys.length === 1 && blockingKeys[0] === 'githubReleases';
+
+    const decision = onlyGithubReleases
+      ? 'github-releases-down'
+      : allNoConnection
+      ? 'no-connection'
+      : 'confirmed-outage';
+
+    const posthogStatus = health.posthogOverall?.status;
+    const retriesUsed = Math.max(
+      0,
+      ...(['llmGateway', 'mcp', 'githubReleases'] as const).map((k) => {
+        const ind = health[k]?.rawIndicator ?? '';
+        const m = ind.match(/attempts=(\d+)/);
+        return m ? Number(m[1]) - 1 : 0;
+      }),
+    );
+
+    analytics.wizardCapture('health check blocked', {
+      decision,
+      blocking_keys: blockingKeys,
+      posthog_status_reachable:
+        posthogStatus !== ServiceHealthStatus.NoConnection,
+      posthog_status_reports_incident:
+        posthogStatus === ServiceHealthStatus.Down ||
+        posthogStatus === ServiceHealthStatus.Degraded,
+      retries_used: retriesUsed,
+    });
+  } catch (err) {
+    logToFile(
+      `[health-checks] failed to capture analytics: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
 
 export class WizardStore {
   // ── Internal nanostore atoms ─────────────────────────────────────
@@ -352,6 +411,9 @@ export class WizardStore {
 
   setReadinessResult(result: WizardReadinessResult | null): void {
     this.$session.setKey('readinessResult', result);
+    if (result && result.decision === WizardReadiness.No) {
+      captureHealthCheckBlocked(result);
+    }
     this.emitChange();
   }
 


### PR DESCRIPTION
## Problem

Adding 2 retires and backoffs (500ms + 2000ms) for any non-healthy status

<img width="633" height="355" alt="image" src="https://github.com/user-attachments/assets/02dbff91-bdaa-4101-850b-85832b8855dd" />

## Key behaviors

- **Retries fire on any non-healthy outcome** (HTTP errors *and* network errors). GETs are idempotent so retrying is safe; the practical win is catching transient failures — Cloudflare edge 5xx, post-release CDN lag, brief network hiccups — that would otherwise produce a false positive. Cost: 2.5s of backoff added between attempts (500ms + 2000ms). Total wall time per probe is capped at ~17.5s in the worst case where every attempt also hits the 5s timeout.
- **Down vs. NoConnection** is decided by what we observed across the 3 attempts, not just the last one. If *any* attempt got an HTTP response (even a 500), we have evidence the server replied, so the final status is `Down`. If *every* attempt failed at the network layer (DNS, TCP, TLS, timeout), we never reached the server, so it's `NoConnection`.
- **Reconciliation only upgrades** `NoConnection` → `Down`. We don't downgrade a confirmed HTTP error just because the status page hasn't caught up yet.
- **Both `Down` and `NoConnection` block the run.** The change is in the framing of the screen, not whether the user can proceed.

## Analytics

New `wizard: health check blocked` event fires once per blocked readiness result:

| Property | Values |
|---|---|
| `decision` | `confirmed-outage` / `no-connection` / `github-releases-down` |
| `blocking_keys` | service keys that tripped the block |
| `posthog_status_reachable` | did `posthogstatus.com` respond? |
| `posthog_status_reports_incident` | did it report an active incident? |
| `retries_used` | max retry count across probes |

## Untouched

`statuspage.ts` (Anthropic / GitHub / npm / Cloudflare) and `incidentio.ts` (PostHog status page) — same status-page parsing logic as before. The taxonomy change is additive: `NoConnection` joins `Healthy` / `Degraded` / `Down`.