### PR TITLE
fix: point Slack setup at new /integrations/slack landing page

### DIFF
--- a/src/lib/__tests__/mcp-role-prompts.test.ts
+++ b/src/lib/__tests__/mcp-role-prompts.test.ts
@@ -296,9 +296,7 @@ describe('getSlackAppCard', () => {
   it('exposes the documented learn-more and setup URLs', () => {
     const card = getSlackAppCard();
     expect(card.learnMoreUrl).toBe('https://posthog.com/slack');
-    expect(card.setupUrl).toBe(
-      'https://app.posthog.com/settings/project-integrations#integration-slack',
-    );
+    expect(card.setupUrl).toBe('https://app.posthog.com/integrations/slack');
   });
 
   it('describes both Slack agent capabilities — code/PR and data', () => {

--- a/src/lib/mcp-role-prompts.copy.json
+++ b/src/lib/mcp-role-prompts.copy.json
@@ -509,7 +509,7 @@
 
   "slackApp": {
     "learnMoreUrl": "https://posthog.com/slack",
-    "setupUrl": "https://app.posthog.com/settings/project-integrations#integration-slack",
+    "setupUrl": "https://app.posthog.com/integrations/slack",
     "headline": "@PostHog in Slack",
     "pitch": "Ask about your product data, debug issues, and generate PRs without leaving the thread.",
     "capabilities": [

--- a/src/lib/mcp-role-prompts.ts
+++ b/src/lib/mcp-role-prompts.ts
@@ -96,7 +96,7 @@ export interface SlackAppCard {
   pitch: string;
   /** posthog.com/slack — "learn more". */
   learnMoreUrl: string;
-  /** settings/project-integrations#integration-slack — where the user connects Slack. */
+  /** integrations/slack — where the user connects Slack. */
   setupUrl: string;
   /** The Slack agent's two capabilities (code/PR + data) — fixed, not role-tailored. */
   capabilities: string[];

--- a/src/utils/__tests__/links.test.ts
+++ b/src/utils/__tests__/links.test.ts
@@ -12,13 +12,13 @@ describe('withUtm', () => {
 
   it('preserves existing query params and fragments', () => {
     const url = withUtm(
-      'https://app.posthog.com/settings/project-integrations?a=1#integration-slack',
+      'https://app.posthog.com/integrations/slack?a=1#connect',
       'slack-connect-setup',
     );
     const parsed = new URL(url);
     expect(parsed.searchParams.get('a')).toBe('1');
     expect(parsed.searchParams.get('utm_source')).toBe('wizard');
-    expect(parsed.hash).toBe('#integration-slack');
+    expect(parsed.hash).toBe('#connect');
   });
 
   it('does not re-tag a URL that already carries a utm_source', () => {


### PR DESCRIPTION
## Problem

The Slack connect flow sent users to the project-integrations settings page (`app.posthog.com/settings/project-integrations#integration-slack`). PostHog now has a dedicated landing page for installing integrations at `app.posthog.com/integrations/<slug>`, which is where users should land.

## Changes

- Updated the Slack `setupUrl` source of truth in `mcp-role-prompts.copy.json` to `https://app.posthog.com/integrations/slack`. Both consuming screens (`SlackConnectScreen`, `McpSuggestedPromptsScreen`) read from this, so they pick up the change automatically.
- Updated the `SlackAppCard.setupUrl` doc comment to match.
- Updated the `mcp-role-prompts` test assertion to the new URL.
- Refreshed the `withUtm` query/fragment-preservation test fixture, which referenced the now-dead settings URL, to use the new integrations URL.

No Linear, Jira, or GitHub setup redirects exist in the wizard today — Slack was the only one.

## Test plan

- `pnpm build` — clean
- `pnpm test` — 59 suites, 907 tests pass
- `pnpm fix` — formatting/lint clean

## LLM context

Co-authored with Claude Code (Opus 4.8). Searched the codebase for settings-page integration redirects; Slack was the only match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)