### PR TITLE
feat(agent-runner): don't abort non-interactive runs on a health-check outage

### DIFF
--- a/src/lib/agent/agent-runner.ts
+++ b/src/lib/agent/agent-runner.ts
@@ -55,6 +55,7 @@ import {
 } from '@utils/debug';
 import { createBenchmarkPipeline } from '@lib/middleware/benchmark';
 import { wizardAbort, WizardError, registerCleanup } from '@utils/wizard-abort';
+import { isNonInteractiveEnvironment } from '@utils/environment';
 import { formatScanReport, writeScanReport } from '@lib/yara-hooks';
 import { detectNodePackageManagers } from '@lib/detection/package-manager';
 import type { PackageManagerDetector } from '@lib/detection/package-manager';
@@ -279,12 +280,17 @@ async function bootstrapProgram(
 
       await getUI().showBlockingOutage(readiness);
 
-      await wizardAbort({
-        message:
-          'Cannot start — external services are down:\n' +
-          blockingLabels.map((l) => `  - ${l}`).join('\n') +
-          '\n\nPlease try again later.',
-      });
+      // The TUI lets the user continue past an outage; non-interactive runs
+      // (CI) do the same automatically — the degraded services are reported
+      // above, but we proceed rather than aborting on a transient upstream blip.
+      if (!isNonInteractiveEnvironment()) {
+        await wizardAbort({
+          message:
+            'Cannot start — external services are down:\n' +
+            blockingLabels.map((l) => `  - ${l}`).join('\n') +
+            '\n\nPlease try again later.',
+        });
+      }
     } else if (readiness.decision === WizardReadiness.YesWithWarnings) {
       getUI().setReadinessWarnings(readiness);
     }

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -114,7 +114,7 @@ export class LoggingUI implements WizardUI {
   }
 
   showBlockingOutage(result: WizardReadinessResult): Promise<void> {
-    console.log(`▲  Service health issues detected — blocking outage.`);
+    console.log(`▲  Service health issues detected.`);
     const blockingKeys = getBlockingServiceKeys(result.health);
     if (blockingKeys.length > 0) {
       console.log(`│`);
@@ -131,7 +131,9 @@ export class LoggingUI implements WizardUI {
     for (const reason of result.reasons) {
       console.log(`│  ${reason}`);
     }
-    console.log(`│  The wizard cannot start while these services are down.`);
+    console.log(
+      `│  Continuing anyway — health checks are advisory in non-interactive runs.`,
+    );
     return Promise.resolve();
   }
 


### PR DESCRIPTION
## Problem

CI refuses to run when there are minor service disruptions

<!-- Who is affected and why does this matter? -->

<!-- Closes #ISSUE_ID -->

## Changes

CI should still run anyway.

<!-- What changed and why this approach. -->

## Test plan

ran CI during minor Anthropic disruption

<!-- How was this tested? Steps to verify, commands run, or "covered by CI". -->

<!-- ## LLM context -->

<!-- If an LLM agent co-authored this PR, uncomment and leave relevant context about the session or tools used. -->