### PR TITLE
chore: make wizard run variant runner-derived

### DIFF
--- a/src/lib/agent/__tests__/variant-gating.test.ts
+++ b/src/lib/agent/__tests__/variant-gating.test.ts
@@ -1,7 +1,4 @@
-import {
-  buildWizardMetadata,
-  isOrchestratorEnabled,
-} from '@lib/agent/agent-interface';
+import { isOrchestratorEnabled } from '@lib/agent/agent-interface';
 
 describe('isOrchestratorEnabled', () => {
   it('is true only when the wizard-orchestrator flag is true', () => {
@@ -17,20 +14,5 @@ describe('isOrchestratorEnabled', () => {
     );
     expect(isOrchestratorEnabled({})).toBe(false);
     expect(isOrchestratorEnabled()).toBe(false);
-  });
-});
-
-describe('buildWizardMetadata', () => {
-  it('selects a known variant header from the flag', () => {
-    expect(buildWizardMetadata({ 'wizard-variant': 'subagents' })).toEqual({
-      VARIANT: 'subagents',
-    });
-  });
-
-  it('falls back to the base variant for unknown or missing flags', () => {
-    expect(buildWizardMetadata({ 'wizard-variant': 'nope' })).toEqual({
-      VARIANT: 'base',
-    });
-    expect(buildWizardMetadata({})).toEqual({ VARIANT: 'base' });
   });
 });

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -13,8 +13,6 @@ import { analytics } from '@utils/analytics';
 import {
   WIZARD_REMARK_EVENT_NAME,
   POSTHOG_PROPERTY_HEADER_PREFIX,
-  WIZARD_VARIANT_FLAG_KEY,
-  WIZARD_VARIANTS,
   WIZARD_ORCHESTRATOR_FLAG_KEY,
   WIZARD_USER_AGENT,
   DEFAULT_AGENT_MODEL,
@@ -247,19 +245,6 @@ type AgentRunConfig = {
     | import('@lib/wizard-session').PendingQuestion
     | null;
 };
-
-/**
- * Select wizard metadata from WIZARD_VARIANTS using the variant feature flag.
- * If the flag is missing or the value is not in config, returns the "base" variant (VARIANT: "base").
- */
-export function buildWizardMetadata(
-  flags: Record<string, string> = {},
-): Record<string, string> {
-  const variantKey = flags[WIZARD_VARIANT_FLAG_KEY];
-  const variant =
-    (variantKey && WIZARD_VARIANTS[variantKey]) ?? WIZARD_VARIANTS['base'];
-  return { ...variant };
-}
 
 /**
  * Whether this run uses the experimental task-queue orchestrator. Gated by the

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -17,11 +17,13 @@
  */
 
 import type { WizardSession } from '../../wizard-session';
+import { analytics } from '@utils/analytics';
 import { isOrchestratorEnabled } from '../agent-interface';
 import { getUI } from '../../../ui';
 import { runOrchestrator } from './orchestrator/orchestrator-runner';
 import type { ProgramConfig } from '../../programs/program-step';
-import type { ProgramRun } from './shared/types';
+import { WizardVariant } from './shared/types';
+import type { ProgramRun, BootstrapResult } from './shared/types';
 import { bootstrapProgram } from './shared/bootstrap';
 import { runLinearProgram } from './linear';
 
@@ -57,9 +59,9 @@ export async function runAgent(
 /**
  * Run a program's agent pipeline.
  *
- * Runs the shared bootstrap, then forks on the `wizard-variant` flag. The
- * `orchestrator` variant routes to the experimental task-queue runner; every
- * other variant runs the linear pipeline.
+ * Runs the shared bootstrap, then forks on the `wizard-orchestrator` flag.
+ * When enabled the run routes to the experimental task-queue runner; otherwise
+ * it runs the linear pipeline.
  */
 export async function runProgram(
   session: WizardSession,
@@ -70,8 +72,19 @@ export async function runProgram(
 
   if (isOrchestratorEnabled(boot.wizardFlags)) {
     getUI().log.info('Task-queue orchestrator enabled.');
+    stampVariant(boot, WizardVariant.ORCHESTRATOR);
     return runOrchestrator(session, programConfig, boot);
   }
 
+  stampVariant(boot, WizardVariant.BASE);
   return runLinearProgram(session, config, programConfig, boot);
+}
+
+/**
+ * Record which runner arm ran. Tags every wizard event and every gateway trace
+ * with the variant, so runs segment by arm (base vs orchestrator, later pi).
+ */
+function stampVariant(boot: BootstrapResult, variant: WizardVariant): void {
+  analytics.setTag('variant', variant);
+  boot.wizardMetadata.VARIANT = variant;
 }

--- a/src/lib/agent/runner/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/orchestrator/orchestrator-runner.ts
@@ -120,10 +120,6 @@ export async function runOrchestrator(
     );
   }
 
-  // Every wizard event from here on carries the variant, so orchestrator runs
-  // segment cleanly from the linear baseline.
-  analytics.setTag('variant', 'orchestrator');
-
   // Responsiveness is the headline metric of the dark launch: time to first
   // visible progress, and no single step dominating wall-clock. Track it from
   // queue transitions, with the resolved model so cheap work is attributable
@@ -263,8 +259,7 @@ export async function runOrchestrator(
     detectPackageManager: detectNodePackageManagers,
     skillsBaseUrl: boot.skillsBaseUrl,
     wizardFlags: boot.wizardFlags,
-    // Tag agent events as orchestrator so telemetry segments from the baseline.
-    wizardMetadata: { ...boot.wizardMetadata, VARIANT: 'orchestrator' },
+    wizardMetadata: boot.wizardMetadata,
     integrationLabel: programConfig.id,
     orchestrator: {
       store,

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -11,7 +11,6 @@ import type { WizardSession } from '@lib/wizard-session';
 import { getOrAskForProjectData } from '@utils/setup-utils';
 import { analytics, groupsFromUser } from '@utils/analytics';
 import { getUI } from '@ui';
-import { buildWizardMetadata } from '@lib/agent/agent-interface';
 import {
   checkAllSettingsConflicts,
   backupAndFixClaudeSettings,
@@ -226,13 +225,12 @@ export async function bootstrapProgram(
     }
   }
 
-  // Feature flags, variant metadata, and MCP url. Both arms need these, and the
-  // fork decision reads the flags.
+  // Feature flags and MCP url. Both arms need these, and the fork decision reads
+  // the flags.
   const wizardFlags = await analytics.getAllFlagsForWizard();
-  const wizardMetadata = buildWizardMetadata(wizardFlags);
-  // Tag every wizard event with the variant so runs segment in PostHog; the
-  // orchestrator arm overwrites this with its own variant when it forks.
-  analytics.setTag('variant', wizardMetadata.VARIANT);
+  // Gateway trace tags for this run. The runner stamps its variant onto this
+  // after the fork (see runProgram), so the value reflects which arm ran.
+  const wizardMetadata: Record<string, string> = {};
 
   // One MCP url for every region: the server resolves the user's region from
   // the bearer token, so the EU subdomain (a Claude Code OAuth workaround) is

--- a/src/lib/agent/runner/shared/types.ts
+++ b/src/lib/agent/runner/shared/types.ts
@@ -15,6 +15,17 @@ import type { ApiProject } from '@lib/api';
 export type { PromptContext, Credentials };
 
 /**
+ * Which runner arm executed a run. Stamped onto wizard analytics and the gateway
+ * trace tags after the fork (see `runProgram`), so runs segment by arm. `PI` is
+ * planned — the pi-coding-agent runner is not wired yet.
+ */
+export enum WizardVariant {
+  BASE = 'base',
+  ORCHESTRATOR = 'orchestrator',
+  PI = 'pi',
+}
+
+/**
  * A known `[ABORT] <reason>` case. First matching entry is rendered on
  * the error outro; unmatched aborts use a generic fallback.
  */

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -188,17 +188,10 @@ export const WIZARD_OAUTH_SCOPES = [
 
 export const WIZARD_INTERACTION_EVENT_NAME = 'wizard interaction';
 export const WIZARD_REMARK_EVENT_NAME = 'wizard remark';
-/** Feature flag key whose value selects a variant from WIZARD_VARIANTS. */
-export const WIZARD_VARIANT_FLAG_KEY = 'wizard-variant';
 /** Boolean feature flag that routes a run to the experimental orchestrator runner. */
 export const WIZARD_ORCHESTRATOR_FLAG_KEY = 'wizard-orchestrator';
 /** Feature flag key that gates the intro-screen "Tools" menu. */
 export const WIZARD_TOOLS_MENU_FLAG_KEY = 'wizard-tools-menu';
-/** Variant key -> metadata for wizard run (VARIANT flag selects which entry to use). */
-export const WIZARD_VARIANTS: Record<string, Record<string, string>> = {
-  base: { VARIANT: 'base' },
-  subagents: { VARIANT: 'subagents' },
-};
 /** User-Agent for wizard HTTP requests and MCP server identification. */
 export const WIZARD_USER_AGENT = `posthog/wizard; version: ${VERSION}`;
 


### PR DESCRIPTION
Removes the dead wizard-variant flag plumbing. The flag drove a base/subagents selection that nothing branched on, and the subagents arm was never used.

Replaces it with a WizardVariant enum (base, orchestrator, and a planned pi), stamped at the runner fork in runProgram based on which arm runs. Bootstrap no longer hardcodes a variant and the orchestrator no longer sets its own literal, so the variant always reflects the runner that ran. Behavior is unchanged.

Prep for #723. PR #726 builds on this to attach the trace tags.

## Test plan

Covered by the full snapshot run in #726. The gateway headers from that run show VARIANT=base stamped by the runner (not a flag), confirming the runner-derived variant:

![gateway trace tags](https://raw.githubusercontent.com/PostHog/wizard/assets/snapshot-proof/proof/gateway-tags.png)