### PR TITLE
feat: tag LLM gateway traces with program_id and run identifiers

### DIFF
--- a/src/lib/agent/__tests__/run-tags.test.ts
+++ b/src/lib/agent/__tests__/run-tags.test.ts
@@ -1,0 +1,33 @@
+import { buildRunTags } from '@lib/agent/agent-interface';
+
+describe('buildRunTags', () => {
+  it('carries the run identifiers as gateway trace tags', () => {
+    expect(
+      buildRunTags({
+        programId: 'audit',
+        integration: 'nextjs',
+        runId: 'run-123',
+        skillId: 'audit-events',
+      }),
+    ).toEqual({
+      program_id: 'audit',
+      integration: 'nextjs',
+      run_id: 'run-123',
+      skill_id: 'audit-events',
+    });
+  });
+
+  it('omits skill_id when the run has none', () => {
+    const tags = buildRunTags({
+      programId: 'posthog-integration',
+      integration: 'nextjs',
+      runId: 'run-123',
+    });
+    expect(tags).not.toHaveProperty('skill_id');
+    expect(tags).toEqual({
+      program_id: 'posthog-integration',
+      integration: 'nextjs',
+      run_id: 'run-123',
+    });
+  });
+});

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -247,6 +247,26 @@ type AgentRunConfig = {
 };
 
 /**
+ * Global identifiers attached to every LLM gateway trace for a run. They ride on
+ * each `$ai_generation` the gateway emits (as `X-POSTHOG-PROPERTY-*` headers via
+ * `buildAgentEnv`), so traces are filterable by program, framework, and run for
+ * cost attribution and dashboards. `skill_id` is omitted when the run has none.
+ */
+export function buildRunTags(args: {
+  programId: string;
+  integration: string;
+  runId: string;
+  skillId?: string;
+}): Record<string, string> {
+  return {
+    program_id: args.programId,
+    integration: args.integration,
+    run_id: args.runId,
+    ...(args.skillId ? { skill_id: args.skillId } : {}),
+  };
+}
+
+/**
  * Whether this run uses the experimental task-queue orchestrator. Gated by the
  * boolean `wizard-orchestrator` feature flag, targeted to the user in the wizard's
  * analytics project.

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -11,6 +11,7 @@ import type { WizardSession } from '@lib/wizard-session';
 import { getOrAskForProjectData } from '@utils/setup-utils';
 import { analytics, groupsFromUser } from '@utils/analytics';
 import { getUI } from '@ui';
+import { buildRunTags } from '@lib/agent/agent-interface';
 import {
   checkAllSettingsConflicts,
   backupAndFixClaudeSettings,
@@ -230,7 +231,12 @@ export async function bootstrapProgram(
   const wizardFlags = await analytics.getAllFlagsForWizard();
   // Gateway trace tags for this run. The runner stamps its variant onto this
   // after the fork (see runProgram), so the value reflects which arm ran.
-  const wizardMetadata: Record<string, string> = {};
+  const wizardMetadata = buildRunTags({
+    programId: programConfig.id,
+    integration: config.integrationLabel,
+    runId: analytics.runId,
+    skillId: config.skillId,
+  });
 
   // One MCP url for every region: the server resolves the user's region from
   // the bearer token, so the EU subdomain (a Claude Code OAuth workaround) is

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -54,7 +54,7 @@ export class Analytics {
     {};
   private distinctId?: string;
   private anonymousId: string;
-  private runId: string;
+  private _runId: string;
   private sessionId: string | null = null;
   private appName = 'wizard';
   private activeFlags: Record<string, string> | null = null;
@@ -102,10 +102,15 @@ export class Analytics {
     // from `anonymousId`, the pre-login *person* id that gets aliased onto
     // the real user at login. `$session_id` is intentionally not set here —
     // it stays null until OAuth completes (see identifyUser).
-    this.runId = uuidv4();
-    this.tags.run_id = this.runId;
+    this._runId = uuidv4();
+    this.tags.run_id = this._runId;
 
     this.distinctId = undefined;
+  }
+
+  /** Per-process run id, tagged on every event and gateway trace. */
+  get runId(): string {
+    return this._runId;
   }
 
   /**
@@ -264,7 +269,7 @@ export class Analytics {
       properties: {
         // Hoisted out of `tags` so the run's terminal event is filterable by
         // run, and joins the session when one was opened (post-OAuth runs).
-        run_id: this.runId,
+        run_id: this._runId,
         ...(this.sessionId ? { $session_id: this.sessionId } : {}),
         status,
         tags: this.tags,


### PR DESCRIPTION
Attaches the wizard's identifiers to every LLM gateway trace so wizard traces can be filtered for cost attribution and dashboards. program_id, integration, run_id, and skill_id are added to wizardMetadata, which becomes X-POSTHOG-PROPERTY-* headers on each call. The gateway forwards them onto every $ai_generation event, so no gateway change is needed.

Also exposes Analytics.runId via a getter and adds buildRunTags as the tested assembly point.

Closes #723. Stacked on #725.

## Test plan

Unit tests for buildRunTags (full tag set, and skill_id omitted when null). Then drove a full real run with the e2e-harness snapshot route against a fresh clone of vercel/next-app-router-playground, authed with a test key on project 228144. The run went green end to end (intro to auth to run to outro), and the gateway received the new tags on every LLM call:

![gateway trace tags](https://raw.githubusercontent.com/PostHog/wizard/assets/snapshot-proof/proof/gateway-tags.png)

Rendered run screens (framework detected as nextjs; outro confirms the integration completed):

![wizard run](https://raw.githubusercontent.com/PostHog/wizard/assets/snapshot-proof/proof/wizard-run.png)