### PR TITLE
feat(commands): add flat `mcp-analytics` command

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -32,6 +32,7 @@ if (process.env.NODE_ENV === 'test') {
 import { Wizard } from './src/wizard';
 import { basicIntegrationCommand } from './src/commands/basic-integration';
 import { mcpCommand } from './src/commands/mcp';
+import { mcpAnalyticsCommand } from './src/commands/mcp-analytics';
 import { auditCommand } from './src/commands/audit';
 import { doctorCommand } from './src/commands/doctor';
 import { migrateCommand } from './src/commands/migrate';
@@ -61,6 +62,7 @@ function resolveInstallDir(): string {
 
 Wizard.use(basicIntegrationCommand)
   .use(mcpCommand)
+  .use(mcpAnalyticsCommand)
   .use(cliCommand)
   .use(auditCommand)
   .use(doctorCommand)

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -20,6 +20,7 @@ import type { Arguments } from 'yargs';
 import type { MockedFunction } from 'vitest';
 import { auditCommand } from '../commands/audit';
 import { migrateCommand } from '../commands/migrate';
+import { mcpAnalyticsCommand } from '../commands/mcp-analytics';
 import { revenueCommand } from '../commands/revenue';
 import { warehouseCommand } from '../commands/warehouse';
 import { uploadSourcemapsCommand } from '../commands/upload-sourcemaps';
@@ -77,6 +78,11 @@ describe('top-level command shapes', () => {
   test('revenue-analytics is a flat skill command', () => {
     expect(revenueCommand.name).toBe('revenue-analytics');
     expect(revenueCommand.children).toBeUndefined();
+  });
+
+  test('mcp-analytics is a flat skill command', () => {
+    expect(mcpAnalyticsCommand.name).toBe('mcp-analytics');
+    expect(mcpAnalyticsCommand.children).toBeUndefined();
   });
 
   test('warehouse is a flat skill command', () => {
@@ -170,6 +176,12 @@ describe('flat skill commands', () => {
     revenueCommand.handler!(makeArgv({ debug: true }));
     const [config] = mockRunWizard.mock.calls[0] as [{ skillId?: string }];
     expect(config.skillId).toBe('revenue-analytics-setup');
+  });
+
+  test('mcp-analytics dispatches with mcp-analytics skillId', () => {
+    mcpAnalyticsCommand.handler!(makeArgv({ debug: true }));
+    const [config] = mockRunWizard.mock.calls[0] as [{ skillId?: string }];
+    expect(config.skillId).toBe('mcp-analytics');
   });
 
   test('warehouse dispatches with data-warehouse-source-setup skillId', () => {

--- a/src/commands/mcp-analytics.ts
+++ b/src/commands/mcp-analytics.ts
@@ -1,0 +1,14 @@
+import { mcpAnalyticsConfig } from '@lib/programs/mcp-analytics/index';
+
+import type { Command } from './command';
+import { nativeCommandFactory } from './factories/native-command-factory';
+
+/**
+ * `wizard mcp-analytics` — flat skill command, instrument-an-MCP-server today.
+ *
+ * Distinct from `wizard mcp add`: this instruments the user's own MCP server
+ * with the `@posthog/mcp` SDK, rather than installing the PostHog MCP server
+ * into a coding agent. Stays flat while instrumenting is the only action.
+ */
+export const mcpAnalyticsCommand: Command =
+  nativeCommandFactory(mcpAnalyticsConfig);

--- a/src/lib/programs/mcp-analytics/index.ts
+++ b/src/lib/programs/mcp-analytics/index.ts
@@ -1,0 +1,64 @@
+import type { AbortCase } from '@lib/agent/agent-runner';
+import { createSkillProgram } from '@lib/programs/agent-skill/index';
+
+const MCP_ANALYTICS_REPORT_FILE = 'posthog-mcp-analytics-report.md';
+
+/**
+ * `[ABORT]` reasons the mcp-analytics skill emits when the project can't be
+ * instrumented. Kept in sync with the stop conditions in the skill's
+ * `description.md` (context-mill `context/skills/mcp-analytics`).
+ */
+const MCP_ANALYTICS_ABORT_CASES: AbortCase[] = [
+  {
+    match: /^not a javascript mcp server$/i,
+    message: 'Not a JavaScript/TypeScript MCP server',
+    body:
+      'MCP analytics is currently TypeScript/JavaScript-only — the `@posthog/mcp` ' +
+      'SDK is a Node package (a Python SDK is on the roadmap). This project ' +
+      "doesn't look like a JS/TS MCP server, so there's nothing to instrument. " +
+      'See https://posthog.com/docs/mcp-analytics for the supported setups.',
+  },
+  {
+    match: /^no mcp server found$/i,
+    message: 'No MCP server found',
+    body:
+      'This command instruments an existing MCP server with PostHog analytics, ' +
+      'but no MCP server was found in this project. If you just want PostHog ' +
+      'product analytics, run `npx @posthog/wizard` instead.',
+  },
+];
+
+/**
+ * `wizard mcp-analytics` — flat skill command.
+ *
+ * Instruments the user's own MCP server with the `@posthog/mcp` SDK so it
+ * reports `$mcp_*` analytics about itself. This is the opposite of
+ * `wizard mcp add` (which installs the PostHog MCP *server* into a coding
+ * agent) — keep the two distinct.
+ *
+ * Flat while instrumenting is the only action. If an uninstrument / `remove`
+ * leaf ever lands, restructure into a family with `familyCommandFactory` and
+ * publish each leaf as a `cliEntries` entry with `parentCommand:
+ * 'mcp-analytics'` from context-mill — a deliberate breaking change, done then,
+ * not pre-emptively.
+ */
+export const mcpAnalyticsConfig = createSkillProgram({
+  skillId: 'mcp-analytics',
+  command: 'mcp-analytics',
+  id: 'mcp-analytics',
+  description: 'Add PostHog MCP analytics to your MCP server',
+  integrationLabel: 'mcp-analytics',
+  customPrompt:
+    "Instrument this project's MCP server with PostHog MCP analytics. Run the " +
+    '`mcp-analytics` skill end-to-end: detect the server style, install ' +
+    '`@posthog/mcp` and `posthog-node`, wrap the server (or use `PostHogMCP` ' +
+    'for a custom dispatcher), wire the project API key and host, and verify. ' +
+    'Make only additive changes — do not alter tool behavior. The final report ' +
+    `is written to ./${MCP_ANALYTICS_REPORT_FILE}.`,
+  successMessage: `MCP analytics configured! View the report at ./${MCP_ANALYTICS_REPORT_FILE}`,
+  reportFile: MCP_ANALYTICS_REPORT_FILE,
+  docsUrl: 'https://posthog.com/docs/mcp-analytics',
+  spinnerMessage: 'Setting up MCP analytics...',
+  estimatedDurationMinutes: 5,
+  abortCases: MCP_ANALYTICS_ABORT_CASES,
+});

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -29,6 +29,7 @@ import {
   mcpRemoveConfig,
   mcpTutorialConfig,
 } from './mcp/index.js';
+import { mcpAnalyticsConfig } from './mcp-analytics/index.js';
 import { slackConnectConfig } from './slack/index.js';
 
 // Generic skill program — runs an arbitrary context-mill skill chosen at
@@ -76,6 +77,7 @@ export const PROGRAM_REGISTRY = [
   mcpAddConfig,
   mcpRemoveConfig,
   mcpTutorialConfig,
+  mcpAnalyticsConfig,
   slackConnectConfig,
 ] as const satisfies readonly ProgramConfig[];
 
@@ -99,6 +101,7 @@ export const Program = {
   McpAdd: mcpAddConfig.id,
   McpRemove: mcpRemoveConfig.id,
   McpTutorial: mcpTutorialConfig.id,
+  McpAnalytics: mcpAnalyticsConfig.id,
   SlackConnect: slackConnectConfig.id,
 } as const;
 


### PR DESCRIPTION
## What

Registers `wizard mcp-analytics` — a flat, skill-backed command that instruments a user's **own** MCP server with the [`@posthog/mcp`](https://posthog.com/docs/mcp-analytics) SDK (it runs the context-mill `mcp-analytics` skill).

Not to be confused with `wizard mcp add`, which installs the PostHog MCP *server* into a coding agent. This is the opposite direction — instrumenting the user's server so it reports `$mcp_*` analytics about itself.

## How

- `src/lib/programs/mcp-analytics/index.ts` — `ProgramConfig` via `createSkillProgram`, with `[ABORT]` cases for non-JS / non-MCP projects
- `src/commands/mcp-analytics.ts` — `nativeCommandFactory(mcpAnalyticsConfig)`
- wired into `program-registry.ts` (`PROGRAM_REGISTRY` + `Program`) and `bin.ts`
- two `programs-cli` tests (flat shape + dispatches with the `mcp-analytics` skillId)

Flat command, following the `migrate` / `revenue-analytics` precedent — one action today, so no pre-emptive family.

## Validation

- `pnpm typecheck` — clean for the new files (one pre-existing unrelated `CrateStack.tsx` error remains)
- `programs-cli.test.ts` — 22/22 pass
- prettier/eslint clean

## Dependency

Needs the companion **context-mill** PR (PostHog/context-mill#202) released first, so the `mcp-analytics` skill resolves from the published manifest.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
