### PR TITLE
feat: stream wizard run state to PostHog in headless mode

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -7,6 +7,38 @@ const { mockBuildSessionCli, mockProvisionNewAccountCli } = vi.hoisted(() => ({
   mockProvisionNewAccountCli: vi.fn(),
 }));
 
+// Headless-only machinery, stubbed so the headless path doesn't construct a
+// real WizardStore (which would re-call the mocked buildSession) or open a real
+// network stream. The spies assert the stream is wired in headless and not CI.
+const { mockStreamAttach, mockStreamShutdown } = vi.hoisted(() => ({
+  mockStreamAttach: vi.fn(),
+  mockStreamShutdown: vi.fn(),
+}));
+vi.mock('../lib/task-stream/index', () => ({
+  // shutdown() hardcodes a resolved Promise (not a bare vi.fn) so the
+  // interactive runWizard's dangling SIGTERM handler — which calls
+  // shutdown().catch() and outlives these tests — never hits undefined.catch.
+  TaskStreamPush: class {
+    attach() {
+      mockStreamAttach();
+    }
+    shutdown() {
+      mockStreamShutdown();
+      return Promise.resolve();
+    }
+  },
+  PostHogDestination: class {},
+}));
+vi.mock('../ui/tui/store', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../ui/tui/store')>()),
+  WizardStore: class {
+    session: unknown;
+    setRunPhase = vi.fn();
+    setOutroData = vi.fn();
+    syncTodos = vi.fn();
+  },
+}));
+
 vi.mock('semver', () => ({ satisfies: () => true }));
 // importOriginal keeps real exports (e.g. RunPhase) while overriding
 // buildSession — vitest throws on access to exports a partial mock omits.
@@ -285,6 +317,18 @@ describe('CLI argument parsing', () => {
       const { analytics } = await import('../utils/analytics');
       expect(analytics.setTag).toHaveBeenCalledWith('build', 'ci');
     });
+
+    test('does not stream wizard-session state in CI', async () => {
+      await runCLI([
+        '--ci',
+        '--api-key',
+        'phx_test',
+        '--install-dir',
+        '/tmp/test',
+      ]);
+
+      expect(mockStreamAttach).not.toHaveBeenCalled();
+    });
   });
 
   // The experimental headless flag is the published-build sibling of --ci: it
@@ -340,6 +384,19 @@ describe('CLI argument parsing', () => {
       const { analytics } = await import('../utils/analytics');
       expect(analytics.setTag).toHaveBeenCalledWith('build', 'headless');
       expect(analytics.setTag).not.toHaveBeenCalledWith('build', 'ci');
+    });
+
+    test('attaches and flushes the wizard-session stream', async () => {
+      await runCLI([
+        headlessFlag,
+        '--api-key',
+        'pha_test',
+        '--install-dir',
+        '/tmp/test',
+      ]);
+
+      expect(mockStreamAttach).toHaveBeenCalled();
+      expect(mockStreamShutdown).toHaveBeenCalled();
     });
 
     test('does not require --region when headless is set', async () => {

--- a/src/lib/runners/run-non-interactive.ts
+++ b/src/lib/runners/run-non-interactive.ts
@@ -4,6 +4,9 @@ import { LoggingUI } from '@ui/logging-ui';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import { analytics } from '@utils/analytics';
 import { resolveNoTelemetry } from './resolve-no-telemetry';
+import type { WizardStore } from '@ui/tui/store';
+import type { TaskStreamPush } from '@lib/task-stream/task-stream-push';
+import type { OutroData, RunPhase as RunPhaseT } from '@lib/wizard-session';
 
 /**
  * The two non-interactive run modes. Both drive the same pipeline today; the
@@ -79,7 +82,9 @@ export function runNonInteractive(
 
   void (async () => {
     const path = await import('path');
-    const { buildSession } = await import('@lib/wizard-session');
+    const { buildSession, RunPhase, OutroKind } = await import(
+      '@lib/wizard-session'
+    );
     const { readEnvironment } = await import('@utils/environment');
     const { readApiKeyFromEnv } = await import('@utils/env-api-key');
     const { configureLogFileFromEnvironment, logToFile } = await import(
@@ -119,6 +124,49 @@ export function runNonInteractive(
     getUI().intro('Welcome to the PostHog setup wizard');
     getUI().log.info(`Running ${config.id} in ${modeLabel(mode)} mode`);
 
+    // Headless streams run state to the PostHog backend so the web app can show
+    // live progress. Reuses the interactive TaskStreamPush + WizardStore (no Ink
+    // render): HeadlessUI keeps LoggingUI's output and feeds task updates into
+    // the store; this runner drives the phase transitions. CI does not stream.
+    let store: WizardStore | null = null;
+    let taskStream: TaskStreamPush | null = null;
+    if (mode === 'headless') {
+      const { WizardStore } = await import('@ui/tui/store');
+      const { HeadlessUI } = await import('@ui/headless-ui');
+      const { TaskStreamPush, PostHogDestination } = await import(
+        '@lib/task-stream/index'
+      );
+
+      store = new WizardStore(config.id);
+      store.session = session;
+      setUI(new HeadlessUI(store));
+      taskStream = new TaskStreamPush({
+        store,
+        programId: config.id,
+        destinations: [
+          new PostHogDestination({
+            getCredentials: () => session.credentials,
+            onError: (e) => logToFile('[headless task-stream]', e.message),
+          }),
+        ],
+        enabled: !session.noTelemetry,
+      });
+      taskStream.attach();
+      store.setRunPhase(RunPhase.Running);
+    }
+
+    // wizardAbort exits via process.exit, so flush the terminal phase before any
+    // exit. No-op for CI.
+    const settleStream = async (
+      phase: RunPhaseT,
+      outroData?: OutroData,
+    ): Promise<void> => {
+      if (!store || !taskStream) return;
+      if (outroData) store.setOutroData(outroData);
+      store.setRunPhase(phase);
+      await taskStream.shutdown(2000);
+    };
+
     try {
       if (config.ciPreRun) {
         await config.ciPreRun(session);
@@ -149,6 +197,10 @@ export function runNonInteractive(
           | { kind: string; [k: string]: unknown }
           | undefined;
         if (detectError) {
+          await settleStream(RunPhase.Error, {
+            kind: OutroKind.Error,
+            message: `Prerequisites not met: ${detectError.kind}`,
+          });
           await wizardAbort({
             message: `Prerequisites not met: ${detectError.kind}\n\nSee ${
               runDef?.docsUrl ?? POSTHOG_DOCS_URL
@@ -163,6 +215,7 @@ export function runNonInteractive(
 
       const { runAgent } = await import('@lib/agent/agent-runner');
       await runAgent(config, session);
+      await settleStream(RunPhase.Completed);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -177,6 +230,10 @@ export function runNonInteractive(
         session.frameworkConfig?.metadata.docsUrl ??
         runDef?.docsUrl ??
         POSTHOG_DOCS_URL;
+      await settleStream(RunPhase.Error, {
+        kind: OutroKind.Error,
+        message: errorMessage,
+      });
       await wizardAbort({
         message: `Something went wrong: ${errorMessage}\n\nYou can read the documentation at ${docsUrl} to set up manually.${debugInfo}`,
         error: error as Error,

--- a/src/ui/__tests__/headless-ui.test.ts
+++ b/src/ui/__tests__/headless-ui.test.ts
@@ -1,0 +1,33 @@
+// Load @ui first so the logging-ui → readiness → debug → @ui import cycle
+// resolves in the order the app uses (@ui before logging-ui). Importing
+// HeadlessUI as the entry otherwise hits `new LoggingUI()` in @ui before
+// logging-ui has finished initializing.
+import '@ui';
+import { HeadlessUI } from '../headless-ui';
+import { TaskStatus } from '../wizard-ui';
+import type { WizardStore } from '../tui/store';
+
+describe('HeadlessUI', () => {
+  it('forwards task updates to the store and still logs to the console', () => {
+    const syncTodos = vi.fn();
+    const store = { syncTodos } as unknown as WizardStore;
+    const ui = new HeadlessUI(store);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const todos = [
+      {
+        content: 'Install SDK',
+        status: TaskStatus.InProgress,
+        activeForm: 'Installing SDK',
+      },
+      { content: 'Done', status: TaskStatus.Completed },
+    ];
+    ui.syncTodos(todos);
+
+    expect(syncTodos).toHaveBeenCalledWith(todos);
+    // LoggingUI.syncTodos logs the active task line, so console output is kept.
+    expect(logSpy).toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+});

--- a/src/ui/headless-ui.ts
+++ b/src/ui/headless-ui.ts
@@ -1,0 +1,23 @@
+import { LoggingUI } from './logging-ui';
+import type { WizardStore } from './tui/store';
+
+/**
+ * `LoggingUI` plus it feeds run state into a `WizardStore` so the background
+ * wizard-session sync (`TaskStreamPush`) can observe a headless run. We extend
+ * `LoggingUI` (not `InkUI`) because its blocking/gate methods would wait on a
+ * TUI that never renders; the runner drives phase transitions on the store
+ * directly, so only the per-run updates (today: the task list) tee through here.
+ * To stream more later, override `setEventPlan` / `setStage` the same way.
+ */
+export class HeadlessUI extends LoggingUI {
+  constructor(private readonly store: WizardStore) {
+    super();
+  }
+
+  syncTodos(
+    todos: Array<{ content: string; status: string; activeForm?: string }>,
+  ): void {
+    super.syncTodos(todos);
+    this.store.syncTodos(todos);
+  }
+}


### PR DESCRIPTION
Headless runs now stream run phase + task list to the PostHog backend
(POST /api/projects/{id}/wizard/sessions/) so the web app can show live
progress — the same wizard-session stream the interactive TUI already drives.
Previously the stream was wired only into the interactive runner and bound to
the TUI store, so headless/cloud runs reported nothing.

- New HeadlessUI (src/ui/headless-ui.ts): extends LoggingUI (keeps console
  output + correct non-interactive auth/gate behavior) and tees task updates
  into a WizardStore so TaskStreamPush can observe them. InkUI can't be reused —
  its gate/blocking methods wait on a TUI that never renders.
- runNonInteractive: headless-gated wiring that reuses the existing
  WizardStore + TaskStreamPush + PostHogDestination with no Ink render. The
  runner drives phase transitions (Running at start; Completed/Error flushed
  before every exit, since wizardAbort exits via process.exit). Gated on the
  existing telemetry flag; CI does not stream.
- Credentials come from session.credentials (set in shared bootstrap).

Scope: phase + task list. Event plan, a SIGTERM flush for cancelled runs, and
dashboard/notebook URLs are deferred (noted as extension points).

Backend: cloud runs must omit --no-telemetry for the stream to fire.

Tests: HeadlessUI unit test; cli.test asserts headless attaches + flushes the
stream while CI does not.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>