### PR TITLE
feat: add Poke, Grok, and LibreChat as supported MCP clients

### DIFF
--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/grok.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/grok.test.ts
@@ -1,0 +1,54 @@
+import { GrokMCPClient } from '@steps/add-mcp-server-to-clients/clients/grok';
+import { isBrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+import { openTrackedLink } from '@utils/links';
+
+vi.mock('@utils/links', () => ({
+  openTrackedLink: vi.fn(),
+}));
+
+const openTrackedLinkMock = openTrackedLink as Mock;
+
+const CONNECTOR_URL = 'https://grok.com/connectors';
+
+describe('GrokMCPClient', () => {
+  let client: GrokMCPClient;
+
+  beforeEach(() => {
+    client = new GrokMCPClient();
+    vi.clearAllMocks();
+  });
+
+  it('has the expected name and connector metadata', () => {
+    expect(client.name).toBe('Grok');
+    expect(client.connectorUrl).toBe(CONNECTOR_URL);
+    expect(client.finishInstruction).toBe(
+      'Click "New Connector" → "Custom", paste https://mcp.posthog.com/mcp as the MCP server URL, and connect.',
+    );
+  });
+
+  it('is recognised as a browser-finishable client', () => {
+    expect(isBrowserFinishable(client)).toBe(true);
+  });
+
+  it('is supported on every platform', async () => {
+    await expect(client.isClientSupported()).resolves.toBe(true);
+  });
+
+  it('never reports the server as locally installed', async () => {
+    await expect(client.isServerInstalled()).resolves.toBe(false);
+  });
+
+  it('opens the connectors page as a tracked link on addServer', async () => {
+    await expect(client.addServer()).resolves.toEqual({ success: true });
+    expect(openTrackedLinkMock).toHaveBeenCalledWith(
+      CONNECTOR_URL,
+      'grok-connector',
+      { auto: true, skipUtm: true },
+    );
+  });
+
+  it('removeServer is a no-op that reports nothing removed', async () => {
+    await expect(client.removeServer()).resolves.toEqual({ success: false });
+    expect(openTrackedLinkMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/librechat.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/librechat.test.ts
@@ -1,0 +1,54 @@
+import { LibreChatMCPClient } from '@steps/add-mcp-server-to-clients/clients/librechat';
+import { isBrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+import { openTrackedLink } from '@utils/links';
+
+vi.mock('@utils/links', () => ({
+  openTrackedLink: vi.fn(),
+}));
+
+const openTrackedLinkMock = openTrackedLink as Mock;
+
+const CONNECTOR_URL = 'https://www.librechat.ai/docs/features/mcp';
+
+describe('LibreChatMCPClient', () => {
+  let client: LibreChatMCPClient;
+
+  beforeEach(() => {
+    client = new LibreChatMCPClient();
+    vi.clearAllMocks();
+  });
+
+  it('has the expected name and connector metadata', () => {
+    expect(client.name).toBe('LibreChat');
+    expect(client.connectorUrl).toBe(CONNECTOR_URL);
+    expect(client.finishInstruction).toBe(
+      'In LibreChat → MCP Settings, add a streamable-http server with URL https://mcp.posthog.com/mcp.',
+    );
+  });
+
+  it('is recognised as a browser-finishable client', () => {
+    expect(isBrowserFinishable(client)).toBe(true);
+  });
+
+  it('is supported on every platform', async () => {
+    await expect(client.isClientSupported()).resolves.toBe(true);
+  });
+
+  it('never reports the server as locally installed', async () => {
+    await expect(client.isServerInstalled()).resolves.toBe(false);
+  });
+
+  it('opens the MCP docs page as a tracked link on addServer', async () => {
+    await expect(client.addServer()).resolves.toEqual({ success: true });
+    expect(openTrackedLinkMock).toHaveBeenCalledWith(
+      CONNECTOR_URL,
+      'librechat-connector',
+      { auto: true, skipUtm: true },
+    );
+  });
+
+  it('removeServer is a no-op that reports nothing removed', async () => {
+    await expect(client.removeServer()).resolves.toEqual({ success: false });
+    expect(openTrackedLinkMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/poke.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/poke.test.ts
@@ -1,0 +1,54 @@
+import { PokeMCPClient } from '@steps/add-mcp-server-to-clients/clients/poke';
+import { isBrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+import { openTrackedLink } from '@utils/links';
+
+vi.mock('@utils/links', () => ({
+  openTrackedLink: vi.fn(),
+}));
+
+const openTrackedLinkMock = openTrackedLink as Mock;
+
+const CONNECTOR_URL = 'https://poke.com/settings/connections/integrations/new';
+
+describe('PokeMCPClient', () => {
+  let client: PokeMCPClient;
+
+  beforeEach(() => {
+    client = new PokeMCPClient();
+    vi.clearAllMocks();
+  });
+
+  it('has the expected name and connector metadata', () => {
+    expect(client.name).toBe('Poke');
+    expect(client.connectorUrl).toBe(CONNECTOR_URL);
+    expect(client.finishInstruction).toBe(
+      'Paste https://mcp.posthog.com/mcp as the MCP server URL and click "Create Integration".',
+    );
+  });
+
+  it('is recognised as a browser-finishable client', () => {
+    expect(isBrowserFinishable(client)).toBe(true);
+  });
+
+  it('is supported on every platform', async () => {
+    await expect(client.isClientSupported()).resolves.toBe(true);
+  });
+
+  it('never reports the server as locally installed', async () => {
+    await expect(client.isServerInstalled()).resolves.toBe(false);
+  });
+
+  it('opens the integration page as a tracked link on addServer', async () => {
+    await expect(client.addServer()).resolves.toEqual({ success: true });
+    expect(openTrackedLinkMock).toHaveBeenCalledWith(
+      CONNECTOR_URL,
+      'poke-connector',
+      { auto: true, skipUtm: true },
+    );
+  });
+
+  it('removeServer is a no-op that reports nothing removed', async () => {
+    await expect(client.removeServer()).resolves.toEqual({ success: false });
+    expect(openTrackedLinkMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/steps/add-mcp-server-to-clients/clients/grok.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/grok.ts
@@ -1,0 +1,50 @@
+import { MCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
+import { BrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+import { openTrackedLink } from '@utils/links';
+
+/**
+ * Grok (grok.com, by xAI). Grok connects custom MCP servers through its hosted
+ * Connectors page, not a local config or CLI. So instead of writing files we
+ * open the connectors page and let the user add a custom connector pointing at
+ * the PostHog MCP server URL.
+ */
+export class GrokMCPClient extends MCPClient implements BrowserFinishable {
+  name = 'Grok';
+  connectorUrl = 'https://grok.com/connectors';
+  finishInstruction =
+    'Click "New Connector" → "Custom", paste https://mcp.posthog.com/mcp as the MCP server URL, and connect.';
+
+  isClientSupported(): Promise<boolean> {
+    // Browser-based — available on every platform.
+    return Promise.resolve(true);
+  }
+
+  isServerInstalled(): Promise<boolean> {
+    // The connector lives in the user's Grok account; nothing local to
+    // inspect. Returning false also keeps it out of `mcp remove`.
+    return Promise.resolve(false);
+  }
+
+  addServer(): Promise<{ success: boolean }> {
+    // Not a PostHog property, so no UTMs — just the tracked open.
+    openTrackedLink(this.connectorUrl, 'grok-connector', {
+      auto: true,
+      skipUtm: true,
+    });
+    return Promise.resolve({ success: true });
+  }
+
+  removeServer(): Promise<{ success: boolean }> {
+    return Promise.resolve({ success: false });
+  }
+
+  getConfigPath(): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+  getServerPropertyName(): string {
+    throw new Error('Not implemented');
+  }
+}
+
+export default GrokMCPClient;

--- a/src/steps/add-mcp-server-to-clients/clients/librechat.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/librechat.ts
@@ -1,0 +1,53 @@
+import { MCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
+import { BrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+import { openTrackedLink } from '@utils/links';
+
+/**
+ * LibreChat (librechat.ai). LibreChat is self-hosted and configured via a YAML
+ * file (`librechat.yaml`) whose location varies per deployment, so there's no
+ * universal local config path we can safely rewrite (the other config-file
+ * clients here are JSON). Newer LibreChat versions can add MCP servers from the
+ * in-app MCP Settings panel without editing YAML, so we follow the
+ * browser-finishable pattern: open the MCP docs and let the user add a
+ * streamable-http server pointing at the PostHog MCP server URL.
+ */
+export class LibreChatMCPClient extends MCPClient implements BrowserFinishable {
+  name = 'LibreChat';
+  connectorUrl = 'https://www.librechat.ai/docs/features/mcp';
+  finishInstruction =
+    'In LibreChat → MCP Settings, add a streamable-http server with URL https://mcp.posthog.com/mcp.';
+
+  isClientSupported(): Promise<boolean> {
+    // Self-hosted and browser-based — available on every platform.
+    return Promise.resolve(true);
+  }
+
+  isServerInstalled(): Promise<boolean> {
+    // Config lives in the user's own LibreChat deployment; nothing local to
+    // inspect. Returning false also keeps it out of `mcp remove`.
+    return Promise.resolve(false);
+  }
+
+  addServer(): Promise<{ success: boolean }> {
+    // Not a PostHog property, so no UTMs — just the tracked open.
+    openTrackedLink(this.connectorUrl, 'librechat-connector', {
+      auto: true,
+      skipUtm: true,
+    });
+    return Promise.resolve({ success: true });
+  }
+
+  removeServer(): Promise<{ success: boolean }> {
+    return Promise.resolve({ success: false });
+  }
+
+  getConfigPath(): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+  getServerPropertyName(): string {
+    throw new Error('Not implemented');
+  }
+}
+
+export default LibreChatMCPClient;

--- a/src/steps/add-mcp-server-to-clients/clients/poke.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/poke.ts
@@ -1,0 +1,50 @@
+import { MCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
+import { BrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
+import { openTrackedLink } from '@utils/links';
+
+/**
+ * Poke (poke.com, by The Interaction Company). Poke is a hosted assistant —
+ * MCP servers are connected through its web app, not a local config or CLI.
+ * So instead of writing files we open the "new integration" page and let the
+ * user paste the PostHog MCP server URL and click "Create Integration".
+ */
+export class PokeMCPClient extends MCPClient implements BrowserFinishable {
+  name = 'Poke';
+  connectorUrl = 'https://poke.com/settings/connections/integrations/new';
+  finishInstruction =
+    'Paste https://mcp.posthog.com/mcp as the MCP server URL and click "Create Integration".';
+
+  isClientSupported(): Promise<boolean> {
+    // Browser-based — available on every platform.
+    return Promise.resolve(true);
+  }
+
+  isServerInstalled(): Promise<boolean> {
+    // The integration lives in the user's Poke account; nothing local to
+    // inspect. Returning false also keeps it out of `mcp remove`.
+    return Promise.resolve(false);
+  }
+
+  addServer(): Promise<{ success: boolean }> {
+    // Not a PostHog property, so no UTMs — just the tracked open.
+    openTrackedLink(this.connectorUrl, 'poke-connector', {
+      auto: true,
+      skipUtm: true,
+    });
+    return Promise.resolve({ success: true });
+  }
+
+  removeServer(): Promise<{ success: boolean }> {
+    return Promise.resolve({ success: false });
+  }
+
+  getConfigPath(): Promise<string> {
+    throw new Error('Not implemented');
+  }
+
+  getServerPropertyName(): string {
+    throw new Error('Not implemented');
+  }
+}
+
+export default PokeMCPClient;

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -11,6 +11,8 @@ import { VisualStudioCodeClient } from './clients/visual-studio-code';
 import { ZedClient } from './clients/zed';
 import { CodexMCPClient } from './clients/codex';
 import { PokeMCPClient } from './clients/poke';
+import { GrokMCPClient } from './clients/grok';
+import { LibreChatMCPClient } from './clients/librechat';
 import { ALL_FEATURE_VALUES } from './defaults';
 import { debug } from '@utils/debug';
 import { isPluginCapable, PluginCapable } from './plugin-client';
@@ -21,6 +23,8 @@ export const getSupportedClients = async (): Promise<MCPClient[]> => {
     new ClaudeWebMCPClient(),
     new CodexMCPClient(),
     new PokeMCPClient(),
+    new GrokMCPClient(),
+    new LibreChatMCPClient(),
     new CursorMCPClient(),
     new VisualStudioCodeClient(),
     new ZedClient(),

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -10,6 +10,7 @@ import { ClaudeWebMCPClient } from './clients/claude-web';
 import { VisualStudioCodeClient } from './clients/visual-studio-code';
 import { ZedClient } from './clients/zed';
 import { CodexMCPClient } from './clients/codex';
+import { PokeMCPClient } from './clients/poke';
 import { ALL_FEATURE_VALUES } from './defaults';
 import { debug } from '@utils/debug';
 import { isPluginCapable, PluginCapable } from './plugin-client';
@@ -19,6 +20,7 @@ export const getSupportedClients = async (): Promise<MCPClient[]> => {
     new ClaudeCodeMCPClient(),
     new ClaudeWebMCPClient(),
     new CodexMCPClient(),
+    new PokeMCPClient(),
     new CursorMCPClient(),
     new VisualStudioCodeClient(),
     new ZedClient(),


### PR DESCRIPTION
## Problem

Several MCP-capable assistants weren't in the wizard's supported-client list, so users connecting PostHog via the wizard had no option for them. The list is hand-curated in `getSupportedClients` — clients only appear if a class is written and registered.

## Changes

Add three new MCP clients, all of which connect MCP servers outside a local JSON config and so use the existing `BrowserFinishable` pattern (like Claude Desktop/Web):

- **Poke** (poke.com) — opens Poke's "new integration" page; user pastes the PostHog MCP server URL.
- **Grok** (xAI) — opens `grok.com/connectors`; user adds a custom connector with the PostHog MCP server URL.
- **LibreChat** — self-hosted and YAML-configured (`librechat.yaml`) with no universal config path, and `DefaultMCPClient` only writes JSON, so a config-file approach would corrupt it. Instead we open the MCP docs and instruct the user to add a streamable-http server via the in-app MCP Settings panel.

## Test plan

- `pnpm build && pnpm test` pass.
- New unit tests for each client (`clients/__tests__/{poke,grok,librechat}.test.ts`) cover name/connector metadata, browser-finishable detection, platform support, and the tracked-link open on `addServer`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AV33BDCJ3/p1782418048496999)*
