### PR TITLE
fix(self-driving): github auth screen

### DIFF
--- a/src/__tests__/clipboard.test.ts
+++ b/src/__tests__/clipboard.test.ts
@@ -1,0 +1,34 @@
+import { browserOpenCommands } from '@utils/clipboard';
+
+const URL =
+  'https://us.posthog.com/api/environments/227926/integrations/authorize?kind=github';
+
+describe('browserOpenCommands', () => {
+  it('uses `open` on macOS, URL as a single argv', () => {
+    expect(browserOpenCommands(URL, 'darwin')).toEqual([
+      { cmd: 'open', args: [URL] },
+    ]);
+  });
+
+  it('uses `cmd /c start "" <url>` on Windows, URL as a single argv', () => {
+    expect(browserOpenCommands(URL, 'win32')).toEqual([
+      { cmd: 'cmd', args: ['/c', 'start', '', URL] },
+    ]);
+  });
+
+  it('falls back from xdg-open to x-www-browser on Linux', () => {
+    expect(browserOpenCommands(URL, 'linux')).toEqual([
+      { cmd: 'xdg-open', args: [URL] },
+      { cmd: 'x-www-browser', args: [URL] },
+    ]);
+  });
+
+  it('never splits the URL across argv elements (no shell parsing surface)', () => {
+    for (const platform of ['darwin', 'win32', 'linux'] as const) {
+      for (const { args } of browserOpenCommands(URL, platform)) {
+        // The full URL — query string and all — must survive as one argv entry.
+        expect(args).toContain(URL);
+      }
+    }
+  });
+});

--- a/src/__tests__/link-helpers.test.ts
+++ b/src/__tests__/link-helpers.test.ts
@@ -72,13 +72,13 @@ describe('splitPromptIntoSegments', () => {
   });
 
   it('keeps trailing punctuation with the prose, not the url', () => {
-    expect(splitPromptIntoSegments('open https://x.test. Then return.')).toEqual(
-      [
-        { type: 'text', value: 'open' },
-        { type: 'url', value: 'https://x.test' },
-        { type: 'text', value: '. Then return.' },
-      ],
-    );
+    expect(
+      splitPromptIntoSegments('open https://x.test. Then return.'),
+    ).toEqual([
+      { type: 'text', value: 'open' },
+      { type: 'url', value: 'https://x.test' },
+      { type: 'text', value: '. Then return.' },
+    ]);
   });
 
   it('breaks out multiple inline urls on one line', () => {

--- a/src/__tests__/link-helpers.test.ts
+++ b/src/__tests__/link-helpers.test.ts
@@ -46,9 +46,9 @@ describe('truncateUrlLabel', () => {
   it('always shows the full host even when the host fills the budget', () => {
     const url = `https://very-long-subdomain.example.com/${'a'.repeat(80)}`;
     const label = truncateUrlLabel(url, 30);
-    expect(label.startsWith('https://very-long-subdomain.example.com')).toBe(
-      true,
-    );
+    const parsed = new URL(label.slice(0, -1));
+    expect(parsed.protocol).toBe('https:');
+    expect(parsed.hostname).toBe('very-long-subdomain.example.com');
     expect(label.endsWith('…')).toBe(true);
   });
 

--- a/src/__tests__/link-helpers.test.ts
+++ b/src/__tests__/link-helpers.test.ts
@@ -1,5 +1,6 @@
 import {
   osc8Hyperlink,
+  truncateUrlLabel,
   extractUrls,
   splitPromptIntoSegments,
 } from '@ui/tui/primitives/link-helpers';
@@ -20,6 +21,46 @@ describe('osc8Hyperlink', () => {
     expect(osc8Hyperlink('https://x.test', 'open')).toBe(
       `${ESC}]8;;https://x.test${BEL}open${ESC}]8;;${BEL}`,
     );
+  });
+});
+
+describe('truncateUrlLabel', () => {
+  it('leaves a short url untouched', () => {
+    expect(truncateUrlLabel('https://x.test/foo')).toBe('https://x.test/foo');
+  });
+
+  it('keeps the scheme + host and collapses the noisy tail', () => {
+    const url =
+      'https://github.com/login/oauth/authorize?client_id=abc123&state=xyz&redirect_uri=https%3A%2F%2Fapp.posthog.com%2Fcallback';
+    const label = truncateUrlLabel(url, 56);
+    expect(label.length).toBeLessThanOrEqual(56);
+    expect(label.startsWith('https://github.com/login/oauth/authorize')).toBe(
+      true,
+    );
+    expect(label.endsWith('…')).toBe(true);
+    // The bulk of the query-string noise is hidden.
+    expect(label).not.toContain('state=');
+    expect(label).not.toContain('redirect_uri');
+  });
+
+  it('always shows the full host even when the host fills the budget', () => {
+    const url = `https://very-long-subdomain.example.com/${'a'.repeat(80)}`;
+    const label = truncateUrlLabel(url, 30);
+    expect(label.startsWith('https://very-long-subdomain.example.com')).toBe(
+      true,
+    );
+    expect(label.endsWith('…')).toBe(true);
+  });
+
+  it('does not ellipsize a host-only url with no tail to hide', () => {
+    const url = `https://${'a'.repeat(80)}.example.com`;
+    expect(truncateUrlLabel(url, 30)).toBe(url);
+  });
+
+  it('falls back to head truncation for a non-url string', () => {
+    const label = truncateUrlLabel('not a url '.repeat(20), 20);
+    expect(label.length).toBe(20);
+    expect(label.endsWith('…')).toBe(true);
   });
 });
 

--- a/src/__tests__/link-helpers.test.ts
+++ b/src/__tests__/link-helpers.test.ts
@@ -61,10 +61,36 @@ describe('splitPromptIntoSegments', () => {
     ]);
   });
 
-  it('keeps inline urls inside the text segment', () => {
+  it('breaks an inline url onto its own segment, keeping surrounding prose', () => {
     expect(splitPromptIntoSegments('visit https://x.test for details')).toEqual(
-      [{ type: 'text', value: 'visit https://x.test for details' }],
+      [
+        { type: 'text', value: 'visit' },
+        { type: 'url', value: 'https://x.test' },
+        { type: 'text', value: 'for details' },
+      ],
     );
+  });
+
+  it('keeps trailing punctuation with the prose, not the url', () => {
+    expect(splitPromptIntoSegments('open https://x.test. Then return.')).toEqual(
+      [
+        { type: 'text', value: 'open' },
+        { type: 'url', value: 'https://x.test' },
+        { type: 'text', value: '. Then return.' },
+      ],
+    );
+  });
+
+  it('breaks out multiple inline urls on one line', () => {
+    expect(
+      splitPromptIntoSegments('a https://one.test b https://two.test c'),
+    ).toEqual([
+      { type: 'text', value: 'a' },
+      { type: 'url', value: 'https://one.test' },
+      { type: 'text', value: 'b' },
+      { type: 'url', value: 'https://two.test' },
+      { type: 'text', value: 'c' },
+    ]);
   });
 
   it('handles a url-only prompt', () => {

--- a/src/ui/tui/primitives/LinkText.tsx
+++ b/src/ui/tui/primitives/LinkText.tsx
@@ -1,13 +1,12 @@
 /**
  * LinkText — renders prompt text with URLs as OSC 8 hyperlinks.
  *
- * Every URL (standalone or inline in prose) is pulled onto its own line and
- * wrapped (`wrap="wrap"`) so the full URL is shown within the overlay instead of
- * truncated — the user can read and select all of it. Ink's wrap (wrap-ansi)
- * re-emits the OSC 8 escape on every wrapped visual line, so the click target
- * stays the exact, full URL no matter where the visible text breaks. A manual
- * selection of a wrapped line still picks up the line break, so for a clean copy
- * `WizardAskScreen` copies a sole URL to the clipboard (auto + a `c` keybind).
+ * Every URL (standalone or inline in prose) is pulled onto its own line. Long
+ * URLs are truncated for display (`scheme://host` kept, the noisy path/query
+ * tail collapsed to an ellipsis) so the overlay stays clean instead of a URL
+ * wrapping across several lines. The OSC 8 escape carries the *full* URL as the
+ * click target regardless of the shortened label, and `WizardAskScreen` opens
+ * (`o`) / copies (`c`) the full URL too, so no path loses the real destination.
  * Prose renders unchanged.
  *
  * Used by the `wizard_ask` overlay only for programs that opt into rich link
@@ -15,7 +14,11 @@
  */
 import { Box, Text } from 'ink';
 import { Colors } from '@ui/tui/styles';
-import { osc8Hyperlink, splitPromptIntoSegments } from './link-helpers.js';
+import {
+  osc8Hyperlink,
+  truncateUrlLabel,
+  splitPromptIntoSegments,
+} from './link-helpers.js';
 
 interface LinkTextProps {
   text: string;
@@ -28,7 +31,7 @@ export const LinkText = ({ text }: LinkTextProps) => {
       {segments.map((segment, i) =>
         segment.type === 'url' ? (
           <Text key={i} color={Colors.accent} underline wrap="wrap">
-            {osc8Hyperlink(segment.value)}
+            {osc8Hyperlink(segment.value, truncateUrlLabel(segment.value))}
           </Text>
         ) : (
           <Text key={i}>{segment.value}</Text>

--- a/src/ui/tui/primitives/LinkText.tsx
+++ b/src/ui/tui/primitives/LinkText.tsx
@@ -1,13 +1,14 @@
 /**
- * LinkText — renders prompt text with standalone URLs as OSC 8 hyperlinks.
+ * LinkText — renders prompt text with URLs as OSC 8 hyperlinks.
  *
- * Each URL gets its own line, wrapped (`wrap="wrap"`) so the full URL is shown
- * within the overlay instead of truncated — the user can read and select all of
- * it. Ink's wrap (wrap-ansi) re-emits the OSC 8 escape on every wrapped visual
- * line, so the click target stays the exact, full URL no matter where the
- * visible text breaks. A manual selection of a wrapped line still picks up the
- * line break, so for a clean copy `WizardAskScreen` auto-copies a sole URL to
- * the clipboard. Prose renders unchanged.
+ * Every URL (standalone or inline in prose) is pulled onto its own line and
+ * wrapped (`wrap="wrap"`) so the full URL is shown within the overlay instead of
+ * truncated — the user can read and select all of it. Ink's wrap (wrap-ansi)
+ * re-emits the OSC 8 escape on every wrapped visual line, so the click target
+ * stays the exact, full URL no matter where the visible text breaks. A manual
+ * selection of a wrapped line still picks up the line break, so for a clean copy
+ * `WizardAskScreen` copies a sole URL to the clipboard (auto + a `c` keybind).
+ * Prose renders unchanged.
  *
  * Used by the `wizard_ask` overlay only for programs that opt into rich link
  * rendering (see `PendingQuestion.richLinks`). Other flows are untouched.

--- a/src/ui/tui/primitives/index.ts
+++ b/src/ui/tui/primitives/index.ts
@@ -17,6 +17,7 @@ export { ModalOverlay } from './ModalOverlay.js';
 export { LinkText } from './LinkText.js';
 export {
   osc8Hyperlink,
+  truncateUrlLabel,
   extractUrls,
   splitPromptIntoSegments,
 } from './link-helpers.js';

--- a/src/ui/tui/primitives/link-helpers.ts
+++ b/src/ui/tui/primitives/link-helpers.ts
@@ -23,9 +23,6 @@ const OSC_8 = `${ESC}]8;;`;
 /** Matches an http(s) URL run (no surrounding whitespace). */
 const URL_RUN = /https?:\/\/[^\s]+/g;
 
-/** A line whose entire (trimmed) content is a single URL. */
-const STANDALONE_URL_LINE = /^https?:\/\/\S+$/;
-
 /** Trailing characters that are punctuation around a URL, not part of it. */
 const TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
 
@@ -53,12 +50,17 @@ export type PromptSegment =
   | { type: 'url'; value: string };
 
 /**
- * Split prompt text into renderable segments, breaking out any line that is
- * *solely* a URL into its own `url` segment. Consecutive non-URL lines stay
- * grouped in one `text` segment (newlines preserved) so paragraph spacing is
- * unchanged. URLs that appear inline within prose are left in the text
- * segment — only standalone-line URLs are special-cased, which is how the
- * wizard's prompts present links a user is meant to open.
+ * Split prompt text into renderable segments, breaking *every* URL out onto its
+ * own `url` segment — whether it sits alone on a line or inline within prose.
+ * Pulling it out matters: `LinkText` renders a `url` segment as a single OSC 8
+ * hyperlink, so the click target stays the exact full URL even when it wraps. A
+ * URL left inline in a `text` segment is plain text the terminal may auto-detect
+ * per *visual* line, which opens a broken half-URL when it wraps.
+ *
+ * Consecutive URL-free lines stay grouped in one `text` segment (newlines
+ * preserved) so paragraph spacing is unchanged. The prose surrounding an inline
+ * URL is kept as `text` segments before/after it (trailing URL punctuation stays
+ * with the prose), so it reads the same minus the link being on its own line.
  */
 export function splitPromptIntoSegments(text: string): PromptSegment[] {
   const segments: PromptSegment[] = [];
@@ -72,12 +74,32 @@ export function splitPromptIntoSegments(text: string): PromptSegment[] {
   };
 
   for (const line of text.split('\n')) {
-    const trimmed = line.trim();
-    if (STANDALONE_URL_LINE.test(trimmed)) {
-      flush();
-      segments.push({ type: 'url', value: trimTrailingPunctuation(trimmed) });
-    } else {
+    URL_RUN.lastIndex = 0;
+    if (!URL_RUN.test(line)) {
       buffer.push(line);
+      continue;
+    }
+    // The line has at least one URL: emit the buffered prose, then walk the
+    // line emitting text/url/text around each URL.
+    flush();
+    let cursor = 0;
+    URL_RUN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = URL_RUN.exec(line)) !== null) {
+      const url = trimTrailingPunctuation(match[0]);
+      const before = line.slice(cursor, match.index).trim();
+      if (before) {
+        segments.push({ type: 'text', value: before });
+      }
+      segments.push({ type: 'url', value: url });
+      // Resume after the URL itself — any stripped trailing punctuation stays
+      // as prose for the next slice.
+      cursor = match.index + url.length;
+      URL_RUN.lastIndex = cursor;
+    }
+    const after = line.slice(cursor).trim();
+    if (after) {
+      segments.push({ type: 'text', value: after });
     }
   }
   flush();

--- a/src/ui/tui/primitives/link-helpers.ts
+++ b/src/ui/tui/primitives/link-helpers.ts
@@ -20,6 +20,8 @@ const ESC = String.fromCharCode(0x1b);
 const BEL = String.fromCharCode(0x07);
 const OSC_8 = `${ESC}]8;;`;
 
+const ELLIPSIS = '…';
+
 /** Matches an http(s) URL run (no surrounding whitespace). */
 const URL_RUN = /https?:\/\/[^\s]+/g;
 
@@ -37,6 +39,43 @@ function trimTrailingPunctuation(url: string): string {
  */
 export function osc8Hyperlink(url: string, label: string = url): string {
   return `${OSC_8}${url}${BEL}${label}${OSC_8}${BEL}`;
+}
+
+/**
+ * Shorten a URL for *display only*, keeping the trust-relevant head visible.
+ *
+ * A long authorize URL is mostly query-string noise (`?client_id=…&state=…`).
+ * The part a user needs to judge where they're being sent, the scheme and host,
+ * sits at the front. So we always keep `scheme://host` intact and collapse the
+ * long path/query tail to an ellipsis, never the other way round.
+ *
+ * This is purely the visible label. Callers pair it with `osc8Hyperlink(url,
+ * label)` so the click target, and the copy/open keybinds, stay the full URL.
+ * Returns the URL unchanged when it already fits within `maxLength`.
+ */
+export function truncateUrlLabel(url: string, maxLength = 56): string {
+  if (url.length <= maxLength) return url;
+
+  let head: string;
+  let tail: string;
+  try {
+    const parsed = new URL(url);
+    head = `${parsed.protocol}//${parsed.host}`;
+    tail = url.slice(head.length);
+  } catch {
+    // Not parseable as a URL: fall back to a plain head truncation.
+    return url.slice(0, Math.max(1, maxLength - ELLIPSIS.length)) + ELLIPSIS;
+  }
+
+  // The host alone already fills (or overflows) the budget: show it whole (it's
+  // the trust signal) and ellipsize only if we're actually hiding a tail.
+  if (head.length >= maxLength - ELLIPSIS.length) {
+    return tail.length > 0 ? head + ELLIPSIS : head;
+  }
+
+  // Fill the remaining room with as much of the path/query as fits, then ellipsize.
+  const room = maxLength - head.length - ELLIPSIS.length;
+  return head + tail.slice(0, room) + ELLIPSIS;
 }
 
 /** Extract every http(s) URL in `text`, trailing punctuation removed. */

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -18,6 +18,7 @@ import {
 } from '@ui/tui/primitives/index';
 import { Colors, Icons } from '@ui/tui/styles';
 import { copyToClipboard } from '@utils/clipboard';
+import { useKeyBindings } from '@ui/tui/hooks/useKeyBindings';
 import type { AskAnswers, AskQuestion } from '@lib/wizard-session';
 
 interface WizardAskScreenProps {
@@ -48,6 +49,11 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
   const promptUrls = richLinks ? extractUrls(currentPrompt) : [];
   const soleUrl = promptUrls.length === 1 ? promptUrls[0] : null;
 
+  // The `c` keybind would steal keystrokes from a free-text answer, so only
+  // offer copy on picker questions (where the user isn't typing).
+  const isTextQuestion = pending?.questions[index]?.kind === 'text';
+  const canCopy = !!soleUrl && !isTextQuestion;
+
   useEffect(() => {
     setCopied(false);
     if (!soleUrl) return;
@@ -59,6 +65,25 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
       active = false;
     };
   }, [soleUrl]);
+
+  // Explicit, discoverable copy: auto-copy above is silent and can fail, so a
+  // `c` keybind (shown in the hints bar) lets the user copy the link on demand.
+  useKeyBindings(
+    'wizard-ask-copy',
+    canCopy
+      ? [
+          {
+            match: 'c',
+            label: 'c',
+            action: 'copy link',
+            handler: () => {
+              if (!soleUrl) return;
+              void copyToClipboard(soleUrl).then((ok) => setCopied(ok));
+            },
+          },
+        ]
+      : [],
+  );
 
   if (!pending) return null;
 
@@ -105,12 +130,18 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
           <Text>{question.prompt}</Text>
         )}
       </Box>
-      {pending.richLinks && copied && (
+      {canCopy && (
         <Box marginTop={1}>
-          <Text dimColor>
-            Link copied to clipboard — paste it in your browser if it isn&apos;t
-            clickable.
-          </Text>
+          {copied ? (
+            <Text color={Colors.success}>
+              {Icons.check} Link copied to clipboard — paste it in your browser
+              if it isn&apos;t clickable.
+            </Text>
+          ) : (
+            <Text dimColor>
+              Press <Text color={Colors.accent}>c</Text> to copy the link.
+            </Text>
+          )}
         </Box>
       )}
       <Box marginTop={1}>

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -149,21 +149,20 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
           <Text>{question.prompt}</Text>
         )}
       </Box>
-      {canActOnLink && (
-        <Box marginTop={1} flexDirection="column">
-          <Text dimColor>
-            Press <Text color={Colors.accent}>[O]</Text> to open it in your
-            browser, or <Text color={Colors.accent}>[C]</Text> to copy the link.
-          </Text>
+      {/* Key hints (o / c) live in the bottom KeyboardHintsBar; this block only
+          confirms the action once taken, so there's no redundant in-modal prose
+          for the confirmation to collide with on redraw. */}
+      {canActOnLink && linkStatus !== 'idle' && (
+        <Box marginTop={1}>
           {linkStatus === 'opened' ? (
             <Text color={Colors.success}>
               {Icons.check} Opening the link in your browser…
             </Text>
-          ) : linkStatus === 'copied' ? (
+          ) : (
             <Text color={Colors.success}>
-              {Icons.check} Link copied to clipboard — paste it in your browser.
+              {Icons.check} Link copied to clipboard. Paste it in your browser.
             </Text>
-          ) : null}
+          )}
         </Box>
       )}
       <Box marginTop={1}>

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -17,7 +17,7 @@ import {
   extractUrls,
 } from '@ui/tui/primitives/index';
 import { Colors, Icons } from '@ui/tui/styles';
-import { copyToClipboard } from '@utils/clipboard';
+import { copyToClipboard, openInBrowser } from '@utils/clipboard';
 import { useKeyBindings } from '@ui/tui/hooks/useKeyBindings';
 import type { AskAnswers, AskQuestion } from '@lib/wizard-session';
 
@@ -38,7 +38,11 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
   const [index, setIndex] = useState(0);
   const [answers, setAnswers] = useState<AskAnswers>({});
   const [lastPendingId, setLastPendingId] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  // What the user last did with the link, so the overlay can confirm it. The
+  // auto-copy below seeds 'copied'; pressing `o`/`c` overrides it.
+  const [linkStatus, setLinkStatus] = useState<'idle' | 'copied' | 'opened'>(
+    'idle',
+  );
 
   // For rich-link prompts (opt-in programs only) copy a lone URL to the
   // clipboard, so users on terminals without OSC 8 support can still paste it.
@@ -49,36 +53,51 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
   const promptUrls = richLinks ? extractUrls(currentPrompt) : [];
   const soleUrl = promptUrls.length === 1 ? promptUrls[0] : null;
 
-  // The `c` keybind would steal keystrokes from a free-text answer, so only
-  // offer copy on picker questions (where the user isn't typing).
+  // The `o`/`c` keybinds would steal keystrokes from a free-text answer, so
+  // only offer them on picker questions (where the user isn't typing).
   const isTextQuestion = pending?.questions[index]?.kind === 'text';
-  const canCopy = !!soleUrl && !isTextQuestion;
+  const canActOnLink = !!soleUrl && !isTextQuestion;
 
   useEffect(() => {
-    setCopied(false);
+    setLinkStatus('idle');
     if (!soleUrl) return;
     let active = true;
     void copyToClipboard(soleUrl).then((ok) => {
-      if (active && ok) setCopied(true);
+      // Only seed 'copied' if the user hasn't already acted (e.g. pressed `o`
+      // before this async copy resolved) — don't clobber their action.
+      if (active && ok) setLinkStatus((s) => (s === 'idle' ? 'copied' : s));
     });
     return () => {
       active = false;
     };
   }, [soleUrl]);
 
-  // Explicit, discoverable copy: auto-copy above is silent and can fail, so a
-  // `c` keybind (shown in the hints bar) lets the user copy the link on demand.
+  // Explicit, discoverable link actions. OSC 8 makes the link clickable only on
+  // terminals that support it (not macOS Terminal.app), so `o` opens it in the
+  // browser directly — the one path that works everywhere — and `c` copies it
+  // as a fallback. Both register hints in the bar via useKeyBindings.
   useKeyBindings(
-    'wizard-ask-copy',
-    canCopy
+    'wizard-ask-link',
+    canActOnLink && soleUrl
       ? [
+          {
+            match: 'o',
+            label: 'o',
+            action: 'open in browser',
+            handler: () => {
+              void openInBrowser(soleUrl).then((ok) => {
+                if (ok) setLinkStatus('opened');
+              });
+            },
+          },
           {
             match: 'c',
             label: 'c',
             action: 'copy link',
             handler: () => {
-              if (!soleUrl) return;
-              void copyToClipboard(soleUrl).then((ok) => setCopied(ok));
+              void copyToClipboard(soleUrl).then((ok) => {
+                if (ok) setLinkStatus('copied');
+              });
             },
           },
         ]
@@ -130,18 +149,21 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
           <Text>{question.prompt}</Text>
         )}
       </Box>
-      {canCopy && (
-        <Box marginTop={1}>
-          {copied ? (
+      {canActOnLink && (
+        <Box marginTop={1} flexDirection="column">
+          <Text dimColor>
+            Press <Text color={Colors.accent}>o</Text> to open it in your
+            browser, or <Text color={Colors.accent}>c</Text> to copy the link.
+          </Text>
+          {linkStatus === 'opened' ? (
             <Text color={Colors.success}>
-              {Icons.check} Link copied to clipboard — paste it in your browser
-              if it isn&apos;t clickable.
+              {Icons.check} Opening the link in your browser…
             </Text>
-          ) : (
-            <Text dimColor>
-              Press <Text color={Colors.accent}>c</Text> to copy the link.
+          ) : linkStatus === 'copied' ? (
+            <Text color={Colors.success}>
+              {Icons.check} Link copied to clipboard — paste it in your browser.
             </Text>
-          )}
+          ) : null}
         </Box>
       )}
       <Box marginTop={1}>

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -152,8 +152,8 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
       {canActOnLink && (
         <Box marginTop={1} flexDirection="column">
           <Text dimColor>
-            Press <Text color={Colors.accent}>o</Text> to open it in your
-            browser, or <Text color={Colors.accent}>c</Text> to copy the link.
+            Press <Text color={Colors.accent}>[O]</Text> to open it in your
+            browser, or <Text color={Colors.accent}>[C]</Text> to copy the link.
           </Text>
           {linkStatus === 'opened' ? (
             <Text color={Colors.success}>

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,13 +1,20 @@
 /**
- * Best-effort clipboard write — no third-party dependency.
+ * Best-effort platform shell-outs for making a URL usable in any terminal —
+ * no third-party dependency.
  *
- * Used as a fallback so users can paste a URL their terminal can't linkify
- * (e.g. macOS Terminal.app, which lacks OSC 8 hyperlink support). Shells out to
- * the platform clipboard binary over stdin; never throws — returns false when no
- * clipboard command is reachable (CI, headless, or the binary isn't installed).
+ * Two helpers back the `wizard_ask` link overlay, for terminals that can't
+ * linkify a wrapped URL (e.g. macOS Terminal.app, which lacks OSC 8 hyperlink
+ * support):
  *
- * Text is passed via stdin (never as an argv) so there's no shell-injection
- * surface, and `spawn` runs without a shell.
+ * - `copyToClipboard` — pipe the URL to the platform clipboard binary so the
+ *   user can paste it into a browser.
+ * - `openInBrowser` — hand the URL to the platform opener so it launches
+ *   directly, no copy/paste needed.
+ *
+ * Both shell out with `spawn` and never a shell, and pass the URL as an argv
+ * (clipboard via stdin) — so there's no shell-injection surface. Neither throws:
+ * they return false when no command is reachable (CI, headless, or the binary
+ * isn't installed).
  */
 import { spawn } from 'node:child_process';
 import { logToFile } from './debug.js';
@@ -52,5 +59,56 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     if (await writeWith(command, text)) return true;
   }
   logToFile('[clipboard] no working clipboard command found');
+  return false;
+}
+
+/**
+ * Platform browser-open commands, in preference order. The URL is one argv
+ * element — never concatenated into a shell string — so a `?kind=…` query or
+ * any other character can't escape into the command line.
+ *
+ * `win32` has no shell-free single binary for this: `start` is a `cmd` builtin,
+ * so we invoke `cmd /c start "" <url>` (the empty `""` is `start`'s window-title
+ * argument, which would otherwise swallow the URL). The URL is still a discrete
+ * argv element, not interpolated into the command string.
+ *
+ * Takes `platform` as an argument (defaulting to the host) so the mapping is a
+ * pure function the tests can exercise across platforms.
+ */
+export function browserOpenCommands(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): ClipboardCommand[] {
+  if (platform === 'darwin') return [{ cmd: 'open', args: [url] }];
+  if (platform === 'win32') {
+    return [{ cmd: 'cmd', args: ['/c', 'start', '', url] }];
+  }
+  // Linux / BSD: xdg-open is the freedesktop standard; x-www-browser is the
+  // Debian alternatives fallback.
+  return [
+    { cmd: 'xdg-open', args: [url] },
+    { cmd: 'x-www-browser', args: [url] },
+  ];
+}
+
+function spawnOpener({ cmd, args }: ClipboardCommand): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      // Detach the opener's stdio so it can't write over the Ink TUI, and
+      // resolve on a clean exit. ENOENT (missing binary) surfaces as 'error'.
+      const child = spawn(cmd, args, { stdio: 'ignore' });
+      child.on('error', () => resolve(false));
+      child.on('close', (code) => resolve(code === 0));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+export async function openInBrowser(url: string): Promise<boolean> {
+  for (const command of browserOpenCommands(url)) {
+    if (await spawnOpener(command)) return true;
+  }
+  logToFile('[clipboard] no working browser-open command found');
   return false;
 }


### PR DESCRIPTION
## Problem
On the self-driving flow's "Connect GitHub" step, the `wizard_ask` modal shows a long GitHub App authorize URL that wraps across lines in the fixed-width TUI. On terminals without OSC 8 hyperlink support (notably macOS Terminal.app), cmd-clicking grabs only the unwrapped half of the URL, and manual selection picks up the border/padding/line break — so the user can't reliably open or copy the link.

## Changes

**1. Render the URL as a single OSC 8 hyperlink (link-rendering fix)**
`splitPromptIntoSegments` pulls every URL (inline or standalone) onto its own segment so `LinkText` emits it as one OSC 8 hyperlink whose click target stays the full URL on every wrapped line.

before:
<img width="640" height="204" alt="image" src="https://github.com/user-attachments/assets/59fec2f2-37d2-4d7d-acab-2606393e5374" />

after: `c` hint to copy or `o` to open in browser if the auto-copy fails/link is unclickable
![Uploading CleanShot 2026-06-28 at 12.48.14@2x.png…]()

**2. `press o to open in browser` (the real cross-terminal fix)**
OSC 8 fixes clicking on iTerm2/VS Code but not Terminal.app, and `c` still requires a manual paste. New `openInBrowser(url)` helper in `src/utils/clipboard.ts` shells out to the platform opener (`open` on macOS, `xdg-open`/`x-www-browser` on Linux, `cmd /c start "" <url>` on Windows), mirroring the existing spawn-without-shell, never-throw clipboard pattern — the URL is passed as an argv, never through a shell. Wired into `WizardAskScreen` via `useKeyBindings` so `o` appears in the hints bar, gated exactly like `c` (rich-link prompt, exactly one URL, non-text question). This makes the link usable on **every** terminal regardless of OSC 8 support. `c` stays as the copy fallback.

The link/keybind logic stays generic TUI machinery — it keys off the `richLinks` flag, never the self-driving program name.

## Test plan
- `pnpm build && pnpm test && pnpm fix` all pass (added unit tests for `browserOpenCommands` in `src/__tests__/clipboard.test.ts`).
- Verified the macOS opener launches at the full URL (query string intact) and that the helper returns `false` rather than throwing when no opener binary exists
- ran locally and verified it works
