### PR TITLE
feat(oauth): honor --project-id on the OAuth login path

### DIFF
--- a/src/utils/__tests__/project-resolution.test.ts
+++ b/src/utils/__tests__/project-resolution.test.ts
@@ -1,0 +1,49 @@
+import { resolveGrantedProject } from '@utils/project-resolution';
+
+describe('resolveGrantedProject', () => {
+  // The main integration flow (and every other program) runs without --project-id;
+  // this case must stay identical to the pre-flag behavior: use scoped_teams[0].
+  it('uses the granted project when no --project-id is passed', () => {
+    expect(resolveGrantedProject(undefined, [123, 456])).toEqual({
+      ok: true,
+      projectId: 123,
+    });
+  });
+
+  it('returns no project when nothing is granted and no --project-id is passed', () => {
+    expect(resolveGrantedProject(undefined, [])).toEqual({
+      ok: true,
+      projectId: undefined,
+    });
+    expect(resolveGrantedProject(undefined, undefined)).toEqual({
+      ok: true,
+      projectId: undefined,
+    });
+  });
+
+  it('honors --project-id when the user granted access to it', () => {
+    expect(resolveGrantedProject(456, [123, 456])).toEqual({
+      ok: true,
+      projectId: 456,
+    });
+  });
+
+  it('flags a mismatch when a different project was authorized', () => {
+    expect(resolveGrantedProject(456, [123])).toEqual({
+      ok: false,
+      requested: 456,
+      granted: 123,
+    });
+  });
+
+  it('defers to the no-access guard when --project-id is passed but nothing was granted', () => {
+    expect(resolveGrantedProject(456, [])).toEqual({
+      ok: true,
+      projectId: undefined,
+    });
+    expect(resolveGrantedProject(456, undefined)).toEqual({
+      ok: true,
+      projectId: undefined,
+    });
+  });
+});

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -66,6 +66,8 @@ export function isAuthorizationTimeout(error: Error): boolean {
 interface OAuthConfig {
   scopes: string[];
   signup?: boolean;
+  /** Project to pre-select on the consent screen (the `--project-id` flag). */
+  projectId?: number;
 }
 
 function getLocalOAuthOrigin(port: number): string {
@@ -365,6 +367,10 @@ export async function performOAuthFlow(
       authUrl.searchParams.set('code_challenge_method', 'S256');
       authUrl.searchParams.set('scope', config.scopes.join(' '));
       authUrl.searchParams.set('required_access_level', 'project');
+      if (config.projectId !== undefined) {
+        // Pre-select this project on the consent screen so the user just clicks Authorize.
+        authUrl.searchParams.set('team_id', String(config.projectId));
+      }
 
       // UTM-tag both kickoff URLs so the journey into the app is
       // attributable to the wizard command that started it.

--- a/src/utils/project-resolution.ts
+++ b/src/utils/project-resolution.ts
@@ -1,0 +1,34 @@
+export type GrantedProjectResolution =
+  | { ok: true; projectId: number | undefined }
+  | { ok: false; requested: number; granted: number };
+
+/**
+ * Decide which project to use after OAuth. `--project-id` (when passed) is authoritative,
+ * but only when the user granted access to it on the consent screen; a different grant is a
+ * mismatch the caller must surface. With no `--project-id` this returns the granted project
+ * (`scopedTeams[0]`), preserving the pre-flag behavior for every wizard program (the main
+ * integration flow included).
+ */
+export function resolveGrantedProject(
+  requestedProjectId: number | undefined,
+  scopedTeams: number[] | undefined,
+): GrantedProjectResolution {
+  // No --project-id: use whatever the user granted, exactly as before the flag existed.
+  if (requestedProjectId === undefined) {
+    return { ok: true, projectId: scopedTeams?.[0] };
+  }
+  // --project-id was among the granted teams: honor it.
+  if (scopedTeams?.includes(requestedProjectId)) {
+    return { ok: true, projectId: requestedProjectId };
+  }
+  // --project-id requested but a different project was authorized: mismatch.
+  if (scopedTeams && scopedTeams.length > 0) {
+    return {
+      ok: false,
+      requested: requestedProjectId,
+      granted: scopedTeams[0],
+    };
+  }
+  // Nothing granted at all — let the caller's "no project access" guard handle it.
+  return { ok: true, projectId: undefined };
+}

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -472,6 +472,7 @@ export async function getOrAskForProjectData(
       email: _options.email,
       region: _options.region,
       programId: _options.programId,
+      projectId: _options.projectId,
     }),
   );
 
@@ -541,6 +542,9 @@ async function askForWizardLogin(options: {
   /** Used to pick the right scope set via `getOAuthScopesForProgram`.
    *  Omitted → default `WIZARD_OAUTH_SCOPES`. */
   programId?: ProgramId | null;
+  /** `--project-id`, if passed. When the user granted access to it on the consent
+   *  screen we use it directly; otherwise we fall back to the first granted team. */
+  projectId?: number;
 }): Promise<ProjectData & { cloudRegion: CloudRegion }> {
   if (options.signup) {
     return askForProvisioningSignup(options.email, options.region);
@@ -549,9 +553,34 @@ async function askForWizardLogin(options: {
   const tokenResponse = await performOAuthFlow({
     scopes: [...getOAuthScopesForProgram(options.programId)],
     signup: false,
+    projectId: options.projectId,
   });
 
-  const projectId = tokenResponse.scoped_teams?.[0];
+  // `--project-id`, when provided, is authoritative — but only if the user actually
+  // granted access to it on the consent screen. If they authorized a different
+  // project, fail loudly instead of silently capturing into the wrong one.
+  const grantedTeams = tokenResponse.scoped_teams;
+  if (
+    options.projectId !== undefined &&
+    grantedTeams?.length &&
+    !grantedTeams.includes(options.projectId)
+  ) {
+    const error = new Error(
+      `You authorized project ${grantedTeams[0]}, but setup is targeting project ${options.projectId}. Re-run and grant access to project ${options.projectId} on the authorization screen.`,
+    );
+    analytics.captureException(error, {
+      step: 'wizard_login',
+      requested_project_id: options.projectId,
+      granted_project_id: grantedTeams[0],
+    });
+    getUI().log.error(error.message);
+    await abort();
+  }
+
+  const projectId =
+    options.projectId !== undefined && grantedTeams?.includes(options.projectId)
+      ? options.projectId
+      : grantedTeams?.[0];
 
   if (projectId === undefined) {
     const error = new Error(

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -29,6 +29,7 @@ import {
   detectRegionFromToken,
 } from './urls';
 import { performOAuthFlow } from './oauth';
+import { resolveGrantedProject } from './project-resolution';
 import { provisionNewAccount } from './provisioning';
 import {
   fetchUserData,
@@ -558,29 +559,26 @@ async function askForWizardLogin(options: {
 
   // `--project-id`, when provided, is authoritative — but only if the user actually
   // granted access to it on the consent screen. If they authorized a different
-  // project, fail loudly instead of silently capturing into the wrong one.
-  const grantedTeams = tokenResponse.scoped_teams;
-  if (
-    options.projectId !== undefined &&
-    grantedTeams?.length &&
-    !grantedTeams.includes(options.projectId)
-  ) {
+  // project, fail loudly instead of silently capturing into the wrong one. With no
+  // `--project-id` this falls back to the granted project, unchanged for every program.
+  const resolution = resolveGrantedProject(
+    options.projectId,
+    tokenResponse.scoped_teams,
+  );
+  if (!resolution.ok) {
     const error = new Error(
-      `You authorized project ${grantedTeams[0]}, but setup is targeting project ${options.projectId}. Re-run and grant access to project ${options.projectId} on the authorization screen.`,
+      `You authorized project ${resolution.granted}, but setup is targeting project ${resolution.requested}. Re-run and grant access to project ${resolution.requested} on the authorization screen.`,
     );
     analytics.captureException(error, {
       step: 'wizard_login',
-      requested_project_id: options.projectId,
-      granted_project_id: grantedTeams[0],
+      requested_project_id: resolution.requested,
+      granted_project_id: resolution.granted,
     });
     getUI().log.error(error.message);
     await abort();
   }
 
-  const projectId =
-    options.projectId !== undefined && grantedTeams?.includes(options.projectId)
-      ? options.projectId
-      : grantedTeams?.[0];
+  const projectId = resolution.ok ? resolution.projectId : undefined;
 
   if (projectId === undefined) {
     const error = new Error(


### PR DESCRIPTION
## Problem

`--project-id` is already a global flag and is honored on the CI path, but on the interactive OAuth path it was silently dropped — the project came solely from `tokenResponse.scoped_teams[0]` (whatever the user picked on the consent screen). So a caller that knows the target project (e.g. PostHog's in-app MCP analytics onboarding) couldn't actually pin it, and if the user picked the wrong project on consent we'd silently capture into it.

## Changes

In `askForWizardLogin` (`src/utils/setup-utils.ts`):
- Accept `projectId` and use it as authoritative when the user granted access to it (`scoped_teams` includes it).
- If `--project-id` was passed but the user authorized a *different* project, fail loudly with a clear message instead of silently using the wrong one.
- Fall back to `scoped_teams[0]` when no `--project-id` is given (unchanged behavior).

In `performOAuthFlow` (`src/utils/oauth.ts`):
- Forward `projectId` to the authorize URL as `team_id`, so the PostHog consent screen can pre-select that project (paired with a dotcom change that reads the hint). Harmless against an older backend that ignores the param.

## Test plan

Agent-authored (PostHog Code); not manually run against a live OAuth flow. Automated checks: `tsc --noEmit` clean for the changed files, `prettier --check` passes. Suggested manual verification: run an OAuth login with `--project-id=<a project you belong to>` and confirm the wizard targets it; with `--project-id=<a project you don't grant>` confirm it errors clearly rather than proceeding.

## LLM context

Authored with PostHog Code at Lucas's direction, as the wizard half of the MCP analytics "pin the project" work. Pairs with a dotcom PR that makes the OAuth consent screen pre-select the `team_id` hint, and the in-app install command that now emits `--project-id`. The `--project-id` flag and its plumbing into `WizardSession` already existed; the only gap was inside `askForWizardLogin`, which dropped it on the non-CI branch.

## Addendum — example & expected behavior

```bash
npx -y @posthog/wizard@latest mcp-analytics --project-id=123
```

What's expected once the full chain is live:

1. The wizard opens the PostHog OAuth consent screen with `team_id=123` in the authorize URL.
2. The consent screen **pre-selects project 123** (via the companion dotcom change), so the user just clicks **Authorize** — no manual project picking.
3. Post-OAuth, the wizard confirms the granted project matches `123` and instruments against it.
   - If the user instead authorizes a *different* project, the wizard **errors clearly** rather than silently capturing into the wrong project.
   - With no `--project-id`, behavior is unchanged: it uses the granted project (`scoped_teams[0]`).

Against an older PostHog backend (before the consent change deploys), `team_id` is simply ignored and the user picks the project manually — so this is safe to merge/release independently.

### Companion PRs (PostHog/posthog)

- **PostHog/posthog#66383** — OAuth consent screen reads the `team_id` hint and pre-selects the project (the direct counterpart to this PR).
- **PostHog/posthog#66237** — in-app MCP analytics onboarding; emits the `--project-id` this PR consumes.
