### PR TITLE
chore(ci): add dependabot for npm version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Dependabot keeps dependencies current by opening version-bump PRs.
+# Every PR runs the Build / Lint / Test workflow (.github/workflows/build.yml),
+# which is the gate that must pass before a human merges.
+#
+# Why @posthog/warlock is pulled out of the group: a warlock bump can add a new
+# rule category. The user-facing abort copy lives in a typed
+# `Record<Category, string>` (src/lib/yara-hooks.ts), so a new category breaks
+# `pnpm build` until the matching copy is added. Keeping warlock ungrouped means
+# that signal lands in its own PR instead of being hidden inside a batch of
+# unrelated bumps.
+version: 2
+updates:
+  - package-ecosystem: 'npm' # also covers the pnpm workspace
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    # Conventional-commit prefix so titles pass pr-conventional-commit.yml.
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      # Batch routine updates into a single rolling PR to keep noise low.
+      # Everything EXCEPT warlock, which we want isolated (see header).
+      npm-dependencies:
+        patterns:
+          - '*'
+        exclude-patterns:
+          - '@posthog/warlock'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,11 @@ updates:
       prefix: 'chore'
       include: 'scope'
     groups:
-      # Batch routine bumps; isolate warlock so a new rule category (which
-      # breaks the typed copy map in src/lib/yara-hooks.ts) lands in its own PR.
-      npm-dependencies:
+      npm-dependencies: # batch routine bumps into one PR
         patterns:
           - '*'
+        # Isolate warlock: a new rule category breaks the typed copy map
+        # (src/lib/yara-hooks.ts), so its bump needs its own PR.
         exclude-patterns:
           - '@posthog/warlock'
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,20 @@ updates:
           - '*'
         exclude-patterns:
           - '@posthog/warlock'
+
+  # GitHub Actions are pinned by commit SHA (e.g. actions/checkout@<sha>), which
+  # is the secure choice but means the pins go stale and miss upstream security
+  # patches. Dependabot bumps the SHA and updates the trailing version comment.
+  - package-ecosystem: 'github-actions'
+    directory: '/' # scans .github/workflows
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'ci'
+      include: 'scope'
+    groups:
+      # One rolling PR for all action bumps.
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    cooldown: # wait out a release before bumping (supply-chain safety)
+      default-days: 7
     commit-message: # prefix keeps titles conventional-commit valid
       prefix: 'chore'
       include: 'scope'
@@ -24,6 +26,8 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: 'ci'
       include: 'scope'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,26 @@
-# Dependabot keeps dependencies current by opening version-bump PRs.
-# Every PR runs the Build / Lint / Test workflow (.github/workflows/build.yml),
-# which is the gate that must pass before a human merges.
-#
-# Why @posthog/warlock is pulled out of the group: a warlock bump can add a new
-# rule category. The user-facing abort copy lives in a typed
-# `Record<Category, string>` (src/lib/yara-hooks.ts), so a new category breaks
-# `pnpm build` until the matching copy is added. Keeping warlock ungrouped means
-# that signal lands in its own PR instead of being hidden inside a batch of
-# unrelated bumps.
+# Weekly version-bump PRs, gated by build.yml before merge.
 version: 2
 updates:
-  - package-ecosystem: 'npm' # also covers the pnpm workspace
+  - package-ecosystem: 'npm' # covers the pnpm workspace
     directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
-    # Conventional-commit prefix so titles pass pr-conventional-commit.yml.
-    commit-message:
+    commit-message: # prefix keeps titles conventional-commit valid
       prefix: 'chore'
       include: 'scope'
     groups:
-      # Batch routine updates into a single rolling PR to keep noise low.
-      # Everything EXCEPT warlock, which we want isolated (see header).
+      # Batch routine bumps; isolate warlock so a new rule category (which
+      # breaks the typed copy map in src/lib/yara-hooks.ts) lands in its own PR.
       npm-dependencies:
         patterns:
           - '*'
         exclude-patterns:
           - '@posthog/warlock'
 
-  # GitHub Actions are pinned by commit SHA (e.g. actions/checkout@<sha>), which
-  # is the secure choice but means the pins go stale and miss upstream security
-  # patches. Dependabot bumps the SHA and updates the trailing version comment.
+  # Actions are SHA-pinned; bump the SHA and its version comment.
   - package-ecosystem: 'github-actions'
-    directory: '/' # scans .github/workflows
+    directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 5
@@ -40,7 +28,6 @@ updates:
       prefix: 'ci'
       include: 'scope'
     groups:
-      # One rolling PR for all action bumps.
       github-actions:
         patterns:
           - '*'


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` so npm dependencies get automatic weekly version-bump PRs, gated by the existing Build/Lint/Test workflow.

## Why

`@posthog/warlock` is currently pinned exactly (`0.2.2`) with no automation, so it never moves until someone hand-edits the version. We want it kept current.

## The warlock-specific bit

Routine deps are batched into one rolling grouped PR to keep noise low. `@posthog/warlock` is deliberately **excluded from the group** so it lands as its own PR.

Reason: a warlock bump can add a new rule category. Our user-facing security abort copy lives in a typed `Record<Category, string>` in `src/lib/yara-hooks.ts`, so a new category breaks `pnpm build`. Isolating warlock means that build break shows up in its own PR (where it forces us to add the matching copy) instead of being buried in a batch of unrelated bumps.

related: https://github.com/PostHog/wizard/pull/751

Commit titles use a `chore(deps):` prefix so they pass the conventional-commit check.