### PR TITLE
fix: Don't stop analytics after integration run inside self-driving

### DIFF
--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -45,6 +45,7 @@ export { shouldDisableAsk } from './shared/bootstrap';
 export async function runAgent(
   programConfig: ProgramConfig,
   session: WizardSession,
+  options: { composed?: boolean } = {},
 ): Promise<void> {
   if (!programConfig.run) {
     throw new Error(`Program "${programConfig.id}" has no run configuration.`);
@@ -55,7 +56,7 @@ export async function runAgent(
       ? await programConfig.run(session)
       : programConfig.run;
 
-  await runProgram(session, runDef, programConfig);
+  await runProgram(session, runDef, programConfig, options);
 }
 
 /**
@@ -69,6 +70,7 @@ export async function runProgram(
   session: WizardSession,
   config: ProgramRun,
   programConfig: ProgramConfig,
+  options: { composed?: boolean } = {},
 ): Promise<void> {
   const boot = await bootstrapProgram(session, config, programConfig);
 
@@ -85,11 +87,18 @@ export async function runProgram(
     if (isOrchestratorEnabled(boot.wizardFlags)) {
       getUI().log.info('Task-queue orchestrator enabled.');
       stampVariant(boot, WizardVariant.ORCHESTRATOR);
+      // composed-run guard is linear-only; the orchestrator is experimental.
       return await runOrchestrator(session, programConfig, boot);
     }
 
     stampVariant(boot, WizardVariant.BASE);
-    return await runLinearProgram(session, config, programConfig, boot);
+    return await runLinearProgram(
+      session,
+      config,
+      programConfig,
+      boot,
+      options.composed ?? false,
+    );
   } finally {
     flushScanReport(session);
   }

--- a/src/lib/agent/runner/linear.ts
+++ b/src/lib/agent/runner/linear.ts
@@ -43,6 +43,7 @@ export async function runLinearProgram(
   config: ProgramRun,
   programConfig: ProgramConfig,
   boot: BootstrapResult,
+  composed = false,
 ): Promise<void> {
   const {
     skillsBaseUrl,
@@ -273,6 +274,10 @@ export async function runLinearProgram(
       projectId,
     });
   }
+
+  // A composed sub-run (integration inside self-driving) skips the terminal
+  // outro + analytics shutdown so the shared client survives the host's run.
+  if (composed) return;
 
   // 11. Outro
   // Push outro data through the UI (not via direct `session.outroData = ...`

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -289,7 +289,10 @@ export const integrationRunStep: ProgramStep = {
   id: 'run',
   label: 'Integration',
   screenId: 'run',
-  run: (session) => runAgent(posthogIntegrationConfig, session),
+  // composed: runs inside the host program (self-driving), so skip the
+  // integration's terminal outro + analytics shutdown of the shared client.
+  run: (session) =>
+    runAgent(posthogIntegrationConfig, session, { composed: true }),
   isComplete: (session) =>
     session.runPhase === RunPhase.Completed ||
     session.runPhase === RunPhase.Error,


### PR DESCRIPTION
## Problem
- When integration runs, it shuts off `analytics` before jumping to self-driving

<!-- Who is affected and why does this matter? -->
<!-- Closes #ISSUE_ID -->

## Changes
- Now it doesn't

<!-- What changed and why this approach. -->

## Test plan

<!-- How was this tested? Steps to verify, commands run, or "covered by CI". -->

<!-- ## LLM context -->

<!-- If an LLM agent co-authored this PR, uncomment and leave relevant context about the session or tools used. -->
