### PR TITLE
feat(self-driving): provision an account when no PostHog is found

### DIFF
--- a/src/commands/self-driving.ts
+++ b/src/commands/self-driving.ts
@@ -10,7 +10,7 @@ export const selfDrivingCommand: Command = {
     ...skillProgramOptions,
     integrate: {
       describe:
-        'Integrate the PostHog SDK first, then set up Self-driving — skips the "do you already have PostHog?" question. Use when the project isn\'t set up yet.',
+        'Integrate the PostHog SDK first, then set up Self-driving — skips the integration prompt and logs you in via OAuth (no "create an account?" question). Use when the project isn\'t set up yet but you already have a PostHog account.',
       type: 'boolean',
       default: false,
     },
@@ -23,9 +23,10 @@ export const selfDrivingCommand: Command = {
     // or a stalled `wizard_ask` with no bridge under --ci).
     if (argv.signup) {
       throw new Error(
-        '`self-driving` cannot run with --signup. It builds on an existing ' +
-          'PostHog integration — run the base `wizard` to create your account ' +
-          'and set up PostHog first, then run `wizard self-driving`.',
+        '`self-driving` cannot run with --signup. Just run `wizard ' +
+          'self-driving`: when your project has no PostHog, it asks whether ' +
+          'you already have an account and offers to create one for you ' +
+          '(no flag needed).',
       );
     }
     if (argv.ci) {

--- a/src/lib/programs/ai-opt-in-gate.ts
+++ b/src/lib/programs/ai-opt-in-gate.ts
@@ -18,9 +18,17 @@
  *
  * The predicates mirror Max's strict reading of
  * `organization.is_ai_data_processing_approved`: only literal `true`
- * proceeds; `null` / `undefined` / `false` all block. CI sessions skip
- * the gate — `--ci` auto-consents to AI usage per the README, and the
- * interactive kill screen would be unworkable headless.
+ * proceeds; `null` / `undefined` / `false` all block. CI and signup
+ * sessions skip the gate:
+ *   - `--ci` auto-consents to AI usage per the README, and the
+ *     interactive kill screen would be unworkable headless.
+ *   - signup (account provisioning) auto-consents too: the provisioning
+ *     access token deliberately omits the `organization:read` scope
+ *     (`WIZARD_PROVISIONING_SCOPES` in constants.ts), so the org's
+ *     approval can never be read back — `apiUser` stays null and the gate
+ *     could never clear. Creating an account through the wizard to run the
+ *     AI agent is itself the consent, mirroring how `shouldDisableAsk`
+ *     already treats `ci || signup` as one non-interactive mode.
  */
 
 import type { WizardSession } from '@lib/wizard-session';
@@ -53,9 +61,13 @@ export function withAiOptInGate(config: ProgramConfig): ProgramStep[] {
     // setCredentials and setApiUser there's a brief emitChange window
     // where apiUser is null, and we don't want to flash the gate then.
     show: (session) =>
-      !session.ci && session.apiUser != null && !aiApproved(session),
-    isComplete: (session) => session.ci || aiApproved(session),
-    gate: (session) => session.ci || aiApproved(session),
+      !session.ci &&
+      !session.signup &&
+      session.apiUser != null &&
+      !aiApproved(session),
+    isComplete: (session) =>
+      session.ci || session.signup || aiApproved(session),
+    gate: (session) => session.ci || session.signup || aiApproved(session),
   };
 
   return [

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -280,11 +280,15 @@ export interface WizardSession {
 
   /**
    * Self-driving only: whether to integrate PostHog as part of this run.
-   * `null` until decided — the integration-check screen asks "do you already
-   * have PostHog?" and sets it (No → true, Yes → false). The `--integrate`
-   * flag pre-sets it to `true`, skipping the question. When `true`, the
-   * self-driving prompt has the agent set up the SDK before the Self-driving
-   * steps. Unused by other programs.
+   * `null` until decided. When detection finds no PostHog SDK, the
+   * integration-check screen sets this to `true` (Self-driving needs an SDK,
+   * so we always integrate in that case) — and, on the same screen, asks
+   * whether the user already has a PostHog account: "yes" leaves `signup`
+   * false (OAuth login); "no" flips `signup` and collects `email`/`region`
+   * so auth provisions a new account. The `--integrate` flag pre-sets this to
+   * `true`, skipping the screen entirely and defaulting to the OAuth login.
+   * When `true`, the self-driving prompt has the agent set up the SDK before
+   * the Self-driving steps. Unused by other programs.
    */
   integrate: boolean | null;
 

--- a/src/ui/tui/__tests__/programs.test.ts
+++ b/src/ui/tui/__tests__/programs.test.ts
@@ -208,6 +208,30 @@ describe('PROGRAM_SEQUENCES', () => {
       expect(entry.show?.(session)).toBe(false);
       expect(entry.isComplete?.(session)).toBe(true);
     });
+
+    it('skips the gate in signup mode regardless of opt-in state', () => {
+      // A provisioned account's token omits `organization:read`, so the org's
+      // AI approval can never be read back. Creating an account through the
+      // wizard to run the agent is itself the consent — signup auto-consents
+      // like CI, so the gate must never block it.
+      const session = buildSession({});
+      session.signup = true;
+      session.apiUser = orgWith(false);
+      const entry = getEntry(Program.SelfDriving, ScreenId.AiOptIn);
+
+      expect(entry.show?.(session)).toBe(false);
+      expect(entry.isComplete?.(session)).toBe(true);
+    });
+
+    it('skips the gate in signup mode even when apiUser is null', () => {
+      const session = buildSession({});
+      session.signup = true;
+      const entry = getEntry(Program.SelfDriving, ScreenId.AiOptIn);
+
+      expect(session.apiUser).toBeNull();
+      expect(entry.show?.(session)).toBe(false);
+      expect(entry.isComplete?.(session)).toBe(true);
+    });
   });
 
   describe('Wizard run predicate', () => {

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -1485,4 +1485,29 @@ describe('WizardStore', () => {
       expect(buildSession({ integrate: true }).integrate).toBe(true);
     });
   });
+
+  describe('chooseProvisionAccount (self-driving "no account" branch)', () => {
+    it('flips signup and records email + region, and integrates', () => {
+      const store = createStore(Program.SelfDriving);
+      store.session = buildSession({});
+
+      store.chooseProvisionAccount('dev@example.com', 'eu');
+
+      expect(store.session.signup).toBe(true);
+      expect(store.session.email).toBe('dev@example.com');
+      expect(store.session.region).toBe('eu');
+      expect(store.session.integrate).toBe(true);
+    });
+
+    it('emits exactly one change event', () => {
+      const store = createStore(Program.SelfDriving);
+      store.session = buildSession({});
+      const cb = vi.fn();
+      store.subscribe(cb);
+
+      store.chooseProvisionAccount('dev@example.com', 'us');
+
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/ui/tui/screens/SelfDrivingIntegrationCheckScreen.tsx
+++ b/src/ui/tui/screens/SelfDrivingIntegrationCheckScreen.tsx
@@ -21,6 +21,9 @@ import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import type { CloudRegion } from '@lib/wizard-session';
 import { PickerMenu } from '@ui/tui/primitives/index';
+import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
+import { IntroScreenLayout } from '@ui/tui/screens/IntroScreenLayout';
+import { POSTHOG_PRIVACY_URL, POSTHOG_TERMS_URL } from '@lib/constants';
 import { Colors } from '@ui/tui/styles';
 
 interface SelfDrivingIntegrationCheckScreenProps {
@@ -45,14 +48,44 @@ export const SelfDrivingIntegrationCheckScreen = ({
   // the region step can hand both to the store in one commit.
   const [email, setEmail] = useState(store.session.email ?? '');
   const [emailError, setEmailError] = useState<string | null>(null);
+  const [showPrivacy, setShowPrivacy] = useState(false);
 
-  // Esc steps back toward the account question (the picker owns input on 'ask').
-  useInput((_input, key) => {
+  useInput((input, key) => {
+    // While the privacy overlay is open, only Esc closes it; the overlay's own
+    // Back menu handles the rest.
+    if (showPrivacy) {
+      if (key.escape) setShowPrivacy(false);
+      return;
+    }
+
+    // [I] opens the full privacy panel. Skipped on the email stage so the
+    // keystroke reaches the text field instead.
+    if ((input === 'i' || input === 'I') && stage !== 'email') {
+      setShowPrivacy(true);
+      return;
+    }
+
+    // Esc steps back toward the account question (the picker owns input on 'ask').
     if (key.escape && stage !== 'ask') {
       setEmailError(null);
       setStage(stage === 'region' ? 'email' : 'ask');
     }
   });
+
+  if (showPrivacy) {
+    return (
+      <IntroScreenLayout
+        installDir={store.session.installDir}
+        title="Wizard privacy & usage"
+        showSubtitle={false}
+        showDetection={false}
+        body={<PrivacyPanel />}
+        menuOptions={[{ label: 'Back', value: 'back' }]}
+        menuAlign="left"
+        onSelect={() => setShowPrivacy(false)}
+      />
+    );
+  }
 
   if (stage === 'region') {
     return (
@@ -80,9 +113,19 @@ export const SelfDrivingIntegrationCheckScreen = ({
             }}
           />
         </Box>
+        <Box marginTop={1} flexDirection="column">
+          <Text dimColor>By creating an account you agree to our terms.</Text>
+          <Text dimColor>
+            Terms: <Text color="cyan">{POSTHOG_TERMS_URL}</Text>
+          </Text>
+          <Text dimColor>
+            Privacy: <Text color="cyan">{POSTHOG_PRIVACY_URL}</Text>
+          </Text>
+        </Box>
         <Box marginTop={1}>
           <Text dimColor>
-            <Text color={Colors.accent}>[Esc]</Text> back
+            <Text color={Colors.accent}>[Esc]</Text> back{'  ·  '}
+            <Text color={Colors.accent}>[I]</Text> privacy & usage
           </Text>
         </Box>
       </Box>
@@ -141,15 +184,11 @@ export const SelfDrivingIntegrationCheckScreen = ({
 
       <Box marginTop={1} flexDirection="column">
         <Text dimColor>
-          This will kick off an agent to explore your project and 
-          find existing PostHog integrations.
-          
-          Self-driving reads PostHog data, so we&apos;ll 
-          set that up first: it gives your signal
-          sources something to watch.
-
-          To do that we need to connect to PostHog — do you already have
-          an account?
+          This will kick off an agent to explore your project and find existing
+          PostHog integrations. Self-driving reads PostHog data, so we&apos;ll
+          set that up first: it gives your signal sources something to watch. To
+          do that we need to connect to PostHog — do you already have an
+          account?
         </Text>
       </Box>
 
@@ -164,7 +203,7 @@ export const SelfDrivingIntegrationCheckScreen = ({
             {
               label: 'No, create one for me',
               value: 'provision',
-              hint: 'we\'ll email you a login link',
+              hint: "we'll email you a login link",
             },
           ]}
           onSelect={(value) => {
@@ -176,6 +215,12 @@ export const SelfDrivingIntegrationCheckScreen = ({
             }
           }}
         />
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>
+          <Text color={Colors.accent}>[I]</Text> privacy & usage
+        </Text>
       </Box>
     </Box>
   );

--- a/src/ui/tui/screens/SelfDrivingIntegrationCheckScreen.tsx
+++ b/src/ui/tui/screens/SelfDrivingIntegrationCheckScreen.tsx
@@ -1,21 +1,36 @@
 /**
  * SelfDrivingIntegrationCheckScreen — shown only when detection found no
- * PostHog in the project. It's a notice, not a question: Self-driving requires
- * a PostHog SDK, so the single action sets `integrate = true` and the run
- * integrates first. Skipped entirely when PostHog is already present (or under
- * `--integrate`).
+ * PostHog in the project. Self-driving needs a PostHog SDK, so we always
+ * integrate first; but a project with no SDK is often a project with no PostHog
+ * account either, so this screen first asks whether the user already has one:
+ *
+ *   - "Yes — log me in"        → setIntegrate(true); auth runs the OAuth login.
+ *   - "No — create one for me" → collect email + region, then
+ *                                chooseProvisionAccount(): auth provisions a new
+ *                                account (and emails a login link) instead.
+ *
+ * Both answers integrate the SDK; they only differ in how auth gets credentials.
+ * Skipped entirely when PostHog is already present (or under `--integrate`,
+ * which forces integration + the default OAuth login).
  */
 
-import { Box, Text } from 'ink';
-import { useSyncExternalStore } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { TextInput } from '@inkjs/ui';
+import { useState, useSyncExternalStore } from 'react';
 
 import type { WizardStore } from '@ui/tui/store';
+import type { CloudRegion } from '@lib/wizard-session';
 import { PickerMenu } from '@ui/tui/primitives/index';
 import { Colors } from '@ui/tui/styles';
 
 interface SelfDrivingIntegrationCheckScreenProps {
   store: WizardStore;
 }
+
+/** Multi-step screen state: pick account status → email → region. */
+type Stage = 'ask' | 'email' | 'region';
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 
 export const SelfDrivingIntegrationCheckScreen = ({
   store,
@@ -24,6 +39,99 @@ export const SelfDrivingIntegrationCheckScreen = ({
     (cb) => store.subscribe(cb),
     () => store.getSnapshot(),
   );
+
+  const [stage, setStage] = useState<Stage>('ask');
+  // Pre-fill from `--email` when it was passed; tracked across stages so
+  // the region step can hand both to the store in one commit.
+  const [email, setEmail] = useState(store.session.email ?? '');
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  // Esc steps back toward the account question (the picker owns input on 'ask').
+  useInput((_input, key) => {
+    if (key.escape && stage !== 'ask') {
+      setEmailError(null);
+      setStage(stage === 'region' ? 'email' : 'ask');
+    }
+  });
+
+  if (stage === 'region') {
+    return (
+      <Box flexDirection="column" flexGrow={1}>
+        <Text bold color={Colors.accent}>
+          Where should we create your account?
+        </Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text dimColor>
+            We&apos;ll create your PostHog account for {email} in this region.
+          </Text>
+        </Box>
+        <Box marginTop={1}>
+          <PickerMenu
+            message="Pick your cloud region"
+            options={[
+              { label: 'US', value: 'us', hint: 'us.posthog.com' },
+              { label: 'EU', value: 'eu', hint: 'eu.posthog.com' },
+            ]}
+            onSelect={(value) => {
+              const region = (
+                Array.isArray(value) ? value[0] : value
+              ) as CloudRegion;
+              store.chooseProvisionAccount(email.trim(), region);
+            }}
+          />
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>
+            <Text color={Colors.accent}>[Esc]</Text> back
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (stage === 'email') {
+    return (
+      <Box flexDirection="column" flexGrow={1}>
+        <Text bold color={Colors.accent}>
+          Create your PostHog account
+        </Text>
+        <Box marginTop={1} flexDirection="column">
+          <Text dimColor>
+            We&apos;ll create your account and email you a login link. What
+            email should we use?
+          </Text>
+        </Box>
+        <Box marginTop={1} width="100%">
+          <TextInput
+            placeholder="you@company.com"
+            defaultValue={email}
+            onChange={setEmail}
+            onSubmit={(value) => {
+              const trimmed = value.trim();
+              if (!EMAIL_RE.test(trimmed)) {
+                setEmailError('Please enter a valid email address.');
+                return;
+              }
+              setEmail(trimmed);
+              setEmailError(null);
+              setStage('region');
+            }}
+          />
+        </Box>
+        {emailError && (
+          <Box marginTop={1}>
+            <Text color="yellow">{emailError}</Text>
+          </Box>
+        )}
+        <Box marginTop={1}>
+          <Text dimColor>
+            <Text color={Colors.accent}>[Enter]</Text> continue{'  ·  '}
+            <Text color={Colors.accent}>[Esc]</Text> back
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box flexDirection="column" flexGrow={1}>
@@ -39,13 +147,34 @@ export const SelfDrivingIntegrationCheckScreen = ({
           Self-driving reads PostHog data, so we&apos;ll 
           set that up first: it gives your signal
           sources something to watch.
+
+          To do that we need to connect to PostHog — do you already have
+          an account?
         </Text>
       </Box>
 
       <Box marginTop={1}>
         <PickerMenu
-          options={[{ label: 'Set up PostHog [Enter]', value: 'yes' }]}
-          onSelect={() => store.setIntegrate(true)}
+          options={[
+            {
+              label: 'Yes, log me in',
+              value: 'login',
+              hint: 'opens PostHog to authorize',
+            },
+            {
+              label: 'No, create one for me',
+              value: 'provision',
+              hint: 'we\'ll email you a login link',
+            },
+          ]}
+          onSelect={(value) => {
+            const choice = Array.isArray(value) ? value[0] : value;
+            if (choice === 'login') {
+              store.setIntegrate(true);
+            } else {
+              setStage('email');
+            }
+          }}
         />
       </Box>
     </Box>

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -27,6 +27,7 @@ import {
   type DiscoveredFeature,
   type PendingQuestion,
   type AskAnswers,
+  type CloudRegion,
   AdditionalFeature,
   McpOutcome,
   RunPhase,
@@ -754,6 +755,29 @@ export class WizardStore {
       self_driving_integrate: integrate,
       ...(extra?.via ? { self_driving_integrate_via: extra.via } : {}),
       ...(extra?.path ? { self_driving_integrate_path: extra.path } : {}),
+      ...sessionProperties(this.session),
+    });
+    this.emitChange();
+  }
+
+  /**
+   * Self-driving "no PostHog account" branch of the integration check. The
+   * project has no SDK, so we always integrate (`integrate = true`); and since
+   * the user has no account, we flip `signup` and record the `email` / `region`
+   * collected on the screen so `authenticate` → `getOrAskForProjectData` takes
+   * the provisioning path (create account + email a login link) instead of
+   * OAuth. The "yes, I have an account" branch uses `setIntegrate(true)` and
+   * leaves `signup` false so auth runs the normal OAuth login.
+   */
+  chooseProvisionAccount(email: string, region: CloudRegion): void {
+    this.$session.setKey('signup', true);
+    this.$session.setKey('email', email);
+    this.$session.setKey('region', region);
+    this.$session.setKey('integrate', true);
+    analytics.wizardCapture('self-driving integration check', {
+      self_driving_integrate: true,
+      self_driving_has_account: false,
+      provision_region: region,
       ...sessionProperties(this.session),
     });
     this.emitChange();

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -2,6 +2,11 @@ import axios from 'axios';
 import { provisionNewAccount } from '@utils/provisioning';
 
 vi.mock('axios');
+// Return the override verbatim so region-based prod routing applies (no IS_DEV
+// localhost); undefined means no override.
+vi.mock('../urls', () => ({
+  resolveBaseUrl: (baseUrl?: string) => baseUrl,
+}));
 vi.mock('../debug', () => ({ logToFile: vi.fn() }));
 vi.mock('../analytics', () => ({
   analytics: { captureException: vi.fn() },
@@ -201,6 +206,53 @@ describe('provisionNewAccount', () => {
       region: 'EU',
     });
     expect(result.host).toBe('https://eu.posthog.com');
+
+    // EU provisioning must target the EU host with the EU client, and every
+    // follow-up call (token exchange, resources) stays on the EU host.
+    for (const call of mockedAxios.post.mock.calls) {
+      expect(call[0]).toContain('https://eu.posthog.com');
+    }
+    expect((accountCall[1] as Record<string, unknown>).client_id).toBe(
+      'bx2C5sZRN03TkdjraCcetvQFPGH6N2Y9vRLkcKEy',
+    );
+  });
+
+  it('routes US provisioning to the US host and client', async () => {
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: { id: 'req_us', type: 'oauth', oauth: { code: 'code_us' } },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          token_type: 'bearer',
+          access_token: 'pha_us',
+          refresh_token: 'phr_us',
+          expires_in: 3600,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          status: 'complete',
+          id: '7',
+          service_id: 'analytics',
+          complete: {
+            access_configuration: {
+              api_key: 'phc_us',
+              host: 'https://us.posthog.com',
+            },
+          },
+        },
+      });
+
+    await provisionNewAccount('us@example.com', '', 'US');
+
+    for (const call of mockedAxios.post.mock.calls) {
+      expect(call[0]).toContain('https://us.posthog.com');
+    }
+    const accountCall = mockedAxios.post.mock.calls[0];
+    expect((accountCall[1] as Record<string, unknown>).client_id).toBe(
+      'c4Rdw8DIxgtQfA80IiSnGKlNX8QN00cFWF00QQhM',
+    );
   });
 
   it('sends project name in resources configuration', async () => {

--- a/src/utils/provisioning.ts
+++ b/src/utils/provisioning.ts
@@ -12,6 +12,7 @@ import axios from 'axios';
 import { z } from 'zod';
 import {
   POSTHOG_DEV_CLIENT_ID,
+  POSTHOG_EU_CLIENT_ID,
   POSTHOG_US_CLIENT_ID,
   WIZARD_PROVISIONING_SCOPES,
   WIZARD_USER_AGENT,
@@ -25,26 +26,37 @@ const API_VERSION = '0.1d';
 
 /**
  * Provisioning host. Follows a `--base-url` override (and IS_DEV → localhost),
- * else the region-agnostic prod provisioning host (always US; the target region
- * is passed in the request body).
- *
- * // TODO: Make this work with EU provisioning.
+ * else the prod provisioning host for the target region. Unlike the login OAuth
+ * flow (which goes through the region-agnostic `oauth.posthog.com` proxy), the
+ * provisioning API is region-specific: an EU account must be created against
+ * `eu.posthog.com`, and the subsequent token-exchange / resources calls stay on
+ * the same host (they carry the account's bearer token).
  */
-const getProvisioningBaseUrl = (baseUrl?: string): string =>
-  resolveBaseUrl(baseUrl) ?? 'https://us.posthog.com';
+const getProvisioningBaseUrl = (
+  region: 'US' | 'EU',
+  baseUrl?: string,
+): string => {
+  const override = resolveBaseUrl(baseUrl);
+  if (override) return override;
+  return region === 'EU' ? 'https://eu.posthog.com' : 'https://us.posthog.com';
+};
 
 /**
  * OAuth client ID for provisioning. A pinned base URL means a dev-seeded stack
- * that registers the dev client; prod uses the US client.
+ * that registers the dev client; prod uses the client registered for the target
+ * region (the wizard OAuth app is registered separately per region).
  *
  * TODO: same assumption as `getOAuthClientId` in oauth.ts — a pinned base URL is
  * treated as a dev-seeded instance. Make configurable if we ever point
  * `--base-url` at a non-dev instance with its own OAuth app.
- *
- * TODO: Make this work with EU provisioning.
  */
-const getProvisioningClientId = (baseUrl?: string): string =>
-  resolveBaseUrl(baseUrl) ? POSTHOG_DEV_CLIENT_ID : POSTHOG_US_CLIENT_ID;
+const getProvisioningClientId = (
+  region: 'US' | 'EU',
+  baseUrl?: string,
+): string => {
+  if (resolveBaseUrl(baseUrl)) return POSTHOG_DEV_CLIENT_ID;
+  return region === 'EU' ? POSTHOG_EU_CLIENT_ID : POSTHOG_US_CLIENT_ID;
+};
 
 function generateCodeVerifier(): string {
   return crypto.randomBytes(32).toString('base64url');
@@ -124,7 +136,7 @@ export async function provisionNewAccount(
 ): Promise<ProvisioningResult> {
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = generateCodeChallenge(codeVerifier);
-  const provisioningBaseUrl = getProvisioningBaseUrl(opts?.baseUrl);
+  const provisioningBaseUrl = getProvisioningBaseUrl(region, opts?.baseUrl);
 
   logToFile('[provisioning] starting account creation');
 
@@ -135,7 +147,7 @@ export async function provisionNewAccount(
       id: crypto.randomUUID(),
       email,
       name,
-      client_id: getProvisioningClientId(opts?.baseUrl),
+      client_id: getProvisioningClientId(region, opts?.baseUrl),
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
       scopes: WIZARD_PROVISIONING_SCOPES,


### PR DESCRIPTION
## What

Builds on the [#760](https://github.com/PostHog/wizard/pull/760) self-driving "integrate first" flow. When self-driving falls back to **"no PostHog found"**, we now ask the user whether they already have a PostHog account, and route auth accordingly — instead of always assuming OAuth.

The merged integration-check screen now offers two answers (both still integrate the SDK first):

- **Yes — log me in** → authenticate via OAuth (unchanged default).
- **No — create one for me** → collect **email** + **cloud region**, flip `session.signup`, and let `authenticate()` take the **existing provisioning path** (`askForProvisioningSignup` → `provisionNewAccount`: create the account, email a login link). No `--signup` / `--email` flags needed — it's all interactive now.

## Why

A project with no PostHog SDK is often a project whose owner has no PostHog account yet. Previously that user hit OAuth and had to go create an account out-of-band first. Now the wizard provisions one for them in place.

## Notable detail — AI opt-in gate

A provisioning access token deliberately omits the `organization:read` scope (`WIZARD_PROVISIONING_SCOPES`), so `apiUser` stays `null` and `organization.is_ai_data_processing_approved` can never be read back. The AI opt-in gate (`session.ci || aiApproved`) would therefore **never clear** for a provisioned account and the run would hang. This treats `signup` as auto-consent alongside `ci` (they're already grouped as one non-interactive mode in `shouldDisableAsk`) — which also fixes the same latent hang in the base `wizard --signup` flow.

## Changes

- `SelfDrivingIntegrationCheckScreen.tsx` — rewritten to a 3-stage screen: ask → email input → region picker.
- `store.ts` — `chooseProvisionAccount(email, region)` sets `signup`/`email`/`region`/`integrate` in one atomic emit.
- `ai-opt-in-gate.ts` — `signup` auto-consents like `ci`.
- `self-driving.ts` — refreshed `--integrate` help text and the `--signup`-rejection message (points users at the interactive flow).
- `wizard-session.ts` — corrected the stale `integrate` doc comment.
- Tests in `store.test.ts` and `programs.test.ts`.

## Testing

`pnpm build` ✅ · `pnpm lint` ✅ (0 errors) · targeted unit tests ✅. The only failing tests in the full suite are 3 pre-existing `provision-cli.test.ts` failures present on `main` before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)