### PR TITLE
Add ingestion-warnings command

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -35,6 +35,7 @@ import { mcpCommand } from './src/commands/mcp';
 import { mcpAnalyticsCommand } from './src/commands/mcp-analytics';
 import { auditCommand } from './src/commands/audit';
 import { doctorCommand } from './src/commands/doctor';
+import { ingestionWarningsCommand } from './src/commands/ingestion-warnings';
 import { migrateCommand } from './src/commands/migrate';
 import { revenueCommand } from './src/commands/revenue';
 import { warehouseCommand } from './src/commands/warehouse';
@@ -66,6 +67,7 @@ Wizard.use(basicIntegrationCommand)
   .use(cliCommand)
   .use(auditCommand)
   .use(doctorCommand)
+  .use(ingestionWarningsCommand)
   .use(migrateCommand)
   .use(revenueCommand)
   .use(warehouseCommand)

--- a/src/commands/ingestion-warnings.ts
+++ b/src/commands/ingestion-warnings.ts
@@ -1,0 +1,15 @@
+import { ingestionWarningsConfig } from '@lib/programs/ingestion-warnings/index';
+
+import type { Command } from './command';
+import { nativeCommandFactory } from './factories/native-command-factory';
+
+/**
+ * `wizard ingestion-warnings` — flat skill command.
+ *
+ * Diagnoses the ingestion warnings firing on the user's PostHog project and
+ * fixes the instrumentation producing them. Stays flat: there's a single
+ * thing to do here, not a family of choices.
+ */
+export const ingestionWarningsCommand: Command = nativeCommandFactory(
+  ingestionWarningsConfig,
+);

--- a/src/lib/programs/ingestion-warnings/index.ts
+++ b/src/lib/programs/ingestion-warnings/index.ts
@@ -1,0 +1,39 @@
+import type { AbortCase } from '@lib/agent/agent-runner';
+import { createSkillProgram } from '@lib/programs/agent-skill/index';
+
+/**
+ * `[ABORT] <reason>` cases the ingestion-warnings skill can emit.
+ * Kept in sync with the abort reason declared in the context-mill skill's
+ * `description.md` / `references/1-triage.md`.
+ */
+export const INGESTION_WARNINGS_ABORT_CASES: AbortCase[] = [
+  {
+    // Skill emits: [ABORT] Could not read ingestion warnings and no PostHog instrumentation found to scan
+    match:
+      /^could not read ingestion warnings and no posthog instrumentation found to scan$/i,
+    message: 'No ingestion warnings to work from',
+    body:
+      "The wizard couldn't read this project's ingestion warnings and found " +
+      'no PostHog SDK usage in this directory to scan for the patterns that ' +
+      'cause them. Run this command from the root of the project that sends ' +
+      'events to PostHog, signed in to the right project.',
+    docsUrl: 'https://posthog.com/docs/data/ingestion-warnings',
+  },
+];
+
+export const ingestionWarningsConfig = createSkillProgram({
+  skillId: 'ingestion-warnings',
+  command: 'ingestion-warnings',
+  id: 'ingestion-warnings',
+  description:
+    "Diagnose and fix the instrumentation behind your project's ingestion warnings",
+  integrationLabel: 'ingestion-warnings',
+  successMessage:
+    'Ingestion warnings triaged! See ./posthog-ingestion-warnings-report.md',
+  reportFile: 'posthog-ingestion-warnings-report.md',
+  docsUrl: 'https://posthog.com/docs/data/ingestion-warnings',
+  spinnerMessage: 'Diagnosing ingestion warnings...',
+  estimatedDurationMinutes: 5,
+  abortCases: INGESTION_WARNINGS_ABORT_CASES,
+  requires: ['posthog-integration'],
+});

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -18,6 +18,7 @@ import { warehouseSourceConfig } from './warehouse-source/index.js';
 import { auditConfig } from './audit/index.js';
 import { eventsAuditConfig } from './events-audit/index.js';
 import { posthogDoctorConfig } from './posthog-doctor/index.js';
+import { ingestionWarningsConfig } from './ingestion-warnings/index.js';
 import { webAnalyticsDoctorConfig } from './web-analytics-doctor/index.js';
 import { migrationConfig } from './migration/index.js';
 import { errorTrackingUploadSourceMapsConfig } from './error-tracking-upload-source-maps/index.js';
@@ -70,6 +71,7 @@ export const PROGRAM_REGISTRY = [
   auditConfig,
   eventsAuditConfig,
   posthogDoctorConfig,
+  ingestionWarningsConfig,
   webAnalyticsDoctorConfig,
   migrationConfig,
   selfDrivingConfig,
@@ -95,6 +97,7 @@ export const Program = {
   Audit: auditConfig.id,
   EventsAudit: eventsAuditConfig.id,
   PosthogDoctor: posthogDoctorConfig.id,
+  IngestionWarnings: ingestionWarningsConfig.id,
   WebAnalyticsDoctor: webAnalyticsDoctorConfig.id,
   SelfDriving: selfDrivingConfig.id,
   AgentSkill: agentSkillConfig.id,


### PR DESCRIPTION
## Problem

PostHog surfaces ingestion warnings (events dropped, mis-merged, or degraded at ingest) but there's no guided way to fix the instrumentation producing them — they always trace back to a known SDK misuse. `wizard doctor` already detects them as a health issue but offers only a generic docs link.

## Changes

Wires the new context-mill [`ingestion-warnings` skill](https://github.com/PostHog/context-mill/pull/207) into the wizard as a first-class native command: **`npx @posthog/wizard@latest ingestion-warnings`**.

- `src/lib/programs/ingestion-warnings/index.ts` — `createSkillProgram` config + an abort case for the skill's `[ABORT] Could not read ingestion warnings and no PostHog instrumentation found to scan` (so the user gets a structured outro, not a generic failure).
- `src/commands/ingestion-warnings.ts` — `nativeCommandFactory` command file.
- Registered in `program-registry.ts` and `bin.ts`, mirroring `revenue-analytics`.

The command name is also registered by the skill's `cli:` block, so it works from a context-mill release alone; this PR adds the dedicated program so it gets proper messaging and abort handling instead of falling through the generic agent-skill path. **Depends on context-mill#207 shipping** so the `ingestion-warnings` skill resolves at runtime.

## Test plan

- `pnpm build` — clean; `wizard ingestion-warnings` appears in `--help` with the right description.
- `pnpm test` — green (1088 tests).
- `pnpm fix` — clean.
- Not yet run end-to-end against a live project (draft) — that needs context-mill#207 published first.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A7NDJ4DND/p1782832077766109?thread_ts=1782832077.766109&cid=C0A7NDJ4DND)*