### PR TITLE
feat(pi): cli options for harness and sequence

### DIFF
--- a/src/lib/agent/runner/__tests__/runner-plan.test.ts
+++ b/src/lib/agent/runner/__tests__/runner-plan.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
+import { Harness } from '@lib/constants';
 import { ROUTES, MODELS, resolvePair } from '@lib/agent/runner/runner-plan';
 
 const PROGRAM_IDS = PROGRAM_REGISTRY.map((c) => c.id);
@@ -20,7 +21,7 @@ describe('runner-plan ROUTES', () => {
   it('resolves every program to a registered runner and a known model', () => {
     for (const program of PROGRAM_IDS) {
       const pair = resolvePair({ program, flags: {} });
-      expect(['anthropic', 'pi']).toContain(pair.runner);
+      expect(Object.values(Harness)).toContain(pair.runner);
       expect(MODELS[pair.model]).toBeTruthy();
     }
   });

--- a/src/lib/agent/runner/__tests__/runner-plan.test.ts
+++ b/src/lib/agent/runner/__tests__/runner-plan.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
-import { Harness } from '@lib/constants';
+import { Harness, WIZARD_RUNNER_FLAG_KEY } from '@lib/constants';
 import { ROUTES, MODELS, resolvePair } from '@lib/agent/runner/runner-plan';
 
 const PROGRAM_IDS = PROGRAM_REGISTRY.map((c) => c.id);
+const A_PROGRAM = PROGRAM_IDS[0];
 
 describe('runner-plan ROUTES', () => {
   // `ProgramId` widens to `string`, so the type can't force coverage. This is
@@ -41,5 +42,45 @@ describe('runner-plan ROUTES', () => {
       runner: 'anthropic',
       model: 'sonnet',
     });
+  });
+});
+
+// Precedence at the resolution seam. The CLI override middleware is present in
+// dev/test (IS_PRODUCTION_BUILD is false); published builds gate it out, so the
+// CLI arm here is unreachable in prod by construction.
+describe('runner-plan override precedence', () => {
+  it('applies the wizard-runner flag when set to a known harness', () => {
+    const pair = resolvePair({
+      program: A_PROGRAM,
+      flags: { [WIZARD_RUNNER_FLAG_KEY]: Harness.pi },
+    });
+    expect(pair.runner).toBe(Harness.pi);
+  });
+
+  it('ignores an unknown wizard-runner flag value', () => {
+    const pair = resolvePair({
+      program: A_PROGRAM,
+      flags: { [WIZARD_RUNNER_FLAG_KEY]: 'nonsense' },
+    });
+    expect(pair.runner).toBe(Harness.anthropic);
+  });
+
+  it('lets the CLI harness override win over the flag', () => {
+    const pair = resolvePair({
+      program: A_PROGRAM,
+      flags: { [WIZARD_RUNNER_FLAG_KEY]: Harness.anthropic },
+      cliHarness: Harness.pi,
+    });
+    expect(pair.runner).toBe(Harness.pi);
+  });
+
+  it('leaves the model untouched when overriding the runner', () => {
+    const base = resolvePair({ program: A_PROGRAM, flags: {} });
+    const pair = resolvePair({
+      program: A_PROGRAM,
+      flags: {},
+      cliHarness: Harness.pi,
+    });
+    expect(pair.model).toBe(base.model);
   });
 });

--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -13,6 +13,7 @@
  */
 
 import { getUI } from '@ui';
+import { Harness } from '@lib/constants';
 import {
   initializeAgent,
   runAgent as executeAgent,
@@ -28,7 +29,7 @@ import type {
 } from '../types';
 
 export const anthropicBackend: AgentRunner = {
-  name: 'anthropic',
+  name: Harness.anthropic,
 
   async run(inputs: BackendRunInputs): Promise<AgentResult> {
     const {

--- a/src/lib/agent/runner/harness/pi/index.ts
+++ b/src/lib/agent/runner/harness/pi/index.ts
@@ -18,6 +18,7 @@ import { getUI } from '@ui';
 import { getLogFilePath, logToFile } from '@utils/debug';
 import { getLlmGatewayUrlFromHost } from '@utils/urls';
 import {
+  Harness,
   POSTHOG_FLAG_HEADER_PREFIX,
   POSTHOG_PROPERTY_HEADER_PREFIX,
   WIZARD_USER_AGENT,
@@ -191,7 +192,7 @@ function applyOutroMarkers(textBlock: string): void {
 }
 
 export const piBackend: AgentRunner = {
-  name: 'pi',
+  name: Harness.pi,
 
   async run(inputs: BackendRunInputs): Promise<AgentResult> {
     const { session, boot, prompt, spinner, config, programConfig } = inputs;

--- a/src/lib/agent/runner/harness/types.ts
+++ b/src/lib/agent/runner/harness/types.ts
@@ -17,6 +17,7 @@
 
 import type { WizardSession } from '@lib/wizard-session';
 import type { AdditionalFeature } from '@lib/wizard-session';
+import type { Harness } from '@lib/constants';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { SpinnerHandle } from '@ui';
 import type { WizardAskBridge } from '@lib/wizard-ask-bridge';
@@ -95,7 +96,7 @@ export interface TaskRunInputs {
 /** A drop-in agent runner: consumes a fully-assembled run, returns a result. */
 export interface AgentRunner {
   /** Stable name used for logs + telemetry (matches the flag variant). */
-  readonly name: 'anthropic' | 'pi';
+  readonly name: Harness;
   run(inputs: BackendRunInputs): Promise<AgentResult>;
   /**
    * Drive one orchestrator-mode unit of work. Optional — a harness that has

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -19,6 +19,7 @@
 import type { WizardSession } from '../../wizard-session';
 import { analytics } from '@utils/analytics';
 import { isOrchestratorEnabled } from '../agent-interface';
+import { IS_PRODUCTION_BUILD } from '@env';
 import { Sequence } from '@lib/constants';
 import { getUI } from '../../../ui';
 import { runOrchestrator } from './sequence/orchestrator/orchestrator-runner';
@@ -83,10 +84,14 @@ export async function runProgram(
   // harmless no-op. No harness has to know reporting exists.
   registerCleanup(() => flushScanReport(session));
   try {
-    // CLI wins; otherwise fall back to the PostHog flag.
+    // CLI `--sequence` wins; otherwise fall back to the PostHog flag. The
+    // option is gated out of published builds (see wizard.ts), so `cliSequence`
+    // is a constant `undefined` in prod — `IS_PRODUCTION_BUILD` inlines to
+    // `true` and rolldown folds the override arm away, leaving only the flag.
+    const cliSequence = IS_PRODUCTION_BUILD ? undefined : session.sequence;
     const useOrchestrator =
-      session.sequence !== undefined
-        ? session.sequence === Sequence.orchestrator
+      cliSequence !== undefined
+        ? cliSequence === Sequence.orchestrator
         : isOrchestratorEnabled(boot.wizardFlags);
     if (useOrchestrator) {
       getUI().log.info('Task-queue orchestrator enabled.');

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -19,6 +19,7 @@
 import type { WizardSession } from '../../wizard-session';
 import { analytics } from '@utils/analytics';
 import { isOrchestratorEnabled } from '../agent-interface';
+import { Sequence } from '@lib/constants';
 import { getUI } from '../../../ui';
 import { runOrchestrator } from './sequence/orchestrator/orchestrator-runner';
 import type { ProgramConfig } from '../../programs/program-step';
@@ -82,7 +83,12 @@ export async function runProgram(
   // harmless no-op. No harness has to know reporting exists.
   registerCleanup(() => flushScanReport(session));
   try {
-    if (isOrchestratorEnabled(boot.wizardFlags)) {
+    // CLI wins; otherwise fall back to the PostHog flag.
+    const useOrchestrator =
+      session.sequence !== undefined
+        ? session.sequence === Sequence.orchestrator
+        : isOrchestratorEnabled(boot.wizardFlags);
+    if (useOrchestrator) {
       getUI().log.info('Task-queue orchestrator enabled.');
       stampVariant(boot, WizardVariant.ORCHESTRATOR);
       return await runOrchestrator(session, programConfig, boot);

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -84,10 +84,8 @@ export async function runProgram(
   // harmless no-op. No harness has to know reporting exists.
   registerCleanup(() => flushScanReport(session));
   try {
-    // CLI `--sequence` wins; otherwise fall back to the PostHog flag. The
-    // option is gated out of published builds (see wizard.ts), so `cliSequence`
-    // is a constant `undefined` in prod — `IS_PRODUCTION_BUILD` inlines to
-    // `true` and rolldown folds the override arm away, leaving only the flag.
+    // CLI `--sequence` wins over the flag. Forced undefined in prod (the option
+    // is gated out there), so only the flag decides.
     const cliSequence = IS_PRODUCTION_BUILD ? undefined : session.sequence;
     const useOrchestrator =
       cliSequence !== undefined

--- a/src/lib/agent/runner/runner-plan.ts
+++ b/src/lib/agent/runner/runner-plan.ts
@@ -124,15 +124,7 @@ export function runChain<D>(chain: Mw<D>[], ctx: ResolveCtx, base: () => D): D {
   return dispatch(0);
 }
 
-/**
- * The pair insertion point. The chain is empty until the flag middleware lands;
- * the terminal is the config map read. Called per leaf with a role.
- */
-/**
- * PostHog `wizard-runner` flag → override the resolved pair's runner. Model
- * always stays from config. Defers-then-modifies: takes the base pair, then
- * overlays the runner field iff the flag names a known harness.
- */
+/** `wizard-runner` flag → runner override, iff the flag names a known harness. Model stays from config. */
 const flagRunnerOverride: Mw<Pair> = (ctx, next) => {
   const pair = next();
   const flag = ctx.flags[WIZARD_RUNNER_FLAG_KEY];
@@ -141,22 +133,14 @@ const flagRunnerOverride: Mw<Pair> = (ctx, next) => {
     : pair;
 };
 
-/**
- * CLI `--harness` override. Sits ahead of `flagRunnerOverride` in the chain so
- * it wraps — and therefore wins over — the flag result. Dev/test only: the
- * option that populates `ctx.cliHarness` is gated out of published builds (see
- * wizard.ts), and this entry is dropped from the chain below in prod, so the
- * override path is unreachable and tree-shaken there.
- */
+/** `--harness` override. Dev/test only — the option is gated out of published builds. */
 const cliHarnessOverride: Mw<Pair> = (ctx, next) => {
   const pair = next();
   return ctx.cliHarness ? { ...pair, runner: ctx.cliHarness } : pair;
 };
 
-// Order = priority: the first entry wraps the rest, so it has the last word.
-// `IS_PRODUCTION_BUILD` inlines to `true` in published builds, collapsing the
-// spread to `[]` and leaving `cliHarnessOverride` unreferenced for rolldown to
-// drop.
+// First entry wraps the rest, so it wins. The prod spread collapses to [],
+// dropping cliHarnessOverride from the chain.
 const PAIR_MIDDLEWARE: Mw<Pair>[] = [
   ...(IS_PRODUCTION_BUILD ? [] : [cliHarnessOverride]),
   flagRunnerOverride,

--- a/src/lib/agent/runner/runner-plan.ts
+++ b/src/lib/agent/runner/runner-plan.ts
@@ -19,6 +19,7 @@ import {
   Harness,
   Sequence,
 } from '@lib/constants';
+import { IS_PRODUCTION_BUILD } from '@env';
 import { logToFile } from '@utils/debug';
 import type { ProgramId } from '@lib/programs/program-registry';
 import type { AgentRunner } from './harness/types';
@@ -128,21 +129,38 @@ export function runChain<D>(chain: Mw<D>[], ctx: ResolveCtx, base: () => D): D {
  * the terminal is the config map read. Called per leaf with a role.
  */
 /**
- * Override the resolved pair's runner. CLI (`ctx.cliHarness`) wins over the
- * PostHog `wizard-runner` flag; model always stays from config.
- * Defers-then-modifies: always takes the base pair, then overlays the runner
- * field iff a CLI value or a known flag value is present.
+ * PostHog `wizard-runner` flag → override the resolved pair's runner. Model
+ * always stays from config. Defers-then-modifies: takes the base pair, then
+ * overlays the runner field iff the flag names a known harness.
  */
-const wizardRunner: Mw<Pair> = (ctx, next) => {
+const flagRunnerOverride: Mw<Pair> = (ctx, next) => {
   const pair = next();
-  if (ctx.cliHarness) return { ...pair, runner: ctx.cliHarness };
   const flag = ctx.flags[WIZARD_RUNNER_FLAG_KEY];
   return flag === Harness.anthropic || flag === Harness.pi
     ? { ...pair, runner: flag }
     : pair;
 };
 
-const PAIR_MIDDLEWARE: Mw<Pair>[] = [wizardRunner];
+/**
+ * CLI `--harness` override. Sits ahead of `flagRunnerOverride` in the chain so
+ * it wraps — and therefore wins over — the flag result. Dev/test only: the
+ * option that populates `ctx.cliHarness` is gated out of published builds (see
+ * wizard.ts), and this entry is dropped from the chain below in prod, so the
+ * override path is unreachable and tree-shaken there.
+ */
+const cliHarnessOverride: Mw<Pair> = (ctx, next) => {
+  const pair = next();
+  return ctx.cliHarness ? { ...pair, runner: ctx.cliHarness } : pair;
+};
+
+// Order = priority: the first entry wraps the rest, so it has the last word.
+// `IS_PRODUCTION_BUILD` inlines to `true` in published builds, collapsing the
+// spread to `[]` and leaving `cliHarnessOverride` unreferenced for rolldown to
+// drop.
+const PAIR_MIDDLEWARE: Mw<Pair>[] = [
+  ...(IS_PRODUCTION_BUILD ? [] : [cliHarnessOverride]),
+  flagRunnerOverride,
+];
 
 export function resolvePair(ctx: ResolveCtx, role = 'default'): Pair {
   const pair = runChain(PAIR_MIDDLEWARE, ctx, () => {

--- a/src/lib/agent/runner/runner-plan.ts
+++ b/src/lib/agent/runner/runner-plan.ts
@@ -13,15 +13,22 @@
  *   MODELS   model alias → gateway id (retires the hardcoded model literals)
  */
 
-import { DEFAULT_AGENT_MODEL, WIZARD_RUNNER_FLAG_KEY } from '@lib/constants';
+import {
+  DEFAULT_AGENT_MODEL,
+  WIZARD_RUNNER_FLAG_KEY,
+  Harness,
+  Sequence,
+} from '@lib/constants';
 import { logToFile } from '@utils/debug';
 import type { ProgramId } from '@lib/programs/program-registry';
 import type { AgentRunner } from './harness/types';
 import { anthropicBackend } from './harness/anthropic';
 import { piBackend } from './harness/pi';
 
-export type RunnerName = 'anthropic' | 'pi';
-export type RouterName = 'linear' | 'orchestrator';
+/** Legacy alias — new code should use `Harness` from `@lib/constants`. */
+export type RunnerName = Harness;
+/** Legacy alias — new code should use `Sequence` from `@lib/constants`. */
+export type RouterName = Sequence;
 export type ModelAlias = 'sonnet' | 'opus' | 'gpt5';
 
 /** What a leaf of agent work resolves to. */
@@ -66,8 +73,8 @@ export interface Route {
 
 /** The shared default plan. Every program points here until it overrides. */
 export const DEFAULT_ROUTE: Route = {
-  router: 'linear',
-  runner: 'anthropic',
+  router: Sequence.linear,
+  runner: Harness.anthropic,
   model: 'sonnet',
 };
 
@@ -102,6 +109,8 @@ export const ROUTES: Partial<Record<ProgramId, Route>> = {
 export interface ResolveCtx {
   program: ProgramId;
   flags: Record<string, string>;
+  /** CLI override (`--harness` / `POSTHOG_WIZARD_HARNESS`). Wins over `flags`. */
+  cliHarness?: Harness;
 }
 
 /** A resolver middleware: defer via `next()`, or assert by returning a value. */
@@ -119,14 +128,16 @@ export function runChain<D>(chain: Mw<D>[], ctx: ResolveCtx, base: () => D): D {
  * the terminal is the config map read. Called per leaf with a role.
  */
 /**
- * `wizard-runner` flag → override the resolved pair's runner (model stays from
- * config). Defers-then-modifies: always takes the base pair, then overlays the
- * runner field iff the flag names a known runner.
+ * Override the resolved pair's runner. CLI (`ctx.cliHarness`) wins over the
+ * PostHog `wizard-runner` flag; model always stays from config.
+ * Defers-then-modifies: always takes the base pair, then overlays the runner
+ * field iff a CLI value or a known flag value is present.
  */
 const wizardRunner: Mw<Pair> = (ctx, next) => {
   const pair = next();
+  if (ctx.cliHarness) return { ...pair, runner: ctx.cliHarness };
   const flag = ctx.flags[WIZARD_RUNNER_FLAG_KEY];
-  return flag === 'anthropic' || flag === 'pi'
+  return flag === Harness.anthropic || flag === Harness.pi
     ? { ...pair, runner: flag }
     : pair;
 };

--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -120,7 +120,11 @@ export async function runLinearProgram(
   // through the selected runner. The runner owns the agent loop + model
   // transport; everything around it (skill install, prompt, ask bridge, error
   // routing, outro) stays here so every runner shares it.
-  const pair = resolvePair({ program: programConfig.id, flags: wizardFlags });
+  const pair = resolvePair({
+    program: programConfig.id,
+    flags: wizardFlags,
+    cliHarness: session.harness,
+  });
   const agentResult = await getRunner(pair.runner).run({
     session,
     config,

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -22,9 +22,10 @@ import { ciExcludedTaskTypes } from '@utils/ci-flag-overrides';
 import { logToFile } from '@utils/debug';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { BootstrapResult } from '../../shared/types';
-// Orchestrator mode hard-codes `anthropic` here until pi implements `runTask`.
-// When that lands, this becomes a `resolvePair(...)`-driven harness pick — see
-// `switchboard-interface.md` (step 4).
+// Orchestrator resolves its harness from the CLI `--harness` override (default
+// anthropic); the `runTask` guard below rejects a harness that can't run tasks.
+// When pi implements `runTask` this can move to a `resolvePair(...)`-driven pick
+// — see `switchboard-interface.md` (step 4) in the workbench repo.
 import { getRunner } from '../../runner-plan';
 import { Harness } from '@lib/constants';
 import type { AgentRunner } from '../../harness/types';
@@ -61,16 +62,17 @@ function toTodoStatus(status: TaskStatus): string {
 }
 
 /**
- * Resolve the harness for an orchestrator run. Hard-coded to `anthropic`
- * because pi has not implemented `runTask` yet; the registry-based check
- * below is what makes adding pi later a one-line change. `getRunner` is also
- * how we get the future `resolvePair(...).runner` resolution into orchestrator
- * mode without re-plumbing.
+ * Resolve the harness for an orchestrator run. The CLI `--harness` override
+ * wins; default is `anthropic`. A harness that can't run tasks (pi has no
+ * `runTask` yet) hits the guard below and fails loudly rather than silently
+ * downgrading to anthropic. `getRunner` is also how the future
+ * `resolvePair(...).runner` resolution reaches orchestrator mode without
+ * re-plumbing.
  */
-function resolveOrchestratorHarness(): AgentRunner & {
+function resolveOrchestratorHarness(session: WizardSession): AgentRunner & {
   runTask: NonNullable<AgentRunner['runTask']>;
 } {
-  const name = Harness.anthropic;
+  const name = session.harness ?? Harness.anthropic;
   const harness = getRunner(name);
   if (!harness.runTask) {
     throw new Error(
@@ -110,7 +112,7 @@ export async function runOrchestrator(
 ): Promise<void> {
   const runId = randomUUID();
 
-  const harness = resolveOrchestratorHarness();
+  const harness = resolveOrchestratorHarness(session);
 
   // The WHAT (agent prompts) is served from context-mill. Fetch the registry
   // once up front: its types drive enqueue validation, and resolving a task to

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -22,10 +22,6 @@ import { ciExcludedTaskTypes } from '@utils/ci-flag-overrides';
 import { logToFile } from '@utils/debug';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { BootstrapResult } from '../../shared/types';
-// Orchestrator resolves its harness from the CLI `--harness` override (default
-// anthropic); the `runTask` guard below rejects a harness that can't run tasks.
-// When pi implements `runTask` this can move to a `resolvePair(...)`-driven pick
-// — see `switchboard-interface.md` (step 4) in the workbench repo.
 import { getRunner } from '../../runner-plan';
 import { Harness } from '@lib/constants';
 import type { AgentRunner } from '../../harness/types';
@@ -62,12 +58,9 @@ function toTodoStatus(status: TaskStatus): string {
 }
 
 /**
- * Resolve the harness for an orchestrator run. The CLI `--harness` override
- * wins; default is `anthropic`. A harness that can't run tasks (pi has no
- * `runTask` yet) hits the guard below and fails loudly rather than silently
- * downgrading to anthropic. `getRunner` is also how the future
- * `resolvePair(...).runner` resolution reaches orchestrator mode without
- * re-plumbing.
+ * Resolve the harness for an orchestrator run — `--harness` override, default
+ * anthropic. Throws for a harness without `runTask` (e.g. pi) rather than
+ * downgrading.
  */
 function resolveOrchestratorHarness(session: WizardSession): AgentRunner & {
   runTask: NonNullable<AgentRunner['runTask']>;

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -25,7 +25,8 @@ import type { BootstrapResult } from '../../shared/types';
 // Orchestrator mode hard-codes `anthropic` here until pi implements `runTask`.
 // When that lands, this becomes a `resolvePair(...)`-driven harness pick — see
 // `switchboard-interface.md` (step 4).
-import { getRunner, type RunnerName } from '../../runner-plan';
+import { getRunner } from '../../runner-plan';
+import { Harness } from '@lib/constants';
 import type { AgentRunner } from '../../harness/types';
 import {
   QueueStore,
@@ -69,7 +70,7 @@ function toTodoStatus(status: TaskStatus): string {
 function resolveOrchestratorHarness(): AgentRunner & {
   runTask: NonNullable<AgentRunner['runTask']>;
 } {
-  const name: RunnerName = 'anthropic';
+  const name = Harness.anthropic;
   const harness = getRunner(name);
   if (!harness.runTask) {
     throw new Error(

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -227,8 +227,11 @@ export async function bootstrapProgram(
   }
 
   // Feature flags and MCP url. Both arms need these, and the fork decision reads
-  // the flags.
+  // the flags. This map is PostHog-side only — CLI `--harness` / `--sequence`
+  // precedence lives at the resolution sites (`runner/index.ts` for sequence,
+  // `resolvePair` for harness), not here.
   const wizardFlags = await analytics.getAllFlagsForWizard();
+
   // Gateway trace tags for this run. The runner stamps its variant onto this
   // after the fork (see runProgram), so the value reflects which arm ran.
   const wizardMetadata = buildRunTags({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,6 +18,28 @@ export const DEFAULT_AGENT_MODEL = 'claude-sonnet-4-6';
  */
 export const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
 
+// ── Agent runner routing axes ────────────────────────────────────────
+
+/**
+ * The two agent runner routing axes: **harness** (which agent SDK drives the LLM)
+ * and **sequence** (which pipeline shape orchestrates the work). Single source
+ * of truth for yargs `choices`, session fields, the runner registry, and tests
+ * — `Object.values(Harness)` gives an iterable of the values when an array is
+ * needed. Adding a member is enough to pick it up everywhere.
+ *
+ * Naming matches the directory layout — see `src/lib/agent/runner/harness/`
+ * and `src/lib/agent/runner/sequence/`.
+ */
+export enum Harness {
+  anthropic = 'anthropic',
+  pi = 'pi',
+}
+
+export enum Sequence {
+  linear = 'linear',
+  orchestrator = 'orchestrator',
+}
+
 // ── Integration / CLI ───────────────────────────────────────────────
 
 /**

--- a/src/lib/runners/run-non-interactive.ts
+++ b/src/lib/runners/run-non-interactive.ts
@@ -1,4 +1,4 @@
-import { POSTHOG_DOCS_URL } from '@lib/constants';
+import { POSTHOG_DOCS_URL, type Harness, type Sequence } from '@lib/constants';
 import { getUI, setUI } from '@ui';
 import { LoggingUI } from '@ui/logging-ui';
 import type { ProgramConfig } from '@lib/programs/program-step';
@@ -113,6 +113,8 @@ export function runNonInteractive(
       benchmark: options.benchmark as boolean | undefined,
       yaraReport: options.yaraReport as boolean | undefined,
       noTelemetry: resolveNoTelemetry(options),
+      harness: options.harness as Harness | undefined,
+      sequence: options.sequence as Sequence | undefined,
       ...env,
     });
     session.programLabel = config.id;

--- a/src/lib/runners/run-wizard.ts
+++ b/src/lib/runners/run-wizard.ts
@@ -1,6 +1,7 @@
 import { VERSION } from '@lib/version';
 import { logToFile, getLogFilePath } from '@utils/debug';
 import type { ProgramConfig } from '@lib/programs/program-step';
+import type { Harness, Sequence } from '@lib/constants';
 import type { startTUI as StartTUIFn } from '@ui/tui/start-tui';
 import type { TaskStreamPush as TaskStreamPushClass } from '@lib/task-stream/task-stream-push';
 import { resolveNoTelemetry } from './resolve-no-telemetry';
@@ -49,6 +50,8 @@ export function runWizard(
         benchmark: options.benchmark as boolean | undefined,
         yaraReport: options.yaraReport as boolean | undefined,
         noTelemetry: resolveNoTelemetry(options),
+        harness: options.harness as Harness | undefined,
+        sequence: options.sequence as Sequence | undefined,
       });
       session.programLabel = config.id;
       if (options.skillId) {

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -183,15 +183,17 @@ export interface WizardSession {
   noTelemetry: boolean;
 
   /**
-   * CLI override of the resolved harness. When set, `bootstrap.ts` overlays
-   * `wizardFlags[WIZARD_RUNNER_FLAG_KEY]` with this value *after* the
-   * PostHog authorization snapshot is taken. See `cli-plan.md`.
+   * CLI override of the resolved harness (`--harness` / `POSTHOG_WIZARD_HARNESS`).
+   * Read by `resolvePair` as `cliHarness` to override the resolved runner; wins
+   * over the PostHog runner flag. Undefined when the option is unset. See
+   * `cli-plan.md` in the workbench repo.
    */
   harness?: Harness;
   /**
-   * CLI override of the resolved sequence. When set, `bootstrap.ts` overlays
-   * `wizardFlags[WIZARD_ORCHESTRATOR_FLAG_KEY]` (as `'true'` / `'false'`)
-   * *after* the PostHog authorization snapshot is taken. See `cli-plan.md`.
+   * CLI override of the resolved sequence (`--sequence` / `POSTHOG_WIZARD_SEQUENCE`).
+   * Read in `runProgram` (runner/index.ts) to pick orchestrator vs linear; wins
+   * over the PostHog orchestrator flag. Undefined when the option is unset. See
+   * `cli-plan.md` in the workbench repo.
    */
   sequence?: Sequence;
 

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -10,7 +10,7 @@
  * Business logic reads from the session. Never calls a prompt.
  */
 
-import type { Integration } from './constants';
+import type { Harness, Integration, Sequence } from './constants';
 import type { FrameworkConfig } from './framework-config';
 import type { WizardReadinessResult } from './health-checks/readiness';
 import type { SettingsConflict } from './agent/claude-settings';
@@ -182,6 +182,19 @@ export interface WizardSession {
   projectId?: number;
   noTelemetry: boolean;
 
+  /**
+   * CLI override of the resolved harness. When set, `bootstrap.ts` overlays
+   * `wizardFlags[WIZARD_RUNNER_FLAG_KEY]` with this value *after* the
+   * PostHog authorization snapshot is taken. See `cli-plan.md`.
+   */
+  harness?: Harness;
+  /**
+   * CLI override of the resolved sequence. When set, `bootstrap.ts` overlays
+   * `wizardFlags[WIZARD_ORCHESTRATOR_FLAG_KEY]` (as `'true'` / `'false'`)
+   * *after* the PostHog authorization snapshot is taken. See `cli-plan.md`.
+   */
+  sequence?: Sequence;
+
   // From detection + screens
   setupConfirmed: boolean;
   integration: Integration | null;
@@ -305,6 +318,8 @@ export function buildSession(args: {
   yaraReport?: boolean;
   projectId?: string;
   noTelemetry?: boolean;
+  harness?: Harness;
+  sequence?: Sequence;
 }): WizardSession {
   return {
     debug: args.debug ?? false,
@@ -320,6 +335,8 @@ export function buildSession(args: {
     yaraReport: args.yaraReport ?? false,
     projectId: parseProjectIdArg(args.projectId),
     noTelemetry: args.noTelemetry ?? false,
+    harness: args.harness,
+    sequence: args.sequence,
 
     setupConfirmed: false,
     integration: args.integration ?? null,

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -182,19 +182,9 @@ export interface WizardSession {
   projectId?: number;
   noTelemetry: boolean;
 
-  /**
-   * CLI override of the resolved harness (`--harness` / `POSTHOG_WIZARD_HARNESS`).
-   * Read by `resolvePair` as `cliHarness` to override the resolved runner; wins
-   * over the PostHog runner flag. Undefined when the option is unset. See
-   * `cli-plan.md` in the workbench repo.
-   */
+  /** `--harness` override, read by `resolvePair`. Wins over the runner flag. */
   harness?: Harness;
-  /**
-   * CLI override of the resolved sequence (`--sequence` / `POSTHOG_WIZARD_SEQUENCE`).
-   * Read in `runProgram` (runner/index.ts) to pick orchestrator vs linear; wins
-   * over the PostHog orchestrator flag. Undefined when the option is unset. See
-   * `cli-plan.md` in the workbench repo.
-   */
+  /** `--sequence` override, read in `runProgram`. Wins over the orchestrator flag. */
   sequence?: Sequence;
 
   // From detection + screens

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,5 @@
+import type { Harness, Sequence } from '@lib/constants';
+
 export type CloudRegion = 'us' | 'eu';
 
 export type AIModel =
@@ -28,4 +30,9 @@ export type WizardRunOptions = {
   projectId?: number;
 
   localMcp: boolean;
+
+  /** CLI override of the resolved harness. See `cli-plan.md`. */
+  harness?: Harness;
+  /** CLI override of the resolved sequence. See `cli-plan.md`. */
+  sequence?: Sequence;
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -31,8 +31,8 @@ export type WizardRunOptions = {
 
   localMcp: boolean;
 
-  /** CLI override of the resolved harness. See `cli-plan.md` in the workbench repo. */
+  /** `--harness` override. */
   harness?: Harness;
-  /** CLI override of the resolved sequence. See `cli-plan.md` in the workbench repo. */
+  /** `--sequence` override. */
   sequence?: Sequence;
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -31,8 +31,8 @@ export type WizardRunOptions = {
 
   localMcp: boolean;
 
-  /** CLI override of the resolved harness. See `cli-plan.md`. */
+  /** CLI override of the resolved harness. See `cli-plan.md` in the workbench repo. */
   harness?: Harness;
-  /** CLI override of the resolved sequence. See `cli-plan.md`. */
+  /** CLI override of the resolved sequence. See `cli-plan.md` in the workbench repo. */
   sequence?: Sequence;
 };

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -86,20 +86,6 @@ export const GLOBAL_OPTIONS = {
     type: 'boolean' as const,
     hidden: true,
   },
-  harness: {
-    describe:
-      'Override the agent harness (anthropic | pi). Non-default choices require the corresponding PostHog authorization; see cli-plan.md\nenv: POSTHOG_WIZARD_HARNESS',
-    choices: Object.values(Harness),
-    type: 'string' as const,
-    hidden: true,
-  },
-  sequence: {
-    describe:
-      'Override the runner sequence (linear | orchestrator). Non-default choices require the corresponding PostHog authorization; see cli-plan.md\nenv: POSTHOG_WIZARD_SEQUENCE',
-    choices: Object.values(Sequence),
-    type: 'string' as const,
-    hidden: true,
-  },
 };
 
 export class Wizard {
@@ -119,13 +105,33 @@ export class Wizard {
     // --ci and headless are kept as separate flags so they can diverge — see
     // basic-integration's dispatch. headless is deliberately not advertised.
     if (!IS_PRODUCTION_BUILD) {
-      cli = cli.option('ci', {
-        default: false,
-        describe:
-          'Enable CI mode for non-interactive execution\nenv: POSTHOG_WIZARD_CI',
-        type: 'boolean',
-        hidden: true,
-      });
+      cli = cli
+        .option('ci', {
+          default: false,
+          describe:
+            'Enable CI mode for non-interactive execution\nenv: POSTHOG_WIZARD_CI',
+          type: 'boolean',
+          hidden: true,
+        })
+        // Runner overrides — dev/test only, same lifecycle as --ci. Left
+        // undeclared in published builds so the override paths (runner-plan.ts
+        // middleware, runner/index.ts sequence read) tree-shake away and can
+        // never be reached in the shipped package. See cli-plan.md in the
+        // workbench repo.
+        .option('harness', {
+          describe:
+            'Override the agent harness (anthropic | pi). Wins over the PostHog runner flag.\nenv: POSTHOG_WIZARD_HARNESS',
+          choices: Object.values(Harness),
+          type: 'string',
+          hidden: true,
+        })
+        .option('sequence', {
+          describe:
+            'Override the runner sequence (linear | orchestrator). Wins over the PostHog orchestrator flag.\nenv: POSTHOG_WIZARD_SEQUENCE',
+          choices: Object.values(Sequence),
+          type: 'string',
+          hidden: true,
+        });
     }
 
     this.cli = cli
@@ -180,6 +186,31 @@ export class Wizard {
       if (argvHasCI || envHasCI) {
         process.stderr.write(
           `\n\x1b[1;91m✖ CI mode is not currently supported in published builds.\x1b[0m\n\n`,
+        );
+        process.exit(1);
+      }
+
+      // Same treatment as --ci: the --harness / --sequence runner overrides are
+      // dev/test-only and left undeclared in published builds. strictOptions
+      // would reject the flags as unknown, and POSTHOG_WIZARD_HARNESS /
+      // POSTHOG_WIZARD_SEQUENCE silently no-op (yargs only resolves env vars for
+      // declared options) — which would look like the override took effect while
+      // it didn't. Detect both up front and exit with a message that explains why.
+      const argvHasOverride = args.some(
+        (a) =>
+          a === '--harness' ||
+          a.startsWith('--harness=') ||
+          a === '--sequence' ||
+          a.startsWith('--sequence='),
+      );
+      const envHasOverride =
+        (process.env.POSTHOG_WIZARD_HARNESS != null &&
+          process.env.POSTHOG_WIZARD_HARNESS !== '') ||
+        (process.env.POSTHOG_WIZARD_SEQUENCE != null &&
+          process.env.POSTHOG_WIZARD_SEQUENCE !== '');
+      if (argvHasOverride || envHasOverride) {
+        process.stderr.write(
+          `\n\x1b[1;91m✖ The --harness and --sequence overrides are not available in published builds.\x1b[0m\n\n`,
         );
         process.exit(1);
       }

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -3,6 +3,7 @@ import { hideBin } from 'yargs/helpers';
 import type { Argv } from 'yargs';
 import { IS_PRODUCTION_BUILD } from '@env';
 import { HEADLESS_FLAG } from '@lib/headless-mode';
+import { Harness, Sequence } from '@lib/constants';
 import { toCommandModule, type Command } from './commands/command';
 
 /**
@@ -83,6 +84,20 @@ export const GLOBAL_OPTIONS = {
     describe:
       'Print YARA scanner summary after the agent run\nenv: POSTHOG_WIZARD_YARA_REPORT',
     type: 'boolean' as const,
+    hidden: true,
+  },
+  harness: {
+    describe:
+      'Override the agent harness (anthropic | pi). Non-default choices require the corresponding PostHog authorization; see cli-plan.md\nenv: POSTHOG_WIZARD_HARNESS',
+    choices: Object.values(Harness),
+    type: 'string' as const,
+    hidden: true,
+  },
+  sequence: {
+    describe:
+      'Override the runner sequence (linear | orchestrator). Non-default choices require the corresponding PostHog authorization; see cli-plan.md\nenv: POSTHOG_WIZARD_SEQUENCE',
+    choices: Object.values(Sequence),
+    type: 'string' as const,
     hidden: true,
   },
 };

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -113,11 +113,7 @@ export class Wizard {
           type: 'boolean',
           hidden: true,
         })
-        // Runner overrides — dev/test only, same lifecycle as --ci. Left
-        // undeclared in published builds so the override paths (runner-plan.ts
-        // middleware, runner/index.ts sequence read) tree-shake away and can
-        // never be reached in the shipped package. See cli-plan.md in the
-        // workbench repo.
+        // Runner overrides — dev/test only, same lifecycle as --ci.
         .option('harness', {
           describe:
             'Override the agent harness (anthropic | pi). Wins over the PostHog runner flag.\nenv: POSTHOG_WIZARD_HARNESS',
@@ -190,12 +186,8 @@ export class Wizard {
         process.exit(1);
       }
 
-      // Same treatment as --ci: the --harness / --sequence runner overrides are
-      // dev/test-only and left undeclared in published builds. strictOptions
-      // would reject the flags as unknown, and POSTHOG_WIZARD_HARNESS /
-      // POSTHOG_WIZARD_SEQUENCE silently no-op (yargs only resolves env vars for
-      // declared options) — which would look like the override took effect while
-      // it didn't. Detect both up front and exit with a message that explains why.
+      // --harness / --sequence are dev/test-only. In published builds the env
+      // vars would silently no-op, so reject them explicitly instead.
       const argvHasOverride = args.some(
         (a) =>
           a === '--harness' ||


### PR DESCRIPTION
CLI options to run wizard with specific harnesses and sequences. can work with or override feature flags

default is `anthropic` and `linear`

```
wizard --harness anthropic --sequence linear
wizard --harness anthropic --sequence orchestrator
wizard --harness pi --sequence linear
wizard --harness pi --sequence orchestrator
```
