### PR TITLE
feat(self-driving): auto-open the primary link in richLinks wizard_ask prompts

### DIFF
--- a/src/__tests__/link-helpers.test.ts
+++ b/src/__tests__/link-helpers.test.ts
@@ -2,6 +2,7 @@ import {
   osc8Hyperlink,
   truncateUrlLabel,
   extractUrls,
+  extractFirstUrl,
   splitPromptIntoSegments,
 } from '@ui/tui/primitives/link-helpers';
 
@@ -83,6 +84,26 @@ describe('extractUrls', () => {
   it('strips trailing sentence punctuation', () => {
     expect(extractUrls('see https://x.test.')).toEqual(['https://x.test']);
     expect(extractUrls('(https://x.test)')).toEqual(['https://x.test']);
+  });
+});
+
+describe('extractFirstUrl', () => {
+  it('returns the first url by textual position when there are several', () => {
+    // e.g. self-driving's GitHub-connect prompt: the authorize link, then a
+    // later "already connected?" settings-page URL.
+    expect(
+      extractFirstUrl(
+        `Open this link: ${LINEAR_URL}\n\n(Need something else? See https://x.test/settings.)`,
+      ),
+    ).toBe(LINEAR_URL);
+  });
+
+  it('returns the sole url when there is exactly one', () => {
+    expect(extractFirstUrl(`open ${LINEAR_URL} now`)).toBe(LINEAR_URL);
+  });
+
+  it('returns null when there is no url', () => {
+    expect(extractFirstUrl('no links here')).toBeNull();
   });
 });
 

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -619,6 +619,60 @@ describe('WizardStore', () => {
     });
   });
 
+  describe('hasAutoOpenedLink / markLinkAutoOpened', () => {
+    it('reports a url as not-yet-opened until marked', () => {
+      const store = createStore();
+      const url = 'https://x.test/authorize';
+      expect(store.hasAutoOpenedLink(url)).toBe(false);
+      store.markLinkAutoOpened(url);
+      expect(store.hasAutoOpenedLink(url)).toBe(true);
+    });
+
+    it('tracks each url independently', () => {
+      const store = createStore();
+      store.markLinkAutoOpened('https://x.test/a');
+      expect(store.hasAutoOpenedLink('https://x.test/a')).toBe(true);
+      expect(store.hasAutoOpenedLink('https://x.test/b')).toBe(false);
+    });
+
+    it('is session-scoped: survives across separate wizard_ask requests on the same store, mirroring a GitHub-connect retry round', () => {
+      const store = createStore();
+      const url =
+        'http://localhost:8010/api/environments/1/integrations/authorize?kind=github';
+      store.markLinkAutoOpened(url);
+
+      void store.requestQuestion({
+        id: 'github-connect-1',
+        source: 'self-driving-setup',
+        richLinks: true,
+        questions: [
+          {
+            id: 'github-connect',
+            prompt: url,
+            kind: 'single' as const,
+            options: [],
+          },
+        ],
+      });
+      store.cancelPendingQuestion();
+      void store.requestQuestion({
+        id: 'github-connect-2',
+        source: 'self-driving-setup',
+        richLinks: true,
+        questions: [
+          {
+            id: 'github-connect',
+            prompt: url,
+            kind: 'single' as const,
+            options: [],
+          },
+        ],
+      });
+
+      expect(store.hasAutoOpenedLink(url)).toBe(true);
+    });
+  });
+
   // ── Agent observation state ──────────────────────────────────────
 
   describe('statusMessages', () => {

--- a/src/ui/tui/primitives/index.ts
+++ b/src/ui/tui/primitives/index.ts
@@ -19,6 +19,7 @@ export {
   osc8Hyperlink,
   truncateUrlLabel,
   extractUrls,
+  extractFirstUrl,
   splitPromptIntoSegments,
 } from './link-helpers.js';
 export type { PromptSegment } from './link-helpers.js';

--- a/src/ui/tui/primitives/link-helpers.ts
+++ b/src/ui/tui/primitives/link-helpers.ts
@@ -84,6 +84,19 @@ export function extractUrls(text: string): string[] {
   return matches.map(trimTrailingPunctuation);
 }
 
+/**
+ * The first http(s) URL in `text` by textual position, or `null` if there
+ * isn't one. Unlike the `o`/`c` keybinds below (which only activate for a
+ * prompt with exactly one URL, to keep "copy the link" unambiguous), this
+ * is used to auto-open the primary action link even on a prompt that also
+ * mentions a secondary URL (e.g. self-driving's GitHub-connect prompt,
+ * which follows the authorize link with an "already connected? re-link
+ * here" settings URL).
+ */
+export function extractFirstUrl(text: string): string | null {
+  return extractUrls(text)[0] ?? null;
+}
+
 export type PromptSegment =
   | { type: 'text'; value: string }
   | { type: 'url'; value: string };

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -14,6 +14,7 @@ import {
   LinkText,
   ModalOverlay,
   PickerMenu,
+  extractFirstUrl,
   extractUrls,
 } from '@ui/tui/primitives/index';
 import { Colors, Icons } from '@ui/tui/styles';
@@ -52,6 +53,11 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
   const currentPrompt = pending?.questions[index]?.prompt ?? '';
   const promptUrls = richLinks ? extractUrls(currentPrompt) : [];
   const soleUrl = promptUrls.length === 1 ? promptUrls[0] : null;
+  // The primary action link, even on a prompt that mentions a second,
+  // secondary URL (e.g. self-driving's GitHub-connect prompt, which follows
+  // the authorize link with an "already connected?" settings URL) — see
+  // the auto-open effect below.
+  const firstUrl = richLinks ? extractFirstUrl(currentPrompt) : null;
 
   // The `o`/`c` keybinds would steal keystrokes from a free-text answer, so
   // only offer them on picker questions (where the user isn't typing).
@@ -79,6 +85,26 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
     // 'idle' so the o/c hint shows until the user acts.
     void copyToClipboard(soleUrl);
   }, [soleUrl]);
+
+  // Auto-open the primary link so the user doesn't have to reach for `o`
+  // themselves — additive on top of the explicit o/c actions above, which
+  // stay available to reopen or copy afterward. `store.hasAutoOpenedLink`
+  // is session-scoped (survives this overlay unmounting/remounting between
+  // separate wizard_ask calls), so a retry round that re-asks with the same
+  // link — e.g. self-driving's GitHub-connect retries — never reopens a
+  // browser tab; a genuinely different URL still opens normally. Runs for
+  // both the single- and multi-URL case (unlike the o/c hint, which only
+  // shows for a lone URL), so it also covers GitHub-connect's two-URL
+  // prompt. Reconciles `linkStatus` only when the opened URL is the one the
+  // o/c hint is about, so that hint doesn't lie about being 'idle' once the
+  // link is already open.
+  useEffect(() => {
+    if (!firstUrl || store.hasAutoOpenedLink(firstUrl)) return;
+    store.markLinkAutoOpened(firstUrl);
+    void openInBrowser(firstUrl).then((ok) => {
+      if (ok && firstUrl === soleUrl) setLinkStatus('opened');
+    });
+  }, [firstUrl, soleUrl, store]);
 
   // Explicit, discoverable link actions. OSC 8 makes the link clickable only on
   // terminals that support it (not macOS Terminal.app), so `o` opens it in the

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -178,6 +178,18 @@ export class WizardStore {
   private _resolvePendingQuestion: ((answers: AskAnswers) => void) | null =
     null;
 
+  /**
+   * URLs already auto-opened via the WizardAsk overlay's richLinks flow.
+   * Keyed on the raw URL so a retry round that re-asks the same question
+   * with the same link (e.g. self-driving's up-to-3 GitHub-connect retry
+   * rounds) never reopens a browser tab for a link the user already has
+   * open. A genuinely different URL is still eligible to open. Session-
+   * scoped — lives as long as this store instance, i.e. one wizard run —
+   * rather than component-local state, since the overlay's local state
+   * resets on every fresh `pendingQuestion` even when the link is unchanged.
+   */
+  private _autoOpenedLinks = new Set<string>();
+
   constructor(program: ProgramId = Program.PostHogIntegration) {
     this.router = new WizardRouter(program);
     this._initFromProgram(program);
@@ -594,6 +606,17 @@ export class WizardStore {
       cancelled[q.id] = '__cancelled__';
     }
     this.resolvePendingQuestion(cancelled);
+  }
+
+  /** Whether `url` was already auto-opened during this wizard run. */
+  hasAutoOpenedLink(url: string): boolean {
+    return this._autoOpenedLinks.has(url);
+  }
+
+  /** Record that `url` was auto-opened, so a later retry with the same
+   *  link (same or a fresh WizardAsk overlay mount) doesn't reopen it. */
+  markLinkAutoOpened(url: string): void {
+    this._autoOpenedLinks.add(url);
   }
 
   /**


### PR DESCRIPTION
## What

Self-driving hands the user long OAuth/authorize URLs (GitHub connect, Linear, Zendesk) via `wizard_ask`. #741 already added explicit `o` (open in browser) / `c` (copy link) keybinds for this — a real improvement over plain OSC 8 — but the user still has to reach for them, and that mechanism only activates for a prompt with exactly one URL. It doesn't cover a prompt with a second, secondary URL, which is exactly self-driving's GitHub-connect prompt: the authorize link, followed by an "already connected? use your integrations settings" fallback URL.

This auto-opens the primary link on top of that existing mechanism, using the same `openInBrowser()` call `o` already uses.

## How

- `extractFirstUrl()`: the first URL by textual position, regardless of how many URLs the prompt has — unlike the `o`/`c` hint's `soleUrl`, which only activates for exactly one URL.
- `WizardAskScreen`: new effect opens `firstUrl` once per URL. Reconciles `linkStatus` only when the opened URL is the one the `o`/`c` hint is about, so that hint doesn't keep showing "press o/c" once the link is already open.
- `WizardStore`: a session-scoped `_autoOpenedLinks` set, so a retry round that re-asks the same question with the same link (self-driving's GitHub-connect retry loop, up to 3 rounds) never reopens a browser tab. A genuinely different URL still opens normally.
- Purely additive: `o`/`c` remain available to reopen or copy afterward, and a failed/unavailable open (headless box, no default browser) leaves the existing OSC 8 + manual fallback exactly as it was.

## Verification

- `npx vitest run src/__tests__/link-helpers.test.ts src/ui/tui/__tests__/store.test.ts src/__tests__/clipboard.test.ts` — 3 files, 123 tests, all pass
- `npx vitest run src/ui/tui` (broader sanity check) — 9 files, 199 tests, all pass
- `pnpm typecheck` — no new errors (confirmed identical pre-existing error set on clean `main` via `git stash`)
- eslint/prettier clean on changed files

## Known gaps (pre-existing, not introduced here)

- Other screens with links (e.g. `SlackConnectScreen`) use explicit-click UX by design and are untouched.