### PR TITLE
feat(tui): Hidden Ctrl+T HUD showing running/final LLM token cost

### DIFF
--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -55,6 +55,8 @@ const mockUIInstance = {
   syncTodos: vi.fn(),
   groupMultiselect: vi.fn(),
   multiselect: vi.fn(),
+  addTokenUsage: vi.fn(),
+  setFinalTokenCostUsd: vi.fn(),
 };
 vi.mock('../../ui', () => ({
   getUI: () => mockUIInstance,

--- a/src/lib/agent/__tests__/token-pricing.test.ts
+++ b/src/lib/agent/__tests__/token-pricing.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@lib/agent/token-pricing';
 
 describe('pricePerMtokForModel', () => {
-  it('defaults to Sonnet pricing when no model is given', () => {
+  it('defaults to Sonnet pricing (DEFAULT_AGENT_MODEL) when no model is given', () => {
     expect(pricePerMtokForModel(undefined)).toEqual({
       input: 3,
       output: 15,
@@ -16,16 +16,26 @@ describe('pricePerMtokForModel', () => {
     });
   });
 
-  it('matches Haiku by substring, ignoring the dated version suffix', () => {
-    expect(pricePerMtokForModel('claude-haiku-4-5-20251001').input).toBe(1);
+  it('strips a dated release suffix to match the undated table entry', () => {
+    // HAIKU_MODEL is exactly this string.
+    expect(pricePerMtokForModel('claude-haiku-4-5-20251001')?.input).toBe(1);
   });
 
-  it('matches Opus by substring', () => {
-    expect(pricePerMtokForModel('claude-opus-4-5-20251101').input).toBe(15);
+  it('does not conflate different versions of the same family', () => {
+    // Regression test: an earlier version of this table matched by family
+    // name ("opus", "sonnet") and priced every sibling the same, which
+    // silently mis-priced e.g. Opus 4.5 at Opus 4.1's rate (3x too high).
+    // Sonnet 5 must NOT resolve to Sonnet 4.6's price just because both
+    // are "sonnet".
+    const sonnet46 = pricePerMtokForModel('claude-sonnet-4-6');
+    const sonnet5 = pricePerMtokForModel('claude-sonnet-5');
+    expect(sonnet46?.input).toBe(3);
+    expect(sonnet5?.input).toBe(2);
+    expect(sonnet5).not.toEqual(sonnet46);
   });
 
-  it('falls back to Sonnet pricing for an unrecognized model', () => {
-    expect(pricePerMtokForModel('claude-mystery-9000').input).toBe(3);
+  it('returns undefined for an unrecognized model, rather than guessing', () => {
+    expect(pricePerMtokForModel('claude-mystery-9000')).toBeUndefined();
   });
 });
 
@@ -50,15 +60,6 @@ describe('computeTokenCostUsd', () => {
     expect(cost).toBeCloseTo(3.75, 5);
   });
 
-  it('returns 0 for an all-zero usage delta', () => {
-    expect(computeTokenCostUsd(0, 0, 0, 0, 0, 0)).toBe(0);
-  });
-
-  it('defaults to Sonnet pricing when no model is passed', () => {
-    const cost = computeTokenCostUsd(1_000_000, 0, 0, 0, 0, 0);
-    expect(cost).toBeCloseTo(3, 5);
-  });
-
   it('prices a Haiku turn at Haiku rates, not Sonnet', () => {
     const cost = computeTokenCostUsd(
       1_000_000,
@@ -75,7 +76,7 @@ describe('computeTokenCostUsd', () => {
     expect(cost).toBeCloseTo(1 + 5, 5);
   });
 
-  it('prices an Opus turn at Opus rates', () => {
+  it('prices an Opus 4.5 turn at Opus 4.5 rates, not Opus 4.1', () => {
     const cost = computeTokenCostUsd(
       1_000_000,
       0,
@@ -85,7 +86,8 @@ describe('computeTokenCostUsd', () => {
       0,
       'claude-opus-4-5-20251101',
     );
-    expect(cost).toBeCloseTo(15, 5);
+    // $5/Mtok input -- Opus 4.5 is half of Opus 4.1's $15/Mtok published rate.
+    expect(cost).toBeCloseTo(5, 5);
   });
 });
 

--- a/src/lib/agent/__tests__/token-pricing.test.ts
+++ b/src/lib/agent/__tests__/token-pricing.test.ts
@@ -26,9 +26,12 @@ describe('pricePerMtokForModel', () => {
     // name ("opus", "sonnet") and priced every sibling the same, which
     // silently mis-priced e.g. Opus 4.5 at Opus 4.1's rate (3x too high).
     // Sonnet 5 must NOT resolve to Sonnet 4.6's price just because both
-    // are "sonnet".
-    const sonnet46 = pricePerMtokForModel('claude-sonnet-4-6');
-    const sonnet5 = pricePerMtokForModel('claude-sonnet-5');
+    // are "sonnet". Fixed `now`: during its launch promo (see below),
+    // Sonnet 5 is genuinely cheaper than 4.6, so this must not depend on
+    // whichever date the test happens to run on.
+    const duringPromo = new Date('2026-08-01T00:00:00Z');
+    const sonnet46 = pricePerMtokForModel('claude-sonnet-4-6', duringPromo);
+    const sonnet5 = pricePerMtokForModel('claude-sonnet-5', duringPromo);
     expect(sonnet46?.input).toBe(3);
     expect(sonnet5?.input).toBe(2);
     expect(sonnet5).not.toEqual(sonnet46);
@@ -37,11 +40,34 @@ describe('pricePerMtokForModel', () => {
   it('returns undefined for an unrecognized model, rather than guessing', () => {
     expect(pricePerMtokForModel('claude-mystery-9000')).toBeUndefined();
   });
+
+  describe('claude-sonnet-5 launch promo (time-dependent pricing)', () => {
+    it('prices at the promotional discount before the promo ends', () => {
+      const beforeCutoff = new Date('2026-08-31T23:59:59Z');
+      expect(pricePerMtokForModel('claude-sonnet-5', beforeCutoff)).toEqual({
+        input: 2,
+        output: 10,
+        cacheRead: 0.2,
+        cacheCreation5m: 2.5,
+        cacheCreation1h: 4,
+      });
+    });
+
+    it("reverts to Sonnet 4.6's rate once the promo ends", () => {
+      // Regression test: forgetting to let this revert would silently
+      // undercharge every Sonnet 5 turn forever after 2026-08-31.
+      const afterCutoff = new Date('2026-09-01T00:00:00Z');
+      const sonnet5 = pricePerMtokForModel('claude-sonnet-5', afterCutoff);
+      const sonnet46 = pricePerMtokForModel('claude-sonnet-4-6', afterCutoff);
+      expect(sonnet5).toEqual(sonnet46);
+      expect(sonnet5?.input).toBe(3);
+    });
+  });
 });
 
 describe('computeTokenCostUsd', () => {
   it('prices input, output, and cache-read tokens at their per-Mtok rates', () => {
-    // 1M input ($3) + 1M output ($15) + 1M cache-read ($0.30), no cache creation.
+    // 1M input ($3) + 1M output ($15) + 1M cache-read ($0.30), no cache write
     const cost = computeTokenCostUsd({
       inputTokens: 1_000_000,
       outputTokens: 1_000_000,

--- a/src/lib/agent/__tests__/token-pricing.test.ts
+++ b/src/lib/agent/__tests__/token-pricing.test.ts
@@ -1,0 +1,59 @@
+import {
+  computeTokenCostUsd,
+  formatTokenCount,
+  formatCostUsd,
+} from '@lib/agent/token-pricing';
+
+describe('computeTokenCostUsd', () => {
+  it('prices input, output, and cache-read tokens at their per-Mtok rates', () => {
+    // 1M input ($3) + 1M output ($15) + 1M cache-read ($0.30), no cache creation.
+    const cost = computeTokenCostUsd(1_000_000, 1_000_000, 1_000_000, 0, 0, 0);
+    expect(cost).toBeCloseTo(3 + 15 + 0.3, 5);
+  });
+
+  it('prices cache creation at the 5m/1h breakdown rates when present', () => {
+    // 1M ephemeral-5m ($3.75) + 1M ephemeral-1h ($6), fallback total ignored.
+    const cost = computeTokenCostUsd(0, 0, 0, 1_000_000, 1_000_000, 2_000_000);
+    expect(cost).toBeCloseTo(3.75 + 6, 5);
+  });
+
+  it('falls back to the 5m rate for the plain total when no breakdown is reported', () => {
+    // Some SDK turns report cache_creation_input_tokens without the
+    // ephemeral_5m/1h breakdown -- price the whole total at the 5m rate
+    // rather than treating it as free.
+    const cost = computeTokenCostUsd(0, 0, 0, 0, 0, 1_000_000);
+    expect(cost).toBeCloseTo(3.75, 5);
+  });
+
+  it('returns 0 for an all-zero usage delta', () => {
+    expect(computeTokenCostUsd(0, 0, 0, 0, 0, 0)).toBe(0);
+  });
+});
+
+describe('formatTokenCount', () => {
+  it('formats sub-thousand counts verbatim', () => {
+    expect(formatTokenCount(42)).toBe('42');
+  });
+
+  it('formats thousands with a K suffix', () => {
+    expect(formatTokenCount(12_345)).toBe('12.3K');
+  });
+
+  it('formats millions with an M suffix', () => {
+    expect(formatTokenCount(2_500_000)).toBe('2.50M');
+  });
+});
+
+describe('formatCostUsd', () => {
+  it('formats ordinary costs to 2 decimal places', () => {
+    expect(formatCostUsd(1.2345)).toBe('$1.23');
+  });
+
+  it('shows 4 decimal places for sub-cent costs, so they do not round to $0.00', () => {
+    expect(formatCostUsd(0.0042)).toBe('$0.0042');
+  });
+
+  it('formats zero as $0.00, not the sub-cent form', () => {
+    expect(formatCostUsd(0)).toBe('$0.00');
+  });
+});

--- a/src/lib/agent/__tests__/token-pricing.test.ts
+++ b/src/lib/agent/__tests__/token-pricing.test.ts
@@ -1,8 +1,33 @@
 import {
   computeTokenCostUsd,
+  pricePerMtokForModel,
   formatTokenCount,
   formatCostUsd,
 } from '@lib/agent/token-pricing';
+
+describe('pricePerMtokForModel', () => {
+  it('defaults to Sonnet pricing when no model is given', () => {
+    expect(pricePerMtokForModel(undefined)).toEqual({
+      input: 3,
+      output: 15,
+      cacheRead: 0.3,
+      cacheCreation5m: 3.75,
+      cacheCreation1h: 6,
+    });
+  });
+
+  it('matches Haiku by substring, ignoring the dated version suffix', () => {
+    expect(pricePerMtokForModel('claude-haiku-4-5-20251001').input).toBe(1);
+  });
+
+  it('matches Opus by substring', () => {
+    expect(pricePerMtokForModel('claude-opus-4-5-20251101').input).toBe(15);
+  });
+
+  it('falls back to Sonnet pricing for an unrecognized model', () => {
+    expect(pricePerMtokForModel('claude-mystery-9000').input).toBe(3);
+  });
+});
 
 describe('computeTokenCostUsd', () => {
   it('prices input, output, and cache-read tokens at their per-Mtok rates', () => {
@@ -27,6 +52,40 @@ describe('computeTokenCostUsd', () => {
 
   it('returns 0 for an all-zero usage delta', () => {
     expect(computeTokenCostUsd(0, 0, 0, 0, 0, 0)).toBe(0);
+  });
+
+  it('defaults to Sonnet pricing when no model is passed', () => {
+    const cost = computeTokenCostUsd(1_000_000, 0, 0, 0, 0, 0);
+    expect(cost).toBeCloseTo(3, 5);
+  });
+
+  it('prices a Haiku turn at Haiku rates, not Sonnet', () => {
+    const cost = computeTokenCostUsd(
+      1_000_000,
+      1_000_000,
+      0,
+      0,
+      0,
+      0,
+      'claude-haiku-4-5-20251001',
+    );
+    // $1/Mtok input + $5/Mtok output -- 1/3 and 1/3 of the Sonnet cost this
+    // same delta would get without a model, so a Haiku-overridden run (e.g.
+    // source-map detection) doesn't get billed at Sonnet's rate.
+    expect(cost).toBeCloseTo(1 + 5, 5);
+  });
+
+  it('prices an Opus turn at Opus rates', () => {
+    const cost = computeTokenCostUsd(
+      1_000_000,
+      0,
+      0,
+      0,
+      0,
+      0,
+      'claude-opus-4-5-20251101',
+    );
+    expect(cost).toBeCloseTo(15, 5);
   });
 });
 

--- a/src/lib/agent/__tests__/token-pricing.test.ts
+++ b/src/lib/agent/__tests__/token-pricing.test.ts
@@ -42,13 +42,27 @@ describe('pricePerMtokForModel', () => {
 describe('computeTokenCostUsd', () => {
   it('prices input, output, and cache-read tokens at their per-Mtok rates', () => {
     // 1M input ($3) + 1M output ($15) + 1M cache-read ($0.30), no cache creation.
-    const cost = computeTokenCostUsd(1_000_000, 1_000_000, 1_000_000, 0, 0, 0);
+    const cost = computeTokenCostUsd({
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheCreation5m: 0,
+      cacheCreation1h: 0,
+      cacheCreationTokens: 0,
+    });
     expect(cost).toBeCloseTo(3 + 15 + 0.3, 5);
   });
 
   it('prices cache creation at the 5m/1h breakdown rates when present', () => {
     // 1M ephemeral-5m ($3.75) + 1M ephemeral-1h ($6), fallback total ignored.
-    const cost = computeTokenCostUsd(0, 0, 0, 1_000_000, 1_000_000, 2_000_000);
+    const cost = computeTokenCostUsd({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreation5m: 1_000_000,
+      cacheCreation1h: 1_000_000,
+      cacheCreationTokens: 2_000_000,
+    });
     expect(cost).toBeCloseTo(3.75 + 6, 5);
   });
 
@@ -56,20 +70,27 @@ describe('computeTokenCostUsd', () => {
     // Some SDK turns report cache_creation_input_tokens without the
     // ephemeral_5m/1h breakdown -- price the whole total at the 5m rate
     // rather than treating it as free.
-    const cost = computeTokenCostUsd(0, 0, 0, 0, 0, 1_000_000);
+    const cost = computeTokenCostUsd({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreation5m: 0,
+      cacheCreation1h: 0,
+      cacheCreationTokens: 1_000_000,
+    });
     expect(cost).toBeCloseTo(3.75, 5);
   });
 
   it('prices a Haiku turn at Haiku rates, not Sonnet', () => {
-    const cost = computeTokenCostUsd(
-      1_000_000,
-      1_000_000,
-      0,
-      0,
-      0,
-      0,
-      'claude-haiku-4-5-20251001',
-    );
+    const cost = computeTokenCostUsd({
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 0,
+      cacheCreation5m: 0,
+      cacheCreation1h: 0,
+      cacheCreationTokens: 0,
+      model: 'claude-haiku-4-5-20251001',
+    });
     // $1/Mtok input + $5/Mtok output -- 1/3 and 1/3 of the Sonnet cost this
     // same delta would get without a model, so a Haiku-overridden run (e.g.
     // source-map detection) doesn't get billed at Sonnet's rate.
@@ -77,15 +98,15 @@ describe('computeTokenCostUsd', () => {
   });
 
   it('prices an Opus 4.5 turn at Opus 4.5 rates, not Opus 4.1', () => {
-    const cost = computeTokenCostUsd(
-      1_000_000,
-      0,
-      0,
-      0,
-      0,
-      0,
-      'claude-opus-4-5-20251101',
-    );
+    const cost = computeTokenCostUsd({
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreation5m: 0,
+      cacheCreation1h: 0,
+      cacheCreationTokens: 0,
+      model: 'claude-opus-4-5-20251101',
+    });
     // $5/Mtok input -- Opus 4.5 is half of Opus 4.1's $15/Mtok published rate.
     expect(cost).toBeCloseTo(5, 5);
   });

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -1603,18 +1603,26 @@ function handleSDKMessage(
       // middleware's TokenTrackerPlugin/CacheTrackerPlugin extraction (no
       // dedup for SDK-retried turns — see addTokenUsage's doc comment), so
       // this stays live-updating for every run, not just `--benchmark`.
-      const usage = message.message?.usage as
+      // `message.message` is a BetaMessage (the raw Anthropic API response),
+      // which carries `model` alongside `usage` — read per turn, not from
+      // the run's nominal model, since a subagent dispatched via the Agent
+      // tool can genuinely run on a different model than the main session.
+      const assistantApiMessage = message.message as
         | {
-            input_tokens?: number;
-            output_tokens?: number;
-            cache_read_input_tokens?: number;
-            cache_creation_input_tokens?: number;
-            cache_creation?: {
-              ephemeral_5m_input_tokens?: number;
-              ephemeral_1h_input_tokens?: number;
+            model?: string;
+            usage?: {
+              input_tokens?: number;
+              output_tokens?: number;
+              cache_read_input_tokens?: number;
+              cache_creation_input_tokens?: number;
+              cache_creation?: {
+                ephemeral_5m_input_tokens?: number;
+                ephemeral_1h_input_tokens?: number;
+              };
             };
           }
         | undefined;
+      const usage = assistantApiMessage?.usage;
       if (usage) {
         getUI().addTokenUsage({
           inputTokens: Number(usage.input_tokens ?? 0),
@@ -1627,6 +1635,7 @@ function handleSDKMessage(
           cacheCreation1h: Number(
             usage.cache_creation?.ephemeral_1h_input_tokens ?? 0,
           ),
+          model: assistantApiMessage?.model,
         });
       }
 

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import * as os from 'os';
 import { createRequire } from 'node:module';
 import { getUI, type SpinnerHandle } from '@ui';
+import type { TokenUsageDelta } from '@ui/wizard-ui';
 import { debug, logToFile, initLogFile, getLogFilePath } from '@utils/debug';
 import type { WizardRunOptions } from '@utils/types';
 import { analytics } from '@utils/analytics';
@@ -1561,6 +1562,48 @@ function extractTaskIdFromResult(content: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * Extracts a `TokenUsageDelta` for the hidden Ctrl+T token/cost HUD from an
+ * SDK assistant message, or `null` when the message carries no usage (e.g.
+ * a duplicate/retried turn). `message.message` is a BetaMessage (the raw
+ * Anthropic API response), which carries `model` alongside `usage` — read
+ * per turn, not from the run's nominal model, since a subagent dispatched
+ * via the Agent tool can genuinely run on a different model than the main
+ * session.
+ */
+function extractTokenUsageDelta(message: SDKMessage): TokenUsageDelta | null {
+  const apiMessage = message.message as
+    | {
+        model?: string;
+        usage?: {
+          input_tokens?: number;
+          output_tokens?: number;
+          cache_read_input_tokens?: number;
+          cache_creation_input_tokens?: number;
+          cache_creation?: {
+            ephemeral_5m_input_tokens?: number;
+            ephemeral_1h_input_tokens?: number;
+          };
+        };
+      }
+    | undefined;
+  const usage = apiMessage?.usage;
+  if (!usage) return null;
+  return {
+    inputTokens: Number(usage.input_tokens ?? 0),
+    outputTokens: Number(usage.output_tokens ?? 0),
+    cacheReadTokens: Number(usage.cache_read_input_tokens ?? 0),
+    cacheCreationTokens: Number(usage.cache_creation_input_tokens ?? 0),
+    cacheCreation5m: Number(
+      usage.cache_creation?.ephemeral_5m_input_tokens ?? 0,
+    ),
+    cacheCreation1h: Number(
+      usage.cache_creation?.ephemeral_1h_input_tokens ?? 0,
+    ),
+    model: apiMessage?.model,
+  };
+}
+
 function handleSDKMessage(
   message: SDKMessage,
   options: WizardRunOptions,
@@ -1603,41 +1646,8 @@ function handleSDKMessage(
       // middleware's TokenTrackerPlugin/CacheTrackerPlugin extraction (no
       // dedup for SDK-retried turns — see addTokenUsage's doc comment), so
       // this stays live-updating for every run, not just `--benchmark`.
-      // `message.message` is a BetaMessage (the raw Anthropic API response),
-      // which carries `model` alongside `usage` — read per turn, not from
-      // the run's nominal model, since a subagent dispatched via the Agent
-      // tool can genuinely run on a different model than the main session.
-      const assistantApiMessage = message.message as
-        | {
-            model?: string;
-            usage?: {
-              input_tokens?: number;
-              output_tokens?: number;
-              cache_read_input_tokens?: number;
-              cache_creation_input_tokens?: number;
-              cache_creation?: {
-                ephemeral_5m_input_tokens?: number;
-                ephemeral_1h_input_tokens?: number;
-              };
-            };
-          }
-        | undefined;
-      const usage = assistantApiMessage?.usage;
-      if (usage) {
-        getUI().addTokenUsage({
-          inputTokens: Number(usage.input_tokens ?? 0),
-          outputTokens: Number(usage.output_tokens ?? 0),
-          cacheReadTokens: Number(usage.cache_read_input_tokens ?? 0),
-          cacheCreationTokens: Number(usage.cache_creation_input_tokens ?? 0),
-          cacheCreation5m: Number(
-            usage.cache_creation?.ephemeral_5m_input_tokens ?? 0,
-          ),
-          cacheCreation1h: Number(
-            usage.cache_creation?.ephemeral_1h_input_tokens ?? 0,
-          ),
-          model: assistantApiMessage?.model,
-        });
-      }
+      const tokenUsageDelta = extractTokenUsageDelta(message);
+      if (tokenUsageDelta) getUI().addTokenUsage(tokenUsageDelta);
 
       // Extract text content from assistant messages
       const content = message.message?.content;

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -890,6 +890,13 @@ export async function runAgent(
       cache_read_input_tokens: usage?.cache_read_input_tokens,
       ...config?.analyticsProperties,
     });
+    // Reconcile the hidden Ctrl+T HUD's running cost estimate to the SDK's
+    // authoritative total — same trick the benchmark's
+    // CostTrackerPlugin.onFinalize uses to correct per-turn drift.
+    const totalCostUsd = Number(lastResultMessage?.total_cost_usd ?? 0);
+    if (totalCostUsd > 0) {
+      getUI().setFinalTokenCostUsd(totalCostUsd);
+    }
     try {
       middleware?.finalize(lastResultMessage, durationMs);
     } catch (e) {
@@ -1592,6 +1599,37 @@ function handleSDKMessage(
 
   switch (message.type) {
     case 'assistant': {
+      // Feed the hidden Ctrl+T token/cost HUD. Mirrors the benchmark
+      // middleware's TokenTrackerPlugin/CacheTrackerPlugin extraction (no
+      // dedup for SDK-retried turns — see addTokenUsage's doc comment), so
+      // this stays live-updating for every run, not just `--benchmark`.
+      const usage = message.message?.usage as
+        | {
+            input_tokens?: number;
+            output_tokens?: number;
+            cache_read_input_tokens?: number;
+            cache_creation_input_tokens?: number;
+            cache_creation?: {
+              ephemeral_5m_input_tokens?: number;
+              ephemeral_1h_input_tokens?: number;
+            };
+          }
+        | undefined;
+      if (usage) {
+        getUI().addTokenUsage({
+          inputTokens: Number(usage.input_tokens ?? 0),
+          outputTokens: Number(usage.output_tokens ?? 0),
+          cacheReadTokens: Number(usage.cache_read_input_tokens ?? 0),
+          cacheCreationTokens: Number(usage.cache_creation_input_tokens ?? 0),
+          cacheCreation5m: Number(
+            usage.cache_creation?.ephemeral_5m_input_tokens ?? 0,
+          ),
+          cacheCreation1h: Number(
+            usage.cache_creation?.ephemeral_1h_input_tokens ?? 0,
+          ),
+        });
+      }
+
       // Extract text content from assistant messages
       const content = message.message?.content;
       if (Array.isArray(content)) {

--- a/src/lib/agent/token-pricing.ts
+++ b/src/lib/agent/token-pricing.ts
@@ -1,6 +1,6 @@
 /**
- * Shared USD-per-token pricing for the agent's default model, and the cost
- * formula applied to a token usage delta.
+ * Shared USD-per-token pricing by model family, and the cost formula applied
+ * to a token usage delta.
  *
  * Single source of truth for both the benchmark's `CostTrackerPlugin`
  * (`@lib/middleware/benchmarks/cost-tracker`) and the live token/cost HUD
@@ -8,21 +8,81 @@
  * never drift apart. Both reconcile against the SDK's own authoritative
  * `total_cost_usd` once the run finishes — this table only prices the
  * *live-updating* estimate shown while the agent is still running.
+ *
+ * Model-aware because a run's model isn't fixed: `AgentConfig.modelOverride`
+ * switches specific programs to Haiku (e.g. source-map detection), and the
+ * SDK reports a `model` string on every individual assistant turn (subagents
+ * dispatched via the Agent tool can run on a different model than the main
+ * session) — pricing everything at one flat rate would badly misprice a
+ * Haiku-priced turn as if it were Sonnet. Callers that know the turn's model
+ * should pass it; callers that don't (e.g. a caller with no model context)
+ * fall back to Sonnet, the default model for interactive runs.
  */
 
-/** Claude Sonnet 4.6 pricing (USD per 1M tokens) */
-export const PRICE_PER_MTOK = {
+export interface PricePerMtok {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation5m: number;
+  cacheCreation1h: number;
+}
+
+/**
+ * Cache pricing follows Anthropic's standard ratios relative to input —
+ * cacheRead = input × 0.1, cacheCreation5m = input × 1.25, cacheCreation1h =
+ * input × 2 — consistent across the model families below. Verify against
+ * https://www.anthropic.com/pricing if a rate ever looks stale.
+ */
+const HAIKU_PRICE_PER_MTOK: PricePerMtok = {
+  input: 1,
+  output: 5,
+  cacheRead: 0.1,
+  cacheCreation5m: 1.25,
+  cacheCreation1h: 2,
+};
+
+/** Claude Sonnet 4.6 pricing (USD per 1M tokens) — the default model. */
+const SONNET_PRICE_PER_MTOK: PricePerMtok = {
   input: 3,
   output: 15,
   cacheRead: 0.3,
   cacheCreation5m: 3.75,
   cacheCreation1h: 6,
-} as const;
+};
+
+const OPUS_PRICE_PER_MTOK: PricePerMtok = {
+  input: 15,
+  output: 75,
+  cacheRead: 1.5,
+  cacheCreation5m: 18.75,
+  cacheCreation1h: 30,
+};
 
 /**
- * Cost in USD for one usage delta. `cacheCreation5m`/`cacheCreation1h` come
- * from the SDK's `usage.cache_creation` breakdown, which is only reported on
- * some turns — when both are 0, `cacheCreationFallback` (the plain
+ * The default model's price table, for callers with no model context.
+ * @deprecated Prefer `pricePerMtokForModel(model)` — kept for the (rare)
+ * caller that genuinely doesn't have a model string available.
+ */
+export const PRICE_PER_MTOK = SONNET_PRICE_PER_MTOK;
+
+/**
+ * Resolve the right price table for a model id, matched on a substring
+ * (e.g. `claude-haiku-4-5-20251001` matches `'haiku'`) so a dated version
+ * suffix never breaks the match. Missing/unrecognized model falls back to
+ * Sonnet, the default model for interactive runs.
+ */
+export function pricePerMtokForModel(model?: string): PricePerMtok {
+  if (!model) return SONNET_PRICE_PER_MTOK;
+  if (model.includes('haiku')) return HAIKU_PRICE_PER_MTOK;
+  if (model.includes('opus')) return OPUS_PRICE_PER_MTOK;
+  return SONNET_PRICE_PER_MTOK;
+}
+
+/**
+ * Cost in USD for one usage delta, priced at `model`'s rates (see
+ * `pricePerMtokForModel`). `cacheCreation5m`/`cacheCreation1h` come from the
+ * SDK's `usage.cache_creation` breakdown, which is only reported on some
+ * turns — when both are 0, `cacheCreationFallback` (the plain
  * `cache_creation_input_tokens` total) is priced at the 5m rate instead, so a
  * turn without the breakdown still gets a reasonable estimate rather than
  * being priced at $0.
@@ -34,16 +94,18 @@ export function computeTokenCostUsd(
   cacheCreation5m: number,
   cacheCreation1h: number,
   cacheCreationFallback: number,
+  model?: string,
 ): number {
+  const price = pricePerMtokForModel(model);
   const hasBreakdown = cacheCreation5m > 0 || cacheCreation1h > 0;
   return (
-    inputTokens * (PRICE_PER_MTOK.input / 1e6) +
-    outputTokens * (PRICE_PER_MTOK.output / 1e6) +
-    cacheReadTokens * (PRICE_PER_MTOK.cacheRead / 1e6) +
+    inputTokens * (price.input / 1e6) +
+    outputTokens * (price.output / 1e6) +
+    cacheReadTokens * (price.cacheRead / 1e6) +
     (hasBreakdown
-      ? cacheCreation5m * (PRICE_PER_MTOK.cacheCreation5m / 1e6) +
-        cacheCreation1h * (PRICE_PER_MTOK.cacheCreation1h / 1e6)
-      : cacheCreationFallback * (PRICE_PER_MTOK.cacheCreation5m / 1e6))
+      ? cacheCreation5m * (price.cacheCreation5m / 1e6) +
+        cacheCreation1h * (price.cacheCreation1h / 1e6)
+      : cacheCreationFallback * (price.cacheCreation5m / 1e6))
   );
 }
 

--- a/src/lib/agent/token-pricing.ts
+++ b/src/lib/agent/token-pricing.ts
@@ -1,6 +1,6 @@
 /**
- * Shared USD-per-token pricing by model family, and the cost formula applied
- * to a token usage delta.
+ * Shared exact-match USD-per-token pricing by model id, and the cost formula
+ * applied to a token usage delta.
  *
  * Single source of truth for both the benchmark's `CostTrackerPlugin`
  * (`@lib/middleware/benchmarks/cost-tracker`) and the live token/cost HUD
@@ -13,11 +13,24 @@
  * switches specific programs to Haiku (e.g. source-map detection), and the
  * SDK reports a `model` string on every individual assistant turn (subagents
  * dispatched via the Agent tool can run on a different model than the main
- * session) — pricing everything at one flat rate would badly misprice a
- * Haiku-priced turn as if it were Sonnet. Callers that know the turn's model
- * should pass it; callers that don't (e.g. a caller with no model context)
- * fall back to Sonnet, the default model for interactive runs.
+ * session).
+ *
+ * Deliberately matched by *exact* model id, not family name (no
+ * `model.includes('opus')`-style fallback): different versions of the same
+ * family are priced differently — e.g. Claude Opus 4.5 ($5/$25 per Mtok) is
+ * half of Opus 4.1's rate ($15/$75), and Claude Sonnet 5 ($2/$10) undercuts
+ * Sonnet 4.6 ($3/$15) — so matching on "opus" or "sonnet" alone silently
+ * mis-prices a newer/older sibling at the wrong rate. The only normalization
+ * applied is stripping a trailing release-date suffix (`stripDateSuffix`),
+ * since Anthropic's dated and undated ids for the *same* version always
+ * carry the same price (verified for every entry below).
+ *
+ * Prices verified against https://models.dev/api.json (Anthropic section)
+ * on 2026-07-01 — re-verify there when adding an entry or bumping
+ * DEFAULT_AGENT_MODEL/HAIKU_MODEL, since this table isn't fetched live.
  */
+
+import { DEFAULT_AGENT_MODEL } from '@lib/constants';
 
 export interface PricePerMtok {
   input: number;
@@ -28,59 +41,69 @@ export interface PricePerMtok {
 }
 
 /**
- * Cache pricing follows Anthropic's standard ratios relative to input —
- * cacheRead = input × 0.1, cacheCreation5m = input × 1.25, cacheCreation1h =
- * input × 2 — consistent across the model families below. Verify against
- * https://www.anthropic.com/pricing if a rate ever looks stale.
+ * `cacheCreation1h` isn't published by models.dev (it only has one
+ * cache-write rate); extrapolated at `input × 2`, the ratio that holds for
+ * every model below (mirrors `cacheCreation5m` = `input × 1.25`, `cacheRead`
+ * = `input × 0.1` — Anthropic's standard prompt-caching multipliers).
+ * Rounded to 6 decimal places to clean up binary float noise from the
+ * multiplication (e.g. `3 * 0.1` is `0.30000000000000004`, not `0.3`) — well
+ * past cent-level precision at the 1M-token scale these prices are quoted at.
  */
-const HAIKU_PRICE_PER_MTOK: PricePerMtok = {
-  input: 1,
-  output: 5,
-  cacheRead: 0.1,
-  cacheCreation5m: 1.25,
-  cacheCreation1h: 2,
-};
-
-/** Claude Sonnet 4.6 pricing (USD per 1M tokens) — the default model. */
-const SONNET_PRICE_PER_MTOK: PricePerMtok = {
-  input: 3,
-  output: 15,
-  cacheRead: 0.3,
-  cacheCreation5m: 3.75,
-  cacheCreation1h: 6,
-};
-
-const OPUS_PRICE_PER_MTOK: PricePerMtok = {
-  input: 15,
-  output: 75,
-  cacheRead: 1.5,
-  cacheCreation5m: 18.75,
-  cacheCreation1h: 30,
-};
-
-/**
- * The default model's price table, for callers with no model context.
- * @deprecated Prefer `pricePerMtokForModel(model)` — kept for the (rare)
- * caller that genuinely doesn't have a model string available.
- */
-export const PRICE_PER_MTOK = SONNET_PRICE_PER_MTOK;
-
-/**
- * Resolve the right price table for a model id, matched on a substring
- * (e.g. `claude-haiku-4-5-20251001` matches `'haiku'`) so a dated version
- * suffix never breaks the match. Missing/unrecognized model falls back to
- * Sonnet, the default model for interactive runs.
- */
-export function pricePerMtokForModel(model?: string): PricePerMtok {
-  if (!model) return SONNET_PRICE_PER_MTOK;
-  if (model.includes('haiku')) return HAIKU_PRICE_PER_MTOK;
-  if (model.includes('opus')) return OPUS_PRICE_PER_MTOK;
-  return SONNET_PRICE_PER_MTOK;
+function pricingFromInput(input: number, output: number): PricePerMtok {
+  const round = (n: number): number => Math.round(n * 1e6) / 1e6;
+  return {
+    input,
+    output,
+    cacheRead: round(input * 0.1),
+    cacheCreation5m: round(input * 1.25),
+    cacheCreation1h: round(input * 2),
+  };
 }
 
 /**
- * Cost in USD for one usage delta, priced at `model`'s rates (see
- * `pricePerMtokForModel`). `cacheCreation5m`/`cacheCreation1h` come from the
+ * Exact-match price table, keyed by the *undated* model id prefix —
+ * `pricePerMtokForModel` strips a dated suffix before falling back to this
+ * table, so e.g. `HAIKU_MODEL` (`claude-haiku-4-5-20251001`) resolves via
+ * the `'claude-haiku-4-5'` entry without needing its own duplicate key.
+ * `DEFAULT_AGENT_MODEL` (`claude-sonnet-4-6`) has no date suffix, so it's
+ * keyed directly. The rest are additional real Anthropic model ids kept
+ * priced correctly in case a subagent or a future default ever reports one
+ * (a turn on an id NOT in this table contributes $0 to the live estimate
+ * rather than guessing — see `pricePerMtokForModel`).
+ */
+const PRICE_TABLE: Record<string, PricePerMtok> = {
+  [DEFAULT_AGENT_MODEL]: pricingFromInput(3, 15),
+  'claude-haiku-4-5': pricingFromInput(1, 5), // HAIKU_MODEL + a date suffix
+  'claude-opus-4-5': pricingFromInput(5, 25),
+  'claude-sonnet-5': pricingFromInput(2, 10),
+};
+
+/** Strips a trailing 8-digit release-date suffix (e.g. `-20251001`) — never
+ *  the version segment, so differently-versioned models are never conflated.
+ *  `claude-haiku-4-5-20251001` → `claude-haiku-4-5`; `claude-sonnet-4-6` (no
+ *  date suffix) is returned unchanged. */
+function stripDateSuffix(model: string): string {
+  return model.replace(/-\d{8}$/, '');
+}
+
+/**
+ * Exact-match pricing lookup. `undefined` model (a caller with no model
+ * context, e.g. the benchmark's `CostTrackerPlugin`) falls back to
+ * `DEFAULT_AGENT_MODEL`'s price, the default for interactive runs. A
+ * *given* but unrecognized model id returns `undefined` rather than
+ * guessing from its family name — seeing `undefined` and skipping that
+ * delta is strictly more accurate than the family-fallback this replaced,
+ * which silently priced e.g. every Opus turn at Opus 4.1's rate.
+ */
+export function pricePerMtokForModel(model?: string): PricePerMtok | undefined {
+  if (!model) return PRICE_TABLE[DEFAULT_AGENT_MODEL];
+  return PRICE_TABLE[model] ?? PRICE_TABLE[stripDateSuffix(model)];
+}
+
+/**
+ * Cost in USD for one usage delta, priced at `model`'s exact rates (see
+ * `pricePerMtokForModel`) — 0 when `model` is given but not in the table,
+ * rather than guessing. `cacheCreation5m`/`cacheCreation1h` come from the
  * SDK's `usage.cache_creation` breakdown, which is only reported on some
  * turns — when both are 0, `cacheCreationFallback` (the plain
  * `cache_creation_input_tokens` total) is priced at the 5m rate instead, so a
@@ -97,6 +120,7 @@ export function computeTokenCostUsd(
   model?: string,
 ): number {
   const price = pricePerMtokForModel(model);
+  if (!price) return 0;
   const hasBreakdown = cacheCreation5m > 0 || cacheCreation1h > 0;
   return (
     inputTokens * (price.input / 1e6) +

--- a/src/lib/agent/token-pricing.ts
+++ b/src/lib/agent/token-pricing.ts
@@ -18,12 +18,13 @@
  * Deliberately matched by *exact* model id, not family name (no
  * `model.includes('opus')`-style fallback): different versions of the same
  * family are priced differently — e.g. Claude Opus 4.5 ($5/$25 per Mtok) is
- * half of Opus 4.1's rate ($15/$75), and Claude Sonnet 5 ($2/$10) undercuts
- * Sonnet 4.6 ($3/$15) — so matching on "opus" or "sonnet" alone silently
- * mis-prices a newer/older sibling at the wrong rate. The only normalization
- * applied is stripping a trailing release-date suffix (`stripDateSuffix`),
- * since Anthropic's dated and undated ids for the *same* version always
- * carry the same price (verified for every entry below).
+ * half of Opus 4.1's rate ($15/$75) — so matching on "opus" or "sonnet"
+ * alone silently mis-prices a newer/older sibling at the wrong rate. The
+ * only normalization applied is stripping a trailing release-date suffix
+ * (`stripDateSuffix`), since Anthropic's dated and undated ids for the
+ * *same* version always carry the same price (verified for every entry
+ * below). Claude Sonnet 5 is the one exception with a *time-dependent*
+ * price — see `sonnet5Price` — rather than a fixed table entry.
  *
  * Prices verified against https://models.dev/api.json (Anthropic section)
  * on 2026-07-01 — re-verify there when adding an entry or bumping
@@ -70,13 +71,32 @@ function pricingFromInput(input: number, output: number): PricePerMtok {
  * priced correctly in case a subagent or a future default ever reports one
  * (a turn on an id NOT in this table contributes $0 to the live estimate
  * rather than guessing — see `pricePerMtokForModel`).
+ *
+ * `'claude-sonnet-5'` is intentionally absent — its price is time-dependent
+ * (promotional launch discount), so it's resolved separately by
+ * `pricePerMtokForModel` via `SONNET_5_PRICE`.
  */
 const PRICE_TABLE: Record<string, PricePerMtok> = {
   [DEFAULT_AGENT_MODEL]: pricingFromInput(3, 15),
   'claude-haiku-4-5': pricingFromInput(1, 5), // HAIKU_MODEL + a date suffix
   'claude-opus-4-5': pricingFromInput(5, 25),
-  'claude-sonnet-5': pricingFromInput(2, 10),
 };
+
+/**
+ * Claude Sonnet 5 launched at a promotional discount through 2026-08-31
+ * UTC; from 2026-09-01 it reverts to the same rate as Sonnet 4.6 ($3/$15)
+ * — not a coincidence, Anthropic prices it identically to 4.6 once the
+ * promo ends. Re-verify against https://models.dev/api.json if this ever
+ * looks off, and delete this special case once the promo window has
+ * passed (its `PRICE_TABLE[DEFAULT_AGENT_MODEL]` price is the same anyway).
+ */
+const SONNET_5_PROMO_ENDS_UTC = new Date('2026-09-01T00:00:00Z');
+
+function sonnet5Price(now: Date): PricePerMtok {
+  return now < SONNET_5_PROMO_ENDS_UTC
+    ? pricingFromInput(2, 10)
+    : pricingFromInput(3, 15);
+}
 
 /** Strips a trailing 8-digit release-date suffix (e.g. `-20251001`) — never
  *  the version segment, so differently-versioned models are never conflated.
@@ -94,10 +114,19 @@ function stripDateSuffix(model: string): string {
  * guessing from its family name — seeing `undefined` and skipping that
  * delta is strictly more accurate than the family-fallback this replaced,
  * which silently priced e.g. every Opus turn at Opus 4.1's rate.
+ *
+ * `now` is injectable (defaults to the real clock) only so
+ * `sonnet5Price`'s promo-window check is deterministic in tests — no
+ * other entry in this table is time-dependent.
  */
-export function pricePerMtokForModel(model?: string): PricePerMtok | undefined {
+export function pricePerMtokForModel(
+  model?: string,
+  now: Date = new Date(),
+): PricePerMtok | undefined {
   if (!model) return PRICE_TABLE[DEFAULT_AGENT_MODEL];
-  return PRICE_TABLE[model] ?? PRICE_TABLE[stripDateSuffix(model)];
+  const undated = stripDateSuffix(model);
+  if (undated === 'claude-sonnet-5') return sonnet5Price(now);
+  return PRICE_TABLE[model] ?? PRICE_TABLE[undated];
 }
 
 /**

--- a/src/lib/agent/token-pricing.ts
+++ b/src/lib/agent/token-pricing.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared USD-per-token pricing for the agent's default model, and the cost
+ * formula applied to a token usage delta.
+ *
+ * Single source of truth for both the benchmark's `CostTrackerPlugin`
+ * (`@lib/middleware/benchmarks/cost-tracker`) and the live token/cost HUD
+ * (`agent-interface.ts`'s per-turn usage accumulation), so the two estimates
+ * never drift apart. Both reconcile against the SDK's own authoritative
+ * `total_cost_usd` once the run finishes — this table only prices the
+ * *live-updating* estimate shown while the agent is still running.
+ */
+
+/** Claude Sonnet 4.6 pricing (USD per 1M tokens) */
+export const PRICE_PER_MTOK = {
+  input: 3,
+  output: 15,
+  cacheRead: 0.3,
+  cacheCreation5m: 3.75,
+  cacheCreation1h: 6,
+} as const;
+
+/**
+ * Cost in USD for one usage delta. `cacheCreation5m`/`cacheCreation1h` come
+ * from the SDK's `usage.cache_creation` breakdown, which is only reported on
+ * some turns — when both are 0, `cacheCreationFallback` (the plain
+ * `cache_creation_input_tokens` total) is priced at the 5m rate instead, so a
+ * turn without the breakdown still gets a reasonable estimate rather than
+ * being priced at $0.
+ */
+export function computeTokenCostUsd(
+  inputTokens: number,
+  outputTokens: number,
+  cacheReadTokens: number,
+  cacheCreation5m: number,
+  cacheCreation1h: number,
+  cacheCreationFallback: number,
+): number {
+  const hasBreakdown = cacheCreation5m > 0 || cacheCreation1h > 0;
+  return (
+    inputTokens * (PRICE_PER_MTOK.input / 1e6) +
+    outputTokens * (PRICE_PER_MTOK.output / 1e6) +
+    cacheReadTokens * (PRICE_PER_MTOK.cacheRead / 1e6) +
+    (hasBreakdown
+      ? cacheCreation5m * (PRICE_PER_MTOK.cacheCreation5m / 1e6) +
+        cacheCreation1h * (PRICE_PER_MTOK.cacheCreation1h / 1e6)
+      : cacheCreationFallback * (PRICE_PER_MTOK.cacheCreation5m / 1e6))
+  );
+}
+
+/**
+ * Shared display formatters for the hidden Ctrl+T HUD (`TokenCostHud`) and
+ * the post-exit scrollback line (`exit-line.ts`) — kept here, not in either
+ * of those files, since `exit-line.ts` is deliberately free of `ink`/React
+ * imports (it must stay a pure, unit-testable function), and importing a
+ * named export from a `.tsx` file would pull `ink` into its module graph
+ * anyway. This module has no such dependency.
+ */
+export function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+export function formatCostUsd(usd: number): string {
+  if (usd > 0 && usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}

--- a/src/lib/agent/token-pricing.ts
+++ b/src/lib/agent/token-pricing.ts
@@ -101,35 +101,39 @@ export function pricePerMtokForModel(model?: string): PricePerMtok | undefined {
 }
 
 /**
- * Cost in USD for one usage delta, priced at `model`'s exact rates (see
- * `pricePerMtokForModel`) — 0 when `model` is given but not in the table,
- * rather than guessing. `cacheCreation5m`/`cacheCreation1h` come from the
- * SDK's `usage.cache_creation` breakdown, which is only reported on some
- * turns — when both are 0, `cacheCreationFallback` (the plain
- * `cache_creation_input_tokens` total) is priced at the 5m rate instead, so a
- * turn without the breakdown still gets a reasonable estimate rather than
+ * Cost in USD for one usage delta, priced at `usage.model`'s exact rates
+ * (see `pricePerMtokForModel`) — 0 when `model` is given but not in the
+ * table, rather than guessing. `cacheCreation5m`/`cacheCreation1h` come from
+ * the SDK's `usage.cache_creation` breakdown, which is only reported on
+ * some turns — when both are 0, `cacheCreationTokens` (the plain
+ * `cache_creation_input_tokens` total) is priced at the 5m rate instead, so
+ * a turn without the breakdown still gets a reasonable estimate rather than
  * being priced at $0.
+ *
+ * Takes the same shape as `TokenUsageDelta` (`@ui/wizard-ui`) so a caller
+ * that already has one — `WizardStore.addTokenUsage` — can pass it straight
+ * through instead of re-listing its fields in a fixed positional order.
  */
-export function computeTokenCostUsd(
-  inputTokens: number,
-  outputTokens: number,
-  cacheReadTokens: number,
-  cacheCreation5m: number,
-  cacheCreation1h: number,
-  cacheCreationFallback: number,
-  model?: string,
-): number {
-  const price = pricePerMtokForModel(model);
+export function computeTokenCostUsd(usage: {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreation5m: number;
+  cacheCreation1h: number;
+  cacheCreationTokens: number;
+  model?: string;
+}): number {
+  const price = pricePerMtokForModel(usage.model);
   if (!price) return 0;
-  const hasBreakdown = cacheCreation5m > 0 || cacheCreation1h > 0;
+  const hasBreakdown = usage.cacheCreation5m > 0 || usage.cacheCreation1h > 0;
   return (
-    inputTokens * (price.input / 1e6) +
-    outputTokens * (price.output / 1e6) +
-    cacheReadTokens * (price.cacheRead / 1e6) +
+    usage.inputTokens * (price.input / 1e6) +
+    usage.outputTokens * (price.output / 1e6) +
+    usage.cacheReadTokens * (price.cacheRead / 1e6) +
     (hasBreakdown
-      ? cacheCreation5m * (price.cacheCreation5m / 1e6) +
-        cacheCreation1h * (price.cacheCreation1h / 1e6)
-      : cacheCreationFallback * (price.cacheCreation5m / 1e6))
+      ? usage.cacheCreation5m * (price.cacheCreation5m / 1e6) +
+        usage.cacheCreation1h * (price.cacheCreation1h / 1e6)
+      : usage.cacheCreationTokens * (price.cacheCreation5m / 1e6))
   );
 }
 

--- a/src/lib/middleware/benchmarks/cost-tracker.ts
+++ b/src/lib/middleware/benchmarks/cost-tracker.ts
@@ -14,6 +14,11 @@ export interface CostData {
 
 // Pricing table + formula moved to `@lib/agent/token-pricing` so the live
 // token/cost HUD's per-turn estimate can't drift from this benchmark's.
+// No model is passed here (falls back to Sonnet pricing) -- MiddlewareContext
+// has no model field to thread through, and `--benchmark` always measures
+// the default flow, never a Haiku-overridden program. Still reconciles to
+// the SDK's authoritative total_cost_usd in onFinalize below, same as the
+// live HUD, so this only risks the unreconciled per-phase breakdown.
 const computeCost = computeTokenCostUsd;
 
 export class CostTrackerPlugin implements Middleware {

--- a/src/lib/middleware/benchmarks/cost-tracker.ts
+++ b/src/lib/middleware/benchmarks/cost-tracker.ts
@@ -14,12 +14,12 @@ export interface CostData {
 
 // Pricing table + formula moved to `@lib/agent/token-pricing` so the live
 // token/cost HUD's per-turn estimate can't drift from this benchmark's.
-// No model is passed here (falls back to Sonnet pricing) -- MiddlewareContext
-// has no model field to thread through, and `--benchmark` always measures
-// the default flow, never a Haiku-overridden program. Still reconciles to
-// the SDK's authoritative total_cost_usd in onFinalize below, same as the
-// live HUD, so this only risks the unreconciled per-phase breakdown.
-const computeCost = computeTokenCostUsd;
+// No model is passed to computeTokenCostUsd below (falls back to Sonnet
+// pricing) -- MiddlewareContext has no model field to thread through, and
+// `--benchmark` always measures the default flow, never a Haiku-overridden
+// program. Still reconciles to the SDK's authoritative total_cost_usd in
+// onFinalize below, same as the live HUD, so this only risks the
+// unreconciled per-phase breakdown.
 
 export class CostTrackerPlugin implements Middleware {
   readonly name = 'cost';
@@ -45,14 +45,14 @@ export class CostTrackerPlugin implements Middleware {
     const c1h = cacheSnap?.cacheCreation1h ?? 0;
     const baseIn = Math.max(0, totalIn - read - creation);
 
-    const phaseCost = computeCost(
-      baseIn,
-      tokenSnap?.outputTokens ?? 0,
-      read,
-      c5m,
-      c1h,
-      creation,
-    );
+    const phaseCost = computeTokenCostUsd({
+      inputTokens: baseIn,
+      outputTokens: tokenSnap?.outputTokens ?? 0,
+      cacheReadTokens: read,
+      cacheCreation5m: c5m,
+      cacheCreation1h: c1h,
+      cacheCreationTokens: creation,
+    });
 
     this.phaseCosts.push({ phase: fromPhase, cost: phaseCost });
     this.totalCost += phaseCost;
@@ -77,14 +77,14 @@ export class CostTrackerPlugin implements Middleware {
     const c1h = cacheSnap?.cacheCreation1h ?? 0;
     const baseIn = Math.max(0, totalIn - read - creation);
 
-    const lastPhaseCost = computeCost(
-      baseIn,
-      tokenSnap?.outputTokens ?? 0,
-      read,
-      c5m,
-      c1h,
-      creation,
-    );
+    const lastPhaseCost = computeTokenCostUsd({
+      inputTokens: baseIn,
+      outputTokens: tokenSnap?.outputTokens ?? 0,
+      cacheReadTokens: read,
+      cacheCreation5m: c5m,
+      cacheCreation1h: c1h,
+      cacheCreationTokens: creation,
+    });
 
     this.phaseCosts.push({ phase: ctx.currentPhase, cost: lastPhaseCost });
     this.totalCost += lastPhaseCost;

--- a/src/lib/middleware/benchmarks/cost-tracker.ts
+++ b/src/lib/middleware/benchmarks/cost-tracker.ts
@@ -3,6 +3,7 @@ import type {
   MiddlewareContext,
   MiddlewareStore,
 } from '@lib/middleware/types';
+import { computeTokenCostUsd } from '@lib/agent/token-pricing';
 import type { TokenData } from './token-tracker';
 import type { CacheData } from './cache-tracker';
 
@@ -11,34 +12,9 @@ export interface CostData {
   phaseCosts: Array<{ phase: string; cost: number }>;
 }
 
-/** Claude Sonnet 4.6 pricing (USD per 1M tokens) */
-const PRICE_PER_MTOK = {
-  input: 3,
-  output: 15,
-  cacheRead: 0.3,
-  cacheCreation5m: 3.75,
-  cacheCreation1h: 6,
-} as const;
-
-function computeCost(
-  inputTokens: number,
-  outputTokens: number,
-  cacheReadTokens: number,
-  cacheCreation5m: number,
-  cacheCreation1h: number,
-  cacheCreationFallback: number,
-): number {
-  const hasBreakdown = cacheCreation5m > 0 || cacheCreation1h > 0;
-  return (
-    inputTokens * (PRICE_PER_MTOK.input / 1e6) +
-    outputTokens * (PRICE_PER_MTOK.output / 1e6) +
-    cacheReadTokens * (PRICE_PER_MTOK.cacheRead / 1e6) +
-    (hasBreakdown
-      ? cacheCreation5m * (PRICE_PER_MTOK.cacheCreation5m / 1e6) +
-        cacheCreation1h * (PRICE_PER_MTOK.cacheCreation1h / 1e6)
-      : cacheCreationFallback * (PRICE_PER_MTOK.cacheCreation5m / 1e6))
-  );
-}
+// Pricing table + formula moved to `@lib/agent/token-pricing` so the live
+// token/cost HUD's per-turn estimate can't drift from this benchmark's.
+const computeCost = computeTokenCostUsd;
 
 export class CostTrackerPlugin implements Middleware {
   readonly name = 'cost';

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -9,6 +9,7 @@ import {
   type WizardUI,
   type SpinnerHandle,
   type AuthErrorDetail,
+  type TokenUsageDelta,
 } from './wizard-ui';
 import type { SettingsConflict } from '@lib/agent/claude-settings';
 import type { ApiUser } from '@lib/api';
@@ -268,14 +269,7 @@ export class LoggingUI implements WizardUI {
     // No-op in CI mode
   }
 
-  addTokenUsage(_delta: {
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreationTokens: number;
-    cacheCreation5m: number;
-    cacheCreation1h: number;
-  }): void {
+  addTokenUsage(_delta: TokenUsageDelta): void {
     // No-op — the hidden Ctrl+T HUD is TUI-only
   }
 

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -268,6 +268,21 @@ export class LoggingUI implements WizardUI {
     // No-op in CI mode
   }
 
+  addTokenUsage(_delta: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+    cacheCreation5m: number;
+    cacheCreation1h: number;
+  }): void {
+    // No-op — the hidden Ctrl+T HUD is TUI-only
+  }
+
+  setFinalTokenCostUsd(_costUsd: number): void {
+    // No-op — the hidden Ctrl+T HUD is TUI-only
+  }
+
   setOutroData(_data: import('@lib/wizard-session').OutroData): void {
     // No-op in CI mode
   }

--- a/src/ui/tui/__tests__/exit-line.test.ts
+++ b/src/ui/tui/__tests__/exit-line.test.ts
@@ -117,4 +117,72 @@ describe('getExitLine', () => {
     expect(line).toMatch(/exited\.$/);
     expect(line).not.toContain('coding agent');
   });
+
+  describe('token/cost tally (hidden Ctrl+T HUD survives into scrollback)', () => {
+    it('appends the running cost estimate on a success outro', () => {
+      const store = storeWithOutro({
+        kind: OutroKind.Success,
+        message: 'Done!',
+      });
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+
+      const line = stripAnsi(getExitLine(store));
+
+      expect(line).toContain('Cost (estimate): $3.00');
+      expect(line).toContain('in 1.00M');
+    });
+
+    it('labels the tally "Final cost" once reconciled to the SDK total', () => {
+      const store = storeWithOutro({
+        kind: OutroKind.Success,
+        message: 'Done!',
+      });
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+      store.setFinalTokenCostUsd(1.5);
+
+      const line = stripAnsi(getExitLine(store));
+
+      expect(line).toContain('Final cost: $1.50');
+    });
+
+    it('appends the tally after the "exited" line for non-success outcomes too', () => {
+      const store = storeWithOutro({ kind: OutroKind.Error, message: 'boom' });
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+
+      const line = stripAnsi(getExitLine(store));
+
+      expect(line).toMatch(/exited\./);
+      expect(line).toContain('Cost (estimate): $3.00');
+    });
+
+    it('omits the tally entirely when the run never produced any usage', () => {
+      const line = stripAnsi(
+        getExitLine(
+          storeWithOutro({ kind: OutroKind.Success, message: 'Done!' }),
+        ),
+      );
+      expect(line).not.toContain('Cost');
+    });
+  });
 });

--- a/src/ui/tui/__tests__/exit-line.test.ts
+++ b/src/ui/tui/__tests__/exit-line.test.ts
@@ -24,6 +24,11 @@ function storeWithOutro(
   return store;
 }
 
+/** Force `tokenHudVisible` to `visible`, regardless of its IS_DEV default. */
+function setHudVisible(store: WizardStore, visible: boolean): void {
+  if (store.tokenHudVisible !== visible) store.toggleTokenHud();
+}
+
 describe('getExitLine', () => {
   it('echoes the handoff prompt on its own line so it survives in scrollback', () => {
     const prompt =
@@ -119,11 +124,12 @@ describe('getExitLine', () => {
   });
 
   describe('token/cost tally (hidden Ctrl+T HUD survives into scrollback)', () => {
-    it('appends the running cost estimate on a success outro', () => {
+    it('appends the running cost estimate on a success outro when the HUD is visible', () => {
       const store = storeWithOutro({
         kind: OutroKind.Success,
         message: 'Done!',
       });
+      setHudVisible(store, true);
       store.addTokenUsage({
         inputTokens: 1_000_000,
         outputTokens: 0,
@@ -144,6 +150,7 @@ describe('getExitLine', () => {
         kind: OutroKind.Success,
         message: 'Done!',
       });
+      setHudVisible(store, true);
       store.addTokenUsage({
         inputTokens: 1_000_000,
         outputTokens: 0,
@@ -161,6 +168,7 @@ describe('getExitLine', () => {
 
     it('appends the tally after the "exited" line for non-success outcomes too', () => {
       const store = storeWithOutro({ kind: OutroKind.Error, message: 'boom' });
+      setHudVisible(store, true);
       store.addTokenUsage({
         inputTokens: 1_000_000,
         outputTokens: 0,
@@ -177,11 +185,37 @@ describe('getExitLine', () => {
     });
 
     it('omits the tally entirely when the run never produced any usage', () => {
-      const line = stripAnsi(
-        getExitLine(
-          storeWithOutro({ kind: OutroKind.Success, message: 'Done!' }),
-        ),
-      );
+      const store = storeWithOutro({
+        kind: OutroKind.Success,
+        message: 'Done!',
+      });
+      setHudVisible(store, true);
+
+      const line = stripAnsi(getExitLine(store));
+
+      expect(line).not.toContain('Cost');
+    });
+
+    it('omits the tally when the HUD was toggled off, even with usage to show', () => {
+      // The user explicitly hid the HUD (or it's a production run, where it
+      // defaults hidden) -- the cost tally shouldn't appear out of nowhere
+      // in scrollback for someone who never asked to see it.
+      const store = storeWithOutro({
+        kind: OutroKind.Success,
+        message: 'Done!',
+      });
+      setHudVisible(store, false);
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+
+      const line = stripAnsi(getExitLine(store));
+
       expect(line).not.toContain('Cost');
     });
   });

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -620,7 +620,7 @@ describe('WizardStore', () => {
   });
 
   describe('tokenUsage / toggleTokenHud (hidden Ctrl+T HUD)', () => {
-    it('starts at zero and hidden', () => {
+    it('starts at zero usage, and visible by default in dev/test (IS_DEV)', () => {
       const store = createStore();
       expect(store.tokenUsage).toEqual({
         inputTokens: 0,
@@ -630,15 +630,18 @@ describe('WizardStore', () => {
         costUsd: 0,
         costIsFinal: false,
       });
-      expect(store.tokenHudVisible).toBe(false);
+      // Defaults to IS_DEV, which is true under vitest (NODE_ENV=test) --
+      // see WizardStore's $tokenHudVisible doc comment.
+      expect(store.tokenHudVisible).toBe(true);
     });
 
-    it('toggleTokenHud flips visibility each call', () => {
+    it('toggleTokenHud flips visibility each call, from whatever it started at', () => {
       const store = createStore();
+      const initial = store.tokenHudVisible;
       store.toggleTokenHud();
-      expect(store.tokenHudVisible).toBe(true);
+      expect(store.tokenHudVisible).toBe(!initial);
       store.toggleTokenHud();
-      expect(store.tokenHudVisible).toBe(false);
+      expect(store.tokenHudVisible).toBe(initial);
     });
 
     it('addTokenUsage accumulates token counts and cost across calls', () => {
@@ -665,6 +668,35 @@ describe('WizardStore', () => {
       // $3/Mtok input + $15/Mtok output, from the shared pricing table.
       expect(store.tokenUsage.costUsd).toBeCloseTo(2 * 3 + 15, 5);
       expect(store.tokenUsage.costIsFinal).toBe(false);
+    });
+
+    it('prices each delta at its own model, not a single run-wide rate', () => {
+      // A Haiku-overridden turn (e.g. source-map detection) followed by a
+      // default-model turn -- each must be priced at its own rate, since a
+      // subagent can genuinely run on a different model than the main
+      // session's turns.
+      const store = createStore();
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+        model: 'claude-haiku-4-5-20251001',
+      });
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+
+      // $1 (Haiku) + $3 (Sonnet default) -- not $6 if both were priced as
+      // Sonnet, and not $2 if both were priced as Haiku.
+      expect(store.tokenUsage.costUsd).toBeCloseTo(1 + 3, 5);
     });
 
     it('setFinalTokenCostUsd overwrites the running estimate and marks it final', () => {

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -619,6 +619,111 @@ describe('WizardStore', () => {
     });
   });
 
+  describe('tokenUsage / toggleTokenHud (hidden Ctrl+T HUD)', () => {
+    it('starts at zero and hidden', () => {
+      const store = createStore();
+      expect(store.tokenUsage).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        costUsd: 0,
+        costIsFinal: false,
+      });
+      expect(store.tokenHudVisible).toBe(false);
+    });
+
+    it('toggleTokenHud flips visibility each call', () => {
+      const store = createStore();
+      store.toggleTokenHud();
+      expect(store.tokenHudVisible).toBe(true);
+      store.toggleTokenHud();
+      expect(store.tokenHudVisible).toBe(false);
+    });
+
+    it('addTokenUsage accumulates token counts and cost across calls', () => {
+      const store = createStore();
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+
+      expect(store.tokenUsage.inputTokens).toBe(2_000_000);
+      expect(store.tokenUsage.outputTokens).toBe(1_000_000);
+      // $3/Mtok input + $15/Mtok output, from the shared pricing table.
+      expect(store.tokenUsage.costUsd).toBeCloseTo(2 * 3 + 15, 5);
+      expect(store.tokenUsage.costIsFinal).toBe(false);
+    });
+
+    it('setFinalTokenCostUsd overwrites the running estimate and marks it final', () => {
+      const store = createStore();
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+
+      store.setFinalTokenCostUsd(1.23);
+
+      expect(store.tokenUsage.costUsd).toBe(1.23);
+      expect(store.tokenUsage.costIsFinal).toBe(true);
+      // Token counts (not cost) are untouched by reconciliation.
+      expect(store.tokenUsage.inputTokens).toBe(1_000_000);
+    });
+
+    it('addTokenUsage is a no-op once the cost has been finalized', () => {
+      const store = createStore();
+      store.setFinalTokenCostUsd(1.0);
+
+      store.addTokenUsage({
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+
+      // A late-arriving turn (e.g. post-success cleanup) must not perturb
+      // the already-reconciled final number.
+      expect(store.tokenUsage.costUsd).toBe(1.0);
+      expect(store.tokenUsage.inputTokens).toBe(0);
+    });
+
+    it('emits a change so subscribers re-render', () => {
+      const store = createStore();
+      const versions: number[] = [];
+      store.subscribe(() => versions.push(store.getSnapshot()));
+
+      store.toggleTokenHud();
+      store.addTokenUsage({
+        inputTokens: 1,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        cacheCreation5m: 0,
+        cacheCreation1h: 0,
+      });
+
+      expect(versions.length).toBe(2);
+    });
+  });
+
   // ── Agent observation state ──────────────────────────────────────
 
   describe('statusMessages', () => {

--- a/src/ui/tui/components/TokenCostHud.tsx
+++ b/src/ui/tui/components/TokenCostHud.tsx
@@ -16,7 +16,7 @@
  */
 import { Box, Text } from 'ink';
 import { Colors } from '@ui/tui/styles';
-import type { TokenUsageSnapshot } from '@ui/tui/store';
+import { totalTokenCount, type TokenUsageSnapshot } from '@ui/tui/store';
 import { formatTokenCount, formatCostUsd } from '@lib/agent/token-pricing';
 
 /** Self-documents the hidden shortcut once the panel is showing. */
@@ -34,15 +34,10 @@ interface TokenCostLineParts {
 }
 
 function tokenCostLineParts(usage: TokenUsageSnapshot): TokenCostLineParts {
-  const totalTokens =
-    usage.inputTokens +
-    usage.outputTokens +
-    usage.cacheReadTokens +
-    usage.cacheCreationTokens;
   const label = usage.costIsFinal ? 'Final cost' : 'Cost (running)';
   const costPart = `${label}: ${formatCostUsd(usage.costUsd)}`;
 
-  if (totalTokens === 0) {
+  if (totalTokenCount(usage) === 0) {
     return { costPart, breakdownPart: ' · no agent turns yet' };
   }
   return {
@@ -55,20 +50,45 @@ function tokenCostLineParts(usage: TokenUsageSnapshot): TokenCostLineParts {
   };
 }
 
+interface TokenCostLineLayout {
+  costPart: string;
+  breakdownPart: string;
+  /** True when "Ctrl+T to hide" fits on the cost line's row at `width`
+   *  columns (with `MIN_GAP` to spare); false when it needs its own row. */
+  hintFitsInline: boolean;
+  /** Blank columns to pad before the hint when it fits inline. */
+  gap: number;
+}
+
+/** Single source of truth for both `tokenCostHudRowCount` (so
+ *  `ScreenContainer`'s height budget can never disagree with what renders)
+ *  and the component's own render — computed once per call rather than
+ *  separately in each. */
+function layoutTokenCostLine(
+  usage: TokenUsageSnapshot,
+  width: number,
+): TokenCostLineLayout {
+  const { costPart, breakdownPart } = tokenCostLineParts(usage);
+  const lineLength = costPart.length + breakdownPart.length;
+  return {
+    costPart,
+    breakdownPart,
+    hintFitsInline: lineLength + MIN_GAP + HINT_TEXT.length <= width,
+    gap: Math.max(MIN_GAP, width - lineLength - HINT_TEXT.length),
+  };
+}
+
 /**
  * How many rows `TokenCostHud` renders for `usage` at `width` columns of
- * available text space — 1 when the hint fits on the cost line's row (with
- * `MIN_GAP` to spare), 2 when it needs its own row below. `ScreenContainer`
- * calls this with the exact same `usage`/`width` it passes to the
- * component, so its height budget can never disagree with what renders.
+ * available text space — 1 when the hint fits on the cost line's row, 2
+ * when it needs its own row below. `ScreenContainer` calls this with the
+ * exact same `usage`/`width` it passes to the component.
  */
 export function tokenCostHudRowCount(
   usage: TokenUsageSnapshot,
   width: number,
 ): 1 | 2 {
-  const { costPart, breakdownPart } = tokenCostLineParts(usage);
-  const lineLength = costPart.length + breakdownPart.length;
-  return lineLength + MIN_GAP + HINT_TEXT.length <= width ? 1 : 2;
+  return layoutTokenCostLine(usage, width).hintFitsInline ? 1 : 2;
 }
 
 interface TokenCostHudProps {
@@ -80,20 +100,20 @@ interface TokenCostHudProps {
 }
 
 export const TokenCostHud = ({ usage, width }: TokenCostHudProps) => {
-  const { costPart, breakdownPart } = tokenCostLineParts(usage);
-  const inline = tokenCostHudRowCount(usage, width) === 1;
-  const lineLength = costPart.length + breakdownPart.length;
-  const gap = Math.max(MIN_GAP, width - lineLength - HINT_TEXT.length);
+  const { costPart, breakdownPart, hintFitsInline, gap } = layoutTokenCostLine(
+    usage,
+    width,
+  );
 
   return (
     <Box flexDirection="column" paddingX={1}>
       <Text wrap="truncate">
         <Text color={Colors.accent}>{costPart}</Text>
         <Text dimColor>{breakdownPart}</Text>
-        {inline && <Text>{' '.repeat(gap)}</Text>}
-        {inline && <Text dimColor>{HINT_TEXT}</Text>}
+        {hintFitsInline && <Text>{' '.repeat(gap)}</Text>}
+        {hintFitsInline && <Text dimColor>{HINT_TEXT}</Text>}
       </Text>
-      {!inline && (
+      {!hintFitsInline && (
         <Text dimColor wrap="truncate">
           {HINT_TEXT}
         </Text>

--- a/src/ui/tui/components/TokenCostHud.tsx
+++ b/src/ui/tui/components/TokenCostHud.tsx
@@ -6,51 +6,98 @@
  * local/dev/test runs (`WizardStore`'s `$tokenHudVisible` initial value),
  * so contributors see it without needing to know the shortcut; defaults
  * hidden in the published build. Once shown, the panel itself names the
- * shortcut (below), so it's self-documenting either way.
+ * shortcut, so it's self-documenting either way.
  *
- * Exactly two rows (this line + the blank spacer `ScreenContainer` renders
- * below it), so `ScreenContainer` can budget a fixed extra height for it
- * without risking layout overflow when the terminal is narrow.
+ * One row when "Ctrl+T to hide" fits on the same row as the cost line
+ * (right-aligned, with a minimum gap), two when the terminal is too narrow
+ * for both — see `tokenCostHudRowCount`, which `ScreenContainer` calls with
+ * the same inputs so its height budget always matches what actually renders
+ * (plus the blank spacer `ScreenContainer` renders below either way).
  */
 import { Box, Text } from 'ink';
 import { Colors } from '@ui/tui/styles';
 import type { TokenUsageSnapshot } from '@ui/tui/store';
 import { formatTokenCount, formatCostUsd } from '@lib/agent/token-pricing';
 
-interface TokenCostHudProps {
-  usage: TokenUsageSnapshot;
+/** Self-documents the hidden shortcut once the panel is showing. */
+const HINT_TEXT = 'Ctrl+T to hide';
+/** Minimum blank columns between the cost line and the hint when they
+ *  share a row, so they never visually run together. */
+const MIN_GAP = 2;
+
+interface TokenCostLineParts {
+  /** e.g. "Cost (running): $1.23" — rendered in the accent color. */
+  costPart: string;
+  /** e.g. " · in 12.3K · out 4.5K · cache read 1.0K · cache write 500", or
+   *  " · no agent turns yet" — rendered dim. */
+  breakdownPart: string;
 }
 
-export const TokenCostHud = ({ usage }: TokenCostHudProps) => {
+function tokenCostLineParts(usage: TokenUsageSnapshot): TokenCostLineParts {
   const totalTokens =
     usage.inputTokens +
     usage.outputTokens +
     usage.cacheReadTokens +
     usage.cacheCreationTokens;
-
   const label = usage.costIsFinal ? 'Final cost' : 'Cost (running)';
+  const costPart = `${label}: ${formatCostUsd(usage.costUsd)}`;
+
+  if (totalTokens === 0) {
+    return { costPart, breakdownPart: ' · no agent turns yet' };
+  }
+  return {
+    costPart,
+    breakdownPart:
+      ` · in ${formatTokenCount(usage.inputTokens)}` +
+      ` · out ${formatTokenCount(usage.outputTokens)}` +
+      ` · cache read ${formatTokenCount(usage.cacheReadTokens)}` +
+      ` · cache write ${formatTokenCount(usage.cacheCreationTokens)}`,
+  };
+}
+
+/**
+ * How many rows `TokenCostHud` renders for `usage` at `width` columns of
+ * available text space — 1 when the hint fits on the cost line's row (with
+ * `MIN_GAP` to spare), 2 when it needs its own row below. `ScreenContainer`
+ * calls this with the exact same `usage`/`width` it passes to the
+ * component, so its height budget can never disagree with what renders.
+ */
+export function tokenCostHudRowCount(
+  usage: TokenUsageSnapshot,
+  width: number,
+): 1 | 2 {
+  const { costPart, breakdownPart } = tokenCostLineParts(usage);
+  const lineLength = costPart.length + breakdownPart.length;
+  return lineLength + MIN_GAP + HINT_TEXT.length <= width ? 1 : 2;
+}
+
+interface TokenCostHudProps {
+  usage: TokenUsageSnapshot;
+  /** Available text width (columns) — decides whether the hint fits on the
+   *  cost line's row. Pass the content width, not the outer box width (the
+   *  panel's own `paddingX={1}` is accounted for by the caller). */
+  width: number;
+}
+
+export const TokenCostHud = ({ usage, width }: TokenCostHudProps) => {
+  const { costPart, breakdownPart } = tokenCostLineParts(usage);
+  const inline = tokenCostHudRowCount(usage, width) === 1;
+  const lineLength = costPart.length + breakdownPart.length;
+  const gap = Math.max(MIN_GAP, width - lineLength - HINT_TEXT.length);
 
   return (
     <Box flexDirection="column" paddingX={1}>
-      <Text color={Colors.accent} wrap="truncate">
-        {label}: {formatCostUsd(usage.costUsd)}
-        {totalTokens > 0 && (
-          <Text dimColor>
-            {' · in '}
-            {formatTokenCount(usage.inputTokens)}
-            {' · out '}
-            {formatTokenCount(usage.outputTokens)}
-            {' · cache read '}
-            {formatTokenCount(usage.cacheReadTokens)}
-            {' · cache write '}
-            {formatTokenCount(usage.cacheCreationTokens)}
-          </Text>
-        )}
-        {totalTokens === 0 && <Text dimColor> · no agent turns yet</Text>}
+      <Text wrap="truncate">
+        <Text color={Colors.accent}>{costPart}</Text>
+        <Text dimColor>{breakdownPart}</Text>
+        {inline && <Text>{' '.repeat(gap)}</Text>}
+        {inline && <Text dimColor>{HINT_TEXT}</Text>}
       </Text>
-      <Text dimColor wrap="truncate">
-        Ctrl+T to hide
-      </Text>
+      {!inline && (
+        <Text dimColor wrap="truncate">
+          {HINT_TEXT}
+        </Text>
+      )}
     </Box>
   );
 };

--- a/src/ui/tui/components/TokenCostHud.tsx
+++ b/src/ui/tui/components/TokenCostHud.tsx
@@ -1,0 +1,50 @@
+/**
+ * TokenCostHud — hidden Ctrl+T panel showing the running (then final) LLM
+ * token/cost estimate for this wizard run. Toggled from `ScreenContainer`;
+ * deliberately not registered via `useKeyBindings`, so the shortcut never
+ * shows in the `KeyboardHintsBar` — it stays undiscoverable except to
+ * whoever already knows it.
+ *
+ * Exactly one row (`wrap="truncate"`), so `ScreenContainer` can budget a
+ * fixed extra line for it in `contentHeight` without risking layout
+ * overflow when the terminal is narrow.
+ */
+import { Box, Text } from 'ink';
+import { Colors } from '@ui/tui/styles';
+import type { TokenUsageSnapshot } from '@ui/tui/store';
+import { formatTokenCount, formatCostUsd } from '@lib/agent/token-pricing';
+
+interface TokenCostHudProps {
+  usage: TokenUsageSnapshot;
+}
+
+export const TokenCostHud = ({ usage }: TokenCostHudProps) => {
+  const totalTokens =
+    usage.inputTokens +
+    usage.outputTokens +
+    usage.cacheReadTokens +
+    usage.cacheCreationTokens;
+
+  const label = usage.costIsFinal ? 'Final cost' : 'Cost (running)';
+
+  return (
+    <Box paddingX={1}>
+      <Text color={Colors.accent} wrap="truncate">
+        {label}: {formatCostUsd(usage.costUsd)}
+        {totalTokens > 0 && (
+          <Text dimColor>
+            {' · in '}
+            {formatTokenCount(usage.inputTokens)}
+            {' · out '}
+            {formatTokenCount(usage.outputTokens)}
+            {' · cache read '}
+            {formatTokenCount(usage.cacheReadTokens)}
+            {' · cache write '}
+            {formatTokenCount(usage.cacheCreationTokens)}
+          </Text>
+        )}
+        {totalTokens === 0 && <Text dimColor> · no agent turns yet</Text>}
+      </Text>
+    </Box>
+  );
+};

--- a/src/ui/tui/components/TokenCostHud.tsx
+++ b/src/ui/tui/components/TokenCostHud.tsx
@@ -1,13 +1,16 @@
 /**
- * TokenCostHud — hidden Ctrl+T panel showing the running (then final) LLM
+ * TokenCostHud — Ctrl+T panel showing the running (then final) LLM
  * token/cost estimate for this wizard run. Toggled from `ScreenContainer`;
  * deliberately not registered via `useKeyBindings`, so the shortcut never
- * shows in the `KeyboardHintsBar` — it stays undiscoverable except to
- * whoever already knows it.
+ * shows in the `KeyboardHintsBar` in production. Defaults visible for
+ * local/dev/test runs (`WizardStore`'s `$tokenHudVisible` initial value),
+ * so contributors see it without needing to know the shortcut; defaults
+ * hidden in the published build. Once shown, the panel itself names the
+ * shortcut (below), so it's self-documenting either way.
  *
- * Exactly one row (`wrap="truncate"`), so `ScreenContainer` can budget a
- * fixed extra line for it in `contentHeight` without risking layout
- * overflow when the terminal is narrow.
+ * Exactly two rows (this line + the blank spacer `ScreenContainer` renders
+ * below it), so `ScreenContainer` can budget a fixed extra height for it
+ * without risking layout overflow when the terminal is narrow.
  */
 import { Box, Text } from 'ink';
 import { Colors } from '@ui/tui/styles';
@@ -28,7 +31,7 @@ export const TokenCostHud = ({ usage }: TokenCostHudProps) => {
   const label = usage.costIsFinal ? 'Final cost' : 'Cost (running)';
 
   return (
-    <Box paddingX={1}>
+    <Box flexDirection="column" paddingX={1}>
       <Text color={Colors.accent} wrap="truncate">
         {label}: {formatCostUsd(usage.costUsd)}
         {totalTokens > 0 && (
@@ -44,6 +47,9 @@ export const TokenCostHud = ({ usage }: TokenCostHudProps) => {
           </Text>
         )}
         {totalTokens === 0 && <Text dimColor> · no agent turns yet</Text>}
+      </Text>
+      <Text dimColor wrap="truncate">
+        Ctrl+T to hide
       </Text>
     </Box>
   );

--- a/src/ui/tui/components/__tests__/TokenCostHud.test.ts
+++ b/src/ui/tui/components/__tests__/TokenCostHud.test.ts
@@ -1,0 +1,60 @@
+import { tokenCostHudRowCount } from '@ui/tui/components/TokenCostHud';
+import type { TokenUsageSnapshot } from '@ui/tui/store';
+
+const ZERO_USAGE: TokenUsageSnapshot = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  costUsd: 0,
+  costIsFinal: false,
+};
+
+const BUSY_USAGE: TokenUsageSnapshot = {
+  inputTokens: 1_234_567,
+  outputTokens: 234_567,
+  cacheReadTokens: 45_678,
+  cacheCreationTokens: 5_678,
+  costUsd: 12.3456,
+  costIsFinal: false,
+};
+
+describe('tokenCostHudRowCount', () => {
+  it('fits the hint on one row when the terminal is wide enough', () => {
+    expect(tokenCostHudRowCount(ZERO_USAGE, 200)).toBe(1);
+  });
+
+  it('needs two rows when the terminal is too narrow for the hint', () => {
+    expect(tokenCostHudRowCount(ZERO_USAGE, 10)).toBe(2);
+  });
+
+  it('is exactly 1 at the boundary width and 2 one column narrower', () => {
+    // Walk down from a width that's definitely wide enough until the row
+    // count flips, then confirm the flip is a hard boundary (no gap, no
+    // off-by-one) rather than hardcoding a magic width number.
+    let width = 200;
+    while (tokenCostHudRowCount(ZERO_USAGE, width - 1) === 1) width -= 1;
+    expect(tokenCostHudRowCount(ZERO_USAGE, width)).toBe(1);
+    expect(tokenCostHudRowCount(ZERO_USAGE, width - 1)).toBe(2);
+  });
+
+  it('needs more width for a busy run than an empty one, since the token breakdown lengthens the line', () => {
+    let zeroWidth = 200;
+    while (tokenCostHudRowCount(ZERO_USAGE, zeroWidth - 1) === 1) {
+      zeroWidth -= 1;
+    }
+    let busyWidth = 200;
+    while (tokenCostHudRowCount(BUSY_USAGE, busyWidth - 1) === 1) {
+      busyWidth -= 1;
+    }
+    expect(busyWidth).toBeGreaterThan(zeroWidth);
+  });
+
+  it('labels the line "Final cost" once reconciled, same length rules apply', () => {
+    const finalUsage: TokenUsageSnapshot = { ...BUSY_USAGE, costIsFinal: true };
+    // Same-shaped cost line either way -- just confirms the final-cost path
+    // doesn't crash or behave differently from the running-cost path here.
+    expect(tokenCostHudRowCount(finalUsage, 200)).toBe(1);
+    expect(tokenCostHudRowCount(finalUsage, 10)).toBe(2);
+  });
+});

--- a/src/ui/tui/components/__tests__/TokenCostHud.test.ts
+++ b/src/ui/tui/components/__tests__/TokenCostHud.test.ts
@@ -10,15 +10,6 @@ const ZERO_USAGE: TokenUsageSnapshot = {
   costIsFinal: false,
 };
 
-const BUSY_USAGE: TokenUsageSnapshot = {
-  inputTokens: 1_234_567,
-  outputTokens: 234_567,
-  cacheReadTokens: 45_678,
-  cacheCreationTokens: 5_678,
-  costUsd: 12.3456,
-  costIsFinal: false,
-};
-
 describe('tokenCostHudRowCount', () => {
   it('fits the hint on one row when the terminal is wide enough', () => {
     expect(tokenCostHudRowCount(ZERO_USAGE, 200)).toBe(1);
@@ -36,25 +27,5 @@ describe('tokenCostHudRowCount', () => {
     while (tokenCostHudRowCount(ZERO_USAGE, width - 1) === 1) width -= 1;
     expect(tokenCostHudRowCount(ZERO_USAGE, width)).toBe(1);
     expect(tokenCostHudRowCount(ZERO_USAGE, width - 1)).toBe(2);
-  });
-
-  it('needs more width for a busy run than an empty one, since the token breakdown lengthens the line', () => {
-    let zeroWidth = 200;
-    while (tokenCostHudRowCount(ZERO_USAGE, zeroWidth - 1) === 1) {
-      zeroWidth -= 1;
-    }
-    let busyWidth = 200;
-    while (tokenCostHudRowCount(BUSY_USAGE, busyWidth - 1) === 1) {
-      busyWidth -= 1;
-    }
-    expect(busyWidth).toBeGreaterThan(zeroWidth);
-  });
-
-  it('labels the line "Final cost" once reconciled, same length rules apply', () => {
-    const finalUsage: TokenUsageSnapshot = { ...BUSY_USAGE, costIsFinal: true };
-    // Same-shaped cost line either way -- just confirms the final-cost path
-    // doesn't crash or behave differently from the running-cost path here.
-    expect(tokenCostHudRowCount(finalUsage, 200)).toBe(1);
-    expect(tokenCostHudRowCount(finalUsage, 10)).toBe(2);
   });
 });

--- a/src/ui/tui/exit-line.ts
+++ b/src/ui/tui/exit-line.ts
@@ -13,7 +13,7 @@
  * function (start-tui.ts itself pulls in the whole render tree).
  */
 
-import type { WizardStore } from './store.js';
+import { totalTokenCount, type WizardStore } from './store.js';
 import { OutroKind } from '@lib/wizard-session';
 import { formatTokenCount, formatCostUsd } from '@lib/agent/token-pricing';
 
@@ -35,12 +35,7 @@ const DIM = '\x1b[2m';
 function tokenCostLine(store: WizardStore): string | null {
   if (!store.tokenHudVisible) return null;
   const usage = store.tokenUsage;
-  const totalTokens =
-    usage.inputTokens +
-    usage.outputTokens +
-    usage.cacheReadTokens +
-    usage.cacheCreationTokens;
-  if (totalTokens === 0) return null;
+  if (totalTokenCount(usage) === 0) return null;
 
   const label = usage.costIsFinal ? 'Final cost' : 'Cost (estimate)';
   return (

--- a/src/ui/tui/exit-line.ts
+++ b/src/ui/tui/exit-line.ts
@@ -23,13 +23,17 @@ const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
 
 /**
- * The hidden Ctrl+T HUD only shows on demand and the outro screen's
- * "any key" dismissal can beat it to the punch — so the run's final
- * token/cost tally is also echoed here unconditionally, guaranteeing it's
- * visible in scrollback regardless of whether the user ever opened the HUD.
- * `null` when the run never produced any usage (e.g. non-agent programs).
+ * Mirrors the hidden Ctrl+T HUD's tally into post-exit scrollback — but only
+ * when the HUD is actually visible at exit (`store.tokenHudVisible`, which
+ * defaults on in dev/test and off in production; `useDismissOnAnyKey`
+ * already keeps Ctrl+T from also dismissing the outro screen underneath
+ * it). A production run where the user never toggled it on shouldn't have a
+ * cost number appear from nowhere once the TUI tears down. `null` when the
+ * HUD is hidden, or the run never produced any usage (e.g. non-agent
+ * programs).
  */
 function tokenCostLine(store: WizardStore): string | null {
+  if (!store.tokenHudVisible) return null;
   const usage = store.tokenUsage;
   const totalTokens =
     usage.inputTokens +

--- a/src/ui/tui/exit-line.ts
+++ b/src/ui/tui/exit-line.ts
@@ -15,15 +15,45 @@
 
 import type { WizardStore } from './store.js';
 import { OutroKind } from '@lib/wizard-session';
+import { formatTokenCount, formatCostUsd } from '@lib/agent/token-pricing';
 
 const RESET_ATTRS = '\x1b[0m';
 const GREEN = '\x1b[32m';
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
 
+/**
+ * The hidden Ctrl+T HUD only shows on demand and the outro screen's
+ * "any key" dismissal can beat it to the punch — so the run's final
+ * token/cost tally is also echoed here unconditionally, guaranteeing it's
+ * visible in scrollback regardless of whether the user ever opened the HUD.
+ * `null` when the run never produced any usage (e.g. non-agent programs).
+ */
+function tokenCostLine(store: WizardStore): string | null {
+  const usage = store.tokenUsage;
+  const totalTokens =
+    usage.inputTokens +
+    usage.outputTokens +
+    usage.cacheReadTokens +
+    usage.cacheCreationTokens;
+  if (totalTokens === 0) return null;
+
+  const label = usage.costIsFinal ? 'Final cost' : 'Cost (estimate)';
+  return (
+    `${DIM}${label}: ${formatCostUsd(usage.costUsd)}` +
+    ` (in ${formatTokenCount(usage.inputTokens)}` +
+    ` · out ${formatTokenCount(usage.outputTokens)}` +
+    ` · cache read ${formatTokenCount(usage.cacheReadTokens)}` +
+    ` · cache write ${formatTokenCount(
+      usage.cacheCreationTokens,
+    )})${RESET_ATTRS}`
+  );
+}
+
 export function getExitLine(store: WizardStore): string {
   const outro = store.session.outroData;
   const label = store.session.programLabel ?? 'Wizard';
+  const costLine = tokenCostLine(store);
 
   if (outro?.kind === OutroKind.Success) {
     const message = outro.message ?? `${label} completed successfully.`;
@@ -58,8 +88,12 @@ export function getExitLine(store: WizardStore): string {
       );
     }
 
+    if (costLine) parts.push(costLine);
+
     return parts.join('\n\n');
   }
 
-  return `${DIM}${label} exited.${RESET_ATTRS}`;
+  return costLine
+    ? `${DIM}${label} exited.${RESET_ATTRS}\n\n${costLine}`
+    : `${DIM}${label} exited.${RESET_ATTRS}`;
 }

--- a/src/ui/tui/hooks/__tests__/useDismissOnAnyKey.test.ts
+++ b/src/ui/tui/hooks/__tests__/useDismissOnAnyKey.test.ts
@@ -9,10 +9,6 @@ describe('isIgnoredForDismiss', () => {
     expect(isIgnoredForDismiss({ ctrl: false, meta: true })).toBe(true);
   });
 
-  it('ignores a keypress with both modifiers held', () => {
-    expect(isIgnoredForDismiss({ ctrl: true, meta: true })).toBe(true);
-  });
-
   it('does not ignore a plain keypress', () => {
     expect(isIgnoredForDismiss({ ctrl: false, meta: false })).toBe(false);
   });

--- a/src/ui/tui/hooks/__tests__/useDismissOnAnyKey.test.ts
+++ b/src/ui/tui/hooks/__tests__/useDismissOnAnyKey.test.ts
@@ -1,0 +1,19 @@
+import { isIgnoredForDismiss } from '@ui/tui/hooks/useDismissOnAnyKey';
+
+describe('isIgnoredForDismiss', () => {
+  it('ignores a ctrl-combo keypress', () => {
+    expect(isIgnoredForDismiss({ ctrl: true, meta: false })).toBe(true);
+  });
+
+  it('ignores a meta-combo keypress', () => {
+    expect(isIgnoredForDismiss({ ctrl: false, meta: true })).toBe(true);
+  });
+
+  it('ignores a keypress with both modifiers held', () => {
+    expect(isIgnoredForDismiss({ ctrl: true, meta: true })).toBe(true);
+  });
+
+  it('does not ignore a plain keypress', () => {
+    expect(isIgnoredForDismiss({ ctrl: false, meta: false })).toBe(false);
+  });
+});

--- a/src/ui/tui/hooks/useDismissOnAnyKey.ts
+++ b/src/ui/tui/hooks/useDismissOnAnyKey.ts
@@ -1,0 +1,32 @@
+/**
+ * useDismissOnAnyKey — "press any key to continue/exit" screens.
+ *
+ * Wraps `useInput` for the recurring "any key dismisses/exits this screen"
+ * pattern (outro screens, terminal error/timeout screens, etc.), ignoring
+ * modifier-combo keypresses (Ctrl/Meta) so a global hidden shortcut — e.g.
+ * Ctrl+T toggling the token/cost HUD — can't also dismiss the screen
+ * underneath it. Ink calls every mounted `useInput` callback for a given
+ * keypress with no `stopPropagation`, so a bare `useInput(() => handler())`
+ * would otherwise fire on every registered shortcut too, not just an
+ * ordinary keypress.
+ *
+ * Use this instead of raw `useInput` for any screen where any ordinary
+ * keypress should proceed, but a modifier combo shouldn't be able to.
+ */
+import { useInput, type Key } from 'ink';
+
+/**
+ * True for a keypress that should NOT count as "any key" for a dismiss
+ * handler — currently just modifier combos. Extracted as a pure predicate
+ * so it's unit-testable without rendering through Ink.
+ */
+export function isIgnoredForDismiss(key: Pick<Key, 'ctrl' | 'meta'>): boolean {
+  return key.ctrl || key.meta;
+}
+
+export function useDismissOnAnyKey(handler: () => void): void {
+  useInput((_input, key) => {
+    if (isIgnoredForDismiss(key)) return;
+    handler();
+  });
+}

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -6,7 +6,12 @@
  * The router derives the active screen from session state.
  */
 
-import type { WizardUI, SpinnerHandle, AuthErrorDetail } from '@ui/wizard-ui';
+import type {
+  WizardUI,
+  SpinnerHandle,
+  AuthErrorDetail,
+  TokenUsageDelta,
+} from '@ui/wizard-ui';
 import type { WizardStore } from './store.js';
 import type { SettingsConflict } from '@lib/agent/claude-settings';
 import type { WizardReadinessResult } from '@lib/health-checks/readiness';
@@ -240,14 +245,7 @@ export class InkUI implements WizardUI {
     this.store.setNotebookUrl(url);
   }
 
-  addTokenUsage(delta: {
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreationTokens: number;
-    cacheCreation5m: number;
-    cacheCreation1h: number;
-  }): void {
+  addTokenUsage(delta: TokenUsageDelta): void {
     this.store.addTokenUsage(delta);
   }
 

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -240,6 +240,21 @@ export class InkUI implements WizardUI {
     this.store.setNotebookUrl(url);
   }
 
+  addTokenUsage(delta: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+    cacheCreation5m: number;
+    cacheCreation1h: number;
+  }): void {
+    this.store.addTokenUsage(delta);
+  }
+
+  setFinalTokenCostUsd(costUsd: number): void {
+    this.store.setFinalTokenCostUsd(costUsd);
+  }
+
   setOutroData(data: OutroData): void {
     // Merge in URLs the agent emitted via `[DASHBOARD_URL]` / `[NOTEBOOK_URL]`
     // markers. These land on the live store during the run; agent-runner's

--- a/src/ui/tui/primitives/ScreenContainer.tsx
+++ b/src/ui/tui/primitives/ScreenContainer.tsx
@@ -13,7 +13,10 @@
 import { Box, useInput } from 'ink';
 import { useSyncExternalStore, type ReactNode } from 'react';
 import { TitleBar } from '@ui/tui/components/TitleBar';
-import { TokenCostHud } from '@ui/tui/components/TokenCostHud';
+import {
+  TokenCostHud,
+  tokenCostHudRowCount,
+} from '@ui/tui/components/TokenCostHud';
 import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 import { KeyboardHintsProvider } from '@ui/tui/hooks/useKeyboardHints';
 import { DissolveTransition } from './DissolveTransition.js';
@@ -53,10 +56,17 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
   const terminalWidth = columns;
   const width = getContentWidth(terminalWidth);
   const hudVisible = store.tokenHudVisible;
-  // The HUD is exactly two rows (cost line + "Ctrl+T to hide" hint), plus a
-  // one-row spacer below it (see TokenCostHud) — budget for all three here
-  // so adding them doesn't push the screen content past the terminal height.
-  const contentHeight = Math.max(5, rows - 3 - (hudVisible ? 3 : 0));
+  // Text width inside TokenCostHud's own paddingX={1} (1 column each side).
+  const hudContentWidth = Math.max(1, width - 2);
+  // 1 row when the "Ctrl+T to hide" hint fits on the cost line's row, 2 when
+  // it needs its own row below (see tokenCostHudRowCount) — plus a one-row
+  // spacer below the HUD. Budget the exact total so it can never disagree
+  // with what TokenCostHud actually renders and push content past the
+  // terminal height.
+  const hudRows = hudVisible
+    ? tokenCostHudRowCount(store.tokenUsage, hudContentWidth) + 1
+    : 0;
+  const contentHeight = Math.max(5, rows - 3 - hudRows);
   const contentAreaWidth = Math.max(10, width - 2);
   const direction = store.lastNavDirection === 'pop' ? 'right' : 'left';
   const activeScreen = screens[store.currentScreen] ?? null;
@@ -67,7 +77,7 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
       <Box height={1} />
       {hudVisible && (
         <>
-          <TokenCostHud usage={store.tokenUsage} />
+          <TokenCostHud usage={store.tokenUsage} width={hudContentWidth} />
           <Box height={1} />
         </>
       )}

--- a/src/ui/tui/primitives/ScreenContainer.tsx
+++ b/src/ui/tui/primitives/ScreenContainer.tsx
@@ -53,9 +53,10 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
   const terminalWidth = columns;
   const width = getContentWidth(terminalWidth);
   const hudVisible = store.tokenHudVisible;
-  // The HUD is exactly one row (see TokenCostHud) — budget for it here so
-  // adding it doesn't push the screen content past the terminal height.
-  const contentHeight = Math.max(5, rows - 3 - (hudVisible ? 1 : 0));
+  // The HUD is exactly one row, plus a one-row spacer below it (see
+  // TokenCostHud) — budget for both here so adding them doesn't push the
+  // screen content past the terminal height.
+  const contentHeight = Math.max(5, rows - 3 - (hudVisible ? 2 : 0));
   const contentAreaWidth = Math.max(10, width - 2);
   const direction = store.lastNavDirection === 'pop' ? 'right' : 'left';
   const activeScreen = screens[store.currentScreen] ?? null;
@@ -64,7 +65,12 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
     <Box flexDirection="column" height={rows} width={width}>
       <TitleBar version={store.version} width={width} />
       <Box height={1} />
-      {hudVisible && <TokenCostHud usage={store.tokenUsage} />}
+      {hudVisible && (
+        <>
+          <TokenCostHud usage={store.tokenUsage} />
+          <Box height={1} />
+        </>
+      )}
       <Box flexDirection="column" flexGrow={1} paddingX={1}>
         <DissolveTransition
           transitionKey={store.currentScreen}

--- a/src/ui/tui/primitives/ScreenContainer.tsx
+++ b/src/ui/tui/primitives/ScreenContainer.tsx
@@ -53,10 +53,10 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
   const terminalWidth = columns;
   const width = getContentWidth(terminalWidth);
   const hudVisible = store.tokenHudVisible;
-  // The HUD is exactly one row, plus a one-row spacer below it (see
-  // TokenCostHud) — budget for both here so adding them doesn't push the
-  // screen content past the terminal height.
-  const contentHeight = Math.max(5, rows - 3 - (hudVisible ? 2 : 0));
+  // The HUD is exactly two rows (cost line + "Ctrl+T to hide" hint), plus a
+  // one-row spacer below it (see TokenCostHud) — budget for all three here
+  // so adding them doesn't push the screen content past the terminal height.
+  const contentHeight = Math.max(5, rows - 3 - (hudVisible ? 3 : 0));
   const contentAreaWidth = Math.max(10, width - 2);
   const direction = store.lastNavDirection === 'pop' ? 'right' : 'left';
   const activeScreen = screens[store.currentScreen] ?? null;

--- a/src/ui/tui/primitives/ScreenContainer.tsx
+++ b/src/ui/tui/primitives/ScreenContainer.tsx
@@ -10,9 +10,10 @@
  * screen content (inside the transition area) so all screens get it.
  */
 
-import { Box } from 'ink';
+import { Box, useInput } from 'ink';
 import { useSyncExternalStore, type ReactNode } from 'react';
 import { TitleBar } from '@ui/tui/components/TitleBar';
+import { TokenCostHud } from '@ui/tui/components/TokenCostHud';
 import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 import { KeyboardHintsProvider } from '@ui/tui/hooks/useKeyboardHints';
 import { DissolveTransition } from './DissolveTransition.js';
@@ -41,9 +42,20 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
     () => store.getSnapshot(),
   );
 
+  // Hidden shortcut: Ctrl+T toggles the token/cost HUD. Deliberately not
+  // wired through useKeyBindings, so it never appears in the hints bar.
+  // Mounted here (not on any individual screen) so it works everywhere —
+  // ScreenContainer is the one component alive for the whole process.
+  useInput((input, key) => {
+    if (key.ctrl && input === 't') store.toggleTokenHud();
+  });
+
   const terminalWidth = columns;
   const width = getContentWidth(terminalWidth);
-  const contentHeight = Math.max(5, rows - 3);
+  const hudVisible = store.tokenHudVisible;
+  // The HUD is exactly one row (see TokenCostHud) — budget for it here so
+  // adding it doesn't push the screen content past the terminal height.
+  const contentHeight = Math.max(5, rows - 3 - (hudVisible ? 1 : 0));
   const contentAreaWidth = Math.max(10, width - 2);
   const direction = store.lastNavDirection === 'pop' ? 'right' : 'left';
   const activeScreen = screens[store.currentScreen] ?? null;
@@ -52,6 +64,7 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
     <Box flexDirection="column" height={rows} width={width}>
       <TitleBar version={store.version} width={width} />
       <Box height={1} />
+      {hudVisible && <TokenCostHud usage={store.tokenUsage} />}
       <Box flexDirection="column" flexGrow={1} paddingX={1}>
         <DissolveTransition
           transitionKey={store.currentScreen}

--- a/src/ui/tui/screens/AuthErrorScreen.tsx
+++ b/src/ui/tui/screens/AuthErrorScreen.tsx
@@ -23,7 +23,13 @@ export const AuthErrorScreen = ({ store }: AuthErrorScreenProps) => {
     () => store.getSnapshot(),
   );
 
-  useInput(() => {
+  useInput((_input, key) => {
+    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
+    // HUD) — this handler means "any (plain) key exits", not "any keypress
+    // Ink can parse". Ink calls every mounted useInput callback for a given
+    // keypress with no stopPropagation, so a global hidden shortcut would
+    // otherwise also exit this screen.
+    if (key.ctrl || key.meta) return;
     process.exit(1);
   });
 

--- a/src/ui/tui/screens/AuthErrorScreen.tsx
+++ b/src/ui/tui/screens/AuthErrorScreen.tsx
@@ -8,10 +8,11 @@
  *     expired, or wrong region. Don't blame Claude Code in this case.
  */
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { Colors } from '@ui/tui/styles';
+import { useDismissOnAnyKey } from '@ui/tui/hooks/useDismissOnAnyKey';
 
 interface AuthErrorScreenProps {
   store: WizardStore;
@@ -23,15 +24,7 @@ export const AuthErrorScreen = ({ store }: AuthErrorScreenProps) => {
     () => store.getSnapshot(),
   );
 
-  useInput((_input, key) => {
-    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
-    // HUD) — this handler means "any (plain) key exits", not "any keypress
-    // Ink can parse". Ink calls every mounted useInput callback for a given
-    // keypress with no stopPropagation, so a global hidden shortcut would
-    // otherwise also exit this screen.
-    if (key.ctrl || key.meta) return;
-    process.exit(1);
-  });
+  useDismissOnAnyKey(() => process.exit(1));
 
   const detail = store.session.authErrorDetail;
   const hasSettingsConflict = detail?.hasSettingsConflict ?? true;

--- a/src/ui/tui/screens/OutroScreen.tsx
+++ b/src/ui/tui/screens/OutroScreen.tsx
@@ -6,12 +6,13 @@
  * ship their own screen component (see audit/AuditOutroScreen.tsx).
  */
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { OutroKind } from '@lib/wizard-session';
 import { Colors } from '@ui/tui/styles';
 import { withUtm } from '@utils/links';
+import { useDismissOnAnyKey } from '@ui/tui/hooks/useDismissOnAnyKey';
 
 interface OutroScreenProps {
   store: WizardStore;
@@ -23,14 +24,9 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
     () => store.getSnapshot(),
   );
 
-  useInput((_input, key) => {
-    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
-    // HUD) — see AuthErrorScreen for why this guard is needed. Dismissal
-    // here chains into ExitScreen's process.exit(), so without this guard
-    // toggling the HUD on the outro screen would kill the process instead.
-    if (key.ctrl || key.meta) return;
-    store.setOutroDismissed();
-  });
+  // Dismissal here chains into ExitScreen's process.exit(), so a modifier
+  // combo (e.g. Ctrl+T toggling the token/cost HUD) must not trigger it too.
+  useDismissOnAnyKey(() => store.setOutroDismissed());
 
   const outroData = store.session.outroData;
 

--- a/src/ui/tui/screens/OutroScreen.tsx
+++ b/src/ui/tui/screens/OutroScreen.tsx
@@ -23,7 +23,12 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
     () => store.getSnapshot(),
   );
 
-  useInput(() => {
+  useInput((_input, key) => {
+    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
+    // HUD) — see AuthErrorScreen for why this guard is needed. Dismissal
+    // here chains into ExitScreen's process.exit(), so without this guard
+    // toggling the HUD on the outro screen would kill the process instead.
+    if (key.ctrl || key.meta) return;
     store.setOutroDismissed();
   });
 

--- a/src/ui/tui/screens/SessionTimeoutScreen.tsx
+++ b/src/ui/tui/screens/SessionTimeoutScreen.tsx
@@ -25,7 +25,10 @@ export const SessionTimeoutScreen = ({ store }: SessionTimeoutScreenProps) => {
     () => store.getSnapshot(),
   );
 
-  useInput(() => {
+  useInput((_input, key) => {
+    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
+    // HUD) — see AuthErrorScreen for why this guard is needed.
+    if (key.ctrl || key.meta) return;
     process.exit(1);
   });
 

--- a/src/ui/tui/screens/SessionTimeoutScreen.tsx
+++ b/src/ui/tui/screens/SessionTimeoutScreen.tsx
@@ -7,11 +7,12 @@
  * the only way forward is to re-run the wizard for a fresh login window.
  */
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { Colors } from '@ui/tui/styles';
 import { OAUTH_TIMEOUT_MS } from '@lib/constants';
+import { useDismissOnAnyKey } from '@ui/tui/hooks/useDismissOnAnyKey';
 
 interface SessionTimeoutScreenProps {
   store: WizardStore;
@@ -25,12 +26,7 @@ export const SessionTimeoutScreen = ({ store }: SessionTimeoutScreenProps) => {
     () => store.getSnapshot(),
   );
 
-  useInput((_input, key) => {
-    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
-    // HUD) — see AuthErrorScreen for why this guard is needed.
-    if (key.ctrl || key.meta) return;
-    process.exit(1);
-  });
+  useDismissOnAnyKey(() => process.exit(1));
 
   return (
     <Box flexDirection="column" flexGrow={1}>

--- a/src/ui/tui/screens/SourceMapsOutroScreen.tsx
+++ b/src/ui/tui/screens/SourceMapsOutroScreen.tsx
@@ -29,7 +29,10 @@ export const SourceMapsOutroScreen = ({
     () => store.getSnapshot(),
   );
 
-  useInput(() => {
+  useInput((_input, key) => {
+    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
+    // HUD) — see AuthErrorScreen for why this guard is needed.
+    if (key.ctrl || key.meta) return;
     store.setOutroDismissed();
   });
 

--- a/src/ui/tui/screens/SourceMapsOutroScreen.tsx
+++ b/src/ui/tui/screens/SourceMapsOutroScreen.tsx
@@ -11,11 +11,12 @@
 
 import { join } from 'node:path';
 import type { ReactNode } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { OutroKind } from '@lib/wizard-session';
 import { Colors } from '@ui/tui/styles';
+import { useDismissOnAnyKey } from '@ui/tui/hooks/useDismissOnAnyKey';
 
 interface SourceMapsOutroScreenProps {
   store: WizardStore;
@@ -29,12 +30,7 @@ export const SourceMapsOutroScreen = ({
     () => store.getSnapshot(),
   );
 
-  useInput((_input, key) => {
-    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
-    // HUD) — see AuthErrorScreen for why this guard is needed.
-    if (key.ctrl || key.meta) return;
-    store.setOutroDismissed();
-  });
+  useDismissOnAnyKey(() => store.setOutroDismissed());
 
   const outroData = store.session.outroData;
 

--- a/src/ui/tui/screens/audit/AuditOutroScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditOutroScreen.tsx
@@ -24,7 +24,10 @@ export const AuditOutroScreen = ({ store }: AuditOutroScreenProps) => {
     () => store.getSnapshot(),
   );
 
-  useInput(() => {
+  useInput((_input, key) => {
+    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
+    // HUD) — see AuthErrorScreen for why this guard is needed.
+    if (key.ctrl || key.meta) return;
     store.setOutroDismissed();
   });
 

--- a/src/ui/tui/screens/audit/AuditOutroScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditOutroScreen.tsx
@@ -6,13 +6,14 @@
  */
 
 import { join } from 'node:path';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { OutroKind } from '@lib/wizard-session';
 import { Colors } from '@ui/tui/styles';
 import { getAuditChecks } from '@lib/programs/audit/types';
 import { AuditChecksOutroSection } from './AuditChecksOutroSection.js';
+import { useDismissOnAnyKey } from '@ui/tui/hooks/useDismissOnAnyKey';
 
 interface AuditOutroScreenProps {
   store: WizardStore;
@@ -24,12 +25,7 @@ export const AuditOutroScreen = ({ store }: AuditOutroScreenProps) => {
     () => store.getSnapshot(),
   );
 
-  useInput((_input, key) => {
-    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
-    // HUD) — see AuthErrorScreen for why this guard is needed.
-    if (key.ctrl || key.meta) return;
-    store.setOutroDismissed();
-  });
+  useDismissOnAnyKey(() => store.setOutroDismissed());
 
   const outroData = store.session.outroData;
 

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -7,7 +7,7 @@
  *   3. Blocking outage: shows affected services with Continue/Exit
  */
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import {
@@ -25,6 +25,7 @@ import { ServiceHealthStatus } from '@lib/health-checks/types';
 import { wizardAbort } from '@utils/wizard-abort';
 import { fetchSkillMenu, downloadSkill } from '@lib/wizard-tools';
 import { REMOTE_SKILLS_BASE_URL } from '@lib/constants';
+import { useDismissOnAnyKey } from '@ui/tui/hooks/useDismissOnAnyKey';
 
 interface HealthCheckScreenProps {
   store: WizardStore;
@@ -34,12 +35,7 @@ const EXAMPLE_PROMPT =
   'Integrate PostHog into this project using the skill files in .posthog/skills/. Read SKILL.md first, then follow the numbered program files in order.';
 
 const SkillsDownloadedScreen = () => {
-  useInput((_input, key) => {
-    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
-    // HUD) — see AuthErrorScreen for why this guard is needed.
-    if (key.ctrl || key.meta) return;
-    process.exit(0);
-  });
+  useDismissOnAnyKey(() => process.exit(0));
 
   return (
     <Box flexDirection="column" flexGrow={1}>

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -34,7 +34,10 @@ const EXAMPLE_PROMPT =
   'Integrate PostHog into this project using the skill files in .posthog/skills/. Read SKILL.md first, then follow the numbered program files in order.';
 
 const SkillsDownloadedScreen = () => {
-  useInput(() => {
+  useInput((_input, key) => {
+    // Ignore modifier-combo keypresses (e.g. Ctrl+T toggling the token/cost
+    // HUD) — see AuthErrorScreen for why this guard is needed.
+    if (key.ctrl || key.meta) return;
     process.exit(0);
   });
 

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -99,6 +99,17 @@ const EMPTY_TOKEN_USAGE: TokenUsageSnapshot = {
   costIsFinal: false,
 };
 
+/** Total tokens across all counters in a `TokenUsageSnapshot` — used by
+ *  both `TokenCostHud` and `exit-line.ts` to detect "no agent turns yet". */
+export function totalTokenCount(usage: TokenUsageSnapshot): number {
+  return (
+    usage.inputTokens +
+    usage.outputTokens +
+    usage.cacheReadTokens +
+    usage.cacheCreationTokens
+  );
+}
+
 interface GateEntry {
   predicate: (session: WizardSession) => boolean;
   promise: Promise<void>;
@@ -924,15 +935,7 @@ export class WizardStore {
   addTokenUsage(delta: TokenUsageDelta): void {
     const cur = this.$tokenUsage.get();
     if (cur.costIsFinal) return;
-    const deltaCostUsd = computeTokenCostUsd(
-      delta.inputTokens,
-      delta.outputTokens,
-      delta.cacheReadTokens,
-      delta.cacheCreation5m,
-      delta.cacheCreation1h,
-      delta.cacheCreationTokens,
-      delta.model,
-    );
+    const deltaCostUsd = computeTokenCostUsd(delta);
     this.$tokenUsage.set({
       inputTokens: cur.inputTokens + delta.inputTokens,
       outputTokens: cur.outputTokens + delta.outputTokens,

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -15,7 +15,12 @@
 
 import { atom, map } from 'nanostores';
 import { logToFile } from '@utils/debug';
-import { TaskStatus, isTaskStatus, type AuthErrorDetail } from '@ui/wizard-ui';
+import {
+  TaskStatus,
+  isTaskStatus,
+  type AuthErrorDetail,
+  type TokenUsageDelta,
+} from '@ui/wizard-ui';
 import {
   type WizardSession,
   type OutroData,
@@ -50,6 +55,7 @@ import type {
 import { getProgramConfig } from '@lib/programs/program-registry';
 import { withAiOptInGate } from '@lib/programs/ai-opt-in-gate';
 import { EXPANDED_COUNT } from '@ui/tui/constants';
+import { IS_DEV } from '@lib/constants';
 import { computeTokenCostUsd } from '@lib/agent/token-pricing';
 
 export { TaskStatus, ScreenId, Overlay, Program, RunPhase, McpOutcome };
@@ -175,7 +181,11 @@ export class WizardStore {
     null,
   );
   private $tokenUsage = atom<TokenUsageSnapshot>(EMPTY_TOKEN_USAGE);
-  private $tokenHudVisible = atom(false);
+  // Defaults on for local/dev/test runs (tsx, `pnpm try`, vitest) so
+  // contributors see it without needing to know the shortcut; defaults off
+  // for the published build, where it stays genuinely hidden. Still
+  // Ctrl+T-toggleable either way.
+  private $tokenHudVisible = atom(IS_DEV);
 
   private _onTasksChanged: (() => void) | null = null;
   /** Last screen seen — used to detect screen transitions for analytics. */
@@ -911,14 +921,7 @@ export class WizardStore {
    * for a hidden debug HUD, not a billing record, and `setFinalTokenCostUsd`
    * corrects the total once the run's authoritative cost is known.
    */
-  addTokenUsage(delta: {
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreationTokens: number;
-    cacheCreation5m: number;
-    cacheCreation1h: number;
-  }): void {
+  addTokenUsage(delta: TokenUsageDelta): void {
     const cur = this.$tokenUsage.get();
     if (cur.costIsFinal) return;
     const deltaCostUsd = computeTokenCostUsd(
@@ -928,6 +931,7 @@ export class WizardStore {
       delta.cacheCreation5m,
       delta.cacheCreation1h,
       delta.cacheCreationTokens,
+      delta.model,
     );
     this.$tokenUsage.set({
       inputTokens: cur.inputTokens + delta.inputTokens,

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -50,6 +50,7 @@ import type {
 import { getProgramConfig } from '@lib/programs/program-registry';
 import { withAiOptInGate } from '@lib/programs/ai-opt-in-gate';
 import { EXPANDED_COUNT } from '@ui/tui/constants';
+import { computeTokenCostUsd } from '@lib/agent/token-pricing';
 
 export { TaskStatus, ScreenId, Overlay, Program, RunPhase, McpOutcome };
 export type { ScreenName, OutroData, WizardSession, ProgramId };
@@ -66,6 +67,31 @@ export interface PlannedEvent {
   name: string;
   description: string;
 }
+
+/**
+ * Running token/cost estimate for the hidden Ctrl+T HUD. Accumulated live
+ * from each assistant turn's usage (see `agent-interface.ts`), then
+ * reconciled to the SDK's authoritative `total_cost_usd` once the run
+ * completes — `costIsFinal` flips so the HUD can show the number as exact
+ * rather than a running estimate.
+ */
+export interface TokenUsageSnapshot {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsd: number;
+  costIsFinal: boolean;
+}
+
+const EMPTY_TOKEN_USAGE: TokenUsageSnapshot = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  costUsd: 0,
+  costIsFinal: false,
+};
 
 interface GateEntry {
   predicate: (session: WizardSession) => boolean;
@@ -148,6 +174,8 @@ export class WizardStore {
   private $currentStage = atom<{ stage: string; startedAt: number } | null>(
     null,
   );
+  private $tokenUsage = atom<TokenUsageSnapshot>(EMPTY_TOKEN_USAGE);
+  private $tokenHudVisible = atom(false);
 
   private _onTasksChanged: (() => void) | null = null;
   /** Last screen seen — used to detect screen transitions for analytics. */
@@ -858,6 +886,66 @@ export class WizardStore {
         ? [...msgs.slice(msgs.length - MAX_STATUS_MESSAGES + 1), message]
         : [...msgs, message];
     this.$statusMessages.set(next);
+    this.emitChange();
+  }
+
+  get tokenUsage(): TokenUsageSnapshot {
+    return this.$tokenUsage.get();
+  }
+
+  get tokenHudVisible(): boolean {
+    return this.$tokenHudVisible.get();
+  }
+
+  /** Hidden Ctrl+T shortcut — see ScreenContainer. Not registered as a
+   *  keyboard hint, so it never shows in the hints bar. */
+  toggleTokenHud(): void {
+    this.$tokenHudVisible.set(!this.$tokenHudVisible.get());
+    this.emitChange();
+  }
+
+  /**
+   * Accumulate one assistant turn's token usage into the running estimate.
+   * Approximate by design (no dedup for SDK-retried/replayed turns, unlike
+   * the benchmark middleware's TurnCounterPlugin) — it's a live indicator
+   * for a hidden debug HUD, not a billing record, and `setFinalTokenCostUsd`
+   * corrects the total once the run's authoritative cost is known.
+   */
+  addTokenUsage(delta: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+    cacheCreation5m: number;
+    cacheCreation1h: number;
+  }): void {
+    const cur = this.$tokenUsage.get();
+    if (cur.costIsFinal) return;
+    const deltaCostUsd = computeTokenCostUsd(
+      delta.inputTokens,
+      delta.outputTokens,
+      delta.cacheReadTokens,
+      delta.cacheCreation5m,
+      delta.cacheCreation1h,
+      delta.cacheCreationTokens,
+    );
+    this.$tokenUsage.set({
+      inputTokens: cur.inputTokens + delta.inputTokens,
+      outputTokens: cur.outputTokens + delta.outputTokens,
+      cacheReadTokens: cur.cacheReadTokens + delta.cacheReadTokens,
+      cacheCreationTokens: cur.cacheCreationTokens + delta.cacheCreationTokens,
+      costUsd: cur.costUsd + deltaCostUsd,
+      costIsFinal: false,
+    });
+    this.emitChange();
+  }
+
+  /** Reconcile the running cost estimate to the SDK's authoritative total
+   *  once the agent run completes — same trick the benchmark's
+   *  CostTrackerPlugin.onFinalize uses to correct any per-turn drift. */
+  setFinalTokenCostUsd(costUsd: number): void {
+    const cur = this.$tokenUsage.get();
+    this.$tokenUsage.set({ ...cur, costUsd, costIsFinal: true });
     this.emitChange();
   }
 

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -203,6 +203,21 @@ export interface WizardUI {
   // ── Notebook URL emitted by the agent via [NOTEBOOK_URL] marker ──
   setNotebookUrl(url: string): void;
 
+  /** Accumulate one assistant turn's token usage into the hidden Ctrl+T
+   *  token/cost HUD's running estimate. No-op outside the TUI. */
+  addTokenUsage(delta: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+    cacheCreation5m: number;
+    cacheCreation1h: number;
+  }): void;
+
+  /** Reconcile the HUD's running cost estimate to the SDK's authoritative
+   *  `total_cost_usd` once the agent run completes. No-op outside the TUI. */
+  setFinalTokenCostUsd(costUsd: number): void;
+
   // ── Outro payload built by agent-runner ──
   // Replaces the direct `session.outroData = X` mutation that breaks once
   // setKey-based store mutations have forked the session reference.

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -28,6 +28,25 @@ export function isTaskStatus(value: string): value is TaskStatus {
   return (Object.values(TaskStatus) as string[]).includes(value);
 }
 
+/**
+ * One assistant turn's token usage, for the hidden Ctrl+T token/cost HUD.
+ * `model` is the model that produced *this* turn (e.g. the SDK's
+ * `message.message.model`) — a subagent can run on a different model than
+ * the main session, and some programs override to Haiku, so pricing must key
+ * off the per-turn model rather than a single run-wide assumption. Omit only
+ * when the caller genuinely has no model context (falls back to Sonnet
+ * pricing — see `pricePerMtokForModel` in `@lib/agent/token-pricing`).
+ */
+export interface TokenUsageDelta {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  cacheCreation5m: number;
+  cacheCreation1h: number;
+  model?: string;
+}
+
 export interface SpinnerHandle {
   start(message?: string): void;
   stop(message?: string): void;
@@ -205,14 +224,7 @@ export interface WizardUI {
 
   /** Accumulate one assistant turn's token usage into the hidden Ctrl+T
    *  token/cost HUD's running estimate. No-op outside the TUI. */
-  addTokenUsage(delta: {
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreationTokens: number;
-    cacheCreation5m: number;
-    cacheCreation1h: number;
-  }): void;
+  addTokenUsage(delta: TokenUsageDelta): void;
 
   /** Reconcile the HUD's running cost estimate to the SDK's authoritative
    *  `total_cost_usd` once the agent run completes. No-op outside the TUI. */


### PR DESCRIPTION
## Problem

Not a big problem, but in development, I'm curious about the costs of a wizard run. Haven't found a way to see it.

## Changes

Proposing a token cost bar at the top, default on in development, hidden in prod. Although in both cases toggleable with Ctrl+T toggle. Shows the current wizard run's accumulated token usage and USD cost estimate.

<img width="1950" height="146" alt="Screenshot 2026-07-01 at 13 27 57@2x" src="https://github.com/user-attachments/assets/878f4d50-ec50-4fcd-b569-d19195dfbbc4" />

## Verification

Had Claude do a bunch of tests. Ran this locally.