### PR TITLE
refactor(skills): replace curl/unzip subprocesses with fetch + fflate

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@posthog/warlock": "0.2.2",
     "axios": "1.7.4",
     "fast-glob": "^3.3.3",
+    "fflate": "^0.8.3",
     "glob": "9.3.5",
     "ink": "^6.8.0",
     "inquirer": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       glob:
         specifier: 9.3.5
         version: 9.3.5
@@ -3213,6 +3216,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -8664,6 +8670,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.8.3: {}
 
   figures@2.0.0:
     dependencies:

--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { zipSync } from 'fflate';
 import {
   ASK_BATCH_THRESHOLD,
   DEFAULT_ASK_MAX_QUESTIONS,
@@ -357,52 +358,52 @@ describe('evaluateAskCap', () => {
   });
 });
 
-describe('extractZip', () => {
-  const zip = '/tmp/skill.zip';
-  const dest = '/tmp/skill-dest';
+describe('extractZipArchive', () => {
+  let dest: string;
 
-  it('falls through to the next tool when one is missing', () => {
-    const calls: string[] = [];
-    const exec = ((cmd: string) => {
-      calls.push(cmd);
-      if (cmd === 'unzip') throw new Error('spawnSync unzip ENOENT');
-    }) as any;
-    expect(__test.extractZip(zip, dest, exec)).toBe('tar');
-    expect(calls).toEqual(['unzip', 'tar']);
+  beforeEach(() => {
+    dest = fs.mkdtempSync(path.join(os.tmpdir(), 'wizard-zip-'));
   });
 
-  it('names every attempted tool when all of them fail', () => {
-    const exec = ((cmd: string) => {
-      throw new Error(`spawnSync ${cmd} ENOENT`);
-    }) as any;
-    expect(() => __test.extractZip(zip, dest, exec)).toThrow(
-      /unzip.*ENOENT.*tar.*ENOENT/s,
+  afterEach(() => {
+    cleanup(dest);
+  });
+
+  it('writes files and nested directories from the archive', () => {
+    const zip = zipSync({
+      'SKILL.md': new TextEncoder().encode('# skill'),
+      'references/deep/notes.md': new TextEncoder().encode('notes'),
+    });
+
+    const written = __test.extractZipArchive(zip, dest);
+
+    expect(written).toBe(2);
+    expect(fs.readFileSync(path.join(dest, 'SKILL.md'), 'utf8')).toBe(
+      '# skill',
     );
+    expect(
+      fs.readFileSync(path.join(dest, 'references/deep/notes.md'), 'utf8'),
+    ).toBe('notes');
   });
 
-  it('adds PowerShell Expand-Archive as the Windows last resort, with quotes escaped', () => {
-    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
-    Object.defineProperty(process, 'platform', { value: 'win32' });
-    try {
-      const attempts = __test.zipExtractionAttempts(
-        "C:\\Users\\o'brien\\skill.zip",
-        'C:\\dest',
-      );
-      expect(attempts.map((a) => a.tool)).toEqual([
-        'unzip',
-        'tar',
-        'powershell.exe',
-      ]);
-      const command = attempts[2].args.join(' ');
-      expect(command).toContain('Expand-Archive');
-      expect(command).toContain("o''brien");
-    } finally {
-      Object.defineProperty(process, 'platform', platform);
-    }
+  it('rejects zip-slip entries that escape the destination', () => {
+    const zip = zipSync({
+      '../evil.txt': new TextEncoder().encode('pwned'),
+    });
+
+    expect(() => __test.extractZipArchive(zip, dest)).toThrow(
+      /escapes destination/,
+    );
+    expect(fs.existsSync(path.join(dest, '..', 'evil.txt'))).toBe(false);
   });
 
-  it('keeps the POSIX attempt list free of PowerShell', () => {
-    const tools = __test.zipExtractionAttempts(zip, dest).map((a) => a.tool);
-    expect(tools).toEqual(['unzip', 'tar']);
+  it('rejects absolute entry paths', () => {
+    const zip = zipSync({
+      '/etc/evil.txt': new TextEncoder().encode('pwned'),
+    });
+
+    expect(() => __test.extractZipArchive(zip, dest)).toThrow(
+      /escapes destination/,
+    );
   });
 });

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -11,11 +11,10 @@
 
 import path from 'path';
 import fs from 'fs';
-import { execFileSync } from 'child_process';
+import { unzipSync } from 'fflate';
 import { z } from 'zod';
 import { logToFile } from '@utils/debug';
 import { analytics } from '@utils/analytics';
-import { skillTmpPath } from '@utils/paths';
 import { writeJsonAtomic, makeMutex } from '@utils/atomic-ledger';
 import type { PackageManagerDetector } from './detection/package-manager';
 import {
@@ -106,49 +105,24 @@ export async function fetchSkillMenu(
   }
 }
 
-// Stock Windows has no unzip; its tar (and macOS's) is bsdtar, which reads
-// zip — GNU tar on Linux doesn't, so unzip stays first.
-function zipExtractionAttempts(
-  zipFile: string,
-  destDir: string,
-): Array<{ tool: string; args: string[] }> {
-  const attempts = [
-    { tool: 'unzip', args: ['-o', zipFile, '-d', destDir] },
-    { tool: 'tar', args: ['-xf', zipFile, '-C', destDir] },
-  ];
-  if (process.platform === 'win32') {
-    const quote = (s: string) => `'${s.replace(/'/g, "''")}'`;
-    attempts.push({
-      tool: 'powershell.exe',
-      args: [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        `Expand-Archive -LiteralPath ${quote(zipFile)} -DestinationPath ${quote(
-          destDir,
-        )} -Force`,
-      ],
-    });
-  }
-  return attempts;
-}
-
-/** Extract with the first tool that works; throws naming every failure. */
-function extractZip(
-  zipFile: string,
-  destDir: string,
-  exec: typeof execFileSync = execFileSync,
-): string {
-  const failures: string[] = [];
-  for (const { tool, args } of zipExtractionAttempts(zipFile, destDir)) {
-    try {
-      exec(tool, args, { timeout: 30000 });
-      return tool;
-    } catch (err: any) {
-      failures.push(`${tool}: ${err.message}`);
+/** Extract a zip buffer, refusing entries that escape destDir (zip-slip). */
+function extractZipArchive(zip: Uint8Array, destDir: string): number {
+  const root = path.resolve(destDir);
+  let written = 0;
+  for (const [entryPath, data] of Object.entries(unzipSync(zip))) {
+    const target = path.resolve(root, entryPath);
+    if (target !== root && !target.startsWith(root + path.sep)) {
+      throw new Error(`zip entry escapes destination: ${entryPath}`);
     }
+    if (entryPath.endsWith('/')) {
+      fs.mkdirSync(target, { recursive: true });
+      continue;
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, data);
+    written++;
   }
-  throw new Error(`could not extract zip — ${failures.join('; ')}`);
+  return written;
 }
 
 /**
@@ -156,35 +130,29 @@ function extractZip(
  * By default installs to `<installDir>/.claude/skills/<id>/`.
  * Pass `skillsRoot` to override the base directory (e.g. `.posthog/skills`).
  */
-export function downloadSkill(
+export async function downloadSkill(
   skillEntry: SkillEntry,
   installDir: string,
   skillsRoot?: string,
-): { success: boolean; error?: string } {
+): Promise<{ success: boolean; error?: string }> {
   const skillDir = skillsRoot
     ? path.join(installDir, skillsRoot, skillEntry.id)
     : path.join(installDir, '.claude', 'skills', skillEntry.id);
-  const tmpFile = skillTmpPath(skillEntry.id);
   let step: 'download' | 'extract' = 'download';
 
   try {
     fs.mkdirSync(skillDir, { recursive: true });
-    // %TEMP% may not exist on Windows, and curl won't create it.
-    fs.mkdirSync(path.dirname(tmpFile), { recursive: true });
-    execFileSync('curl', ['-sL', skillEntry.downloadUrl, '-o', tmpFile], {
-      timeout: 30000,
+    const resp = await fetch(skillEntry.downloadUrl, {
+      signal: AbortSignal.timeout(30000),
     });
+    if (!resp.ok) throw new Error(`download failed with HTTP ${resp.status}`);
+    const zip = new Uint8Array(await resp.arrayBuffer());
     step = 'extract';
-    const extractedWith = extractZip(tmpFile, skillDir);
+    const fileCount = extractZipArchive(zip, skillDir);
     fs.writeFileSync(path.join(skillDir, '.posthog-wizard'), '');
-    try {
-      fs.unlinkSync(tmpFile);
-    } catch {
-      /* ignore cleanup errors */
-    }
 
     logToFile(
-      `downloadSkill: installed ${skillEntry.id} from ${skillEntry.downloadUrl} (extracted via ${extractedWith})`,
+      `downloadSkill: installed ${skillEntry.id} from ${skillEntry.downloadUrl} (${fileCount} files)`,
     );
     return { success: true };
   } catch (err: any) {
@@ -234,7 +202,7 @@ export async function installSkillById(
     .find((s) => s.id === skillId);
   if (!skill) return { kind: 'skill-not-found', skillId };
 
-  const result = downloadSkill(skill, installDir, skillsRoot);
+  const result = await downloadSkill(skill, installDir, skillsRoot);
   if (!result.success) {
     return { kind: 'download-failed', message: result.error ?? 'unknown' };
   }
@@ -816,7 +784,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
           'Skill ID from the skill menu (e.g., "integration-nextjs-app-router")',
         ),
     },
-    (args: { skillId: string }) => {
+    async (args: { skillId: string }) => {
       if (!/^[a-z0-9][a-z0-9_-]*$/.test(args.skillId)) {
         return {
           content: [
@@ -844,7 +812,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         };
       }
 
-      const result = downloadSkill(skill, workingDirectory);
+      const result = await downloadSkill(skill, workingDirectory);
       if (result.success) {
         return {
           content: [
@@ -1275,8 +1243,7 @@ export const WIZARD_TOOL_NAMES = {
 // ---------------------------------------------------------------------------
 
 export const __test = {
-  extractZip,
-  zipExtractionAttempts,
+  extractZipArchive,
   writeLedgerAtomic,
   readLedger,
   applyAuditAdditions,

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -151,7 +151,11 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
         s.id.startsWith(prefix),
       );
       for (const skill of skills) {
-        downloadSkill(skill, store.session.installDir, '.posthog/skills');
+        await downloadSkill(
+          skill,
+          store.session.installDir,
+          '.posthog/skills',
+        );
       }
     }
     setDownloaded(true);

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -10,11 +10,6 @@ export const WIZARD_YARA_REPORT_FILE = join(
   TMP,
   'posthog-wizard-yara-report.json',
 );
-/** Temp path for a skill download zip. */
-export function skillTmpPath(skillId: string): string {
-  return join(TMP, `posthog-skill-${skillId}.zip`);
-}
-
 /**
  * Strip an absolute installDir prefix off a project file path so the UI
  * renders `index.js:12` instead of `/Users/.../index.js:12`. Defends


### PR DESCRIPTION
Closes #808.

Skill installs used curl and unzip from the shell. Some machines don't have them, so installs failed. Now we use Node's built-in fetch and the fflate library. No shell tools needed.

Changes:
- Download the skill zip with fetch instead of curl.
- Unzip in-process with fflate instead of unzip, tar, or PowerShell.
- Reject zip entries that point outside the skill folder (zip-slip).
- Remove the temp file and skillTmpPath. No temp file needed now.
- downloadSkill is now async. Callers updated.
- New tests for extraction and zip-slip.