### PR TITLE
fix(deps): bump @posthog/warlock to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@earendil-works/pi-coding-agent": "^0.79.1",
     "@inkjs/ui": "^2.0.0",
     "@langchain/core": "^0.3.40",
-    "@posthog/warlock": "0.2.2",
+    "@posthog/warlock": "0.2.3",
     "axios": "1.7.4",
     "fast-glob": "^3.3.3",
     "fflate": "^0.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.3.40
         version: 0.3.40(openai@6.26.0(ws@8.18.1)(zod@3.25.76))
       '@posthog/warlock':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       axios:
         specifier: 1.7.4
         version: 1.7.4
@@ -1769,8 +1769,8 @@ packages:
   '@posthog/core@1.23.1':
     resolution: {integrity: sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==}
 
-  '@posthog/warlock@0.2.2':
-    resolution: {integrity: sha512-fpN9eZJ7JvOFej6gfsW1DETJTyo7S2xuu5NQsnBYl8C/cYCmGc8Q0IPiVfBGkIifF1Cic0fzkytFusImxzv4ww==}
+  '@posthog/warlock@0.2.3':
+    resolution: {integrity: sha512-ZlKWA8jU5IlPW5nZ40aE5/MYq/z3HeuKjLiTlH+OyffvDOQkQQ24nBNrMI4tLagGb2tkiNv5l9puAKlSllzWRw==}
     engines: {node: ^20.20.0 || >=22.22.0}
 
   '@protobufjs/aspromise@1.1.2':
@@ -7203,7 +7203,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/warlock@0.2.2':
+  '@posthog/warlock@0.2.3':
     dependencies:
       '@virustotal/yara-x': 1.15.0
 


### PR DESCRIPTION
## Problem

oopsie

#804 migrated the pi harness onto `@posthog/warlock` but left the pin at `0.2.2`. Warlock #59 (the PII capture-rule fixes) shipped as **0.2.3**, so main currently runs the pi security fence on the *un-fixed* rules:

- **Bleed false positive still live** — `0.2.2`'s PII rule uses an argument gap that doesn't stop at `)`, so a properties-less `posthog.capture('event')` bleeds into a following `posthog.identify(userId, { email })` and false-flags it. This is the exact "identify() triggering the PII rule" symptom the incident was about. `0.2.3` fixes it (`[^{]*` → `[^{)]*`).
- **Weaker remediation text** — `0.2.2`'s block message says "use posthog.identify() or person properties"; `0.2.3` names the concrete escape hatches (`identify()`, `setPersonProperties()`, `$set` / `$set_once`), which the pi fence surfaces to a blocked agent so it can self-correct.

## Changes

- Bump `@posthog/warlock` `0.2.2` → `0.2.3` (exact pin, as before) + lockfile.

## Test plan

- `pnpm install` resolves `0.2.3`; lockfile diff is the warlock entry only, no dependency drift.
- Typecheck clean — the test mock's compile-time conformance guard still matches the real `0.2.3` API (no API changes, rules-only release).
- `yara-hooks` + pi `security` suites green (62 tests).

> Note: the wizard test suite mocks `@posthog/warlock`, so it validates the wizard's decision logic, not warlock's rule behavior. A real-warlock smoke test that actually exercises the rules on every bump is the follow-up (stacked PR), alongside removing the `wizard-warlock-disabled` kill-switch flag in favor of version-locking + that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
