### PR TITLE
fix: run prettier without a shell so filenames can't be executed

### DIFF
--- a/src/steps/run-prettier.ts
+++ b/src/steps/run-prettier.ts
@@ -10,6 +10,31 @@ import {
 import { hasDeclaredDependency } from '@utils/package-json';
 import type { WizardRunOptions } from '@utils/types';
 import * as childProcess from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+/**
+ * Absolute path to the project's Prettier CLI entrypoint, or `null` when it
+ * cannot be resolved.
+ *
+ * Prettier moved its binary between major versions (v2 ships `bin-prettier.js`,
+ * v3 `bin/prettier.cjs`), so read the location out of Prettier's own
+ * `package.json` instead of hardcoding it.
+ */
+function resolvePrettierBin(installDir: string): string | null {
+  try {
+    const requireFrom = createRequire(join(installDir, 'noop.js'));
+    const packageJsonPath = requireFrom.resolve('prettier/package.json');
+    const { bin } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      bin?: string | Record<string, string>;
+    };
+    const binPath = typeof bin === 'string' ? bin : bin?.prettier;
+    return binPath ? join(dirname(packageJsonPath), binPath) : null;
+  } catch {
+    return null;
+  }
+}
 
 export async function runPrettierStep({
   installDir,
@@ -24,11 +49,7 @@ export async function runPrettierStep({
       return;
     }
 
-    const changedOrUntrackedFiles = getUncommittedOrUntrackedFiles()
-      .map((filename) => {
-        return filename.startsWith('- ') ? filename.slice(2) : filename;
-      })
-      .join(' ');
+    const changedOrUntrackedFiles = getUncommittedOrUntrackedFiles();
 
     if (!changedOrUntrackedFiles.length) {
       // Likewise, if we can't find changed or untracked files, there's no point in running Prettier.
@@ -45,13 +66,32 @@ export async function runPrettierStep({
       return;
     }
 
+    const prettierBin = resolvePrettierBin(installDir);
+    if (!prettierBin) {
+      // Declared in package.json but not present in node_modules.
+      return;
+    }
+
     const prettierSpinner = getUI().spinner();
     prettierSpinner.start('Running Prettier on your files.');
 
     try {
       await new Promise<void>((resolve, reject) => {
-        childProcess.exec(
-          `npx prettier --ignore-unknown --write ${changedOrUntrackedFiles}`,
+        // Run the CLI under the current Node binary and pass filenames as argv
+        // entries. Interpolating them into a shell command lets a filename such
+        // as `a.ts;rm -rf .` execute as a command, and spawning `npx` would
+        // reintroduce that shell on Windows, where it resolves to `npx.cmd`.
+        // `--` stops Prettier reading a leading-dash filename as a flag.
+        childProcess.execFile(
+          process.execPath,
+          [
+            prettierBin,
+            '--ignore-unknown',
+            '--write',
+            '--',
+            ...changedOrUntrackedFiles,
+          ],
+          { shell: false },
           (err) => {
             if (err) {
               reject(err);

--- a/src/utils/__tests__/setup-utils.test.ts
+++ b/src/utils/__tests__/setup-utils.test.ts
@@ -1,0 +1,113 @@
+import * as childProcess from 'node:child_process';
+
+import { getUncommittedOrUntrackedFiles } from '@utils/setup-utils';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+  exec: vi.fn(),
+}));
+
+const execSync = vi.mocked(childProcess.execSync);
+
+/** Build the NUL-separated payload `git status --porcelain=v1 -z` emits. */
+const gitOutput = (...entries: string[]) =>
+  entries.map((entry) => `${entry}\0`).join('');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getUncommittedOrUntrackedFiles', () => {
+  it('requests NUL-separated output so paths are never quoted or escaped', () => {
+    execSync.mockReturnValue(Buffer.from(''));
+
+    getUncommittedOrUntrackedFiles();
+
+    expect(execSync).toHaveBeenCalledWith(
+      'git status --porcelain=v1 -z',
+      expect.anything(),
+    );
+  });
+
+  it('returns an empty array when there is nothing to format', () => {
+    execSync.mockReturnValue(Buffer.from(''));
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual([]);
+  });
+
+  it('returns an empty array when git fails', () => {
+    execSync.mockImplementation(() => {
+      throw new Error('not a git repository');
+    });
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual([]);
+  });
+
+  it('reads modified, staged, and untracked files', () => {
+    execSync.mockReturnValue(
+      Buffer.from(gitOutput(' M modified.ts', 'A  staged.ts', '?? new.ts')),
+    );
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual([
+      'modified.ts',
+      'staged.ts',
+      'new.ts',
+    ]);
+  });
+
+  it('preserves paths containing spaces', () => {
+    execSync.mockReturnValue(Buffer.from(gitOutput('?? with space.ts')));
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual(['with space.ts']);
+  });
+
+  it('preserves paths containing shell metacharacters', () => {
+    execSync.mockReturnValue(
+      Buffer.from(
+        gitOutput('?? semi;colon.ts', '?? a.ts;>pwned', '?? $(whoami).ts'),
+      ),
+    );
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual([
+      'semi;colon.ts',
+      'a.ts;>pwned',
+      '$(whoami).ts',
+    ]);
+  });
+
+  it('preserves non-ASCII paths without C-quoting them', () => {
+    execSync.mockReturnValue(Buffer.from(gitOutput('?? café.ts')));
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual(['café.ts']);
+  });
+
+  it('keeps the new path of a rename and drops the original', () => {
+    // Rename entries are two fields: `R  <new>\0<old>\0`.
+    execSync.mockReturnValue(
+      Buffer.from(gitOutput('R  new name.ts', 'oldname.ts', '?? other.ts')),
+    );
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual([
+      'new name.ts',
+      'other.ts',
+    ]);
+  });
+
+  it('keeps the new path of a copy and drops the source', () => {
+    execSync.mockReturnValue(
+      Buffer.from(gitOutput('C  copy.ts', 'source.ts', '?? other.ts')),
+    );
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual(['copy.ts', 'other.ts']);
+  });
+
+  it('skips deleted paths, which no longer exist on disk', () => {
+    execSync.mockReturnValue(
+      Buffer.from(
+        gitOutput('D  staged delete.ts', ' D unstaged.ts', '?? kept.ts'),
+      ),
+    );
+
+    expect(getUncommittedOrUntrackedFiles()).toEqual(['kept.ts']);
+  });
+});

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -1,6 +1,5 @@
 import * as childProcess from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import { basename, isAbsolute, join, relative } from 'node:path';
 import { promisify } from 'node:util';
 
@@ -161,11 +160,21 @@ export function detectOrgAndProject(email: string): {
   return { orgName, projectName };
 }
 
+/**
+ * Paths of files that are modified, staged, or untracked, relative to the
+ * current directory.
+ *
+ * Uses `-z` rather than the default line-oriented output: git C-quotes any path
+ * containing a space or a non-ASCII byte (`"with space.ts"`, `"caf\303\251.ts"`),
+ * so the default format cannot be split on whitespace without corrupting those
+ * names. `-z` emits raw, unquoted paths separated by NUL, which no path may
+ * contain.
+ */
 export function getUncommittedOrUntrackedFiles(): string[] {
   let gitStatus: string;
   try {
     gitStatus = childProcess
-      .execSync('git status --porcelain=v1', {
+      .execSync('git status --porcelain=v1 -z', {
         // we only care about stdout
         stdio: ['ignore', 'pipe', 'ignore'],
       })
@@ -174,14 +183,31 @@ export function getUncommittedOrUntrackedFiles(): string[] {
     return [];
   }
 
-  const result: string[] = [];
-  for (const rawLine of gitStatus.split(os.EOL)) {
-    const line = rawLine.trim();
-    if (!line) continue;
-    const match = /^\S+\s+(\S+)/.exec(line);
-    result.push(`- ${match?.[1]}`);
+  const entries = gitStatus.split('\0');
+  const files: string[] = [];
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!entry) continue;
+
+    // Each entry is `XY <path>`, where X is the staged status and Y the
+    // unstaged one.
+    const [x, y] = entry;
+    const filePath = entry.slice(3);
+
+    // Rename and copy entries are followed by a second NUL-terminated field
+    // holding the original path. `entry` already carries the new path, so step
+    // over the original.
+    if (x === 'R' || x === 'C') i++;
+
+    // A deleted path is gone from disk. Handing it to a formatter only makes
+    // the formatter exit non-zero.
+    if (x === 'D' || y === 'D') continue;
+
+    if (filePath) files.push(filePath);
   }
-  return result;
+
+  return files;
 }
 
 export async function isReact19Installed({


### PR DESCRIPTION
Fixes #800

## Problem

Two bugs, and the one that isn't in the issue is the one that bites everyone.

The parser breaks before the shell sees a path. git C-quotes anything with a space or a non-ASCII byte, `/^\S+\s+(\S+)/` only takes the first token, and renames yield the pre-rename path. So an ordinary rename plus a delete is enough: prettier gets `keep.ts oldname.ts "to`, the shell hits an unterminated quote, exit 2, nothing formatted.

Then the reported bug. Filenames are interpolated into `exec`. Spaces get quoted by git, but `;`, `>`, `|` and `$` don't, so a file named `a.ts;>PWNED` executes the redirect.

## Fix

**Read `git status --porcelain=v1 -z` and pass filenames as argv entries instead of interpolating them into a shell command.**

`-z` is git's documented machine-parsing format: no quoting, reversed rename order, guaranteed stable across versions and user config. Keep the post-rename path, skip deletes. Run prettier's CLI under `process.execPath` via `execFile` with `shell: false`, plus `--` so a leading-dash filename isn't read as a flag.

`execFile('npx', ...)` was the smaller diff, but it puts the shell back on Windows, where `npx` is `npx.cmd`. Resolving prettier from `node_modules` avoids that everywhere.

## Testing

10 new tests in `setup-utils.test.ts`; 8 fail on `main`. End to end on a repo with a rename, a delete, `with space.ts` and `a.ts;>PWNED`: before, shell error, nothing formatted. After, exit 0, all formatted, no `PWNED`. Build, tests and lint are green.

## Caveat

Prettier declared but not resolvable from `node_modules` now returns quietly instead of letting `npx` fetch it. That covers running before `install`, and Yarn PnP, which has no `node_modules` at all. Happy to add an `npx` fallback on non-Windows, where `execFile` can reach it without a shell.