### PR TITLE
fix: pin wizard-internal MCP connections to tools mode

### DIFF
--- a/src/lib/__tests__/host-resolution.test.ts
+++ b/src/lib/__tests__/host-resolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { HostResolution } from '@lib/host-resolution';
+import { HostResolution, withMcpToolsModePin } from '@lib/host-resolution';
 
 /**
  * Contract test for HostResolution — the durable record of what the host family
@@ -74,5 +74,31 @@ describe('HostResolution.fromAccessToken', () => {
   it('short-circuits to us in dev/test without a network probe', async () => {
     const h = await HostResolution.fromAccessToken('any-token');
     expect(h.region).toBe('us');
+  });
+});
+
+describe('withMcpToolsModePin', () => {
+  it('pins mode=tools on the prod url', () => {
+    expect(withMcpToolsModePin('https://mcp.posthog.com/mcp')).toBe(
+      'https://mcp.posthog.com/mcp?mode=tools',
+    );
+  });
+
+  it('pins mode=tools on the local dev url', () => {
+    expect(withMcpToolsModePin('http://localhost:8787/mcp')).toBe(
+      'http://localhost:8787/mcp?mode=tools',
+    );
+  });
+
+  it('preserves existing query params while pinning', () => {
+    expect(
+      withMcpToolsModePin('https://mcp.posthog.com/mcp?features=flags'),
+    ).toBe('https://mcp.posthog.com/mcp?features=flags&mode=tools');
+  });
+
+  it('leaves an explicit mode override untouched', () => {
+    expect(withMcpToolsModePin('https://mcp.posthog.com/mcp?mode=cli')).toBe(
+      'https://mcp.posthog.com/mcp?mode=cli',
+    );
   });
 });

--- a/src/lib/__tests__/host-resolution.test.ts
+++ b/src/lib/__tests__/host-resolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { HostResolution, withMcpToolsModePin } from '@lib/host-resolution';
+import { HostResolution, mcpUrlFor } from '@lib/host-resolution';
 
 /**
  * Contract test for HostResolution — the durable record of what the host family
@@ -43,12 +43,12 @@ describe('HostResolution.fromApiHost', () => {
 });
 
 describe('HostResolution mcpUrl', () => {
-  it('defaults to the region-independent prod MCP url', () => {
+  it('defaults to the region-independent prod MCP url, pinned to tools mode', () => {
     expect(HostResolution.fromApiHost('https://us.i.posthog.com').mcpUrl).toBe(
-      'https://mcp.posthog.com/mcp',
+      'https://mcp.posthog.com/mcp?mode=tools',
     );
     expect(HostResolution.fromApiHost('https://eu.i.posthog.com').mcpUrl).toBe(
-      'https://mcp.posthog.com/mcp',
+      'https://mcp.posthog.com/mcp?mode=tools',
     );
   });
 
@@ -56,7 +56,7 @@ describe('HostResolution mcpUrl', () => {
     const h = HostResolution.fromApiHost('https://us.i.posthog.com', {
       localMcp: true,
     });
-    expect(h.mcpUrl).toBe('http://localhost:8787/mcp');
+    expect(h.mcpUrl).toBe('http://localhost:8787/mcp?mode=tools');
   });
 });
 
@@ -77,28 +77,23 @@ describe('HostResolution.fromAccessToken', () => {
   });
 });
 
-describe('withMcpToolsModePin', () => {
+describe('mcpUrlFor', () => {
   it('pins mode=tools on the prod url', () => {
-    expect(withMcpToolsModePin('https://mcp.posthog.com/mcp')).toBe(
-      'https://mcp.posthog.com/mcp?mode=tools',
-    );
+    expect(mcpUrlFor(false)).toBe('https://mcp.posthog.com/mcp?mode=tools');
   });
 
   it('pins mode=tools on the local dev url', () => {
-    expect(withMcpToolsModePin('http://localhost:8787/mcp')).toBe(
-      'http://localhost:8787/mcp?mode=tools',
-    );
+    expect(mcpUrlFor(true)).toBe('http://localhost:8787/mcp?mode=tools');
   });
 
-  it('preserves existing query params while pinning', () => {
-    expect(
-      withMcpToolsModePin('https://mcp.posthog.com/mcp?features=flags'),
-    ).toBe('https://mcp.posthog.com/mcp?features=flags&mode=tools');
-  });
-
-  it('leaves an explicit mode override untouched', () => {
-    expect(withMcpToolsModePin('https://mcp.posthog.com/mcp?mode=cli')).toBe(
-      'https://mcp.posthog.com/mcp?mode=cli',
-    );
+  it('takes an MCP_URL override verbatim', () => {
+    const prev = process.env.MCP_URL;
+    process.env.MCP_URL = 'https://mcp.example.com/mcp?mode=cli';
+    try {
+      expect(mcpUrlFor(false)).toBe('https://mcp.example.com/mcp?mode=cli');
+    } finally {
+      if (prev === undefined) delete process.env.MCP_URL;
+      else process.env.MCP_URL = prev;
+    }
   });
 });

--- a/src/lib/agent/mcp-prompt-streaming.ts
+++ b/src/lib/agent/mcp-prompt-streaming.ts
@@ -15,8 +15,7 @@
 import type { AgentChunk } from '@ui/tui/services/mcp-suggested-prompts-services';
 import type { Credentials } from '@lib/wizard-session';
 import { DEFAULT_AGENT_MODEL, WIZARD_USER_AGENT } from '@lib/constants';
-import { HostResolution, withMcpToolsModePin } from '@lib/host-resolution';
-import { runtimeEnv } from '@env';
+import { HostResolution, mcpUrlFor } from '@lib/host-resolution';
 import { logToFile } from '@utils/debug';
 import { buildAgentEnv } from '@lib/agent/agent-interface';
 import { sanitizeAgentSubprocessEnv } from '@lib/agent/agent-env-isolation';
@@ -45,12 +44,9 @@ const MAX_TURNS = 30;
 
 // One MCP url for every region: the server resolves the user's region from
 // the bearer token, so the EU subdomain (a Claude Code OAuth workaround) is
-// not needed here. `mode=tools` keeps the named-tool roster the suggested
-// prompts rely on (see withMcpToolsModePin).
+// not needed here.
 function resolveMcpUrl(): string {
-  return withMcpToolsModePin(
-    runtimeEnv('MCP_URL') || 'https://mcp.posthog.com/mcp',
-  );
+  return mcpUrlFor(false);
 }
 
 /**

--- a/src/lib/agent/mcp-prompt-streaming.ts
+++ b/src/lib/agent/mcp-prompt-streaming.ts
@@ -15,7 +15,7 @@
 import type { AgentChunk } from '@ui/tui/services/mcp-suggested-prompts-services';
 import type { Credentials } from '@lib/wizard-session';
 import { DEFAULT_AGENT_MODEL, WIZARD_USER_AGENT } from '@lib/constants';
-import { HostResolution } from '@lib/host-resolution';
+import { HostResolution, withMcpToolsModePin } from '@lib/host-resolution';
 import { runtimeEnv } from '@env';
 import { logToFile } from '@utils/debug';
 import { buildAgentEnv } from '@lib/agent/agent-interface';
@@ -45,9 +45,12 @@ const MAX_TURNS = 30;
 
 // One MCP url for every region: the server resolves the user's region from
 // the bearer token, so the EU subdomain (a Claude Code OAuth workaround) is
-// not needed here.
+// not needed here. `mode=tools` keeps the named-tool roster the suggested
+// prompts rely on (see withMcpToolsModePin).
 function resolveMcpUrl(): string {
-  return runtimeEnv('MCP_URL') || 'https://mcp.posthog.com/mcp';
+  return withMcpToolsModePin(
+    runtimeEnv('MCP_URL') || 'https://mcp.posthog.com/mcp',
+  );
 }
 
 /**

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -8,6 +8,7 @@
  */
 
 import type { WizardSession } from '@lib/wizard-session';
+import { withMcpToolsModePin } from '@lib/host-resolution';
 import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
 import { authenticate } from './authenticate';
@@ -266,10 +267,13 @@ export async function bootstrapProgram(
 
   // One MCP url for every region: the server resolves the user's region from
   // the bearer token, so the EU subdomain (a Claude Code OAuth workaround) is
-  // not needed here.
-  const mcpUrl = session.localMcp
-    ? 'http://localhost:8787/mcp'
-    : runtimeEnv('MCP_URL') || 'https://mcp.posthog.com/mcp';
+  // not needed here. `mode=tools` keeps the named-tool roster the agent
+  // prompts and skills expect (see withMcpToolsModePin).
+  const mcpUrl = withMcpToolsModePin(
+    session.localMcp
+      ? 'http://localhost:8787/mcp'
+      : runtimeEnv('MCP_URL') || 'https://mcp.posthog.com/mcp',
+  );
 
   return {
     skillsBaseUrl,

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -8,7 +8,7 @@
  */
 
 import type { WizardSession } from '@lib/wizard-session';
-import { withMcpToolsModePin } from '@lib/host-resolution';
+import { mcpUrlFor } from '@lib/host-resolution';
 import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
 import { authenticate } from './authenticate';
@@ -29,7 +29,6 @@ import { enableDebugLogs, logToFile, initLogFile } from '@utils/debug';
 import { wizardAbort } from '@utils/wizard-abort';
 import { isNonInteractiveEnvironment } from '@utils/environment';
 import { getSkillsBaseUrl } from '@lib/constants';
-import { runtimeEnv } from '@env';
 import type { WizardRunOptions } from '@utils/types';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun, BootstrapResult } from './types';
@@ -267,13 +266,8 @@ export async function bootstrapProgram(
 
   // One MCP url for every region: the server resolves the user's region from
   // the bearer token, so the EU subdomain (a Claude Code OAuth workaround) is
-  // not needed here. `mode=tools` keeps the named-tool roster the agent
-  // prompts and skills expect (see withMcpToolsModePin).
-  const mcpUrl = withMcpToolsModePin(
-    session.localMcp
-      ? 'http://localhost:8787/mcp'
-      : runtimeEnv('MCP_URL') || 'https://mcp.posthog.com/mcp',
-  );
+  // not needed here.
+  const mcpUrl = mcpUrlFor(session.localMcp);
 
   return {
     skillsBaseUrl,

--- a/src/lib/host-resolution.ts
+++ b/src/lib/host-resolution.ts
@@ -63,6 +63,20 @@ function mcpUrlFor(localMcp: boolean): string {
   return runtimeEnv('MCP_URL') || PROD_MCP_URL;
 }
 
+/**
+ * The wizard's internal agent runs speak the named-tool roster, so their MCP
+ * url carries `mode=tools`; an explicit `mode` on the url (e.g. an `MCP_URL`
+ * override) wins, so both server shapes stay reachable in dev.
+ * TODO(#849): drop the pin once both harnesses run on the single-exec CLI mode.
+ */
+export function withMcpToolsModePin(mcpUrl: string): string {
+  const url = new URL(mcpUrl);
+  if (!url.searchParams.has('mode')) {
+    url.searchParams.set('mode', 'tools');
+  }
+  return url.toString();
+}
+
 export class HostResolution {
   /** The resolved cloud region. `'us'` when a base URL is pinned. */
   readonly region: CloudRegion;

--- a/src/lib/host-resolution.ts
+++ b/src/lib/host-resolution.ts
@@ -27,8 +27,11 @@ import {
 import { runtimeEnv } from '@env';
 import type { CloudRegion } from '@utils/types';
 
-const LOCAL_MCP_URL = 'http://localhost:8787/mcp';
-const PROD_MCP_URL = 'https://mcp.posthog.com/mcp';
+// The wizard's internal agents speak the named-tool roster, so the default
+// urls pin `mode=tools`; an `MCP_URL` override is taken verbatim.
+// TODO(#849): drop the pin once both harnesses run on the single-exec CLI mode.
+const LOCAL_MCP_URL = 'http://localhost:8787/mcp?mode=tools';
+const PROD_MCP_URL = 'https://mcp.posthog.com/mcp?mode=tools';
 
 /** Construction-time inputs that aren't implied by the region. */
 export interface HostResolutionOptions {
@@ -58,23 +61,9 @@ function assetHostFromApiHost(apiHost: string): string {
   return apiHost;
 }
 
-function mcpUrlFor(localMcp: boolean): string {
+export function mcpUrlFor(localMcp: boolean): string {
   if (localMcp) return LOCAL_MCP_URL;
   return runtimeEnv('MCP_URL') || PROD_MCP_URL;
-}
-
-/**
- * The wizard's internal agent runs speak the named-tool roster, so their MCP
- * url carries `mode=tools`; an explicit `mode` on the url (e.g. an `MCP_URL`
- * override) wins, so both server shapes stay reachable in dev.
- * TODO(#849): drop the pin once both harnesses run on the single-exec CLI mode.
- */
-export function withMcpToolsModePin(mcpUrl: string): string {
-  const url = new URL(mcpUrl);
-  if (!url.searchParams.has('mode')) {
-    url.searchParams.set('mode', 'tools');
-  }
-  return url.toString();
 }
 
 export class HostResolution {


### PR DESCRIPTION
## Problem

The PostHog MCP server now defaults every client to CLI mode — a single `exec` tool taking command strings — instead of the ~252 named tools (PostHog/posthog#69629). The wizard's agent runs assume the named-tool roster (skills call `mcp__posthog-wizard__insight-create` etc.), so integration runs no longer complete on either harness.

Closes #843

## Changes

Use `?mode=tools` with the MCP as a patch. We'll need a bigger swing to use CLI mode properly later

## Test plan

`pnpm build && pnpm test && pnpm fix` — all 1280 unit tests pass, including coverage for the pinned prod/local urls and the verbatim `MCP_URL` override. Live verification: `/wizard-ci` run against a workbench app, confirming the dashboard step completes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
