### PR TITLE
fix: sync Node preflight range with package.json engines

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 import { satisfies } from 'semver';
 
-const NODE_VERSION_RANGE = '>=18.17.0';
+// Keep in sync with `engines.node` in package.json. npx does not enforce
+// engines, so this preflight is the only thing standing between an old Node
+// runtime and a cryptic dependency crash (e.g. undici's markAsUncloneable
+// TypeError on Node < 22.10).
+const NODE_VERSION_RANGE = '>=22.22.0';
 
 // Have to run this above the other imports because they are importing clack that
 // has the problematic imports.


### PR DESCRIPTION
## Problem

The runtime Node version check in `bin.ts` still enforces `>=18.17.0`, while `package.json` engines requires `>=22.22.0`. npx doesn't enforce engines (it only warns), so users on older Node runtimes pass the preflight and crash later inside dependencies with cryptic errors instead of a clear upgrade message.

Reported via wizard@posthog.com: a user on an old Node runtime was routed to the pi harness, whose bundled `undici@8.5.0` calls `markAsUncloneable` (added in Node 22.10) at module load — surfacing as `API Error: webidl.util.markAsUncloneable is not a function` immediately after login. Present on a small but steady share of pi-harness runs since the experiment started.

## Changes

- Bump `NODE_VERSION_RANGE` in `bin.ts` from `>=18.17.0` to `>=22.22.0`, matching `engines.node`, with a comment explaining why the preflight must stay in sync.

Known limitation (follow-up candidate): on Node 18 the preflight is unreachable entirely — `dist/bin.js` is ESM, so its static import graph parses before any code runs, and `string-width@8`'s `/v` regex flag is a SyntaxError on Node 18's V8. Giving those users a friendly message requires a dependency-free entry wrapper that checks the version before dynamically importing the real bin.

## Test plan

- `pnpm build` (includes smoke + warlock tests) — passed
- `pnpm vitest run` — 96 files, 1305 tests passed
- `pnpm fix` — clean

## Why

A support report showed old-Node users hitting an instant, misleading "API Error" right after authentication; the stale preflight is the root cause and this makes it fail fast with a clear upgrade message.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*