### PR TITLE
refactor: consolidate MCP url + mode resolution into mcpUrlFor

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -63,6 +63,10 @@ type RuntimeEnvKey =
   | 'DEBUG'
   // Agent / MCP
   | 'MCP_URL'
+  // Field kill switch for the MCP tool-surface mode (see mcpUrlFor). Declared
+  // as the hidden `mcp-mode` global option so yargs' POSTHOG_WIZARD env prefix
+  // accepts it instead of strict-rejecting the run.
+  | 'POSTHOG_WIZARD_MCP_MODE'
   | 'POSTHOG_API_KEY'
   // Platform: terminal detection
   | 'TERM'

--- a/src/lib/__tests__/host-resolution.test.ts
+++ b/src/lib/__tests__/host-resolution.test.ts
@@ -77,23 +77,86 @@ describe('HostResolution.fromAccessToken', () => {
   });
 });
 
+/** Run `fn` with an env var pinned, restoring the prior value afterwards. */
+function withEnv(key: string, value: string | undefined, fn: () => void) {
+  const prev = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
+  }
+}
+
 describe('mcpUrlFor', () => {
-  it('pins mode=tools on the prod url', () => {
-    expect(mcpUrlFor(false)).toBe('https://mcp.posthog.com/mcp?mode=tools');
+  it('builds the bare prod url when no mode is requested (server default)', () => {
+    expect(mcpUrlFor()).toBe('https://mcp.posthog.com/mcp');
+    expect(mcpUrlFor({})).toBe('https://mcp.posthog.com/mcp');
   });
 
-  it('pins mode=tools on the local dev url', () => {
-    expect(mcpUrlFor(true)).toBe('http://localhost:8787/mcp?mode=tools');
+  it('pins the requested mode on the prod url', () => {
+    expect(mcpUrlFor({ mode: 'tools' })).toBe(
+      'https://mcp.posthog.com/mcp?mode=tools',
+    );
+    expect(mcpUrlFor({ mode: 'cli' })).toBe(
+      'https://mcp.posthog.com/mcp?mode=cli',
+    );
+  });
+
+  it('pins the requested mode on the local dev url', () => {
+    expect(mcpUrlFor({ local: true, mode: 'tools' })).toBe(
+      'http://localhost:8787/mcp?mode=tools',
+    );
+    expect(mcpUrlFor({ local: true })).toBe('http://localhost:8787/mcp');
+  });
+
+  it('adds a features filter, before the mode param', () => {
+    expect(mcpUrlFor({ features: ['dashboards', 'insights'] })).toBe(
+      'https://mcp.posthog.com/mcp?features=dashboards,insights',
+    );
+    expect(mcpUrlFor({ features: ['dashboards'], mode: 'tools' })).toBe(
+      'https://mcp.posthog.com/mcp?features=dashboards&mode=tools',
+    );
+    expect(mcpUrlFor({ features: [] })).toBe('https://mcp.posthog.com/mcp');
   });
 
   it('takes an MCP_URL override verbatim', () => {
-    const prev = process.env.MCP_URL;
-    process.env.MCP_URL = 'https://mcp.example.com/mcp?mode=cli';
-    try {
-      expect(mcpUrlFor(false)).toBe('https://mcp.example.com/mcp?mode=cli');
-    } finally {
-      if (prev === undefined) delete process.env.MCP_URL;
-      else process.env.MCP_URL = prev;
-    }
+    withEnv('MCP_URL', 'https://mcp.example.com/mcp?mode=cli', () => {
+      expect(mcpUrlFor({ mode: 'tools' })).toBe(
+        'https://mcp.example.com/mcp?mode=cli',
+      );
+    });
+  });
+
+  it('prefers the local dev server over an MCP_URL override', () => {
+    withEnv('MCP_URL', 'https://mcp.example.com/mcp', () => {
+      expect(mcpUrlFor({ local: true, mode: 'tools' })).toBe(
+        'http://localhost:8787/mcp?mode=tools',
+      );
+    });
+  });
+
+  it('lets the POSTHOG_WIZARD_MCP_MODE kill switch win over the requested mode', () => {
+    withEnv('POSTHOG_WIZARD_MCP_MODE', 'cli', () => {
+      expect(mcpUrlFor({ mode: 'tools' })).toBe(
+        'https://mcp.posthog.com/mcp?mode=cli',
+      );
+    });
+    withEnv('POSTHOG_WIZARD_MCP_MODE', 'tools', () => {
+      expect(mcpUrlFor()).toBe('https://mcp.posthog.com/mcp?mode=tools');
+      expect(mcpUrlFor({ local: true, mode: 'cli' })).toBe(
+        'http://localhost:8787/mcp?mode=tools',
+      );
+    });
+  });
+
+  it('ignores an invalid POSTHOG_WIZARD_MCP_MODE value', () => {
+    withEnv('POSTHOG_WIZARD_MCP_MODE', 'bogus', () => {
+      expect(mcpUrlFor({ mode: 'tools' })).toBe(
+        'https://mcp.posthog.com/mcp?mode=tools',
+      );
+    });
   });
 });

--- a/src/lib/agent/mcp-prompt-streaming.ts
+++ b/src/lib/agent/mcp-prompt-streaming.ts
@@ -44,9 +44,10 @@ const MAX_TURNS = 30;
 
 // One MCP url for every region: the server resolves the user's region from
 // the bearer token, so the EU subdomain (a Claude Code OAuth workaround) is
-// not needed here.
+// not needed here. Pinned to the named-tool roster the tutorial's prompts
+// still speak.
 function resolveMcpUrl(): string {
-  return mcpUrlFor(false);
+  return mcpUrlFor({ mode: 'tools' });
 }
 
 /**

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -266,8 +266,9 @@ export async function bootstrapProgram(
 
   // One MCP url for every region: the server resolves the user's region from
   // the bearer token, so the EU subdomain (a Claude Code OAuth workaround) is
-  // not needed here.
-  const mcpUrl = mcpUrlFor(session.localMcp);
+  // not needed here. Pinned to the named-tool roster the harness prompts and
+  // installed skills still speak.
+  const mcpUrl = mcpUrlFor({ local: session.localMcp, mode: 'tools' });
 
   return {
     skillsBaseUrl,

--- a/src/lib/detection/agentic.ts
+++ b/src/lib/detection/agentic.ts
@@ -21,6 +21,7 @@ import {
 import { isAbsolute } from 'path';
 import { detectNodePackageManagers } from './package-manager.js';
 import { getSkillsBaseUrl, HAIKU_MODEL } from '@lib/constants';
+import { mcpUrlFor } from '@lib/host-resolution';
 import type { WizardSession } from '@lib/wizard-session';
 import type { WizardRunOptions } from '@utils/types';
 import type { SpinnerHandle } from '@ui';
@@ -250,9 +251,7 @@ export async function detectProjectsWithAgent(
   const cwd = session.installDir;
   const runOptions = sessionToWizardOptions(session);
 
-  const mcpUrl = session.localMcp
-    ? 'http://localhost:8787/mcp'
-    : 'https://mcp.posthog.com/mcp';
+  const mcpUrl = mcpUrlFor({ local: session.localMcp, mode: 'tools' });
 
   const agent = await initializeAgent(
     {

--- a/src/lib/host-resolution.ts
+++ b/src/lib/host-resolution.ts
@@ -27,11 +27,17 @@ import {
 import { runtimeEnv } from '@env';
 import type { CloudRegion } from '@utils/types';
 
-// The wizard's internal agents speak the named-tool roster, so the default
-// urls pin `mode=tools`; an `MCP_URL` override is taken verbatim.
-// TODO(#849): drop the pin once both harnesses run on the single-exec CLI mode.
-const LOCAL_MCP_URL = 'http://localhost:8787/mcp?mode=tools';
-const PROD_MCP_URL = 'https://mcp.posthog.com/mcp?mode=tools';
+const LOCAL_MCP_BASE = 'http://localhost:8787/mcp';
+const PROD_MCP_BASE = 'https://mcp.posthog.com/mcp';
+
+/**
+ * The MCP server's tool-surface modes: `tools` serves the ~252-named-tool
+ * roster, `cli` serves a single `exec` tool that reaches the same catalog
+ * through command strings. A url without a `mode` param gets the server
+ * default, which is CLI mode for the wizard's client (only Cursor and ChatGPT
+ * are allowlisted to keep the named roster).
+ */
+export type McpMode = 'tools' | 'cli';
 
 /** Construction-time inputs that aren't implied by the region. */
 export interface HostResolutionOptions {
@@ -61,9 +67,41 @@ function assetHostFromApiHost(apiHost: string): string {
   return apiHost;
 }
 
-export function mcpUrlFor(localMcp: boolean): string {
-  if (localMcp) return LOCAL_MCP_URL;
-  return runtimeEnv('MCP_URL') || PROD_MCP_URL;
+export interface McpUrlOptions {
+  /** `--local-mcp`: point at the local dev MCP server. Wins over `MCP_URL`. */
+  local?: boolean;
+  /**
+   * Tool-surface mode to pin on the url; omitted → the server default. The
+   * wizard's internal agent connections pass `'tools'` — their prompts and
+   * installed skills still speak the named-tool roster.
+   * TODO(#849): drop the pins once both harnesses run on the single-exec CLI mode.
+   */
+  mode?: McpMode;
+  /** `features=` filter narrowing the tool catalog the url can reach. */
+  features?: string[];
+}
+
+/**
+ * The one place an MCP server url is built. One url for every region — the
+ * server resolves the user's region from the bearer token. Two overrides:
+ * `MCP_URL` (dev: point at any server) replaces the whole url verbatim, and
+ * `POSTHOG_WIZARD_MCP_MODE` / `--mcp-mode` (the field kill switch for the
+ * CLI-mode migration, #842) wins over the requested mode.
+ */
+export function mcpUrlFor(opts: McpUrlOptions = {}): string {
+  if (!opts.local) {
+    const urlOverride = runtimeEnv('MCP_URL');
+    if (urlOverride) return urlOverride;
+  }
+  const params: string[] = [];
+  if (opts.features && opts.features.length > 0) {
+    params.push(`features=${opts.features.join(',')}`);
+  }
+  const envMode = runtimeEnv('POSTHOG_WIZARD_MCP_MODE');
+  const mode = envMode === 'tools' || envMode === 'cli' ? envMode : opts.mode;
+  if (mode) params.push(`mode=${mode}`);
+  const base = opts.local ? LOCAL_MCP_BASE : PROD_MCP_BASE;
+  return params.length > 0 ? `${base}?${params.join('&')}` : base;
 }
 
 export class HostResolution {
@@ -89,6 +127,8 @@ export class HostResolution {
    * PostHog MCP server URL the agent connects to. Region-independent — the
    * server resolves the user's region from the bearer token — so this is driven
    * only by `--local-mcp` and the `MCP_URL` override, not by region/base-url.
+   * Pinned to the named-tool roster (`mode=tools`), like every internal agent
+   * connection.
    */
   readonly mcpUrl: string;
 
@@ -125,7 +165,7 @@ export class HostResolution {
       appHost: getCloudUrl(region, opts.baseUrl),
       assetHost: assetHostFor(region, opts.baseUrl),
       gatewayUrl: getLlmGatewayUrl(apiHost),
-      mcpUrl: mcpUrlFor(opts.localMcp ?? false),
+      mcpUrl: mcpUrlFor({ local: opts.localMcp, mode: 'tools' }),
     });
   }
 
@@ -145,7 +185,7 @@ export class HostResolution {
       appHost: getUiHostFromHost(apiHost),
       assetHost: assetHostFromApiHost(apiHost),
       gatewayUrl: getLlmGatewayUrl(apiHost),
-      mcpUrl: mcpUrlFor(opts.localMcp ?? false),
+      mcpUrl: mcpUrlFor({ local: opts.localMcp, mode: 'tools' }),
     });
   }
 

--- a/src/steps/add-mcp-server-to-clients/defaults.ts
+++ b/src/steps/add-mcp-server-to-clients/defaults.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+import { mcpUrlFor } from '@lib/host-resolution';
 
 export const DefaultMCPClientConfig = z
   .object({
@@ -243,21 +244,16 @@ export const isAllFeaturesSelected = (features: string[]): boolean =>
   ALL_FEATURE_VALUES.every((feature) => features.includes(feature));
 
 export const buildMCPUrl = (selectedFeatures?: string[], local?: boolean) => {
-  const host = local ? 'http://localhost:8787' : 'https://mcp.posthog.com';
-  const baseUrl = `${host}/mcp`;
-
-  const params: string[] = [];
-
-  // Add features param if not all features selected
-  if (
+  // All-features-selected is equivalent to no filter server-side, so the
+  // param is only added when the user narrowed the catalog. No mode param:
+  // the user's client gets the server's default tool surface.
+  const features =
     selectedFeatures &&
     selectedFeatures.length > 0 &&
     !isAllFeaturesSelected(selectedFeatures)
-  ) {
-    params.push(`features=${selectedFeatures.join(',')}`);
-  }
-
-  return params.length > 0 ? `${baseUrl}?${params.join('&')}` : baseUrl;
+      ? selectedFeatures
+      : undefined;
+  return mcpUrlFor({ local, features });
 };
 
 export const getNativeHTTPServerConfig = (

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -72,6 +72,17 @@ export const GLOBAL_OPTIONS = {
     type: 'boolean' as const,
     hidden: true,
   },
+  'mcp-mode': {
+    // Field kill switch for the MCP CLI-mode migration (#842): wins over the
+    // mode any internal call site requests, wherever the wizard builds an MCP
+    // url (see mcpUrlFor). Declared unconditionally so it works in published
+    // builds, unlike the dev-only runner overrides.
+    describe:
+      'Pin the PostHog MCP tool-surface mode (tools | cli)\nenv: POSTHOG_WIZARD_MCP_MODE',
+    choices: ['tools', 'cli'] as const,
+    type: 'string' as const,
+    hidden: true,
+  },
   'base-url': {
     describe:
       'Override the PostHog base URL (e.g. http://localhost:8010), bypassing region resolution. Pins the API host, cloud URL, and OAuth server.\nenv: POSTHOG_WIZARD_BASE_URL',
@@ -100,7 +111,16 @@ export class Wizard {
   private constructor() {
     let cli = yargs(hideBin(process.argv))
       .env('POSTHOG_WIZARD')
-      .options(GLOBAL_OPTIONS);
+      .options(GLOBAL_OPTIONS)
+      // mcpUrlFor reads the kill switch from the environment (it runs far
+      // below any argv threading), so mirror the flag spelling into the env
+      // var yargs would have populated it from.
+      .middleware((argv) => {
+        const mode = (argv as Record<string, unknown>)['mcp-mode'];
+        if (typeof mode === 'string' && mode !== '') {
+          process.env.POSTHOG_WIZARD_MCP_MODE = mode;
+        }
+      });
 
     // CI mode (--ci) is only supported in dev/test. It is left undeclared in
     // published builds (NODE_ENV==='production'), so .strictOptions() rejects


### PR DESCRIPTION
## Problem

The MCP server url was computed independently in five places, and the P0 tools-mode pin (#851) lives baked into two url constants. The upcoming CLI-mode flips (#845, #846) need one seam to pass a mode through, and a field kill switch to revert them without a release. Agentic detection also missed the `MCP_URL` env override the other call sites honor.

**Why:** this is the refactor seam (W1) of the CLI-mode migration epic #842 — every later flip is a one-word change at a call site of this helper.

Closes #844

## Changes

`mcpUrlFor({ local, mode, features })` in `host-resolution.ts` is now the one place an MCP url is built; all five call sites route through it. Behavior-preserving: the internal agent call sites (runner bootstrap, MCP tutorial streaming, `HostResolution`, agentic detection) pass `mode: 'tools'` explicitly, and `buildMCPUrl` (user-client installs) passes no mode so those urls keep the server default — byte-identical urls before and after, except agentic detection which now honors `MCP_URL` and carries the same tools pin as every other internal connection (it previously missed both).

`POSTHOG_WIZARD_MCP_MODE=tools|cli` (also `--mcp-mode`) is the kill switch: it wins over any requested mode wherever the wizard builds an MCP url. One wiring subtlety: yargs' `.env('POSTHOG_WIZARD')` prefix + `.strictOptions()` rejects any run with an undeclared prefixed env var set ("Unknown argument: mcpMode"), so the option is declared as a hidden global — unconditionally, unlike the dev-only runner overrides, because a field kill switch must work in published builds. A small middleware mirrors the flag spelling into the env var, since the helper reads the environment far below any argv threading.

## Test plan

`pnpm build && pnpm test && pnpm fix` — 1310 tests pass. `host-resolution.test.ts` covers the url matrix (bare/tools/cli × prod/local, features ordering, `MCP_URL` verbatim + local precedence, kill-switch override and invalid-value fallthrough); the untouched `defaults.test.ts` passing proves user-client urls are unchanged. Smoke-tested the built CLI headlessly: `POSTHOG_WIZARD_MCP_MODE=tools` parses and the run proceeds; `=bogus` fails loud with the choices listed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
