### PR TITLE
feat: switch the wizard's MCP connections to CLI mode

### DIFF
--- a/src/lib/__tests__/host-resolution.test.ts
+++ b/src/lib/__tests__/host-resolution.test.ts
@@ -43,12 +43,12 @@ describe('HostResolution.fromApiHost', () => {
 });
 
 describe('HostResolution mcpUrl', () => {
-  it('defaults to the region-independent prod MCP url, pinned to tools mode', () => {
+  it('defaults to the region-independent prod MCP url (server serves cli mode)', () => {
     expect(HostResolution.fromApiHost('https://us.i.posthog.com').mcpUrl).toBe(
-      'https://mcp.posthog.com/mcp?mode=tools',
+      'https://mcp.posthog.com/mcp',
     );
     expect(HostResolution.fromApiHost('https://eu.i.posthog.com').mcpUrl).toBe(
-      'https://mcp.posthog.com/mcp?mode=tools',
+      'https://mcp.posthog.com/mcp',
     );
   });
 
@@ -56,7 +56,7 @@ describe('HostResolution mcpUrl', () => {
     const h = HostResolution.fromApiHost('https://us.i.posthog.com', {
       localMcp: true,
     });
-    expect(h.mcpUrl).toBe('http://localhost:8787/mcp?mode=tools');
+    expect(h.mcpUrl).toBe('http://localhost:8787/mcp');
   });
 });
 
@@ -78,12 +78,12 @@ describe('HostResolution.fromAccessToken', () => {
 });
 
 describe('mcpUrlFor', () => {
-  it('pins mode=tools on the prod url', () => {
-    expect(mcpUrlFor(false)).toBe('https://mcp.posthog.com/mcp?mode=tools');
+  it('builds the bare prod url (server serves the wizard cli mode)', () => {
+    expect(mcpUrlFor(false)).toBe('https://mcp.posthog.com/mcp');
   });
 
-  it('pins mode=tools on the local dev url', () => {
-    expect(mcpUrlFor(true)).toBe('http://localhost:8787/mcp?mode=tools');
+  it('builds the bare local dev url', () => {
+    expect(mcpUrlFor(true)).toBe('http://localhost:8787/mcp');
   });
 
   it('takes an MCP_URL override verbatim', () => {

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -680,6 +680,9 @@ export async function initializeAgent(
           Authorization: `Bearer ${config.posthogApiKey}`,
           'User-Agent': WIZARD_USER_AGENT,
         },
+        // CLI mode's single `exec` tool carries the full command reference on
+        // its schema — keep it in context, never deferred behind tool search.
+        alwaysLoad: true,
       },
       ...Object.fromEntries(
         Object.entries(config.additionalMcpServers ?? {}).map(
@@ -1056,19 +1059,12 @@ export async function runAgent(
           ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
           CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: 'true',
-          // Defer MCP tool schemas to avoid bloating the system prompt.
-          // The posthog-wizard MCP exposes many query tools with large schemas;
-          // without deferral these consume ~113k tokens upfront, leaving
-          // almost no room in Sonnet's 200k context window.
-          ENABLE_TOOL_SEARCH: 'auto:0',
           // SDK 0.3.142 made MCP servers connect in the background by default;
           // the agent may start its first turn before posthog-wizard is ready
           // (audit programs call audit_seed_checks on turn 1, integration
           // programs call load_skill_menu / install_skill). Restore the prior
           // blocking behavior so the SDK waits up to 5s for MCP connect before
-          // turn 1. `alwaysLoad: true` on the server would also work but it
-          // disables tool search deferral and re-inflates the system prompt by
-          // ~113k tokens (the reason ENABLE_TOOL_SEARCH=auto:0 is set above).
+          // turn 1.
           MCP_CONNECTION_NONBLOCKING: '0',
           // PostHog gateway headers: Bedrock fallback + property/flag tags.
           ANTHROPIC_CUSTOM_HEADERS: buildAgentEnv(

--- a/src/lib/agent/mcp-prompt-streaming.ts
+++ b/src/lib/agent/mcp-prompt-streaming.ts
@@ -311,6 +311,10 @@ export async function* runMcpPromptViaSdk(args: {
               Authorization: `Bearer ${credentials.accessToken}`,
               'User-Agent': WIZARD_USER_AGENT,
             },
+            // CLI mode's single `exec` tool carries the full command reference
+            // on its schema — keep it in context, never deferred behind tool
+            // search.
+            alwaysLoad: true,
           },
         },
         // Only let the agent use MCP tools — no shell, no file I/O,
@@ -330,11 +334,6 @@ export async function* runMcpPromptViaSdk(args: {
           ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
           CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: 'true',
-          // Defer MCP tool schemas to avoid bloating the system prompt.
-          // posthog-wizard exposes many query tools with large schemas;
-          // without deferral these consume ~113k tokens upfront, which
-          // matters especially when follow-ups resume sessions.
-          ENABLE_TOOL_SEARCH: 'auto:0',
           // SDK 0.3.142+ connects MCP servers in the background by
           // default; without this the agent may try to call tools
           // before posthog-wizard is connected on turn 1.

--- a/src/lib/host-resolution.ts
+++ b/src/lib/host-resolution.ts
@@ -27,11 +27,10 @@ import {
 import { runtimeEnv } from '@env';
 import type { CloudRegion } from '@utils/types';
 
-// The wizard's internal agents speak the named-tool roster, so the default
-// urls pin `mode=tools`; an `MCP_URL` override is taken verbatim.
-// TODO(#849): drop the pin once both harnesses run on the single-exec CLI mode.
-const LOCAL_MCP_URL = 'http://localhost:8787/mcp?mode=tools';
-const PROD_MCP_URL = 'https://mcp.posthog.com/mcp?mode=tools';
+// The wizard's client gets CLI mode (a single `exec` tool) by server default,
+// so no mode is pinned; an `MCP_URL` override is taken verbatim.
+const LOCAL_MCP_URL = 'http://localhost:8787/mcp';
+const PROD_MCP_URL = 'https://mcp.posthog.com/mcp';
 
 /** Construction-time inputs that aren't implied by the region. */
 export interface HostResolutionOptions {


### PR DESCRIPTION
Drops the `mode=tools` pin so the wizard's MCP connections use the server-default CLI mode (a single `exec` tool), always-loaded instead of deferred behind tool search. Closes #845; part of #842.