### PR TITLE
fix(warehouse): unblock wizard_ask after a timed-out prompt

### DIFF
--- a/src/lib/__tests__/wizard-ask-bridge.test.ts
+++ b/src/lib/__tests__/wizard-ask-bridge.test.ts
@@ -188,13 +188,15 @@ describe('createWizardAskBridge', () => {
   });
 
   describe('timeout', () => {
-    it('resolves every field with the cancelled sentinel when the user does not answer in time', async () => {
+    it('resolves every field with the cancelled sentinel and dismisses the host overlay when the user does not answer in time', async () => {
       vi.useFakeTimers();
       try {
         // showQuestion intentionally never resolves — the timeout has to win.
+        const cancelQuestion = vi.fn();
         const bridge = createWizardAskBridge({
           getSource: () => 'product-tours',
           showQuestion: () => new Promise<AskAnswers>(() => undefined),
+          cancelQuestion,
           timeoutMs: 1000,
         });
 
@@ -212,10 +214,37 @@ describe('createWizardAskBridge', () => {
           audience: CANCELLED_SENTINEL,
         });
 
+        // Without this, the host's pending-question state survives the
+        // timeout and every later wizard_ask in the run is rejected as a
+        // duplicate request.
+        expect(cancelQuestion).toHaveBeenCalledTimes(1);
+
         const cancelledCall = wizardCaptureMock.mock.calls.find(
           ([name]) => name === 'wizard_ask cancelled',
         );
         expect(cancelledCall?.[1]).toMatchObject({ timed_out: true });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not dismiss the overlay when the user answers before the timeout', async () => {
+      vi.useFakeTimers();
+      try {
+        const cancelQuestion = vi.fn();
+        const bridge = createWizardAskBridge({
+          getSource: () => 'product-tours',
+          showQuestion: () => Promise.resolve({ goal: 'ship it' }),
+          cancelQuestion,
+          timeoutMs: 1000,
+        });
+
+        await bridge.request({
+          questions: [{ id: 'goal', prompt: 'Goal?', kind: 'text' }],
+        });
+
+        vi.advanceTimersByTime(1000);
+        expect(cancelQuestion).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
       }

--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -86,6 +86,7 @@ export async function runLinearProgram(
     : createWizardAskBridge({
         getSource: () => session.skillId ?? config.integrationLabel,
         showQuestion: (q) => getUI().requestQuestion(q),
+        cancelQuestion: () => getUI().cancelPendingQuestion(),
         richLinks: config.richLinks ?? false,
         timeoutMs: config.askTimeoutMs,
       });

--- a/src/lib/wizard-ask-bridge.ts
+++ b/src/lib/wizard-ask-bridge.ts
@@ -49,6 +49,14 @@ export interface WizardAskBridgeOptions {
    * Propagated onto every {@link PendingQuestion} this bridge creates.
    */
   richLinks?: boolean;
+  /**
+   * Dismiss the host's in-flight question overlay. Called when the timeout
+   * wins the race: without it the host keeps its pending-question state, and
+   * every later `wizard_ask` in the run fails with "another request is
+   * pending" — one unanswered prompt would block credential collection for
+   * all remaining sources.
+   */
+  cancelQuestion?: () => void;
 }
 
 /** Sentinel returned for unanswered fields on cancellation or timeout. */
@@ -88,12 +96,13 @@ export function createWizardAskBridge(
       const startedAt = Date.now();
       let timer: ReturnType<typeof setTimeout> | undefined;
 
-      // Race the user against the timeout. Whichever fires first wins; the
-      // other branch is harmless because the overlay still resolves via the
-      // store when the user eventually submits (and the answers are simply
-      // discarded).
+      // Race the user against the timeout. Whichever fires first wins. On
+      // timeout we also cancel the host's overlay: resolving our side alone
+      // would leave the host's pending-question state set, and the next
+      // wizard_ask would be rejected as a duplicate request.
       const timeoutPromise = new Promise<AskAnswers>((resolve) => {
         timer = setTimeout(() => {
+          opts.cancelQuestion?.();
           resolve(buildCancelledAnswers(questions));
         }, timeoutMs);
       });

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -1221,6 +1221,10 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
           ],
         };
       } catch (err: any) {
+        // A failed ask never reached the user, so it shouldn't burn the
+        // per-run cap either — otherwise a transient bridge error eats the
+        // budget for every remaining source.
+        askCallCount -= 1;
         logToFile(`wizard_ask: error: ${err?.message ?? err}`);
         return {
           content: [

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -179,6 +179,10 @@ export class LoggingUI implements WizardUI {
     );
   }
 
+  cancelPendingQuestion(): void {
+    // Nothing to dismiss — requestQuestion never opens an overlay here.
+  }
+
   showAuthError(detail?: AuthErrorDetail): void {
     console.log(`✖  Authentication failed (401)`);
     if (detail?.hasSettingsConflict) {

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -171,6 +171,10 @@ export class InkUI implements WizardUI {
     return this.store.requestQuestion(question);
   }
 
+  cancelPendingQuestion(): void {
+    this.store.cancelPendingQuestion();
+  }
+
   startRun(): void {
     this.store.setRunPhase(RunPhase.Running);
   }

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -185,6 +185,13 @@ export interface WizardUI {
    */
   requestQuestion(question: PendingQuestion): Promise<AskAnswers>;
 
+  /**
+   * Dismiss the in-flight wizard_ask overlay, resolving its request with
+   * cancelled sentinels. No-op when nothing is pending. The ask bridge calls
+   * this on timeout so a stale pending question can't block later asks.
+   */
+  cancelPendingQuestion(): void;
+
   // ── Display state ──────────────────────────────────────────────────
   /** Set the detected framework label (e.g., "Django with Wagtail CMS") */
   setDetectedFramework(label: string): void;


### PR DESCRIPTION
## Problem

When a `wizard_ask` prompt times out (default 5 minutes), the bridge resolves the agent's tool call with cancelled sentinels — but the TUI store's pending-question state is never cleared. From then on, every later `wizard_ask` in the run throws `requestQuestion called while another wizard_ask request is pending`, and because the error path never refunded the optimistically-taken cap slot, each failed attempt also burned the per-run budget.

Net effect: one unanswered prompt permanently blocks credential collection for all remaining sources in the run. This shows up clearly in production traces of the warehouse command — agents repeatedly report (via `wizard remark`) being unable to ask for Stripe/Resend credentials after a Postgres prompt timed out, and fall back to deep-links even when the user was still present.

## Changes

- `wizard-ask-bridge.ts`: new `cancelQuestion` option, invoked when the timeout wins the race, so the host dismisses the overlay and clears its pending-question state.
- `linear.ts`: wire `cancelQuestion` to `getUI().cancelPendingQuestion()`.
- `wizard-ui.ts` / `ink-ui.ts` / `logging-ui.ts`: expose `cancelPendingQuestion()` on the UI interface (the TUI store already had it; the logging UI is a no-op).
- `wizard-tools.ts`: refund the ask-cap slot in the `catch` path — an ask that errored never reached the user, so it shouldn't count against the cap.

## Testing

- Extended the bridge timeout test to assert the overlay is dismissed on timeout, and added a case asserting it is *not* dismissed when the user answers in time — this is the exact regression that shipped: the timeout resolving the race while leaving host state behind.
- `vitest run` on `wizard-ask-bridge.test.ts` + `wizard-tools.test.ts`: 37 passed. `prettier` and `eslint` clean on changed files (remaining warnings pre-exist). `pnpm typecheck` failures in `ci-region.test.ts` are pre-existing on `main` and untouched by this diff.
