### PR TITLE
feat(warehouse): close warehouse-source telemetry gaps

### DIFF
--- a/src/lib/programs/warehouse-source/detect.ts
+++ b/src/lib/programs/warehouse-source/detect.ts
@@ -102,5 +102,18 @@ export function detectWarehousePrerequisites(
     return;
   }
 
+  // Tag every subsequent event (agent started/completed, setup wizard
+  // finished, …) with what was detected — without this the analytics can't
+  // say which source types a run attempted, only that a run happened.
+  analytics.setTag(
+    'warehouse_source_kinds',
+    sources.map((s) => s.kind).join(','),
+  );
+  analytics.setTag(
+    'warehouse_source_modes',
+    sources.map((s) => `${s.kind}:${s.mode}`).join(','),
+  );
+  analytics.setTag('warehouse_source_count', sources.length);
+
   setFrameworkContext(DETECTED_WAREHOUSE_SOURCES_KEY, sources);
 }

--- a/src/ui/tui/start-tui.ts
+++ b/src/ui/tui/start-tui.ts
@@ -78,8 +78,20 @@ export function startTUI(
   // end the process — background handles (e.g. the OAuth callback
   // server) keep the event loop alive, leaving a zombie wizard with no
   // UI. Follow the app teardown with a real exit.
-  void waitUntilExit().then(() => {
+  void waitUntilExit().then(async () => {
+    // `cleaned` still false here means Ink tore itself down (ctrl+c) rather
+    // than a runner-driven exit — flush the terminal analytics event before
+    // the process dies, or interrupted runs vanish from the funnel entirely.
+    // shutdown() is a no-op when a runner already reported a real status.
+    const interrupted = !cleaned;
     cleanup();
+    if (interrupted) {
+      try {
+        await analytics.shutdown('cancelled');
+      } catch {
+        /* never block exit on a flush failure */
+      }
+    }
     process.exit(process.exitCode ?? 0);
   });
 

--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -388,6 +388,24 @@ describe('Analytics', () => {
     });
   });
 
+  describe('shutdown', () => {
+    it('emits the terminal event once — the first status wins over the interrupt fallback', async () => {
+      analytics.setTag('program_id', 'warehouse-source');
+
+      await analytics.shutdown('success');
+      // start-tui's ctrl+c fallback fires this on every TUI teardown.
+      await analytics.shutdown('cancelled');
+
+      const finishedCalls = mockPostHogInstance.capture.mock.calls.filter(
+        ([arg]) => arg.event === 'setup wizard finished',
+      );
+      expect(finishedCalls).toHaveLength(1);
+      expect(finishedCalls[0][0].properties).toMatchObject({
+        status: 'success',
+      });
+    });
+  });
+
   describe('groups (before_send injection)', () => {
     type TestEvent = Record<string, unknown> & {
       groups?: Record<string, string>;

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -60,6 +60,7 @@ export class Analytics {
   private activeFlags: Record<string, string> | null = null;
   private groups: Record<string, string> = {};
   private personProperties: Record<string, string> = {};
+  private terminalEventSent = false;
 
   constructor() {
     this.client = new PostHog(ANALYTICS_POSTHOG_PUBLIC_PROJECT_WRITE_KEY, {
@@ -270,6 +271,15 @@ export class Analytics {
     if (Object.keys(this.tags).length === 0) {
       return;
     }
+
+    // First status wins. The interrupt fallback in start-tui fires
+    // shutdown('cancelled') on every TUI teardown; without this guard a run
+    // that already reported 'success' would emit a second, contradicting
+    // terminal event when the user dismisses the outro.
+    if (this.terminalEventSent) {
+      return;
+    }
+    this.terminalEventSent = true;
 
     this.client.capture({
       distinctId: this.distinctId ?? this.anonymousId,


### PR DESCRIPTION
## Problem

Three blind spots make the warehouse-source funnel hard to read (visible on the "Wizard warehouse sources" dashboard):

1. **Interrupted runs vanish.** On ctrl+c, Ink unmounts and `start-tui.ts` calls `process.exit()` directly — `analytics.shutdown()` never runs, so no `setup wizard finished` event is flushed. Over the last 3 weeks the warehouse program logged ~470 agent starts but fewer than 100 terminal events; the missing majority are these silent exits.
2. **No source-type signal.** Agent events only carry `integration: "data-warehouse-source-setup"`, so analytics can't say whether a run attempted Postgres, Stripe, or anything else — or whether the detected source was `in-cli` vs `deep-link`.
3. `analytics.shutdown()` wasn't idempotent, so adding an interrupt-path flush would double-fire the terminal event (a run that reported `success` would emit a second, contradicting `cancelled` event when the user dismissed the outro).

## Changes

- `start-tui.ts`: when Ink tears itself down (ctrl+c) rather than a runner-driven exit, flush `analytics.shutdown('cancelled')` before `process.exit()`.
- `analytics.ts`: `shutdown()` emits the terminal event once — the first status wins; later calls are no-ops. This makes the interrupt fallback safe on every teardown path.
- `warehouse-source/detect.ts`: tag the run with `warehouse_source_kinds` (e.g. `Postgres,Stripe`), `warehouse_source_modes` (e.g. `Postgres:in-cli`), and `warehouse_source_count` once detection succeeds — tags propagate onto every subsequent event (`wizard: agent started/completed`, `setup wizard finished`, …).

## Testing

- Added one test: two `shutdown()` calls emit exactly one `setup wizard finished` with the first status — the regression that would ship if the idempotency guard were dropped while the ctrl+c fallback stays.
- `vitest run` on `analytics.test.ts` + `warehouse-sources/detect.test.ts`: 46 passed. Prettier/eslint clean on changed files.
