### PR TITLE
feat: support Android source-map uploads

### DIFF
--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -9,7 +9,21 @@ describe('SOURCE_MAPS_TARGETS precedence', () => {
   const rank = (id: string) => ids.indexOf(id);
 
   it('covers every automatable variant exactly once', () => {
-    expect([...ids].sort()).toEqual([...AUTOMATABLE_VARIANTS].sort());
+    for (const variant of AUTOMATABLE_VARIANTS) {
+      expect(ids.filter((id) => id === variant)).toHaveLength(1);
+    }
+  });
+
+  it('ranks unsupported native guards ahead of the Android target', () => {
+    expect(SOURCE_MAPS_TARGETS).toContainEqual({
+      id: 'android',
+      name: 'Android',
+    });
+    for (const nativeGuard of ['react-native', 'flutter', 'ios']) {
+      expect(rank(nativeGuard)).toBeGreaterThanOrEqual(0);
+      expect(rank(nativeGuard)).toBeLessThan(rank('android'));
+    }
+    expect(rank('android')).toBeLessThan(rank('nextjs'));
   });
 
   it('ranks bundlers ahead of the generic React variant', () => {
@@ -55,6 +69,76 @@ describe('coerceReport', () => {
     expect(p.instrumentable).toBe(true);
     expect(p.reason).toBeUndefined();
   });
+
+  it('retains an Android project with PostHog as instrumentable', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Android',
+          targetId: 'android',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual({
+      path: '.',
+      framework: 'Android',
+      variant: 'android',
+      hasPostHog: true,
+      instrumentable: true,
+    });
+  });
+
+  it('blocks an Android project that has no PostHog SDK yet', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Android',
+          targetId: 'android',
+          hasPostHog: false,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: 'android',
+        hasPostHog: false,
+        instrumentable: false,
+        reason: expect.stringMatching(/no posthog sdk/i),
+      }),
+    );
+  });
+
+  it.each(['React Native', 'Expo', 'Flutter', 'iOS'])(
+    'blocks a native %s project misclassified as Android',
+    (framework) => {
+      const report = coerceReport({
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework,
+            targetId: 'android',
+            hasPostHog: true,
+          },
+        ],
+      });
+
+      expect(report.projects[0]).toEqual(
+        expect.objectContaining({
+          variant: null,
+          instrumentable: false,
+          reason: expect.stringMatching(/isn't supported/i),
+        }),
+      );
+    },
+  );
 
   it('blocks a supported project that has no PostHog SDK yet', () => {
     const report = coerceReport({

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -46,12 +46,21 @@ export type DetectionReport = {
 
 /**
  * Variant precedence for the agentic picker (most specific first). The detector
- * keeps the EARLIEST matching target, so this ordering is what makes a React app
- * built with Vite resolve to `vite` (bundler-plugin upload) instead of the
- * generic `react` posthog-cli path. Mirrors `pickJsVariant` in detect.ts:
- * opinionated frameworks → bundlers → bare React → Node → generic web.
+ * keeps the EARLIEST matching target. Unsupported native targets are included
+ * as guards before Android so React Native, Flutter, and iOS projects are not
+ * misclassified as instrumentable Android apps. JS ordering mirrors
+ * `pickJsVariant` in detect.ts: opinionated frameworks → bundlers → bare React →
+ * Node → generic web.
  */
+const NON_AUTOMATABLE_NATIVE_VARIANTS: readonly SkillVariant[] = [
+  'react-native',
+  'flutter',
+  'ios',
+];
+
 const VARIANT_PRECEDENCE: readonly SkillVariant[] = [
+  ...NON_AUTOMATABLE_NATIVE_VARIANTS,
+  'android',
   'nextjs',
   'nuxt',
   'angular',
@@ -69,13 +78,14 @@ const precedenceRank = (v: SkillVariant): number => {
 };
 
 /**
- * Source-maps targets: the variants the wizard can automate, by id → name,
- * ordered by VARIANT_PRECEDENCE so the detector's "earliest match wins"
- * tie-break selects the most specific variant. Derived from AUTOMATABLE_VARIANTS
- * so a newly-automatable variant is never silently dropped (unranked ones sort
- * last). Exported for testing.
+ * Source-map detection targets, ordered by VARIANT_PRECEDENCE. Unsupported
+ * native variants remain in the target list so the detector can identify and
+ * block them instead of falling through to Android or a JS target.
  */
-export const SOURCE_MAPS_TARGETS: DetectTarget[] = [...AUTOMATABLE_VARIANTS]
+export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
+  ...NON_AUTOMATABLE_NATIVE_VARIANTS,
+  ...AUTOMATABLE_VARIANTS,
+]
   .sort((a, b) => precedenceRank(a) - precedenceRank(b))
   .map((v) => ({ id: v, name: VARIANT_DISPLAY_NAME[v] }));
 
@@ -98,12 +108,20 @@ function classify(
   return { instrumentable: true };
 }
 
+function isAutomatableVariant(value: string | null): value is SkillVariant {
+  return value !== null && AUTOMATABLE_VARIANTS.includes(value as SkillVariant);
+}
+
 /** Map a generic detection report into source-maps projects. */
 function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
   return {
     repoType: report.repoType,
     projects: report.projects.map((p) => {
-      const variant = (p.targetId as SkillVariant | null) ?? null;
+      const variant =
+        isAutomatableVariant(p.targetId) &&
+        !/\b(?:react[\s-]*native|expo|flutter|ios)\b/i.test(p.framework)
+          ? p.targetId
+          : null;
       return {
         path: p.path,
         framework: p.framework,
@@ -117,12 +135,15 @@ function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
 
 /**
  * Validate the agent's raw JSON into a source-maps detection report. Exported
- * for testing — clamps variants to the automatable set and classifies
- * instrumentability.
+ * for testing — recognises detection-only native targets, then clamps them to
+ * non-instrumentable projects.
  */
 export function coerceReport(parsed: unknown): DetectionReport {
   return toSourceMapsReport(
-    coerceAgenticReport(parsed, AUTOMATABLE_VARIANTS as readonly string[]),
+    coerceAgenticReport(
+      parsed,
+      SOURCE_MAPS_TARGETS.map((target) => target.id),
+    ),
   );
 }
 

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -52,10 +52,11 @@ const DISPLAY_NAME: Record<SkillVariant, string> = {
 
 /**
  * Variants the wizard can wire up source-map upload for automatically. The
- * native variants (react-native, android, flutter, ios) are recognised but not
- * yet automatable, so the agentic picker treats them as non-instrumentable.
+ * native variants (react-native, flutter, ios) are recognised but not yet
+ * automatable, so the agentic picker treats them as non-instrumentable.
  */
 export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
+  'android',
   'web',
   'nextjs',
   'node',
@@ -305,8 +306,8 @@ export function detectSourceMapsPrerequisites(
   const signals = collectSignals(installDir);
   const variant = selectVariant(signals);
 
-  // This program currently targets JS-like stacks only. Avoid selecting native
-  // platforms until dedicated skill variants are available.
+  // The legacy filesystem detector does not automate native platforms. The
+  // live source-map picker uses detectSourceMapsProjects instead.
   if (
     variant &&
     ['react-native', 'flutter', 'ios', 'android'].includes(variant)


### PR DESCRIPTION
## Summary
- enable Android in the existing `upload-source-maps` program
- derive and install the `error-tracking-upload-source-maps-android` skill for eligible projects
- keep projects without PostHog blocked and guard React Native, Expo, Flutter, and iOS projects from Android misclassification
- add regression coverage for native precedence and malformed detector output

## Testing
- `pnpm build && pnpm test && pnpm fix` — 97 files, 1,321 tests passed

## Companion PRs
- PostHog/context-mill#231
- PostHog/wizard-workbench#2748