### PR TITLE
feat: surface the notebook link in the integration outro

### DIFF
--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -268,6 +268,8 @@ Important: Use the detect_package_manager tool (from the wizard-tools MCP server
           changes,
           docsUrl: config.metadata.docsUrl,
           continueUrl,
+          // Set once the agent mirrors the report into a notebook and emits [NOTEBOOK_URL].
+          notebookUrl: sess.notebookUrl ?? undefined,
           handoffPrompt: buildCodingAgentPrompt(SETUP_REPORT_FILE),
         };
       },


### PR DESCRIPTION
`buildOutroData` now returns `notebookUrl` from the session so the integration outro shows the notebook the agent creates and emits via `[NOTEBOOK_URL]`; capture and rendering already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)