### PR TITLE
feat(cli): honor headless flag in family/native command dispatch

### DIFF
--- a/src/commands/factories/shared.ts
+++ b/src/commands/factories/shared.ts
@@ -1,14 +1,15 @@
 import type { Arguments, Options } from 'yargs';
 
-import { runWizard, runWizardCI } from '@lib/runners';
+import { runWizard, runWizardCI, runWizardHeadless } from '@lib/runners';
+import { isHeadless } from '@lib/headless-mode';
 import type { ProgramConfig } from '@lib/programs/program-step';
 
 import { skillProgramOptions } from '../skill-program-options';
 
 /**
  * Dispatch a parsed yargs invocation to the wizard runner. Applies the
- * program's `mapCliOptions` transform, then routes to `runWizard` or
- * `runWizardCI` based on the `--ci` flag.
+ * program's `mapCliOptions` transform, then routes to `runWizardHeadless`,
+ * `runWizardCI`, or `runWizard` based on the headless / `--ci` flags.
  *
  * Every command file used to inline this; the factories call it instead.
  */
@@ -35,7 +36,11 @@ export function dispatchProgram(config: ProgramConfig, argv: Arguments): void {
   const argvRecord = argv as unknown as Record<string, unknown>;
   const extras = config.mapCliOptions?.(argvRecord) ?? {};
   const options = { ...argvRecord, ...extras };
-  if (options.ci) {
+  if (isHeadless(options)) {
+    // Same non-interactive pipeline `--ci` uses; validation (api-key,
+    // install-dir, region) is owned by runNonInteractive.
+    runWizardHeadless(config, options);
+  } else if (options.ci) {
     runWizardCI(config, options);
   } else {
     runWizard(config, options);


### PR DESCRIPTION
## Problem

the headless flag is declared globally but only the bare integration command checks it, so family commands like `wizard audit <area>` can't run non-interactively in production builds (`--ci` is dev-only). posthog cloud runs need `wizard audit all` headless right after the headless install (PostHog/posthog#70681).

## Changes

`dispatchProgram` checks the headless flag first and routes to `runWizardHeadless(config, options)`, the same non-interactive pipeline `--ci` uses. validation stays in `runNonInteractive`, this is routing only.

## Test plan

`vitest run src/__tests__/programs-cli.test.ts src/__tests__/cli.test.ts` and typecheck, both identical before/after (existing failures reproduce on clean master).

## LLM context

claude code session directed by dawid, companion to PostHog/posthog#70681.