### PR TITLE
fix(agent): don't count a parroted [SKILL-INSTALL-FAILED] instruction as a skill failure

### DIFF
--- a/src/lib/agent/__tests__/output-signals.test.ts
+++ b/src/lib/agent/__tests__/output-signals.test.ts
@@ -156,5 +156,28 @@ describe('AgentOutputSignals', () => {
 
       expect(signals.skillInstallFailure()).toBeUndefined();
     });
+
+    it('ignores the model parroting the prompt instruction', () => {
+      const signals = new AgentOutputSignals();
+      signals.push(
+        "If install_skill fails, emit on its own line: [SKILL-INSTALL-FAILED] <skill id — one-line reason>. Then CONTINUE and SKIP to STEP 5 the integration without the skill, following these steps and your knowledge of Next.js and PostHog's official docs, and note in the setup report that the skill could not be installed.",
+      );
+
+      expect(signals.skillInstallFailure()).toBeUndefined();
+    });
+
+    it('still reports a real failure after a parroted instruction', () => {
+      const signals = new AgentOutputSignals();
+      signals.push(
+        'emit: [SKILL-INSTALL-FAILED] <skill id — one-line reason>. Then CONTINUE',
+      );
+      signals.push(
+        '[SKILL-INSTALL-FAILED] integration-nextjs-app-router — download timed out',
+      );
+
+      expect(signals.skillInstallFailure()).toBe(
+        'integration-nextjs-app-router — download timed out',
+      );
+    });
   });
 });

--- a/src/lib/agent/output-signals.ts
+++ b/src/lib/agent/output-signals.ts
@@ -12,7 +12,11 @@
  * hooks' onTerminate callback (`yaraViolationReason` in runAgent) instead.
  */
 
-import { AgentSignals, REMARK_INSTRUCTION } from './signals';
+import {
+  AgentSignals,
+  REMARK_INSTRUCTION,
+  SKILL_INSTALL_FAILED_PLACEHOLDER,
+} from './signals';
 
 /**
  * Single source of truth for the substrings runAgent scans agent output for.
@@ -93,13 +97,19 @@ export class AgentOutputSignals {
   /**
    * Text after the `[SKILL-INSTALL-FAILED]` marker (skill id + reason),
    * trimmed — or undefined when the skill installed fine. A marker with no
-   * trailing text still reports as '' so the failure is never lost.
+   * trailing text still reports as '' so the failure is never lost. A detail
+   * that still contains the instruction's `<skill id — one-line reason>`
+   * placeholder is the model parroting the prompt, not a failure — skipped,
+   * like remark() skips echoes of REMARK_INSTRUCTION.
    */
   skillInstallFailure(): string | undefined {
     const marker = OUTPUT_SIGNALS.SKILL_INSTALL_FAILED;
     for (const line of this.lines) {
       const idx = line.indexOf(marker);
-      if (idx !== -1) return line.slice(idx + marker.length).trim();
+      if (idx === -1) continue;
+      const detail = line.slice(idx + marker.length).trim();
+      if (detail.includes(SKILL_INSTALL_FAILED_PLACEHOLDER)) continue;
+      return detail;
     }
     return undefined;
   }

--- a/src/lib/agent/signals.ts
+++ b/src/lib/agent/signals.ts
@@ -46,6 +46,17 @@ export const AgentSignals = {
 export type AgentSignal = (typeof AgentSignals)[keyof typeof AgentSignals];
 
 /**
+ * The fill-in shown in the integration prompt's failure instruction
+ * ("If install_skill fails, emit: [SKILL-INSTALL-FAILED] <skill id — one-line
+ * reason>. Then CONTINUE…"). Literal models parrot that instruction verbatim
+ * while restating their plan, so the parser treats a marker whose detail
+ * still contains this placeholder as an echo, not a real failure (see
+ * AgentOutputSignals.skillInstallFailure). Shared so prompt and parser
+ * cannot drift.
+ */
+export const SKILL_INSTALL_FAILED_PLACEHOLDER = '<skill id — one-line reason>';
+
+/**
  * End-of-run reflection ask, shared by both harnesses so remarks are
  * comparable. The format clause comes FIRST and nothing trails the marker —
  * literal models (gpt-5-mini) echo whatever text follows it. The parser also

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -4,6 +4,7 @@ import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import type { WizardSession } from '@lib/wizard-session';
 import { OutroKind, RunPhase } from '@lib/wizard-session';
 import { AgentSignals } from '@lib/agent/agent-interface';
+import { SKILL_INSTALL_FAILED_PLACEHOLDER } from '@lib/agent/signals';
 import {
   DEFAULT_PACKAGE_INSTALLATION,
   SPINNER_MESSAGE,
@@ -180,7 +181,7 @@ STEP 2: Call install_skill (from the wizard-tools MCP server) with the chosen sk
    Do NOT run any shell commands to install skills.
    If install_skill fails, emit on its own line: ${
      AgentSignals.SKILL_INSTALL_FAILED
-   } <skill id — one-line reason>. Then CONTINUE and SKIP to STEP 5 the integration without the skill, following these steps and your knowledge of ${
+   } ${SKILL_INSTALL_FAILED_PLACEHOLDER}. Then CONTINUE and SKIP to STEP 5 the integration without the skill, following these steps and your knowledge of ${
           config.metadata.name
         } and PostHog's official docs, and note in the setup report that the skill could not be installed.
 


### PR DESCRIPTION
## Problem

`agent continued without skill` fires on **100% of pi runs** (vs 0% anthropic, last 6h of prod: 63/63 pi runs) with the detail set to the literal unfilled template:

> `<skill id — one-line reason>. Then CONTINUE and SKIP to STEP 5 the integration without the skill, following these steps and your knowledge of Next.js and PostHog's official docs, …`

Skills are installing fine. Literal models (gpt-5.4) parrot the integration prompt's failure instruction verbatim while restating their plan, and `skillInstallFailure()` matched any assistant line containing the `[SKILL-INSTALL-FAILED]` marker. The metric is currently useless for pi and pollutes any skill-health dashboard.

Part of the telemetry findings in #894's investigation thread.

## Fix

- Skip details that still contain the instruction's `<skill id — one-line reason>` placeholder — the signature of an echo — and **keep scanning** so a real failure later in the run is still reported. Mirrors how `remark()` drops echoes of `REMARK_INSTRUCTION`.
- The placeholder is now a shared constant in `signals.ts` (the dependency-free leaf module), used by both the prompt template in `posthog-integration/index.ts` and the parser, so they cannot drift.

## Testing

- Two new tests: a verbatim field-observed parroted line is ignored; a real failure after a parroted instruction is still caught.
- `pnpm build && pnpm test` — 1323 passed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
