### PR TITLE
fix(pi): stop recording allowed scoped rm as bash denied

### DIFF
--- a/src/lib/agent/runner/harness/pi/__tests__/security.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/security.test.ts
@@ -484,6 +484,23 @@ describe('pi-security: plain rm matches the anthropic arm', () => {
     );
   });
 
+  test('an allowed scoped rm never captures a `bash denied` event', async () => {
+    // wizardCanUseTool records analytics on every deny, so the rescue must be
+    // decided BEFORE consulting it — otherwise each allowed rm still shows up
+    // in telemetry as denied.
+    const { analytics } = await import('@utils/analytics');
+    const capture = vi.spyOn(analytics, 'wizardCapture');
+    try {
+      expect(await rmBlocked('rm .posthog-events.json')).toBe(false);
+      expect(capture).not.toHaveBeenCalledWith(
+        'bash denied',
+        expect.anything(),
+      );
+    } finally {
+      capture.mockRestore();
+    }
+  });
+
   test('normalizes a relative workingDirectory', async () => {
     const relRoot = path.relative(process.cwd(), path.resolve('/project'));
     expect(

--- a/src/lib/agent/runner/harness/pi/security.ts
+++ b/src/lib/agent/runner/harness/pi/security.ts
@@ -303,20 +303,24 @@ export async function evaluateToolCall(
   llmProvider?: LLMProvider,
 ): Promise<GateDecision> {
   try {
-    const policy = toClaudePolicyCall(toolName, input);
-    const decision = wizardCanUseTool(policy.name, policy.input, {
-      disallowedTools: ctx.disallowedTools,
-      wizardAskPending: ctx.getWizardAskPending?.() ?? false,
-    });
     // The allowlist is a pi-only restriction; the anthropic arm runs bash
     // unrestricted and leans on the shared YARA scan. Let a plain `rm` of
     // project files through to that same scan so pi matches that behavior.
+    // Checked BEFORE wizardCanUseTool: its deny path captures a `bash denied`
+    // analytics event, which would record every allowed scoped rm as denied.
     const allowedLikeAnthropic =
       toolName === 'bash' &&
       isScopedFileRemoval(str(input.command), ctx.workingDirectory);
 
-    if (decision.behavior === 'deny' && !allowedLikeAnthropic) {
-      return { block: true, reason: decision.message };
+    if (!allowedLikeAnthropic) {
+      const policy = toClaudePolicyCall(toolName, input);
+      const decision = wizardCanUseTool(policy.name, policy.input, {
+        disallowedTools: ctx.disallowedTools,
+        wizardAskPending: ctx.getWizardAskPending?.() ?? false,
+      });
+      if (decision.behavior === 'deny') {
+        return { block: true, reason: decision.message };
+      }
     }
 
     const yaraReason = await preExecutionYaraBlock(


### PR DESCRIPTION
## Problem

Telemetry shows `rm .posthog-events.json` as `bash denied` ("not in allowlist") on pi runs — but the command actually runs. `evaluateToolCall` consulted `wizardCanUseTool` **before** applying the scoped-rm rescue from #834, and `wizardCanUseTool` captures a `bash denied` analytics event on every deny. So every allowed scoped `rm` is recorded as a denial, indistinguishable from a real block in the data.

Part of the telemetry findings in #894's investigation thread.

## Fix

Decide the rescue first and skip the allowlist check entirely for a scoped `rm`. The gate decision is unchanged — a rescued `rm` overrode any deny before, and it still falls through to the shared YARA scan — only the spurious telemetry goes away.

## Testing

- New test pins the behavior: an allowed scoped `rm` never captures a `bash denied` event.
- All 44 pi-security tests pass (containment, injection, quoting, glob/.env/recursion blocks unchanged); `pnpm build && pnpm test` — 1322 passed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
