### PR TITLE
feat(self-driving): attribute self-driving sources as created_via=self_driving

### DIFF
--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -1,0 +1,15 @@
+import { WIZARD_USER_AGENT, wizardUserAgentForProgram } from '@lib/constants';
+
+describe('wizardUserAgentForProgram', () => {
+  it('tags the program so the backend can attribute created_via (self-driving → self_driving)', () => {
+    const ua = wizardUserAgentForProgram('self-driving');
+    // The backend upgrade keys on both the base wizard token and /program:\s*self-driving/
+    // (posthog `is_wizard_self_driving_program`). Keep this literal in sync with that regex.
+    expect(ua).toContain('posthog/wizard');
+    expect(ua).toMatch(/program:\s*self-driving/);
+  });
+
+  it('returns the base user-agent unchanged when no program is given', () => {
+    expect(wizardUserAgentForProgram()).toBe(WIZARD_USER_AGENT);
+  });
+});

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -16,7 +16,7 @@ import {
   WIZARD_REMARK_EVENT_NAME,
   POSTHOG_PROPERTY_HEADER_PREFIX,
   WIZARD_ORCHESTRATOR_FLAG_KEY,
-  WIZARD_USER_AGENT,
+  wizardUserAgentForProgram,
   DEFAULT_AGENT_MODEL,
 } from '@lib/constants';
 import {
@@ -674,7 +674,9 @@ export async function initializeAgent(
         url: config.posthogMcpUrl,
         headers: {
           Authorization: `Bearer ${config.posthogApiKey}`,
-          'User-Agent': WIZARD_USER_AGENT,
+          // Tag the UA with the running program so the backend can attribute what this
+          // run creates (e.g. self-driving warehouse sources → created_via=self_driving).
+          'User-Agent': wizardUserAgentForProgram(config.integrationLabel),
         },
         // CLI mode's single `exec` tool carries the full command reference on
         // its schema — keep it in context, never deferred behind tool search.

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -257,6 +257,18 @@ export const WIZARD_TOOLS_MENU_FLAG_KEY = 'wizard-tools-menu';
 /** User-Agent for wizard HTTP requests and MCP server identification. */
 export const WIZARD_USER_AGENT = `posthog/wizard; version: ${VERSION}`;
 
+/**
+ * User-Agent for a specific program's MCP calls, tagged with `program: <id>` so the
+ * backend can attribute work per program (e.g. the `self-driving` program's warehouse
+ * sources are recorded as `created_via=self_driving` rather than plain `wizard`). The
+ * base `posthog/wizard` token is preserved, so anything keying only on that still matches.
+ */
+export function wizardUserAgentForProgram(programId?: string): string {
+  return programId
+    ? `${WIZARD_USER_AGENT}; program: ${programId}`
+    : WIZARD_USER_AGENT;
+}
+
 // ── HTTP headers ─────────────────────────────────────────────────────
 
 /** Header prefix for PostHog properties (e.g. X-POSTHOG-PROPERTY-VARIANT). */


### PR DESCRIPTION
## Problem

Warehouse sources connected during a `self-driving` run were attributed `created_via=wizard`, the same as any other wizard program. All wizard programs share the `posthog/wizard` user-agent, so the backend had no way to tell a self-driving run apart, and we couldn't cleanly measure what self-driving onboarding creates.

## Changes

- Add `wizardUserAgentForProgram(programId)` in `constants.ts`, which appends a `program: <id>` token to the wizard user-agent while preserving the base `posthog/wizard` token (so anything keying only on that still matches).
- Use it for the `posthog-wizard` MCP server's User-Agent in `initializeAgent`, threading the running program (`config.integrationLabel`).

The backend (PostHog/posthog) reads the `program: self-driving` marker and upgrades `created_via` from `wizard` to `self_driving` — matching the PostHog Code app inbox path. Both sides are backward-compatible: the marker is ignored if the backend hasn't shipped it, and absent if an older wizard is used.

## Test plan

- Added a unit test for `wizardUserAgentForProgram` (tags the program, keeps the base UA, returns the base unchanged when no program is given).
- Typecheck and lint clean on the changed files; `vitest` for the new test passes.
- End-to-end attribution is exercised by the paired backend PR's endpoint test.