### PR TITLE
fix(pi): share the bash allowlist across harnesses; emit bash-denied at enforcement

### DIFF
--- a/src/lib/__tests__/wizard-can-use-tool.test.ts
+++ b/src/lib/__tests__/wizard-can-use-tool.test.ts
@@ -1,4 +1,5 @@
 import { wizardCanUseTool } from '@lib/agent/agent-interface';
+import { analytics } from '@utils/analytics';
 
 vi.mock('../../utils/analytics', () => ({
   analytics: {
@@ -18,6 +19,7 @@ describe('wizardCanUseTool — wizard_ask pending guard', () => {
       expect(result).toEqual({
         behavior: 'deny',
         message: expect.stringMatching(/wizard_ask question is open/),
+        reason: 'wizard_ask pending',
       });
     });
 
@@ -50,6 +52,49 @@ describe('wizardCanUseTool — wizard_ask pending guard', () => {
     expect(result).toEqual({
       behavior: 'deny',
       message: expect.stringMatching(/wizard-tools MCP server/),
+      reason: 'env file',
     });
+  });
+});
+
+describe('wizardCanUseTool — bash policy', () => {
+  it('is a pure predicate — never emits analytics itself', () => {
+    // Telemetry is the caller's job (captureBashDenied), so the decision
+    // function stays free of side effects and can be reused by both harnesses.
+    (analytics.wizardCapture as ReturnType<typeof vi.fn>).mockClear();
+    wizardCanUseTool('Bash', { command: 'rm -rf /' });
+    wizardCanUseTool('Bash', { command: 'npm run test' });
+    expect(analytics.wizardCapture).not.toHaveBeenCalled();
+  });
+
+  it('tags each denial with a machine-readable reason', () => {
+    expect(wizardCanUseTool('Bash', { command: 'npm run test' })).toMatchObject(
+      { behavior: 'deny', reason: 'not in allowlist' },
+    );
+    expect(
+      wizardCanUseTool('Bash', { command: 'npm run lint -- app/(x)/p.tsx' }),
+    ).toMatchObject({ behavior: 'deny', reason: 'dangerous operators' });
+  });
+
+  it('allows a plain rm of a project file when workingDirectory is set', () => {
+    const root = '/project';
+    expect(
+      wizardCanUseTool(
+        'Bash',
+        { command: 'rm .posthog-events.json' },
+        { workingDirectory: root },
+      ).behavior,
+    ).toBe('allow');
+    // …but not without a root to contain against, nor for an escaping path.
+    expect(
+      wizardCanUseTool('Bash', { command: 'rm .posthog-events.json' }).behavior,
+    ).toBe('deny');
+    expect(
+      wizardCanUseTool(
+        'Bash',
+        { command: 'rm ../secret' },
+        { workingDirectory: root },
+      ).behavior,
+    ).toBe('deny');
   });
 });

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -44,6 +44,7 @@ import { AgentOutputSignals } from './output-signals';
 // so existing importers of these from agent-interface keep working.
 export { AgentSignals, AgentErrorType } from './signals';
 export type { AgentSignal } from './signals';
+import { isScopedFileRemoval } from './bash-policy';
 export { AgentOutputSignals } from './output-signals';
 import {
   checkAllSettingsConflicts,
@@ -462,10 +463,16 @@ export function wizardCanUseTool(
   context: {
     wizardAskPending?: boolean;
     disallowedTools?: readonly string[];
+    /**
+     * Project root. When set, a plain `rm` of a file inside it is allowed
+     * (parity with the anthropic arm — see isScopedFileRemoval). Callers on
+     * the pi path pass this; the anthropic path auto-approves Bash anyway.
+     */
+    workingDirectory?: string;
   } = {},
 ):
   | { behavior: 'allow'; updatedInput: Record<string, unknown> }
-  | { behavior: 'deny'; message: string } {
+  | { behavior: 'deny'; message: string; reason: string } {
   // Hard gate on the program's disallow list. The SDK's own disallowedTools
   // option blocks tools at the parent level, but does NOT reliably propagate
   // to dispatched subagents (their AgentDefinition has its own field which the
@@ -477,6 +484,7 @@ export function wizardCanUseTool(
     return {
       behavior: 'deny',
       message: `Tool ${toolName} is disabled for this program.`,
+      reason: 'disallowed tool',
     };
   }
 
@@ -488,6 +496,7 @@ export function wizardCanUseTool(
     return {
       behavior: 'deny',
       message: `${toolName} is paused while a wizard_ask question is open. Wait for the user's answer to come back as a tool result before writing files.`,
+      reason: 'wizard_ask pending',
     };
   }
 
@@ -500,6 +509,7 @@ export function wizardCanUseTool(
       return {
         behavior: 'deny',
         message: `Direct ${toolName} of ${basename} is not allowed. Use the wizard-tools MCP server (check_env_keys / set_env_values) to read or modify environment variables.`,
+        reason: 'env file',
       };
     }
     return { behavior: 'allow', updatedInput: input };
@@ -517,6 +527,7 @@ export function wizardCanUseTool(
         message: `Grep on ${path.basename(
           grepPath,
         )} is not allowed. Use the wizard-tools MCP server (check_env_keys) to check environment variables.`,
+        reason: 'env file',
       };
     }
     return { behavior: 'allow', updatedInput: input };
@@ -531,17 +542,22 @@ export function wizardCanUseTool(
     typeof input.command === 'string' ? input.command : ''
   ).trim();
 
+  // A plain `rm` of a file inside the project is allowed — parity with the
+  // anthropic arm, which runs bash unsandboxed-by-allowlist and lets the
+  // shared YARA destructive-delete rules judge it. Checked first so it isn't
+  // caught by the allowlist below (rm is not a package-manager command).
+  if (isScopedFileRemoval(command, context.workingDirectory)) {
+    return { behavior: 'allow', updatedInput: input };
+  }
+
   // Block definitely dangerous operators: ; ` $ ( )
   if (DANGEROUS_OPERATORS.test(command)) {
     logToFile(`Denying bash command with dangerous operators: ${command}`);
     debug(`Denying bash command with dangerous operators: ${command}`);
-    analytics.wizardCapture('bash denied', {
-      reason: 'dangerous operators',
-      command,
-    });
     return {
       behavior: 'deny',
       message: `Bash command not allowed. Shell operators like ; \` $ ( ) are not permitted.`,
+      reason: 'dangerous operators',
     };
   }
 
@@ -557,13 +573,10 @@ export function wizardCanUseTool(
     if (/[|&]/.test(baseCommand)) {
       logToFile(`Denying bash command with multiple pipes: ${command}`);
       debug(`Denying bash command with multiple pipes: ${command}`);
-      analytics.wizardCapture('bash denied', {
-        reason: 'multiple pipes',
-        command,
-      });
       return {
         behavior: 'deny',
         message: `Bash command not allowed. Only single pipe to tail/head is permitted.`,
+        reason: 'multiple pipes',
       };
     }
 
@@ -578,13 +591,10 @@ export function wizardCanUseTool(
   if (/[|&]/.test(normalized)) {
     logToFile(`Denying bash command with pipe/&: ${command}`);
     debug(`Denying bash command with pipe/&: ${command}`);
-    analytics.wizardCapture('bash denied', {
-      reason: 'disallowed pipe',
-      command,
-    });
     return {
       behavior: 'deny',
       message: `Bash command not allowed. Pipes are only permitted with tail/head for output limiting.`,
+      reason: 'disallowed pipe',
     };
   }
 
@@ -597,14 +607,32 @@ export function wizardCanUseTool(
 
   logToFile(`Denying bash command: ${command}`);
   debug(`Denying bash command: ${command}`);
-  analytics.wizardCapture('bash denied', {
-    reason: 'not in allowlist',
-    command,
-  });
   return {
     behavior: 'deny',
     message: `Bash command not allowed. Only install, build, typecheck, lint, and formatting commands are permitted.`,
+    reason: 'not in allowlist',
   };
+}
+
+/**
+ * Emit the `bash denied` analytics event for a denied Bash call. Kept out of
+ * `wizardCanUseTool` (a pure predicate) and called by each harness at its own
+ * enforcement point, so the event fires exactly when a command is actually
+ * blocked — never when the caller allows it (e.g. a scoped `rm`), and never as
+ * a side effect the predicate can't see the outcome of. Non-Bash denials are
+ * ignored to preserve the metric's meaning.
+ */
+export function captureBashDenied(
+  toolName: string,
+  input: unknown,
+  reason: string,
+): void {
+  if (toolName !== 'Bash') return;
+  const command =
+    typeof (input as { command?: unknown })?.command === 'string'
+      ? (input as { command: string }).command
+      : '';
+  analytics.wizardCapture('bash denied', { reason, command });
 }
 
 /**
@@ -1076,9 +1104,13 @@ export async function runAgent(
             {
               wizardAskPending: agentConfig.getPendingQuestion?.() != null,
               disallowedTools: agentConfig.disallowedTools,
+              workingDirectory: agentConfig.workingDirectory,
             },
           );
           logToFile('canUseTool result:', result);
+          if (result.behavior === 'deny') {
+            captureBashDenied(toolName, input, result.reason);
+          }
           return Promise.resolve(result);
         },
         systemPrompt: {

--- a/src/lib/agent/bash-policy.ts
+++ b/src/lib/agent/bash-policy.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared bash-command policy helpers — the parts of the fence that both
+ * harnesses agree on, kept in a dependency-free leaf module so `wizardCanUseTool`
+ * (the anthropic-side allowlist) and pi's security extension apply the SAME
+ * rules without importing each other.
+ *
+ * Right now this is the scoped file-removal predicate. The anthropic arm runs
+ * bash without an allowlist (the OS sandbox + shared YARA destructive-delete
+ * rules contain it), so a plain `rm <file-inside-the-project>` is permitted
+ * there. pi has no sandbox and gates bash through the allowlist, which would
+ * otherwise reject `rm` outright — so it consults this predicate to permit the
+ * exact same deletion shape, then still runs it through the shared YARA scan.
+ */
+
+import path from 'path';
+
+// Shell metacharacters that chain, substitute, or redirect. A command carrying
+// any of these is more than one action, so we never treat it as a plain `rm`.
+const SHELL_OPERATORS = /[;&|`$(){}<>\n'"\\]/;
+
+/** True when a target resolves to a file strictly inside the project root. */
+function isDeletableProjectFile(
+  target: string,
+  root: string,
+  p: typeof path,
+): boolean {
+  if (target.startsWith('-')) return false; // a flag, not a file
+  if (/[*?[\]~]/.test(target)) return false; // glob / home expansion
+  if (p.basename(target).startsWith('.env')) return false; // secrets
+
+  const resolved = p.resolve(root, target);
+  return resolved !== root && resolved.startsWith(root + p.sep);
+}
+
+/**
+ * A plain `rm [-f] <file...>` whose every target is a file inside the project
+ * root — the deletion shape the anthropic arm permits (there bash isn't
+ * allowlisted; the shared YARA destructive-delete rules catch the dangerous
+ * forms). It refuses any shell operator so a command can't smuggle a second
+ * action. Path checks run through the host's `path` (win32 on Windows, posix
+ * elsewhere); pi always executes commands via a POSIX bash, so targets use
+ * forward slashes.
+ */
+export function isScopedFileRemoval(
+  command: string,
+  rawRoot: string | undefined,
+  p: typeof path = path,
+): boolean {
+  if (!rawRoot) return false; // no root to contain against → never allow
+  const root = p.resolve(rawRoot);
+  const trimmed = command.trim();
+  if (SHELL_OPERATORS.test(trimmed)) return false;
+
+  const [executable, ...args] = trimmed.split(/\s+/);
+  if (executable !== 'rm') return false;
+
+  if (args[0] === '-f') args.shift();
+  if (args.length === 0) return false;
+
+  return args.every((arg) => isDeletableProjectFile(arg, root, p));
+}

--- a/src/lib/agent/runner/harness/pi/__tests__/security.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/security.test.ts
@@ -484,6 +484,29 @@ describe('pi-security: plain rm matches the anthropic arm', () => {
     );
   });
 
+  test('captures `bash denied` only when a command is actually blocked', async () => {
+    // The event fires at the enforcement point on a real deny — never for an
+    // allowed scoped rm, which the shared predicate permits outright.
+    const { analytics } = await import('@utils/analytics');
+    const capture = vi.spyOn(analytics, 'wizardCapture');
+    try {
+      expect(await rmBlocked('rm .posthog-events.json')).toBe(false);
+      expect(capture).not.toHaveBeenCalledWith(
+        'bash denied',
+        expect.anything(),
+      );
+
+      capture.mockClear();
+      expect(await rmBlocked('rm -rf node_modules')).toBe(true);
+      expect(capture).toHaveBeenCalledWith('bash denied', {
+        reason: 'not in allowlist',
+        command: 'rm -rf node_modules',
+      });
+    } finally {
+      capture.mockRestore();
+    }
+  });
+
   test('normalizes a relative workingDirectory', async () => {
     const relRoot = path.relative(process.cwd(), path.resolve('/project'));
     expect(

--- a/src/lib/agent/runner/harness/pi/security.ts
+++ b/src/lib/agent/runner/harness/pi/security.ts
@@ -20,7 +20,13 @@
 import fs from 'fs';
 import path from 'path';
 import type { LLMProvider, ScanMatch } from '@posthog/warlock';
-import { wizardCanUseTool } from '@lib/agent/agent-interface';
+import {
+  wizardCanUseTool,
+  captureBashDenied,
+} from '@lib/agent/agent-interface';
+// Re-exported so existing importers (and tests) keep resolving it here; the
+// canonical definition is the shared bash-policy module.
+export { isScopedFileRemoval } from '@lib/agent/bash-policy';
 import {
   createRepeatBlockTracker,
   isWizardDocumentationPath,
@@ -78,52 +84,6 @@ export interface GateDecision {
 }
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
-
-// Shell metacharacters that chain, substitute, or redirect. A command carrying
-// any of these is more than one action, so we never treat it as a plain `rm`.
-const SHELL_OPERATORS = /[;&|`$(){}<>\n'"\\]/;
-
-/** True when a target resolves to a file strictly inside the project root. */
-function isDeletableProjectFile(
-  target: string,
-  root: string,
-  p: typeof path,
-): boolean {
-  if (target.startsWith('-')) return false; // a flag, not a file
-  if (/[*?[\]~]/.test(target)) return false; // glob / home expansion
-  if (p.basename(target).startsWith('.env')) return false; // secrets
-
-  const resolved = p.resolve(root, target);
-  return resolved !== root && resolved.startsWith(root + p.sep);
-}
-
-/**
- * A plain `rm [-f] <file...>` whose every target is a file inside the project
- * root — the deletion shape the anthropic arm permits (there bash isn't
- * allowlisted; the shared YARA destructive-delete rules catch the dangerous
- * forms). pi rescues the same shape so the fall-through YARA scan can judge
- * it, but refuses any shell operator so it can't smuggle a second command.
- * Path checks run through the host's `path` (win32 on Windows, posix elsewhere);
- * pi always executes commands via a POSIX bash, so targets use forward slashes.
- */
-export function isScopedFileRemoval(
-  command: string,
-  rawRoot: string | undefined,
-  p: typeof path = path,
-): boolean {
-  if (!rawRoot) return false; // no root to contain against → never rescue
-  const root = p.resolve(rawRoot);
-  const trimmed = command.trim();
-  if (SHELL_OPERATORS.test(trimmed)) return false;
-
-  const [executable, ...args] = trimmed.split(/\s+/);
-  if (executable !== 'rm') return false;
-
-  if (args[0] === '-f') args.shift();
-  if (args.length === 0) return false;
-
-  return args.every((arg) => isDeletableProjectFile(arg, root, p));
-}
 
 /** A write that removes more than this fraction of an existing file's
  * non-whitespace content reads as a destructive whole-file rewrite. */
@@ -303,19 +263,19 @@ export async function evaluateToolCall(
   llmProvider?: LLMProvider,
 ): Promise<GateDecision> {
   try {
+    // Same allowlist the anthropic arm uses. Passing workingDirectory lets the
+    // predicate itself allow a plain `rm` of a project file (parity with
+    // anthropic, which runs bash unsandboxed-by-allowlist) — no pi-only
+    // override. The `bash denied` event is emitted here, at the real
+    // enforcement point, so it fires only when the command is actually blocked.
     const policy = toClaudePolicyCall(toolName, input);
     const decision = wizardCanUseTool(policy.name, policy.input, {
       disallowedTools: ctx.disallowedTools,
       wizardAskPending: ctx.getWizardAskPending?.() ?? false,
+      workingDirectory: ctx.workingDirectory,
     });
-    // The allowlist is a pi-only restriction; the anthropic arm runs bash
-    // unrestricted and leans on the shared YARA scan. Let a plain `rm` of
-    // project files through to that same scan so pi matches that behavior.
-    const allowedLikeAnthropic =
-      toolName === 'bash' &&
-      isScopedFileRemoval(str(input.command), ctx.workingDirectory);
-
-    if (decision.behavior === 'deny' && !allowedLikeAnthropic) {
+    if (decision.behavior === 'deny') {
+      captureBashDenied(policy.name, policy.input, decision.reason);
       return { block: true, reason: decision.message };
     }
 


### PR DESCRIPTION
## Problem

Telemetry shows `rm .posthog-events.json` as `bash denied` on pi runs even though the command runs. Root cause: `wizardCanUseTool` was a policy predicate that also fired the `bash denied` analytics event as a side effect.

- The scoped-rm allowance (#834) lived in pi's `evaluateToolCall` as an override applied **after** `wizardCanUseTool` had already captured the denial — so every allowed `rm` still logged as blocked.
- The metric had no cross-harness meaning: the event fired inside the shared predicate, but only pi consults it for bash (the anthropic arm auto-approves Bash and never calls the predicate for it).

## Fix — parity + separation of policy from telemetry

- `wizardCanUseTool` is now a **pure predicate**: no analytics, returns a machine-readable `reason` on every denial.
- The scoped-rm allowance moves **into the shared predicate** (new `bash-policy.ts`, consulted via `workingDirectory`), so both harnesses agree a plain `rm` of a project file is allowed — no pi-only override.
- `captureBashDenied` emits the event at each harness's **real enforcement point**, only for an actually-blocked Bash command. Same event name and `reason` tags, so dashboards keep working — now accurate.

All 44 pi-security tests plus new predicate tests (purity, `reason` tags, scoped-rm allow) pass; `pnpm build && pnpm test` green (1325).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
