### PR TITLE
feat(audit): upload the check ledger for the signals setup review

### DIFF
--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -137,6 +137,19 @@ export async function runLinearProgram(
   });
 
   // 9. Error handling (full set from both runners)
+  if (
+    agentResult.error &&
+    agentResult.error !== AgentErrorType.YARA_VIOLATION &&
+    config.bestEffort
+  ) {
+    analytics.wizardCapture('agent best-effort failure', {
+      integration: config.integrationLabel,
+      error_type: agentResult.error,
+      error_message: agentResult.message ?? null,
+    });
+    return;
+  }
+
   if (agentResult.error === AgentErrorType.ABORT) {
     const reason = agentResult.message ?? '';
     const matched = config.abortCases?.find((c) => c.match.test(reason));

--- a/src/lib/agent/runner/shared/types.ts
+++ b/src/lib/agent/runner/shared/types.ts
@@ -53,6 +53,13 @@ export interface ProgramRun {
   abortCases?: AbortCase[];
   /** Runs after agent completes, before outro (e.g. env var upload). */
   postRun?: (session: WizardSession, credentials: Credentials) => Promise<void>;
+  /**
+   * A complimentary run whose failure must not take the program down: agent
+   * errors degrade to "no result" (analytics + return) instead of aborting.
+   * YARA violations still abort. For composed sub-runs like the audit inside
+   * self-driving; the host program's own run must never set this.
+   */
+  bestEffort?: boolean;
   /** Custom outro data. Omit for default built from successMessage/reportFile/docsUrl. */
   buildOutroData?: (
     session: WizardSession,

--- a/src/lib/programs/__tests__/audit-setup-review.test.ts
+++ b/src/lib/programs/__tests__/audit-setup-review.test.ts
@@ -1,0 +1,180 @@
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MAX_UPLOAD_CHECKS,
+  parseRepositoryFromGitRemote,
+  uploadSetupReview,
+} from '../audit/setup-review';
+import { AUDIT_CHECKS_FILE, type AuditCheck } from '../audit/types';
+import { buildSession } from '../../wizard-session';
+import type { Credentials } from '../../wizard-session';
+import { HostResolution } from '../../host-resolution';
+
+const CREDS: Credentials = {
+  host: HostResolution.fromApiHost('https://us.posthog.com'),
+  projectId: 42,
+  accessToken: 'pha_abc',
+  projectApiKey: 'phc_test',
+};
+
+const CHECKS: AuditCheck[] = [
+  {
+    id: 'identify-stable-distinct-id',
+    area: 'identify',
+    label: 'Stable distinct id',
+    status: 'error',
+    file: 'src/auth.ts',
+    details: 'distinct_id changes per session',
+  },
+  { id: 'init-correct', area: 'setup', label: 'Init correct', status: 'pass' },
+];
+
+let dir: string;
+
+function initGitRepo(remoteUrl?: string): void {
+  childProcess.execSync('git init -q', { cwd: dir });
+  if (remoteUrl) {
+    childProcess.execSync(`git remote add origin ${remoteUrl}`, { cwd: dir });
+  }
+}
+
+function writeLedger(checks: unknown): void {
+  fs.writeFileSync(path.join(dir, AUDIT_CHECKS_FILE), JSON.stringify(checks));
+}
+
+function makeFetch(status = 202) {
+  return vi.fn(() => Promise.resolve(new Response('', { status })));
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'setup-review-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('parseRepositoryFromGitRemote', () => {
+  it.each([
+    ['git@github.com:acme/my-app.git', 'acme/my-app'],
+    ['https://github.com/acme/my-app.git', 'acme/my-app'],
+    ['https://github.com/acme/my-app', 'acme/my-app'],
+  ])('parses %s', (remote, expected) => {
+    initGitRepo(remote);
+    expect(parseRepositoryFromGitRemote(dir)).toBe(expected);
+  });
+
+  it('returns null without a git repo or without an origin remote', () => {
+    expect(parseRepositoryFromGitRemote(dir)).toBeNull();
+    initGitRepo();
+    expect(parseRepositoryFromGitRemote(dir)).toBeNull();
+  });
+});
+
+describe('uploadSetupReview', () => {
+  it('POSTs repository + ledger checks with bearer auth', async () => {
+    initGitRepo('git@github.com:acme/my-app.git');
+    writeLedger(CHECKS);
+    const fetchImpl = makeFetch();
+
+    await uploadSetupReview(
+      buildSession({ installDir: dir }),
+      CREDS,
+      fetchImpl,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [
+      string,
+      NonNullable<Parameters<typeof fetch>[1]>,
+    ];
+    expect(url).toBe(
+      'https://us.posthog.com/api/projects/42/wizard/sessions/setup_review/',
+    );
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer pha_abc',
+    );
+    expect(JSON.parse(init.body as string)).toEqual({
+      repository: 'acme/my-app',
+      checks: CHECKS,
+    });
+  });
+
+  it('caps the uploaded ledger at MAX_UPLOAD_CHECKS entries', async () => {
+    initGitRepo('git@github.com:acme/my-app.git');
+    writeLedger(
+      Array.from({ length: MAX_UPLOAD_CHECKS + 10 }, (_, i) => ({
+        ...CHECKS[0],
+        id: `check-${i}`,
+      })),
+    );
+    const fetchImpl = makeFetch();
+
+    await uploadSetupReview(
+      buildSession({ installDir: dir }),
+      CREDS,
+      fetchImpl,
+    );
+
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [
+      string,
+      NonNullable<Parameters<typeof fetch>[1]>,
+    ];
+    expect(JSON.parse(init.body as string).checks).toHaveLength(
+      MAX_UPLOAD_CHECKS,
+    );
+  });
+
+  it.each([
+    ['ci runs', () => buildSession({ installDir: dir, ci: true }), true, true],
+    ['no origin remote', () => buildSession({ installDir: dir }), false, true],
+    ['no ledger on disk', () => buildSession({ installDir: dir }), true, false],
+  ])(
+    'skips upload for %s',
+    async (_name, makeSession, withRemote, withLedger) => {
+      if (withRemote) initGitRepo('git@github.com:acme/my-app.git');
+      else initGitRepo();
+      if (withLedger) writeLedger(CHECKS);
+      const fetchImpl = makeFetch();
+
+      await uploadSetupReview(makeSession(), CREDS, fetchImpl);
+
+      expect(fetchImpl).not.toHaveBeenCalled();
+    },
+  );
+
+  it('skips upload for an empty or malformed ledger', async () => {
+    initGitRepo('git@github.com:acme/my-app.git');
+    const fetchImpl = makeFetch();
+
+    writeLedger([]);
+    await uploadSetupReview(
+      buildSession({ installDir: dir }),
+      CREDS,
+      fetchImpl,
+    );
+    fs.writeFileSync(path.join(dir, AUDIT_CHECKS_FILE), 'not json');
+    await uploadSetupReview(
+      buildSession({ installDir: dir }),
+      CREDS,
+      fetchImpl,
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the request fails', async () => {
+    initGitRepo('git@github.com:acme/my-app.git');
+    writeLedger(CHECKS);
+    const fetchImpl = vi.fn(() => Promise.reject(new Error('network down')));
+
+    await expect(
+      uploadSetupReview(buildSession({ installDir: dir }), CREDS, fetchImpl),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/programs/__tests__/self-driving-audit.test.ts
+++ b/src/lib/programs/__tests__/self-driving-audit.test.ts
@@ -1,0 +1,102 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runAgent } from '@lib/agent/agent-runner';
+import { auditRunStep } from '@lib/programs/audit/index';
+import { uploadSetupReview } from '@lib/programs/audit/setup-review';
+import { selfDrivingConfig } from '@lib/programs/self-driving/index';
+import {
+  SELF_DRIVING_INTEGRATE_PATH_KEY,
+  POSTHOG_PRESENT_KEY,
+} from '@lib/programs/self-driving/detect';
+import { buildSession, type Credentials } from '@lib/wizard-session';
+import { HostResolution } from '@lib/host-resolution';
+
+vi.mock('@lib/agent/agent-runner', () => ({ runAgent: vi.fn() }));
+vi.mock('@lib/programs/audit/setup-review', () => ({
+  uploadSetupReview: vi.fn(),
+}));
+
+const CREDS: Credentials = {
+  host: HostResolution.fromApiHost('https://us.posthog.com'),
+  projectId: 42,
+  accessToken: 'pha_abc',
+  projectApiKey: 'phc_test',
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('self-driving audit wiring', () => {
+  const steps = selfDrivingConfig.steps;
+  const auditStep = steps.find((s) => s.id === 'audit-run');
+
+  it('places audit-run between integrate-run and the handoff', () => {
+    const ids = steps.map((s) => s.id);
+    expect(ids.indexOf('audit-run')).toBe(ids.indexOf('integrate-run') + 1);
+    expect(ids.indexOf('audit-run')).toBe(
+      ids.indexOf('self-driving-handoff') - 1,
+    );
+  });
+
+  it.each([
+    ['posthog already present', { [POSTHOG_PRESENT_KEY]: true }, null, true],
+    ['fresh integration', {}, true, true],
+    ['integration declined', {}, false, false],
+  ])(
+    'shows the audit step for %s',
+    (_name, frameworkContext, integrate, expected) => {
+      const session = buildSession({ installDir: '/repo' });
+      session.frameworkContext = frameworkContext;
+      session.integrate = integrate;
+      expect(auditStep?.show?.(session)).toBe(expected);
+    },
+  );
+
+  it('audits the picked sub-app dir, falling back to the repo root', () => {
+    const session = buildSession({ installDir: '/repo' });
+    expect(auditStep?.targetDir?.(session)).toBe('/repo');
+    session.frameworkContext[SELF_DRIVING_INTEGRATE_PATH_KEY] = 'apps/web';
+    expect(auditStep?.targetDir?.(session)).toBe(
+      path.join('/repo', 'apps', 'web'),
+    );
+  });
+
+  it('runs the audit composed, best-effort, and without its own upload', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sd-audit-'));
+    try {
+      const session = buildSession({ installDir: dir });
+      await auditRunStep.run?.(session);
+
+      expect(runAgent).toHaveBeenCalledTimes(1);
+      const [config, , opts] = vi.mocked(runAgent).mock.calls[0];
+      expect(opts).toEqual({ composed: true });
+      const programRun =
+        typeof config.run === 'function' ? await config.run(session) : null;
+      expect(programRun?.bestEffort).toBe(true);
+      expect(programRun?.postRun).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uploads the ledger from the integration dir in postRun', async () => {
+    const session = buildSession({ installDir: '/repo' });
+    session.frameworkContext[SELF_DRIVING_INTEGRATE_PATH_KEY] = 'apps/web';
+
+    const run =
+      typeof selfDrivingConfig.run === 'function'
+        ? await selfDrivingConfig.run(session)
+        : selfDrivingConfig.run;
+    await run?.postRun?.(session, CREDS);
+
+    expect(uploadSetupReview).toHaveBeenCalledTimes(1);
+    const [uploadSession, creds] = vi.mocked(uploadSetupReview).mock.calls[0];
+    expect(uploadSession.installDir).toBe(path.join('/repo', 'apps', 'web'));
+    expect(creds).toBe(CREDS);
+  });
+});

--- a/src/lib/programs/__tests__/self-driving-detect.test.ts
+++ b/src/lib/programs/__tests__/self-driving-detect.test.ts
@@ -135,6 +135,7 @@ describe('selfDrivingConfig', () => {
       'auth',
       'integrate-detect',
       'integrate-run',
+      'audit-run',
       'self-driving-handoff',
       'run',
       'outro',

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -65,8 +65,6 @@ const auditRun = async (session: WizardSession): Promise<ProgramRun> => {
 
   return {
     ...baseRun,
-    // Hand the finished ledger to the signals setup review (fail-silent,
-    // interactive runs only — see setup-review.ts for the why).
     postRun: uploadSetupReview,
     // Override the default outro so the dashboard + notebook URLs the
     // agent emits via `[DASHBOARD_URL]` / `[NOTEBOOK_URL]` are surfaced

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -10,6 +10,7 @@ import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
 import { AUDIT_ABORT_CASES } from './detect.js';
 import { AUDIT_CHECKS_KEY, AUDIT_REPORT_FILE } from './types.js';
 import { AUDIT_SEED_CHECKS, seedAuditLedger } from './seed.js';
+import { uploadSetupReview } from './setup-review.js';
 
 /** Audit-specific screens for the shared agent-skill pipeline. */
 const AUDIT_SCREEN_BY_STEP: Record<string, string> = {
@@ -64,6 +65,9 @@ const auditRun = async (session: WizardSession): Promise<ProgramRun> => {
 
   return {
     ...baseRun,
+    // Hand the finished ledger to the signals setup review (fail-silent,
+    // interactive runs only — see setup-review.ts for the why).
+    postRun: uploadSetupReview,
     // Override the default outro so the dashboard + notebook URLs the
     // agent emits via `[DASHBOARD_URL]` / `[NOTEBOOK_URL]` are surfaced
     // on the post-run screen.

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -3,7 +3,7 @@ import {
   createSkillProgram,
 } from '@lib/programs/agent-skill/index';
 import type { ProgramStep, ProgramConfig } from '@lib/programs/program-step';
-import type { ProgramRun } from '@lib/agent/agent-runner';
+import { runAgent, type ProgramRun } from '@lib/agent/agent-runner';
 import type { WizardSession } from '@lib/wizard-session';
 import { OutroKind } from '@lib/wizard-session';
 import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
@@ -100,4 +100,31 @@ export const auditConfig: ProgramConfig = {
   run: auditRun,
   allowedTools: ['Agent'],
   disallowedTools: [WIZARD_TOOL_NAMES.wizardAsk],
+};
+
+/**
+ * Composed variant for host programs: best-effort (an audit failure never
+ * takes the host down) and without the upload postRun — the host uploads the
+ * ledger when its own run succeeds, so the review only fires once the full
+ * setup (e.g. self-driving's GitHub connect) is in place.
+ */
+const composedAuditConfig: ProgramConfig = {
+  ...auditConfig,
+  run: async (session) => ({
+    ...(await auditRun(session)),
+    postRun: undefined,
+    bestEffort: true,
+  }),
+};
+
+/**
+ * Self-contained run step that runs the audit agent. Other programs import
+ * this and splice it into their own step list, supplying `show`/`targetDir`.
+ */
+export const auditRunStep: ProgramStep = {
+  id: 'audit-run',
+  label: 'Setup audit',
+  screenId: 'run',
+  run: (session) => runAgent(composedAuditConfig, session, { composed: true }),
+  isComplete: (session) => session.completedRuns.includes('audit-run'),
 };

--- a/src/lib/programs/audit/setup-review.ts
+++ b/src/lib/programs/audit/setup-review.ts
@@ -1,25 +1,14 @@
 /**
- * Post-audit setup-review upload — the local counterpart of the cloud
- * wizard setup review.
- *
- * The cloud flow captures the audit's check ledger inside the sandbox and
- * feeds it to the signals setup review when the instrumentation PR merges
- * (posthog: run_wizard_audit activity → merge webhook →
- * WizardSetupReviewWorkflow). A local `wizard audit` produces the exact same
- * ledger in the user's working tree, so this module closes the gap: after a
- * successful local audit it POSTs the ledger to
- * `/api/projects/{id}/wizard/sessions/setup_review/`, and the server turns
- * the failing checks into complimentary implementation PRs in the inbox.
- *
- * Best-effort by design, like the cloud activity: a failed upload only means
- * no setup-review signals — it never fails or delays the audit itself, so
- * every exit path here is fail-silent (debug log only). The server owns all
- * policy: one review per team ever, org AI consent, billing exemption.
+ * Post-audit setup-review upload — the local counterpart of the cloud wizard
+ * setup review (posthog: run_wizard_audit activity → merge webhook →
+ * WizardSetupReviewWorkflow). POSTs the audit's check ledger so the server
+ * can turn failing checks into complimentary PRs in the inbox. Best-effort:
+ * fail-silent everywhere, the server owns all policy (one review per team,
+ * consent, billing exemption).
  *
  * Skipped when `session.ci` is set: cloud/headless runs capture the ledger
- * themselves and deliberately wait for the PR merge before reviewing —
- * uploading from inside the sandbox would fire the review before the
- * integration exists on the default branch.
+ * themselves and wait for the PR merge — uploading from the sandbox would
+ * fire the review before the integration exists on the default branch.
  */
 
 import * as childProcess from 'node:child_process';
@@ -34,10 +23,8 @@ import { AUDIT_CHECKS_FILE, coerceAuditChecks } from './types.js';
 export const MAX_UPLOAD_CHECKS = 50;
 
 /**
- * Resolve the project's `owner/repo` from its `origin` remote. The signals
- * pipeline selects the implementation repo from this value, so only a real
- * remote counts — no remote (or a non-GitHub-shaped URL) means there is
- * nothing the review could ship a PR to, and the upload is skipped.
+ * Resolve the project's `owner/repo` from its `origin` remote. Null means
+ * there is no repo the review could ship a PR to, and the upload is skipped.
  */
 export function parseRepositoryFromGitRemote(
   installDir: string,
@@ -59,11 +46,7 @@ export function parseRepositoryFromGitRemote(
   return null;
 }
 
-/**
- * Upload the audit's check ledger for the signals setup review.
- * Wired as the audit program's `postRun`, so it only fires after a
- * successful run. Never throws.
- */
+/** The audit program's `postRun` — fires only after a successful run. Never throws. */
 export async function uploadSetupReview(
   session: WizardSession,
   credentials: Credentials,

--- a/src/lib/programs/audit/setup-review.ts
+++ b/src/lib/programs/audit/setup-review.ts
@@ -1,0 +1,111 @@
+/**
+ * Post-audit setup-review upload — the local counterpart of the cloud
+ * wizard setup review.
+ *
+ * The cloud flow captures the audit's check ledger inside the sandbox and
+ * feeds it to the signals setup review when the instrumentation PR merges
+ * (posthog: run_wizard_audit activity → merge webhook →
+ * WizardSetupReviewWorkflow). A local `wizard audit` produces the exact same
+ * ledger in the user's working tree, so this module closes the gap: after a
+ * successful local audit it POSTs the ledger to
+ * `/api/projects/{id}/wizard/sessions/setup_review/`, and the server turns
+ * the failing checks into complimentary implementation PRs in the inbox.
+ *
+ * Best-effort by design, like the cloud activity: a failed upload only means
+ * no setup-review signals — it never fails or delays the audit itself, so
+ * every exit path here is fail-silent (debug log only). The server owns all
+ * policy: one review per team ever, org AI consent, billing exemption.
+ *
+ * Skipped when `session.ci` is set: cloud/headless runs capture the ledger
+ * themselves and deliberately wait for the PR merge before reviewing —
+ * uploading from inside the sandbox would fire the review before the
+ * integration exists on the default branch.
+ */
+
+import * as childProcess from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { Credentials, WizardSession } from '@lib/wizard-session';
+import { debug } from '@utils/debug';
+import { AUDIT_CHECKS_FILE, coerceAuditChecks } from './types.js';
+
+/** Server-side cap mirrored here so an oversized ledger never 400s the upload. */
+export const MAX_UPLOAD_CHECKS = 50;
+
+/**
+ * Resolve the project's `owner/repo` from its `origin` remote. The signals
+ * pipeline selects the implementation repo from this value, so only a real
+ * remote counts — no remote (or a non-GitHub-shaped URL) means there is
+ * nothing the review could ship a PR to, and the upload is skipped.
+ */
+export function parseRepositoryFromGitRemote(
+  installDir: string,
+): string | null {
+  try {
+    const url = childProcess
+      .execSync('git remote get-url origin', {
+        cwd: installDir,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      .toString()
+      .trim();
+    // git@github.com:acme/my-app.git or https://github.com/acme/my-app.git
+    const match = url.match(/[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
+    if (match) return `${match[1]}/${match[2]}`;
+  } catch {
+    // not a git repo, or no origin remote
+  }
+  return null;
+}
+
+/**
+ * Upload the audit's check ledger for the signals setup review.
+ * Wired as the audit program's `postRun`, so it only fires after a
+ * successful run. Never throws.
+ */
+export async function uploadSetupReview(
+  session: WizardSession,
+  credentials: Credentials,
+  fetchImpl: typeof fetch = (...args) => fetch(...args),
+): Promise<void> {
+  try {
+    if (session.ci) return;
+
+    const repository = parseRepositoryFromGitRemote(session.installDir);
+    if (!repository) {
+      debug('[setup-review] no origin remote, skipping upload');
+      return;
+    }
+
+    const ledgerPath = path.join(session.installDir, AUDIT_CHECKS_FILE);
+    let checks;
+    try {
+      checks = coerceAuditChecks(
+        JSON.parse(fs.readFileSync(ledgerPath, 'utf8')),
+      );
+    } catch {
+      debug('[setup-review] no readable check ledger, skipping upload');
+      return;
+    }
+    if (checks.length === 0) return;
+
+    const url = `${credentials.host.apiHost.replace(/\/$/, '')}/api/projects/${
+      credentials.projectId
+    }/wizard/sessions/setup_review/`;
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${credentials.accessToken}`,
+      },
+      body: JSON.stringify({
+        repository,
+        checks: checks.slice(0, MAX_UPLOAD_CHECKS),
+      }),
+    });
+    debug(`[setup-review] upload status ${response.status}`);
+  } catch (err) {
+    debug('[setup-review] upload failed', err);
+  }
+}

--- a/src/lib/programs/self-driving/index.ts
+++ b/src/lib/programs/self-driving/index.ts
@@ -4,7 +4,8 @@ import type { ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import { OutroKind } from '@lib/wizard-session';
 import { createSkillProgram } from '../agent-skill/index.js';
-import { SELF_DRIVING_PROGRAM } from './steps.js';
+import { uploadSetupReview } from '../audit/setup-review.js';
+import { integrationDir, SELF_DRIVING_PROGRAM } from './steps.js';
 import { SELF_DRIVING_ABORT_CASES } from './detect.js';
 import { buildSelfDrivingPrompt } from './prompt.js';
 import { getTips } from './content/tips.js';
@@ -66,8 +67,16 @@ const run: ProgramRun = {
   // only self-driving runs emit these; every other program is unchanged.
   trackStepProgress: true,
 
-  postRun: async (session) => {
+  postRun: async (session, credentials) => {
     await removeInstalledSkill(session.installDir);
+    // Ship the audit-run step's check ledger for the signals setup review.
+    // Deliberately here, not on the audit run itself: self-driving has just
+    // connected GitHub, so the review's PRs have a repo to land in. No-op when
+    // the audit was skipped or produced nothing.
+    await uploadSetupReview(
+      { ...session, installDir: integrationDir(session) },
+      credentials,
+    );
   },
 
   buildOutroData: (_session, credentials) => {

--- a/src/lib/programs/self-driving/steps.ts
+++ b/src/lib/programs/self-driving/steps.ts
@@ -2,7 +2,7 @@
  * Self-driving program step list.
  *
  * detect → intro → integration-check → health-check → auth → integrate-detect →
- * integrate-run → self-driving-handoff → run → outro. A deterministic check in
+ * integrate-run → audit-run → self-driving-handoff → run → outro. A deterministic check in
  * `detect` decides whether PostHog is already in the project: found → the
  * integration screens are skipped and the integrate-run phase never shows; not
  * found → integration-check reports it and the only action sets up PostHog.
@@ -19,6 +19,7 @@ import type { ProgramStep } from '@lib/programs/program-step';
 import { RunPhase, type WizardSession } from '@lib/wizard-session';
 import { HEALTH_CHECK_STEP } from '@lib/programs/shared/health-check-step';
 import { integrationRunStep } from '@lib/programs/posthog-integration/index';
+import { auditRunStep } from '@lib/programs/audit/index';
 import {
   detectSelfDrivingPrerequisites,
   POSTHOG_PRESENT_KEY,
@@ -36,7 +37,7 @@ const postHogPresent = (session: WizardSession): boolean =>
  * repo (defense-in-depth on top of the coerce-layer clamp), fall back to
  * the root rather than run the agent elsewhere.
  */
-const integrationDir = (session: WizardSession): string => {
+export const integrationDir = (session: WizardSession): string => {
   const rel = session.frameworkContext[SELF_DRIVING_INTEGRATE_PATH_KEY];
   if (typeof rel !== 'string' || rel === '.') return session.installDir;
   const root = resolve(session.installDir);
@@ -108,6 +109,17 @@ export const SELF_DRIVING_PROGRAM: ProgramStep[] = [
     targetDir: integrationDir,
     show: (session) => session.integrate === true,
     isComplete: (session) => session.completedRuns.includes('integrate-run'),
+  },
+  {
+    // The audit's run step, composed like integrate-run: it audits whatever
+    // PostHog setup exists (pre-existing or the one integrate-run just wrote)
+    // and leaves the check ledger on disk; the host postRun uploads it for the
+    // signals setup review once self-driving is fully set up. Best-effort — an
+    // audit failure never blocks the self-driving setup. Skipped when the user
+    // declined the integration (no PostHog to audit).
+    ...auditRunStep,
+    targetDir: integrationDir,
+    show: (session) => postHogPresent(session) || session.integrate === true,
   },
   {
     // Handoff after the integration run: "PostHog is installed — now set up


### PR DESCRIPTION
## Problem

PostHog/posthog#70681 gives cloud wizard runs a post-onboarding setup review: the audit's check ledger feeds the signals pipeline, which ships complimentary implementation PRs to the inbox. local runs never get it — `wizard audit` throws the ledger away, and `wizard self-driving` on a repo with existing posthog never audits at all, so locally onboarded teams start with a cold inbox.

## Changes

goal: `wizard self-driving` on a repo with existing posthog → audit runs → meaningful findings ship a review that creates PR(s) in the inbox.

- new `uploadSetupReview`: POSTs the check ledger to `/api/projects/{id}/wizard/sessions/setup_review/` (bearer auth with the run's oauth token, `wizard_session:write` scope). repository derived from the `origin` remote (no remote → skip), fail-silent, skipped when `session.ci` is set (cloud runs capture the ledger themselves and wait for the PR merge)
- `wizard audit all` uploads via its `postRun`
- self-driving composes the audit as a run step (after integrate-run, before the handoff): it audits pre-existing or freshly integrated posthog, and self-driving's `postRun` uploads the ledger once setup succeeded — by then github is connected, so the review's PRs have a repo to land in
- new `ProgramRun.bestEffort`: a complimentary composed run degrades agent errors to a no-op instead of aborting the host (yara still aborts). the audit never blocks self-driving setup

server owns all policy: one review per team ever, org AI consent, billing exemption.

companion posthog change (the endpoint): PostHog/posthog#71011

## Test plan

`vitest run src/lib/programs/` + agent suites (440 passing): upload payload/auth/caps/skip paths, audit-run step placement + show/targetDir, composed run is best-effort without its own upload, postRun uploads from the integration dir. not yet tested end to end against a live stack.

## LLM context

claude code session directed by dawid, port of the cloud setup review (PostHog/posthog#70681) to local runs.
