### PR TITLE
feat(cli): scope headless flag to base integration + audit

### DIFF
--- a/src/__tests__/headless-scope.test.ts
+++ b/src/__tests__/headless-scope.test.ts
@@ -1,0 +1,37 @@
+import { auditCommand } from '../commands/audit';
+import { basicIntegrationCommand } from '../commands/basic-integration';
+import { revenueCommand } from '../commands/revenue';
+import { HEADLESS_FLAG } from '../lib/headless-mode';
+import { GLOBAL_OPTIONS } from '../wizard';
+import { parseCommand } from './helpers/parse-command.no-jest';
+
+// The experimental headless flag is scoped to exactly two surfaces — the base
+// integration flow (`wizard`) and `wizard audit` — rather than being a global
+// flag. These tests pin that scope so a future change can't silently re-globalise
+// it or leak it onto another command.
+describe('headless flag scope', () => {
+  test('is not a global option', () => {
+    expect(GLOBAL_OPTIONS).not.toHaveProperty(HEADLESS_FLAG);
+  });
+
+  test('is declared on the base integration command', () => {
+    expect(basicIntegrationCommand.options).toHaveProperty(HEADLESS_FLAG);
+  });
+
+  test('is declared on the audit command', () => {
+    expect(auditCommand.options).toHaveProperty(HEADLESS_FLAG);
+  });
+
+  test('is NOT declared on an unrelated native command', () => {
+    expect(revenueCommand.options ?? {}).not.toHaveProperty(HEADLESS_FLAG);
+  });
+
+  test('audit parses the flag under its declared key (end-to-end yargs)', async () => {
+    const argv = await parseCommand(
+      auditCommand,
+      `audit events --${HEADLESS_FLAG} --api-key pha_x --install-dir /tmp/app`,
+    );
+    expect(argv.skill).toBe('events');
+    expect(argv[HEADLESS_FLAG]).toBe(true);
+  });
+});

--- a/src/commands/basic-integration/index.ts
+++ b/src/commands/basic-integration/index.ts
@@ -1,6 +1,6 @@
 import { isNonInteractiveEnvironment } from '@utils/environment';
 import { setEntryCommand } from '@utils/links';
-import { isHeadless } from '@lib/headless-mode';
+import { headlessOption, isHeadless } from '@lib/headless-mode';
 import { provisionCommand } from '../provision';
 import type { Command } from '../command';
 
@@ -29,6 +29,9 @@ export const basicIntegrationCommand: Command = {
       type: 'boolean',
       hidden: true,
     },
+    // The experimental headless flag — declared here (and on `audit`) rather
+    // than globally. Routed by this command's handler via runHeadlessInstall.
+    ...headlessOption,
   },
   check: (argv) => {
     // --playground is the standalone TUI demo; it can't combine with a

--- a/src/lib/headless-mode.ts
+++ b/src/lib/headless-mode.ts
@@ -15,11 +15,32 @@
  * the scary name out of every other file so a future rename is one edit here.
  */
 
+import type { Options } from 'yargs';
+
 /**
  * The on-CLI flag name. Intentionally ugly + undocumented; do not surface it in
  * `--help`, the README, or user-facing error messages.
  */
 export const HEADLESS_FLAG = 'headless-DONOTUSE-EXPERIMENTAL';
+
+/**
+ * The yargs option declaration for the headless flag. Declared per-command
+ * (basic integration + audit) rather than globally, so no other command
+ * accepts it. Spread into a command's `options` to opt it into headless.
+ */
+export const headlessOption: Record<string, Options> = {
+  [HEADLESS_FLAG]: {
+    default: false,
+    // EXPERIMENTAL + UNSTABLE: the non-interactive published-build run path.
+    // Declared unconditionally (unlike --ci) so it works in the shipped
+    // package, but hidden and intentionally ugly-named — the contract may
+    // break without notice, so it must not be advertised.
+    describe:
+      'EXPERIMENTAL — do not use. Unstable, subject to breaking changes.',
+    type: 'boolean',
+    hidden: true,
+  },
+};
 
 /**
  * Read the headless signal off a parsed argv / options bag. yargs always sets

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -7,6 +7,7 @@ import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { WizardSession } from '@lib/wizard-session';
 import { OutroKind } from '@lib/wizard-session';
 import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
+import { headlessOption } from '@lib/headless-mode';
 import { AUDIT_ABORT_CASES } from './detect.js';
 import { AUDIT_CHECKS_KEY, AUDIT_REPORT_FILE } from './types.js';
 import { AUDIT_SEED_CHECKS, seedAuditLedger } from './seed.js';
@@ -98,4 +99,8 @@ export const auditConfig: ProgramConfig = {
   run: auditRun,
   allowedTools: ['Agent'],
   disallowedTools: [WIZARD_TOOL_NAMES.wizardAsk],
+  // The experimental headless flag — declared on `audit` (and basic
+  // integration) rather than globally. mergeCommandOptions lands it on the
+  // `wizard audit` command; dispatchProgram routes it to runWizardHeadless.
+  cliOptions: { ...headlessOption },
 };

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -2,7 +2,6 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import type { Argv } from 'yargs';
 import { IS_PRODUCTION_BUILD } from '@env';
-import { HEADLESS_FLAG } from '@lib/headless-mode';
 import { Harness, Sequence } from '@lib/constants';
 import { toCommandModule, type Command } from './commands/command';
 
@@ -54,17 +53,9 @@ export const GLOBAL_OPTIONS = {
   },
   // ── Internal modes ─────────────────────────────────────────────────
   // Hidden from `--help`. See CONTRIBUTING.md for what each one does.
-  [HEADLESS_FLAG]: {
-    default: false,
-    // EXPERIMENTAL + UNSTABLE: the non-interactive published-build run path.
-    // Declared unconditionally (unlike --ci) so it works in the shipped
-    // package, but hidden and intentionally ugly-named — the contract may
-    // break without notice, so it must not be advertised. See @lib/headless-mode.
-    describe:
-      'EXPERIMENTAL — do not use. Unstable, subject to breaking changes.',
-    type: 'boolean' as const,
-    hidden: true,
-  },
+  // NB: the experimental headless flag is deliberately NOT global — it's
+  // declared per-command (basic integration + audit) via `headlessOption`
+  // in @lib/headless-mode, so no other command accepts it.
   'local-mcp': {
     default: false,
     describe:
@@ -107,9 +98,11 @@ export class Wizard {
     // it there as an unknown argument — exactly like any other unrecognized
     // flag. init() additionally detects it up front to print a clearer message.
     // The published-build, non-interactive path is the experimental headless
-    // flag (declared unconditionally in GLOBAL_OPTIONS, see @lib/headless-mode);
-    // --ci and headless are kept as separate flags so they can diverge — see
-    // basic-integration's dispatch. headless is deliberately not advertised.
+    // flag — declared per-command on basic integration + audit via
+    // `headlessOption` (see @lib/headless-mode), not globally, so no other
+    // command accepts it. --ci and headless are kept as separate flags so they
+    // can diverge — see basic-integration's dispatch. headless is deliberately
+    // not advertised.
     if (!IS_PRODUCTION_BUILD) {
       cli = cli
         .option('ci', {


### PR DESCRIPTION
## Summary

The experimental headless flag (`--headless-DONOTUSE-EXPERIMENTAL`) was registered globally in `GLOBAL_OPTIONS`, so **every** command accepted it. This scopes it to the only two surfaces that should support it: the base integration flow (`wizard`) and `wizard audit`.

Follow-up to #893. A literal revert of that commit wasn't the right move — `wizard audit` reaches its runner *through* the same shared `dispatchProgram` it modified, so reverting would break audit's headless too. Instead, the flag's **declaration** moves from global to per-command; `dispatchProgram`'s routing stays, and strict-mode yargs now rejects `--headless…` on any command that doesn't declare the option.

Headless has never shipped, so there's no back-compat — no aliases needed.

## Changes

- **`src/lib/headless-mode.ts`** — export a reusable `headlessOption` (yargs `Options`), keeping the intentionally-ugly flag name centralized in the module that already owns it.
- **`src/wizard.ts`** — remove the flag from `GLOBAL_OPTIONS` (+ unused import); update the explanatory comment.
- **`src/commands/basic-integration/index.ts`** — spread `headlessOption` into the base flow's `options` (its handler already routes headless via `runHeadlessInstall`).
- **`src/lib/programs/audit/index.ts`** — add `cliOptions: { ...headlessOption }` to `auditConfig`, landing the flag on `wizard audit` via `mergeCommandOptions`.
- **`src/__tests__/headless-scope.test.ts`** (new) — pins the scope: not global, present on `wizard` + `audit`, absent on an unrelated native command, plus an end-to-end yargs parse of `audit events --headless…`.

## Net effect

- `--headless-DONOTUSE-EXPERIMENTAL` accepted **only** on `wizard` and `wizard audit`.
- Every other native command (`revenue-analytics`, `warehouse`, `upload-source-maps`, `slack`, `self-driving`, `migrate`) rejects it as unknown.

## Verification

- `pnpm build` ✓
- `pnpm test` — 1328 passed (99 files) ✓
- `pnpm lint` — 0 errors ✓

## Manual testing

Ran the built CLI (`tsx bin.ts …`) against a real project (`--region us --project-id <redacted>`, personal API key redacted). All commands below share these redacted flags:

```
--headless-DONOTUSE-EXPERIMENTAL --region us --project-id <id> --api-key <phx_…> --install-dir <app>
```

### ✅ Headless accepted + runs on the two allowed commands (both ran to completion)

```bash
tsx bin.ts --headless-DONOTUSE-EXPERIMENTAL --region us --project-id <id> --api-key <key> --install-dir <js-web-app>
# → "Running posthog-integration in Headless mode" → agent ran all 7 steps
# → exit 0, "PostHog integration complete", dashboard created

tsx bin.ts audit events --headless-DONOTUSE-EXPERIMENTAL --region us --project-id <id> --api-key <key> --install-dir <audit-app>
# → "Running agent-skill in Headless mode" → agent ran
# → exit 0, "audit-events complete!", report written
```

### ✅ Headless rejected on every other command (strict-mode yargs)

```bash
tsx bin.ts revenue-analytics   --headless-DONOTUSE-EXPERIMENTAL   # ✖ Unknown arguments: headless-DONOTUSE-EXPERIMENTAL
tsx bin.ts upload-source-maps  --headless-DONOTUSE-EXPERIMENTAL   # ✖ Unknown arguments
tsx bin.ts doctor             --headless-DONOTUSE-EXPERIMENTAL    # ✖ Unknown arguments
tsx bin.ts migrate            --headless-DONOTUSE-EXPERIMENTAL    # ✖ Unknown arguments
tsx bin.ts warehouse          --headless-DONOTUSE-EXPERIMENTAL    # ✖ Unknown arguments
tsx bin.ts self-driving       --headless-DONOTUSE-EXPERIMENTAL    # ✖ Unknown arguments
tsx bin.ts slack              --headless-DONOTUSE-EXPERIMENTAL    # ✖ Unknown arguments
tsx bin.ts mcp tutorial       --headless-DONOTUSE-EXPERIMENTAL    # ✖ Unknown arguments
tsx bin.ts skill audit-events --headless-DONOTUSE-EXPERIMENTAL    # ✖ Unknown arguments
```

### ✅ `--ci` path unaffected (still reaches the agent; stopped once the agent was up)

```bash
tsx bin.ts --ci --region us --project-id <id> --api-key <key> --install-dir <js-web-app>
# → "Running posthog-integration in CI mode" → "Agent initialized. Let's get cooking!" → running steps

tsx bin.ts audit events --ci --region us --project-id <id> --api-key <key> --install-dir <audit-app>
# → "Running agent-skill in CI mode" → "Agent initialized. Let's get cooking!" → running audit steps
```

> Full runs used throwaway copies of the workbench test apps (base integration mutates files); the workbench apps themselves were left untouched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
