### PR TITLE
feat(orchestrator): fail the run properly on a missing skill variant

### DIFF
--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -14,6 +14,8 @@ import { randomUUID } from 'crypto';
 import { existsSync, rmSync } from 'fs';
 import * as path from 'path';
 import { OutroKind, type WizardSession } from '@lib/wizard-session';
+import { POSTHOG_DOCS_URL, type Integration } from '@lib/constants';
+import { FRAMEWORK_REGISTRY } from '@lib/registry';
 import {
   installSkillById,
   fetchSkillMenu,
@@ -269,14 +271,18 @@ export async function runOrchestrator(
     }
   }
   if (missingVariants.length > 0) {
+    // The framework's own docs page from its config; generic docs when detection found none.
+    const docsUrl = session.skillId
+      ? FRAMEWORK_REGISTRY[session.skillId as Integration]?.docsUrl
+      : undefined;
     await wizardAbort({
       message:
         'Setup instructions for this project failed to download.\n' +
         'Please try again, or contact wizard@posthog.com.\n\n' +
         'You can also set up with your agent by downloading the skills here:\n' +
-        '  https://github.com/PostHog/skills\n' +
+        '  https://github.com/PostHog/context-mill/releases\n' +
         'or integrate manually here:\n' +
-        '  https://posthog.com/docs/getting-started/install',
+        `  ${docsUrl ?? POSTHOG_DOCS_URL}`,
       error: new WizardError('Orchestrator preflight: skill variant missing', {
         missing: missingVariants.join(', '),
         framework: session.skillId,

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -13,7 +13,6 @@
 import { randomUUID } from 'crypto';
 import { existsSync, rmSync } from 'fs';
 import * as path from 'path';
-import { IS_PRODUCTION_BUILD } from '@env';
 import { OutroKind, type WizardSession } from '@lib/wizard-session';
 import {
   installSkillById,
@@ -24,6 +23,7 @@ import { getUI } from '@ui';
 import { analytics } from '@utils/analytics';
 import { ciExcludedTaskTypes } from '@utils/ci-flag-overrides';
 import { logToFile } from '@utils/debug';
+import { wizardAbort, WizardError } from '@utils/wizard-abort';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { BootstrapResult } from '../../shared/types';
 import {
@@ -248,12 +248,7 @@ export async function runOrchestrator(
     );
   }
 
-  // Preflight every task's mini-skills. A missing variant means the task runs
-  // skill-less — a silent zero-diff — so log + capture it on every build. In
-  // dev and CI the run then crashes so the gap can't slip through a test pass;
-  // the throw sits behind !IS_PRODUCTION_BUILD, which tsdown inlines to a
-  // literal, so it is stripped from the published bundle (real users get the
-  // degraded run, never a crash).
+  // Preflight every task's mini-skills: a miss would run tasks skill-less, so fail properly instead.
   const missingVariants: string[] = [];
   for (const type of registry.types) {
     for (const skillId of registry.get(type)?.skills ?? []) {
@@ -273,14 +268,15 @@ export async function runOrchestrator(
       });
     }
   }
-  if (!IS_PRODUCTION_BUILD && missingVariants.length > 0) {
-    throw new Error(
-      `Orchestrator preflight: no skill variant for ${missingVariants.join(
-        ', ',
-      )} (framework=${
-        session.skillId ?? 'none'
-      }) — fix the context-mill menu or the framework mapping.`,
-    );
+  if (missingVariants.length > 0) {
+    await wizardAbort({
+      message:
+        'Setup instructions for this project failed to download.\nPlease try again, or contact wizard@posthog.com.',
+      error: new WizardError('Orchestrator preflight: skill variant missing', {
+        missing: missingVariants.join(', '),
+        framework: session.skillId,
+      }),
+    });
   }
 
   // The client injects the basics (project context + the I/O contract) around

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -271,7 +271,12 @@ export async function runOrchestrator(
   if (missingVariants.length > 0) {
     await wizardAbort({
       message:
-        'Setup instructions for this project failed to download.\nPlease try again, or contact wizard@posthog.com.',
+        'Setup instructions for this project failed to download.\n' +
+        'Please try again, or contact wizard@posthog.com.\n\n' +
+        'You can also set up with your agent by downloading the skills here:\n' +
+        '  https://github.com/PostHog/skills\n' +
+        'or integrate manually here:\n' +
+        '  https://posthog.com/docs/getting-started/install',
       error: new WizardError('Orchestrator preflight: skill variant missing', {
         missing: missingVariants.join(', '),
         framework: session.skillId,


### PR DESCRIPTION
Addresses @sarahxsanders's review comment on #853 (https://github.com/PostHog/wizard/pull/853#discussion_r3589614813): the preflight previously crashed in dev/CI builds only and silently degraded in production. One behavior everywhere is easier to maintain, so this replaces the tree-shaken throw with an unconditional `wizardAbort`:

- The user gets the error outro: *"Setup instructions for this project failed to download. Please try again, or contact wizard@posthog.com."*
- The `WizardError` context carries every missing `type/skill` pair and the framework, captured to analytics via `captureException`.
- The per-miss log line and `orchestrator skill variant missing` capture (on the wizard-switchboard dashboard) are unchanged.
- The `IS_PRODUCTION_BUILD` gate and its tree-shake reasoning are gone.

Same `wizardAbort({message, error: WizardError})` pattern as `abortOnInstallFailure` uses for linear-flow skill-install failures.

## Testing

`pnpm build` + orchestrator/loader suites green (171 tests), full suite + lint green on the pre-cherry-pick branch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*