### PR TITLE
fix(oauth): request event definition write scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,12 @@ the allow-list to keep in sync — a net-new scope (e.g.
 it:
 
 ```
-user:read,project:read,llm_gateway:read,dashboard:read,dashboard:write,insight:read,insight:write,query:read,notebook:read,notebook:write,health_issue:read,wizard_session:read,wizard_session:write,feature_flag:read,experiment:read,experiment_saved_metric:read,survey:read,session_recording:read,error_tracking:read,web_analytics:read,llm_analytics:read,cohort:read,person:read,annotation:read,annotation:write,activity_log:read,property_definition:read,event_definition:read,action:read,warehouse_table:read,warehouse_view:read,external_data_source:read,external_data_source:write,alert:read,subscription:read,feature_flag:write,integration:read,organization:read,task:read,task:write,signal_scout:read,signal_scout:write,external_data_source:read,external_data_source:write,llm_skill:read,llm_skill:write,product_enablement:write
+user:read,project:read,llm_gateway:read,dashboard:read,dashboard:write,insight:read,insight:write,query:read,notebook:read,notebook:write,health_issue:read,wizard_session:read,wizard_session:write,feature_flag:read,experiment:read,experiment_saved_metric:read,survey:read,session_recording:read,error_tracking:read,web_analytics:read,llm_analytics:read,cohort:read,person:read,annotation:read,annotation:write,activity_log:read,property_definition:read,event_definition:read,event_definition:write,action:read,warehouse_table:read,warehouse_view:read,external_data_source:read,external_data_source:write,alert:read,subscription:read,feature_flag:write,integration:read,organization:read,task:read,task:write,signal_scout:read,signal_scout:write,external_data_source:read,external_data_source:write,llm_skill:read,llm_skill:write,product_enablement:write
 ```
+
+If an existing Wizard authorization predates a newly required scope, reconnect
+the Wizard OAuth app. Refresh tokens retain their original grant and cannot be
+used to silently add permissions.
 
 # Command changes (CLI overhaul)
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -201,6 +201,9 @@ export const DUMMY_PROJECT_API_KEY = '_YOUR_POSTHOG_PROJECT_TOKEN_';
  * - notebook:write    upload the events-audit report as a PostHog notebook
  *                     in step 6 of the events-audit skill (notebooks-create
  *                     MCP tool requires this scope)
+ * - event_definition:write
+ *                     create event definitions from the completed wizard
+ *                     session's event plan
  *
  * Must be a subset of `ALLOWED_PROVISIONING_SCOPES` in
  * `ee/api/agentic_provisioning/views.py` on the backend.
@@ -213,6 +216,7 @@ export const WIZARD_PROVISIONING_SCOPES = [
   'insight:write',
   'query:read',
   'notebook:write',
+  'event_definition:write',
 ] as const;
 
 /**
@@ -222,6 +226,8 @@ export const WIZARD_PROVISIONING_SCOPES = [
  * - health_issue:read     used by `wizard doctor`
  * - wizard_session:read   list / retrieve / stream sessions
  * - wizard_session:write  stream run state to /api/projects/{id}/wizard/sessions/
+ * - event_definition:write
+ *                          create event definitions when a session completes
  * - organization:read     read `organization.is_ai_data_processing_approved`
  *                         from /api/users/@me/ for the AI opt-in gate
  *

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -1,4 +1,14 @@
-import { extractOAuthCode, isAuthorizationTimeout } from '@utils/oauth';
+import {
+  assertWizardCompletionScope,
+  extractOAuthCode,
+  isAuthorizationTimeout,
+  parseOAuthScopes,
+} from '@utils/oauth';
+import {
+  WIZARD_OAUTH_SCOPES,
+  WIZARD_PROVISIONING_SCOPES,
+} from '@lib/constants';
+import { getOAuthScopesForProgram } from '@lib/oauth/program-scopes';
 
 describe('extractOAuthCode', () => {
   it('extracts the code from a full callback URL', () => {
@@ -68,5 +78,44 @@ describe('isAuthorizationTimeout', () => {
     const error = new Error('Authorization timed out');
     expect(error.message).not.toContain('timeout');
     expect(isAuthorizationTimeout(error)).toBe(true);
+  });
+});
+
+describe('wizard OAuth scopes', () => {
+  it('requests both scopes required to complete wizard sessions', () => {
+    const scopes = getOAuthScopesForProgram(null);
+
+    expect(scopes).toContain('wizard_session:write');
+    expect(scopes).toContain('event_definition:write');
+    expect(WIZARD_OAUTH_SCOPES).toEqual(
+      expect.arrayContaining([...WIZARD_PROVISIONING_SCOPES]),
+    );
+  });
+
+  it('accepts a newly issued token with the completion scope', () => {
+    expect(() =>
+      assertWizardCompletionScope(
+        'user:read wizard_session:write event_definition:write',
+      ),
+    ).not.toThrow();
+  });
+
+  it('asks legacy authorizations to reconnect before completion', () => {
+    expect(() =>
+      assertWizardCompletionScope('user:read wizard_session:write'),
+    ).toThrow(/missing.*event_definition:write.*Reconnect.*revoke/is);
+  });
+
+  it('preserves unrelated granted scopes when parsing the token response', () => {
+    expect(
+      parseOAuthScopes(
+        'user:read project:read wizard_session:write event_definition:write',
+      ),
+    ).toEqual([
+      'user:read',
+      'project:read',
+      'wizard_session:write',
+      'event_definition:write',
+    ]);
   });
 });

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -102,6 +102,7 @@ describe('provisionNewAccount', () => {
       'insight:write',
       'query:read',
       'notebook:write',
+      'event_definition:write',
     ]);
 
     // Verify token exchange includes code_verifier

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -59,6 +59,20 @@ const OAuthTokenResponseSchema = z.object({
 
 export type OAuthTokenResponse = z.infer<typeof OAuthTokenResponseSchema>;
 
+export const WIZARD_COMPLETION_SCOPE = 'event_definition:write';
+
+export function parseOAuthScopes(scope: string): string[] {
+  return scope.split(/\s+/).filter(Boolean);
+}
+
+export function assertWizardCompletionScope(scope: string): void {
+  if (parseOAuthScopes(scope).includes(WIZARD_COMPLETION_SCOPE)) return;
+
+  throw new Error(
+    `Your existing PostHog Wizard authorization is missing the ${WIZARD_COMPLETION_SCOPE} permission required to finish setup. Reconnect the wizard and approve the updated permissions. If PostHog reuses the old approval, revoke the existing Wizard authorization first, then rerun the wizard.`,
+  );
+}
+
 // Stable marker for the authorization-flow timeout. Detection keys off the exact
 // message rather than a loose substring — `.includes('timeout')` never matched
 // `'timed out'`, which silently routed timeouts to the generic failure message.

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -20,7 +20,7 @@ import type { ProgramId } from '@lib/programs/program-registry';
 import { analytics } from './analytics';
 import { getUI } from '@ui';
 import { HostResolution } from '@lib/host-resolution';
-import { performOAuthFlow } from './oauth';
+import { assertWizardCompletionScope, performOAuthFlow } from './oauth';
 import { resolveGrantedProject } from './project-resolution';
 import { provisionNewAccount } from './provisioning';
 import {
@@ -576,6 +576,19 @@ async function askForWizardLogin(options: {
     projectId: options.projectId,
     baseUrl: options.baseUrl,
   });
+
+  try {
+    assertWizardCompletionScope(tokenResponse.scope);
+  } catch (error) {
+    const scopeError =
+      error instanceof Error ? error : new Error('OAuth scope check failed');
+    analytics.captureException(scopeError, {
+      step: 'wizard_login',
+      missing_scope: 'event_definition:write',
+    });
+    getUI().log.error(scopeError.message);
+    await abort();
+  }
 
   // `--project-id`, when provided, is authoritative — but only if the user actually
   // granted access to it on the consent screen. If they authorized a different


### PR DESCRIPTION
## Problem

**Why:** PostHog PR [#70734](https://github.com/PostHog/posthog/pull/70734) requires `event_definition:write` when a wizard session completes. Without the updated grant, normal wizard completion can fail with a missing-scope `403`.

This change must deploy before or alongside that backend PR so wizard tokens have the required permission when the stricter enforcement reaches production.

## Changes

- Request `event_definition:write` in both browser OAuth and agentic provisioning flows while preserving the existing hidden wizard-session grant behavior.
- Detect legacy OAuth grants that lack the new scope and provide actionable reconnection guidance before setup proceeds.
- Update the documented OAuth application scope ceiling.

## Test plan

- `pnpm build`
- `pnpm test` (103 files, 1,421 tests)
- `pnpm fix`
- Focused OAuth, provisioning, and wizard-session destination tests
- `pnpm typecheck` still reports pre-existing errors outside the changed files; no diagnostics reference this PR's files.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
