### PR TITLE
fix(orchestrator): an outro with unfinished steps is not a success

### DIFF
--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import {
   QueueStore,
   QUEUE_DIR_NAME,
+  unfinishedSteps,
   type QueueFile,
   type TaskHandoff,
 } from '@lib/agent/runner/sequence/orchestrator/queue';
@@ -181,5 +182,40 @@ describe('QueueStore', () => {
     listened.start(t.id);
     listened.complete(t.id);
     expect(listened.get(t.id)?.status).toBe('done');
+  });
+});
+
+describe('unfinishedSteps', () => {
+  const counts = (over: Partial<Record<string, number>> = {}) => ({
+    pending: 0,
+    running: 0,
+    done: 0,
+    skipped: 0,
+    failed: 0,
+    ...over,
+  });
+
+  it('reports a fully done run as finished', () => {
+    expect(unfinishedSteps(counts({ done: 9 }))).toBe(0);
+  });
+
+  it('treats a skipped step as a real outcome, not unfinished work', () => {
+    expect(unfinishedSteps(counts({ done: 7, skipped: 2 }))).toBe(0);
+  });
+
+  it('counts a failed step as unfinished', () => {
+    expect(unfinishedSteps(counts({ done: 8, failed: 1 }))).toBe(1);
+  });
+
+  it('counts a step that never ran as unfinished', () => {
+    expect(unfinishedSteps(counts({ done: 4, pending: 5 }))).toBe(5);
+  });
+
+  it('counts a step still running as unfinished', () => {
+    expect(unfinishedSteps(counts({ done: 8, running: 1 }))).toBe(1);
+  });
+
+  it('counts the 4/9 partial run that the outro used to call a success', () => {
+    expect(unfinishedSteps(counts({ done: 4, pending: 4, failed: 1 }))).toBe(5);
   });
 });

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -515,18 +515,36 @@ export async function runOrchestrator(
     ? 'posthog-setup-report.md'
     : store.queuePath;
 
-  const message = conflict
+  // A step the agent skipped is a real outcome — it reported the step does not
+  // apply. A step that failed, or never ran before the queue drained, means the
+  // integration is incomplete, and saying otherwise sends the user away believing
+  // in work that does not exist.
+  const unfinished =
+    summary[TaskStatus.Failed] +
+    summary[TaskStatus.Pending] +
+    summary[TaskStatus.Running];
+
+  const message = unfinished
+    ? `PostHog partially set up: ${summary.done}/${summary.total} steps completed.`
+    : conflict
     ? 'PostHog set up, with one conflict to review.'
     : `PostHog set up: ${summary.done}/${summary.total} steps completed.`;
+
+  const unfinishedBody = unfinished
+    ? `⚠ ${unfinished} step${
+        unfinished === 1 ? '' : 's'
+      } did not complete. The integration is incomplete — check the report before relying on it.`
+    : undefined;
+
   getUI().setOutroData({
-    kind: OutroKind.Success,
+    kind: unfinished ? OutroKind.Error : OutroKind.Success,
     message,
     body: conflict
       ? `⚠ Build conflict: ${conflict}\nFull details are in the report.`
-      : undefined,
+      : unfinishedBody,
     reportFile,
     docsUrl: 'https://posthog.com/docs/ai-engineering/ai-wizard',
   });
   getUI().outro(message);
-  await analytics.shutdown('success');
+  await analytics.shutdown(unfinished ? 'error' : 'success');
 }

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -38,6 +38,7 @@ import {
   QueueStore,
   QUEUE_DIR_NAME,
   TaskStatus,
+  unfinishedSteps,
   type QueuedTask,
 } from './queue';
 import { drainQueue, type RunTask } from './executor';
@@ -515,14 +516,7 @@ export async function runOrchestrator(
     ? 'posthog-setup-report.md'
     : store.queuePath;
 
-  // A step the agent skipped is a real outcome — it reported the step does not
-  // apply. A step that failed, or never ran before the queue drained, means the
-  // integration is incomplete, and saying otherwise sends the user away believing
-  // in work that does not exist.
-  const unfinished =
-    summary[TaskStatus.Failed] +
-    summary[TaskStatus.Pending] +
-    summary[TaskStatus.Running];
+  const unfinished = unfinishedSteps(summary);
 
   const message = unfinished
     ? `PostHog partially set up: ${summary.done}/${summary.total} steps completed.`

--- a/src/lib/agent/runner/sequence/orchestrator/queue.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue.ts
@@ -27,6 +27,21 @@ export const TaskStatus = {
 
 export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
 
+/**
+ * How many steps left the integration incomplete.
+ *
+ * A skipped step is a real outcome — the agent reported the step does not apply.
+ * A step that failed, or never ran before the queue drained, means work the user
+ * is told to expect does not exist.
+ */
+export function unfinishedSteps(summary: Record<TaskStatus, number>): number {
+  return (
+    summary[TaskStatus.Failed] +
+    summary[TaskStatus.Pending] +
+    summary[TaskStatus.Running]
+  );
+}
+
 export interface QueuedTask {
   id: string;
   type: string;


### PR DESCRIPTION
The outro hardcoded success, so a run that failed or never finished a step still rendered ✔ and shut analytics down as a success — observed on a 4/9 run.