### PR TITLE
fix(wizard): stop reporting expected agent aborts as errors

### DIFF
--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -28,7 +28,7 @@ import { createWizardAskBridge } from '../../../wizard-ask-bridge';
 import type { ProgramConfig } from '../../../programs/program-step';
 import { assemblePrompt } from '../../agent-prompt';
 import type { ProgramRun, BootstrapResult } from '../shared/types';
-import { abortOnInstallFailure } from '../shared/errors';
+import { abortOnInstallFailure, resolveAbortOutcome } from '../shared/errors';
 import { shouldDisableAsk, sessionToOptions } from '../shared/bootstrap';
 import { resolveHarness, getHarness } from '../switchboard';
 
@@ -139,33 +139,13 @@ export async function runLinearProgram(
   // 9. Error handling (full set from both runners)
   if (agentResult.error === AgentErrorType.ABORT) {
     const reason = agentResult.message ?? '';
-    const matched = config.abortCases?.find((c) => c.match.test(reason));
-    const outroData: WizardSession['outroData'] = matched
-      ? {
-          kind: OutroKind.Error,
-          message: matched.message,
-          body: matched.body,
-          docsUrl: matched.docsUrl,
-        }
-      : {
-          kind: OutroKind.Error,
-          message: `${config.integrationLabel} aborted`,
-          body: reason || 'The agent aborted the program.',
-          docsUrl: config.docsUrl,
-        };
+    const { outroData, error, matched } = resolveAbortOutcome(reason, config);
     analytics.wizardCapture('agent aborted', {
       integration: config.integrationLabel,
       reason,
       matched: matched?.message ?? null,
     });
-    await wizardAbort({
-      outroData,
-      error: new WizardError(`Agent aborted: ${reason}`, {
-        integration: config.integrationLabel,
-        error_type: AgentErrorType.ABORT,
-        reason,
-      }),
-    });
+    await wizardAbort({ outroData, error });
   }
 
   if (agentResult.error === AgentErrorType.MCP_MISSING) {

--- a/src/lib/agent/runner/shared/__tests__/errors.test.ts
+++ b/src/lib/agent/runner/shared/__tests__/errors.test.ts
@@ -1,0 +1,95 @@
+import { resolveAbortOutcome } from '../errors';
+import { WizardError } from '@utils/wizard-abort';
+import { OutroKind } from '@lib/wizard-session';
+import type { AbortCase } from '../types';
+
+const ABORT_CASES: AbortCase[] = [
+  {
+    match: /^no mcp server found$/i,
+    message: 'No MCP server found',
+    body: 'This command instruments an existing MCP server.',
+    docsUrl: 'https://posthog.com/docs/mcp-analytics',
+  },
+  {
+    match: /^not a javascript mcp server$/i,
+    message: 'Not a JavaScript/TypeScript MCP server',
+    body: 'MCP analytics is currently TypeScript/JavaScript-only.',
+  },
+];
+
+const config = {
+  abortCases: ABORT_CASES,
+  integrationLabel: 'mcp-analytics',
+  docsUrl: 'https://posthog.com/docs',
+};
+
+describe('resolveAbortOutcome', () => {
+  it('does NOT report a matched (expected) abort to error tracking', () => {
+    const { outroData, error, matched } = resolveAbortOutcome(
+      'no mcp server found',
+      config,
+    );
+
+    // The whole point of the fix: expected user conditions carry no error.
+    expect(error).toBeUndefined();
+    expect(matched).toBe(ABORT_CASES[0]);
+    expect(outroData).toEqual({
+      kind: OutroKind.Error,
+      message: 'No MCP server found',
+      body: 'This command instruments an existing MCP server.',
+      docsUrl: 'https://posthog.com/docs/mcp-analytics',
+    });
+  });
+
+  it('matches case-insensitively and uses the first matching case', () => {
+    const { error, matched } = resolveAbortOutcome(
+      'NOT A JAVASCRIPT MCP SERVER',
+      config,
+    );
+
+    expect(error).toBeUndefined();
+    expect(matched).toBe(ABORT_CASES[1]);
+  });
+
+  it('reports an unrecognized abort as a WizardError with context', () => {
+    const { outroData, error, matched } = resolveAbortOutcome(
+      'something genuinely unexpected',
+      config,
+    );
+
+    expect(matched).toBeUndefined();
+    expect(error).toBeInstanceOf(WizardError);
+    expect(error?.message).toBe(
+      'Agent aborted: something genuinely unexpected',
+    );
+    expect((error as WizardError).context).toMatchObject({
+      integration: 'mcp-analytics',
+      reason: 'something genuinely unexpected',
+    });
+    expect(outroData).toMatchObject({
+      kind: OutroKind.Error,
+      message: 'mcp-analytics aborted',
+      body: 'something genuinely unexpected',
+      docsUrl: 'https://posthog.com/docs',
+    });
+  });
+
+  it('falls back to a generic body when an unrecognized abort has no reason', () => {
+    const { error, outroData } = resolveAbortOutcome('', config);
+
+    expect(error).toBeInstanceOf(WizardError);
+    expect(outroData).toMatchObject({
+      body: 'The agent aborted the program.',
+    });
+  });
+
+  it('reports as an error when a program declares no abort cases', () => {
+    const { error, matched } = resolveAbortOutcome('no mcp server found', {
+      integrationLabel: 'nextjs',
+      docsUrl: 'https://posthog.com/docs',
+    });
+
+    expect(matched).toBeUndefined();
+    expect(error).toBeInstanceOf(WizardError);
+  });
+});

--- a/src/lib/agent/runner/shared/errors.ts
+++ b/src/lib/agent/runner/shared/errors.ts
@@ -4,6 +4,61 @@
 
 import type { InstallSkillResult } from '@lib/wizard-tools';
 import { wizardAbort, WizardError } from '@utils/wizard-abort';
+import { AgentErrorType } from '@lib/agent/agent-interface';
+import { OutroKind, type WizardSession } from '@lib/wizard-session';
+import type { AbortCase } from './types';
+
+/**
+ * Decide how to surface an agent `[ABORT] <reason>`.
+ *
+ * A `[ABORT]` is "distinct from errors" (see `AgentSignals.ABORT`): when the
+ * reason matches a program's declared {@link AbortCase} it's an expected user
+ * condition — no MCP server, an unsupported language, an unrecognizable repo —
+ * and must NOT be reported to error tracking. Only unrecognized aborts, which
+ * likely signal a genuine bug, carry a `WizardError` for `captureException`.
+ */
+export function resolveAbortOutcome(
+  reason: string,
+  config: {
+    abortCases?: AbortCase[];
+    integrationLabel: string;
+    docsUrl: string;
+  },
+): {
+  outroData: WizardSession['outroData'];
+  error?: WizardError;
+  matched: AbortCase | undefined;
+} {
+  const matched = config.abortCases?.find((c) => c.match.test(reason));
+  if (matched) {
+    return {
+      outroData: {
+        kind: OutroKind.Error,
+        message: matched.message,
+        body: matched.body,
+        docsUrl: matched.docsUrl,
+      },
+      // Expected condition — render the friendly outro, but do not report it.
+      error: undefined,
+      matched,
+    };
+  }
+
+  return {
+    outroData: {
+      kind: OutroKind.Error,
+      message: `${config.integrationLabel} aborted`,
+      body: reason || 'The agent aborted the program.',
+      docsUrl: config.docsUrl,
+    },
+    error: new WizardError(`Agent aborted: ${reason}`, {
+      integration: config.integrationLabel,
+      error_type: AgentErrorType.ABORT,
+      reason,
+    }),
+    matched,
+  };
+}
 
 export async function abortOnInstallFailure(
   integrationLabel: string,


### PR DESCRIPTION
## What it changes

The wizard keeps a short list of "expected reasons to stop" for each command, like no MCP server in the project, or a language it does not support. Before this PR, every stop was logged to error tracking as if it were a crash. Now the expected ones skip that logging. Only genuinely unexpected stops get flagged as errors.

## Why it works this way

An expected stop is not a failure. It is the wizard correctly recognizing a situation it cannot proceed in and bowing out cleanly. Logging those as exceptions buries the real crashes under noise, and a noisy error dashboard is how real problems, including security ones, slip past unnoticed. So the rule is simple. Known, matched stops are normal outcomes and stay quiet. Unknown stops are still reported, because those are the ones worth investigating.

## User experience

Nothing visible to the user. This is housekeeping. The payoff is internal. The error dashboard stops filling up with "no MCP server found" noise, so real bugs are easier to see. It is the foundation the other two PRs build on.

## Merge order

These three PRs are one fix in three parts. Merge in this order:

1. [wizard #920](https://github.com/PostHog/wizard/pull/920) — base of the wizard stack, merge first.
2. [wizard #929](https://github.com/PostHog/wizard/pull/929) — stacked on #920, merge after it.
3. [context-mill #252](https://github.com/PostHog/context-mill/pull/252) — release after #929, so the skill and the wizard light up together.

**This PR is step 1.**

Nothing breaks if they land out of order. #929 and #252 are each harmless on their own, they just do nothing until both are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
