### PR TITLE
feat(aio): add `wizard aio` command for AI observability setup

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -41,6 +41,7 @@ import { auditCommand } from './src/commands/audit';
 import { doctorCommand } from './src/commands/doctor';
 import { migrateCommand } from './src/commands/migrate';
 import { revenueCommand } from './src/commands/revenue';
+import { aioCommand } from './src/commands/aio';
 import { warehouseCommand } from './src/commands/warehouse';
 import { selfDrivingCommand } from './src/commands/self-driving';
 import { slackCommand } from './src/commands/slack';
@@ -72,6 +73,7 @@ Wizard.use(basicIntegrationCommand)
   .use(doctorCommand)
   .use(migrateCommand)
   .use(revenueCommand)
+  .use(aioCommand)
   .use(warehouseCommand)
   .use(selfDrivingCommand)
   .use(slackCommand)

--- a/src/commands/aio.ts
+++ b/src/commands/aio.ts
@@ -1,0 +1,13 @@
+import { aioConfig } from '@lib/programs/aio/index';
+
+import type { Command } from './command';
+import { nativeCommandFactory } from './factories/native-command-factory';
+
+/**
+ * `wizard aio` — flat skill command for AI observability (LLM analytics).
+ *
+ * Mirrors the `revenue-analytics` shape: a one-liner wrapping the program
+ * config. The default integration flow still offers AI observability as an
+ * opt-in add-on; this command runs the same setup standalone.
+ */
+export const aioCommand: Command = nativeCommandFactory(aioConfig);

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -102,6 +102,7 @@ export const DEFAULT_BINDING: ProgramBinding = {
 export const PROGRAM_BINDINGS: Partial<Record<ProgramId, ProgramBinding>> = {
   'posthog-integration': DEFAULT_BINDING,
   'revenue-analytics-setup': DEFAULT_BINDING,
+  'ai-observability': DEFAULT_BINDING,
   'warehouse-source': DEFAULT_BINDING,
   'error-tracking-upload-source-maps': DEFAULT_BINDING,
   audit: DEFAULT_BINDING,

--- a/src/lib/programs/aio/index.ts
+++ b/src/lib/programs/aio/index.ts
@@ -1,0 +1,33 @@
+import type { ProgramConfig } from '@lib/programs/program-step';
+import { createSkillProgram } from '../agent-skill/index.js';
+
+const REPORT_FILE = 'posthog-ai-observability-report.md';
+const DOCS_URL = 'https://posthog.com/docs/ai-engineering';
+
+/**
+ * `wizard aio` — set up PostHog AI observability (formerly LLM Analytics).
+ *
+ * Standalone entry point for the same instrumentation that the default flow
+ * offers as an opt-in add-on (the `AdditionalFeature.LLM` stop-hook step).
+ * Here it's a first-class program: install the `llm-analytics-setup` skill and
+ * run its workflow directly, on demand, without the full integration flow.
+ */
+export const aioConfig: ProgramConfig = createSkillProgram({
+  skillId: 'llm-analytics-setup',
+  command: 'aio',
+  id: 'ai-observability',
+  description: 'Set up PostHog AI observability (LLM analytics)',
+  integrationLabel: 'llm-analytics-setup',
+  customPrompt:
+    'Integrate AI observability with PostHog for this project. Follow the ' +
+    'installed llm-analytics-setup skill: detect the LLM SDK(s) in use, wire ' +
+    'up PostHog AI observability, and instrument the LLM calls. Update the ' +
+    'report markdown file when complete.',
+  successMessage:
+    'AI observability configured! You can view the report at ./posthog-ai-observability-report.md',
+  reportFile: REPORT_FILE,
+  docsUrl: DOCS_URL,
+  spinnerMessage: 'Setting up AI observability...',
+  estimatedDurationMinutes: 5,
+  requires: ['posthog-integration'],
+});

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -14,6 +14,7 @@ import type { ProgramConfig } from './program-step.js';
 import { POSTHOG_DOCS_URL } from '../constants.js';
 import { posthogIntegrationConfig } from './posthog-integration/index.js';
 import { revenueAnalyticsConfig } from './revenue-analytics/index.js';
+import { aioConfig } from './aio/index.js';
 import { warehouseSourceConfig } from './warehouse-source/index.js';
 import { auditConfig } from './audit/index.js';
 import { eventsAuditConfig } from './events-audit/index.js';
@@ -65,6 +66,7 @@ export const agentSkillConfig: ProgramConfig = {
 export const PROGRAM_REGISTRY = [
   posthogIntegrationConfig,
   revenueAnalyticsConfig,
+  aioConfig,
   warehouseSourceConfig,
   errorTrackingUploadSourceMapsConfig,
   auditConfig,
@@ -89,6 +91,7 @@ export const PROGRAM_REGISTRY = [
 export const Program = {
   PostHogIntegration: posthogIntegrationConfig.id,
   RevenueAnalyticsSetup: revenueAnalyticsConfig.id,
+  AiObservability: aioConfig.id,
   WarehouseSource: warehouseSourceConfig.id,
   ErrorTrackingUploadSourceMaps: errorTrackingUploadSourceMapsConfig.id,
   Migration: migrationConfig.id,


### PR DESCRIPTION
## Problem

AI observability (formerly LLM Analytics) instrumentation could only be reached as an opt-in add-on at the end of the default integration flow — there was no way to run it standalone. Requested so it can be triggered directly, e.g. when integration is already done.

## Changes

- New `aio` program (`src/lib/programs/aio/index.ts`) built on `createSkillProgram`, installing the `llm-analytics-setup` skill and running its workflow. Mirrors the `revenue-analytics` shape.
- New `wizard aio` command (`src/commands/aio.ts`) via `nativeCommandFactory`.
- Registered the program in `program-registry.ts` and added its switchboard binding; wired the command into `bin.ts`.

The default flow still offers AI observability as its stop-hook add-on — this just adds a first-class entry point for the same setup.

## Test plan

- `pnpm build && pnpm test && pnpm lint` — all 1442 tests pass, 0 lint errors.
- `node dist/bin.js aio --help` renders the command.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784306383799029?thread_ts=1784306383.799029&cid=C087XQ7K9K7)*
