### PR TITLE
feat(pi): wire the secret vault into wizard_ask and set_env_values

### DIFF
--- a/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
@@ -119,6 +119,32 @@ describe('pi set_env_values — resolves vault refs host-side', () => {
     expect(env).toContain(`ZENDESK_TOKEN=${SECRET}`);
   });
 
+  it('mixed values map: literal + secretRef written together, secret still never in output', async () => {
+    const { wizardAsk, setEnvValues, workingDirectory } = makeTools({
+      token: SECRET,
+    });
+    const asked = await call(wizardAsk, {
+      questions: [
+        { id: 'token', prompt: 'Zendesk token', kind: 'text', sensitive: true },
+      ],
+    });
+    const { answers } = JSON.parse(textOf(asked)) as {
+      answers: { token: { secretRef: string } };
+    };
+
+    const written = await call(setEnvValues, {
+      filePath: '.env',
+      values: {
+        POSTHOG_HOST: 'https://us.posthog.com',
+        ZENDESK_TOKEN: answers.token,
+      },
+    });
+    expect(textOf(written)).not.toContain(SECRET);
+    const env = await readFile(join(workingDirectory, '.env'), 'utf8');
+    expect(env).toContain('POSTHOG_HOST=https://us.posthog.com');
+    expect(env).toContain(`ZENDESK_TOKEN=${SECRET}`);
+  });
+
   it('an unknown ref fails with a clear error and writes nothing', async () => {
     const { setEnvValues, workingDirectory } = makeTools({});
     const result = await call(setEnvValues, {

--- a/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
@@ -1,69 +1,152 @@
 /**
- * pi wizard_ask — sensitive answers fail closed. pi has no secret-vault
- * wiring, so `sensitive: true` is rejected before the question ever reaches
- * the ask bridge (the MCP path vaults via secretRef instead).
+ * pi wizard_ask + set_env_values secret-vault contract (mirrors the MCP
+ * server): sensitive text answers come back as `{secretRef}` — never the raw
+ * value — and set_env_values resolves refs host-side into the .env file.
  */
+import { mkdtempSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
-import type { WizardAskBridge } from '@lib/wizard-ask-bridge';
+import {
+  CANCELLED_SENTINEL,
+  type WizardAskBridge,
+} from '@lib/wizard-ask-bridge';
 import { createWizardPiTools } from '../tools';
 
-const makeAsk = () => {
-  const request = vi.fn().mockResolvedValue({ q1: 'answer' });
+const SECRET = 'phx_live_zendesk_token_123';
+
+const makeTools = (answers: Record<string, string | string[]>) => {
+  const request = vi.fn().mockResolvedValue(answers);
+  const workingDirectory = mkdtempSync(join(tmpdir(), 'pi-tools-vault-'));
   const tools = createWizardPiTools({
-    workingDirectory: '/tmp',
+    workingDirectory,
     skillsBaseUrl: 'http://localhost:0',
     askBridge: { request } as unknown as WizardAskBridge,
   });
-  const wizardAsk = tools.find((t) => t.name === 'wizard_ask');
-  if (!wizardAsk) throw new Error('wizard_ask not registered');
-  return { wizardAsk, request };
+  const byName = (name: string) => {
+    const tool = tools.find((t) => t.name === name);
+    if (!tool) throw new Error(`${name} not registered`);
+    return tool;
+  };
+  return {
+    request,
+    workingDirectory,
+    wizardAsk: byName('wizard_ask'),
+    setEnvValues: byName('set_env_values'),
+  };
 };
 
 const textOf = (result: unknown) =>
   (result as { content: [{ text: string }] }).content[0].text;
 
-describe('pi wizard_ask sensitive fail-closed', () => {
-  it('rejects sensitive questions before reaching the ask bridge', async () => {
-    const { wizardAsk, request } = makeAsk();
-    const result = await wizardAsk.execute('call-1', {
+/** The ToolDefinition type wants the full runtime arity; the wizard tools only read (id, args). */
+const call = (tool: { execute: unknown }, args: unknown): Promise<unknown> =>
+  (tool.execute as (id: string, args: unknown) => Promise<unknown>)(
+    'call-1',
+    args,
+  );
+
+describe('pi wizard_ask — sensitive answers are vaulted', () => {
+  it('returns {secretRef}, never the raw value', async () => {
+    const { wizardAsk } = makeTools({ token: SECRET, tracker: 'linear' });
+    const result = await call(wizardAsk, {
+      questions: [
+        { id: 'token', prompt: 'Zendesk token', kind: 'text', sensitive: true },
+        { id: 'tracker', prompt: 'Which tracker?', kind: 'text' },
+      ],
+    });
+    const body = textOf(result);
+    expect(body).not.toContain(SECRET);
+    const { answers } = JSON.parse(body) as {
+      answers: { token: { secretRef: string }; tracker: string };
+    };
+    expect(answers.token.secretRef).toMatch(/^secret:/);
+    expect(answers.tracker).toBe('linear'); // non-sensitive stays literal
+  });
+
+  it('a cancelled sensitive answer is returned as the sentinel, not vaulted', async () => {
+    const { wizardAsk } = makeTools({ token: CANCELLED_SENTINEL });
+    const result = await call(wizardAsk, {
+      questions: [
+        { id: 'token', prompt: 'Zendesk token', kind: 'text', sensitive: true },
+      ],
+    });
+    const { answers } = JSON.parse(textOf(result)) as {
+      answers: { token: string };
+    };
+    expect(answers.token).toBe(CANCELLED_SENTINEL);
+  });
+
+  it('still rejects sensitive=true on non-text kinds', async () => {
+    const { wizardAsk, request } = makeTools({});
+    const result = await call(wizardAsk, {
       questions: [
         {
-          id: 'token',
-          prompt: 'Paste your API key',
-          kind: 'text',
+          id: 'pick',
+          prompt: 'Pick one',
+          kind: 'single',
           sensitive: true,
+          options: [{ label: 'a', value: 'a' }],
         },
       ],
     });
-    expect(textOf(result)).toMatch(
-      /question "token" sets sensitive=true, but sensitive answers are not supported/,
-    );
+    expect(textOf(result)).toMatch(/Only kind="text" answers can be sensitive/);
     expect(request).not.toHaveBeenCalled();
   });
+});
 
-  it('a mixed batch is rejected whole — no partial ask reaches the user', async () => {
-    const { wizardAsk, request } = makeAsk();
-    const result = await wizardAsk.execute('call-1', {
+describe('pi set_env_values — resolves vault refs host-side', () => {
+  it('roundtrip: minted ref → real value lands in .env, never in tool output', async () => {
+    const { wizardAsk, setEnvValues, workingDirectory } = makeTools({
+      token: SECRET,
+    });
+    const asked = await call(wizardAsk, {
       questions: [
-        { id: 'q1', prompt: 'Which tracker?', kind: 'text' },
-        {
-          id: 'secret',
-          prompt: 'Zendesk token',
-          kind: 'text',
-          sensitive: true,
-        },
+        { id: 'token', prompt: 'Zendesk token', kind: 'text', sensitive: true },
       ],
     });
-    expect(textOf(result)).toMatch(/sensitive=true/);
-    expect(request).not.toHaveBeenCalled();
+    const { answers } = JSON.parse(textOf(asked)) as {
+      answers: { token: { secretRef: string } };
+    };
+
+    const written = await call(setEnvValues, {
+      filePath: '.env',
+      values: { ZENDESK_TOKEN: answers.token },
+    });
+    expect(textOf(written)).not.toContain(SECRET);
+    const env = await readFile(join(workingDirectory, '.env'), 'utf8');
+    expect(env).toContain(`ZENDESK_TOKEN=${SECRET}`);
   });
 
-  it('non-sensitive questions still flow to the bridge', async () => {
-    const { wizardAsk, request } = makeAsk();
-    const result = await wizardAsk.execute('call-1', {
-      questions: [{ id: 'q1', prompt: 'Which tracker?', kind: 'text' }],
+  it('an unknown ref fails with a clear error and writes nothing', async () => {
+    const { setEnvValues, workingDirectory } = makeTools({});
+    const result = await call(setEnvValues, {
+      filePath: '.env',
+      values: { ZENDESK_TOKEN: { secretRef: 'secret:not-a-real-ref' } },
     });
-    expect(request).toHaveBeenCalledTimes(1);
-    expect(textOf(result)).toContain('"q1": "answer"');
+    expect(textOf(result)).toMatch(/not known to the vault/);
+    await expect(
+      readFile(join(workingDirectory, '.env'), 'utf8'),
+    ).rejects.toThrow();
+  });
+
+  it('refs do not cross runs — a ref minted by one tool set is unknown to another', async () => {
+    const runA = makeTools({ token: SECRET });
+    const asked = await call(runA.wizardAsk, {
+      questions: [
+        { id: 'token', prompt: 'Zendesk token', kind: 'text', sensitive: true },
+      ],
+    });
+    const { answers } = JSON.parse(textOf(asked)) as {
+      answers: { token: { secretRef: string } };
+    };
+
+    const runB = makeTools({});
+    const result = await call(runB.setEnvValues, {
+      filePath: '.env',
+      values: { ZENDESK_TOKEN: answers.token },
+    });
+    expect(textOf(result)).toMatch(/not known to the vault/);
   });
 });

--- a/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
@@ -1,0 +1,69 @@
+/**
+ * pi wizard_ask — sensitive answers fail closed. pi has no secret-vault
+ * wiring, so `sensitive: true` is rejected before the question ever reaches
+ * the ask bridge (the MCP path vaults via secretRef instead).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { WizardAskBridge } from '@lib/wizard-ask-bridge';
+import { createWizardPiTools } from '../tools';
+
+const makeAsk = () => {
+  const request = vi.fn().mockResolvedValue({ q1: 'answer' });
+  const tools = createWizardPiTools({
+    workingDirectory: '/tmp',
+    skillsBaseUrl: 'http://localhost:0',
+    askBridge: { request } as unknown as WizardAskBridge,
+  });
+  const wizardAsk = tools.find((t) => t.name === 'wizard_ask');
+  if (!wizardAsk) throw new Error('wizard_ask not registered');
+  return { wizardAsk, request };
+};
+
+const textOf = (result: unknown) =>
+  (result as { content: [{ text: string }] }).content[0].text;
+
+describe('pi wizard_ask sensitive fail-closed', () => {
+  it('rejects sensitive questions before reaching the ask bridge', async () => {
+    const { wizardAsk, request } = makeAsk();
+    const result = await wizardAsk.execute('call-1', {
+      questions: [
+        {
+          id: 'token',
+          prompt: 'Paste your API key',
+          kind: 'text',
+          sensitive: true,
+        },
+      ],
+    });
+    expect(textOf(result)).toMatch(
+      /question "token" sets sensitive=true, but sensitive answers are not supported/,
+    );
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('a mixed batch is rejected whole — no partial ask reaches the user', async () => {
+    const { wizardAsk, request } = makeAsk();
+    const result = await wizardAsk.execute('call-1', {
+      questions: [
+        { id: 'q1', prompt: 'Which tracker?', kind: 'text' },
+        {
+          id: 'secret',
+          prompt: 'Zendesk token',
+          kind: 'text',
+          sensitive: true,
+        },
+      ],
+    });
+    expect(textOf(result)).toMatch(/sensitive=true/);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('non-sensitive questions still flow to the bridge', async () => {
+    const { wizardAsk, request } = makeAsk();
+    const result = await wizardAsk.execute('call-1', {
+      questions: [{ id: 'q1', prompt: 'Which tracker?', kind: 'text' }],
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(textOf(result)).toContain('"q1": "answer"');
+  });
+});

--- a/src/lib/agent/runner/harness/pi/tools.ts
+++ b/src/lib/agent/runner/harness/pi/tools.ts
@@ -30,7 +30,7 @@ import {
   resolveEnvPath,
   resolveEnvSecretRefs,
   vaultSensitiveAnswers,
-} from '@lib/wizard-tools';
+} from '@lib/wizard-tools/tools';
 import { isFullyCancelled, type WizardAskBridge } from '@lib/wizard-ask-bridge';
 import { createSecretVault } from '@lib/secret-vault';
 import { withMode } from './index';

--- a/src/lib/agent/runner/harness/pi/tools.ts
+++ b/src/lib/agent/runner/harness/pi/tools.ts
@@ -266,7 +266,7 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
           sensitive: Type.Optional(
             Type.Boolean({
               description:
-                "Only valid for kind='text'. Marks the answer as a secret the user types in (API keys, tokens). On pi this is returned literally today — do not echo it back into your text output.",
+                'Not supported on this harness: sensitive questions are rejected (no secret vault yet). Collect secrets via a browser/connect link instead of chat.',
             }),
           ),
         }),
@@ -306,9 +306,12 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
             `Error: question "${q.id}" has kind="${q.kind}" but no options. Provide at least one { label, value }, or use kind="text".`,
           );
         }
-        if (q.sensitive && q.kind !== 'text') {
+        // Fail closed: pi has no secret-vault wiring yet, so a sensitive
+        // answer would enter the model conversation literally. Reject until
+        // the vault is wired (the MCP path already vaults via secretRef).
+        if (q.sensitive) {
           return text(
-            `Error: question "${q.id}" sets sensitive=true but kind="${q.kind}". Only kind="text" answers can be sensitive.`,
+            `Error: question "${q.id}" sets sensitive=true, but sensitive answers are not supported on this harness yet. Do not collect the secret in chat — point the user at a browser/connect link instead.`,
           );
         }
         if (ids.has(q.id)) {

--- a/src/lib/agent/runner/harness/pi/tools.ts
+++ b/src/lib/agent/runner/harness/pi/tools.ts
@@ -7,6 +7,8 @@
  * MCP server so the shared prompt is unchanged. `wizard_ask` is wired here too
  * (same schema, caps, and askBridge as the MCP tool) so interactive programs
  * can interview the user on pi; without a bridge (CI) it errors on call.
+ * Sensitive answers are vaulted to `{secretRef}` and resolved host-side by
+ * set_env_values — the raw value never enters the model conversation.
  */
 
 import fs from 'fs';
@@ -27,7 +29,12 @@ import {
   parseEnvKeys,
   resolveEnvPath,
 } from '@lib/wizard-tools';
-import { isFullyCancelled, type WizardAskBridge } from '@lib/wizard-ask-bridge';
+import {
+  CANCELLED_SENTINEL,
+  isFullyCancelled,
+  type WizardAskBridge,
+} from '@lib/wizard-ask-bridge';
+import { createSecretVault } from '@lib/secret-vault';
 import { withMode } from './index';
 import {
   detectNodePackageManagers,
@@ -66,6 +73,9 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
   // mirroring the MCP server's counters.
   let askCallCount = 0;
   let askAdjacencyNudged = false;
+  // Session-scoped secret vault, same contract as the MCP server: wizard_ask
+  // mints `{secretRef}` for sensitive answers, set_env_values resolves them.
+  const secretVault = createSecretVault();
 
   // Fetch the skill menu at most once per run — the agent calls load_skill_menu
   // 2-3× otherwise, each a fresh HTTP round-trip (profiled slowness).
@@ -156,16 +166,21 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
     name: 'set_env_values',
     label: 'Set env values',
     description:
-      'Create or update environment variable keys in a .env file (creates the file if missing). Pass literal string values.',
+      'Create or update environment variable keys in a .env file (creates the file if missing). Each value is either a literal string or a secret reference `{ "secretRef": "secret:..." }` returned by wizard_ask — refs are resolved locally, so the actual value is written to the file but never returned to the agent.',
     promptSnippet:
       'set_env_values(filePath, values) — write .env keys (never hardcode secrets in source)',
     parameters: Type.Object({
       filePath: Type.String({
         description: ENV_FILE_PATH_DESCRIPTION,
       }),
-      values: Type.Record(Type.String(), Type.String(), {
-        description: 'Key → literal value',
-      }),
+      values: Type.Record(
+        Type.String(),
+        Type.Union([Type.String(), Type.Object({ secretRef: Type.String() })]),
+        {
+          description:
+            'Key → (literal string OR { secretRef } pointing to a vaulted secret)',
+        },
+      ),
     }),
     async execute(_id, args) {
       const forbidden = Object.keys(args.values).find(
@@ -176,11 +191,26 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
           `Error: "${forbidden}" is not a valid PostHog env var name. Use the framework-specific key (e.g. NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN).`,
         );
       }
+      // Resolve secret refs host-side; the value never reaches the agent.
+      const resolvedValues: Record<string, string> = {};
+      for (const [key, val] of Object.entries(args.values)) {
+        if (typeof val === 'string') {
+          resolvedValues[key] = val;
+          continue;
+        }
+        const secret = secretVault.get(val.secretRef);
+        if (secret === undefined) {
+          return text(
+            `Error: secret reference "${val.secretRef}" for key "${key}" is not known to the vault. The ref may have expired, been minted in a different run, or been mistyped.`,
+          );
+        }
+        resolvedValues[key] = secret;
+      }
       const resolved = resolveEnvPath(workingDirectory, args.filePath);
       const existing = fs.existsSync(resolved)
         ? await fs.promises.readFile(resolved, 'utf8')
         : '';
-      const merged = mergeEnvValues(existing, args.values);
+      const merged = mergeEnvValues(existing, resolvedValues);
       const dir = path.dirname(resolved);
       if (!fs.existsSync(dir))
         await fs.promises.mkdir(dir, { recursive: true });
@@ -266,7 +296,7 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
           sensitive: Type.Optional(
             Type.Boolean({
               description:
-                'Not supported on this harness: sensitive questions are rejected (no secret vault yet). Collect secrets via a browser/connect link instead of chat.',
+                "Only valid for kind='text'. The answer is stored in the wizard's secret vault and returned as { secretRef: 'secret:...' } instead of the raw string. Use for API keys and tokens; the ref is resolved only by tools that accept it (e.g. set_env_values).",
             }),
           ),
         }),
@@ -306,12 +336,9 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
             `Error: question "${q.id}" has kind="${q.kind}" but no options. Provide at least one { label, value }, or use kind="text".`,
           );
         }
-        // Fail closed: pi has no secret-vault wiring yet, so a sensitive
-        // answer would enter the model conversation literally. Reject until
-        // the vault is wired (the MCP path already vaults via secretRef).
-        if (q.sensitive) {
+        if (q.sensitive && q.kind !== 'text') {
           return text(
-            `Error: question "${q.id}" sets sensitive=true, but sensitive answers are not supported on this harness yet. Do not collect the secret in chat — point the user at a browser/connect link instead.`,
+            `Error: question "${q.id}" sets sensitive=true but kind="${q.kind}". Only kind="text" answers can be sensitive.`,
           );
         }
         if (ids.has(q.id)) {
@@ -331,12 +358,40 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
       try {
         const answers = await askBridge.request({ questions: args.questions });
         if (isFullyCancelled(answers)) askCallCount -= 1;
+        // Sensitive answers go to the vault; the agent sees an opaque ref
+        // (same contract as the MCP wizard_ask).
+        const sensitiveById = new Map(
+          args.questions
+            .filter((q) => q.sensitive)
+            .map((q) => [q.id, q.prompt]),
+        );
+        const sanitised: Record<
+          string,
+          string | string[] | { secretRef: string }
+        > = {};
+        for (const [id, answer] of Object.entries(answers)) {
+          const label = sensitiveById.get(id);
+          if (
+            label !== undefined &&
+            typeof answer === 'string' &&
+            answer !== CANCELLED_SENTINEL
+          ) {
+            const ref = secretVault.put(answer, {
+              label,
+              source: 'wizard_ask',
+            });
+            sanitised[id] = { secretRef: ref };
+            logToFile(`[pi] wizard_ask: vaulted answer for "${id}" as ${ref}`);
+          } else {
+            sanitised[id] = answer;
+          }
+        }
         logToFile(
           `[pi] wizard_ask: resolved ${
             Object.keys(answers).length
           } answer(s) for ${args.questions.length} question(s)`,
         );
-        return text(JSON.stringify({ answers }, null, 2));
+        return text(JSON.stringify({ answers: sanitised }, null, 2));
       } catch (err) {
         askCallCount -= 1;
         const message = err instanceof Error ? err.message : String(err);

--- a/src/lib/agent/runner/harness/pi/tools.ts
+++ b/src/lib/agent/runner/harness/pi/tools.ts
@@ -28,12 +28,10 @@ import {
   mergeEnvValues,
   parseEnvKeys,
   resolveEnvPath,
+  resolveEnvSecretRefs,
+  vaultSensitiveAnswers,
 } from '@lib/wizard-tools';
-import {
-  CANCELLED_SENTINEL,
-  isFullyCancelled,
-  type WizardAskBridge,
-} from '@lib/wizard-ask-bridge';
+import { isFullyCancelled, type WizardAskBridge } from '@lib/wizard-ask-bridge';
 import { createSecretVault } from '@lib/secret-vault';
 import { withMode } from './index';
 import {
@@ -192,25 +190,17 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
         );
       }
       // Resolve secret refs host-side; the value never reaches the agent.
-      const resolvedValues: Record<string, string> = {};
-      for (const [key, val] of Object.entries(args.values)) {
-        if (typeof val === 'string') {
-          resolvedValues[key] = val;
-          continue;
-        }
-        const secret = secretVault.get(val.secretRef);
-        if (secret === undefined) {
-          return text(
-            `Error: secret reference "${val.secretRef}" for key "${key}" is not known to the vault. The ref may have expired, been minted in a different run, or been mistyped.`,
-          );
-        }
-        resolvedValues[key] = secret;
+      const resolution = resolveEnvSecretRefs(args.values, secretVault);
+      if (!resolution.ok) {
+        return text(
+          `Error: secret reference "${resolution.secretRef}" for key "${resolution.key}" is not known to the vault. The ref may have expired, been minted in a different run, or been mistyped.`,
+        );
       }
       const resolved = resolveEnvPath(workingDirectory, args.filePath);
       const existing = fs.existsSync(resolved)
         ? await fs.promises.readFile(resolved, 'utf8')
         : '';
-      const merged = mergeEnvValues(existing, resolvedValues);
+      const merged = mergeEnvValues(existing, resolution.values);
       const dir = path.dirname(resolved);
       if (!fs.existsSync(dir))
         await fs.promises.mkdir(dir, { recursive: true });
@@ -360,32 +350,11 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
         if (isFullyCancelled(answers)) askCallCount -= 1;
         // Sensitive answers go to the vault; the agent sees an opaque ref
         // (same contract as the MCP wizard_ask).
-        const sensitiveById = new Map(
-          args.questions
-            .filter((q) => q.sensitive)
-            .map((q) => [q.id, q.prompt]),
+        const sanitised = vaultSensitiveAnswers(
+          args.questions,
+          answers,
+          secretVault,
         );
-        const sanitised: Record<
-          string,
-          string | string[] | { secretRef: string }
-        > = {};
-        for (const [id, answer] of Object.entries(answers)) {
-          const label = sensitiveById.get(id);
-          if (
-            label !== undefined &&
-            typeof answer === 'string' &&
-            answer !== CANCELLED_SENTINEL
-          ) {
-            const ref = secretVault.put(answer, {
-              label,
-              source: 'wizard_ask',
-            });
-            sanitised[id] = { secretRef: ref };
-            logToFile(`[pi] wizard_ask: vaulted answer for "${id}" as ${ref}`);
-          } else {
-            sanitised[id] = answer;
-          }
-        }
         logToFile(
           `[pi] wizard_ask: resolved ${
             Object.keys(answers).length

--- a/src/lib/wizard-tools.ts
+++ b/src/lib/wizard-tools.ts
@@ -23,7 +23,11 @@ import {
   type AuditCheck,
   type AuditStatus,
 } from './programs/audit/types';
-import { type WizardAskBridge, isFullyCancelled } from './wizard-ask-bridge';
+import {
+  CANCELLED_SENTINEL,
+  type WizardAskBridge,
+  isFullyCancelled,
+} from './wizard-ask-bridge';
 import { createSecretVault, type SecretVault } from './secret-vault';
 import { fetchWithRetry, type RetryOpts } from './fetch-retry';
 import {
@@ -484,6 +488,74 @@ export function mergeEnvValues(
 }
 
 // ---------------------------------------------------------------------------
+// Secret-vault plumbing shared by the MCP server and the pi-native tools —
+// one implementation so the vault contract cannot drift between harnesses.
+// ---------------------------------------------------------------------------
+
+/**
+ * Swap sensitive text answers for opaque vault refs before they return to
+ * the agent — the raw value never enters the LLM conversation. Cancelled
+ * answers pass through as the sentinel, unvaulted.
+ */
+export function vaultSensitiveAnswers(
+  questions: readonly { id: string; prompt: string; sensitive?: boolean }[],
+  answers: Record<string, string | string[]>,
+  vault: SecretVault,
+): Record<string, string | string[] | { secretRef: string }> {
+  const sensitiveById = new Map(
+    questions.filter((q) => q.sensitive).map((q) => [q.id, q.prompt]),
+  );
+  const sanitised: Record<string, string | string[] | { secretRef: string }> =
+    {};
+  for (const [id, answer] of Object.entries(answers)) {
+    const label = sensitiveById.get(id);
+    if (
+      label !== undefined &&
+      typeof answer === 'string' &&
+      answer !== CANCELLED_SENTINEL
+    ) {
+      const ref = vault.put(answer, { label, source: 'wizard_ask' });
+      sanitised[id] = { secretRef: ref };
+      logToFile(`wizard_ask: vaulted answer for "${id}" as ${ref}`);
+    } else {
+      sanitised[id] = answer;
+    }
+  }
+  return sanitised;
+}
+
+/** Resolution of a values map that may carry `{secretRef}` entries. */
+export type ResolvedEnvValues =
+  | { ok: true; values: Record<string, string>; refKeys: string[] }
+  | { ok: false; key: string; secretRef: string };
+
+/**
+ * Resolve `{secretRef}` entries host-side, so the value is written but never
+ * returned to the agent. Callers format their own error envelope from the
+ * failing key/ref.
+ */
+export function resolveEnvSecretRefs(
+  values: Record<string, string | { secretRef: string }>,
+  vault: SecretVault,
+): ResolvedEnvValues {
+  const resolved: Record<string, string> = {};
+  const refKeys: string[] = [];
+  for (const [key, val] of Object.entries(values)) {
+    if (typeof val === 'string') {
+      resolved[key] = val;
+      continue;
+    }
+    const secret = vault.get(val.secretRef);
+    if (secret === undefined) {
+      return { ok: false, key, secretRef: val.secretRef };
+    }
+    resolved[key] = secret;
+    refKeys.push(key);
+  }
+  return { ok: true, values: resolved, refKeys };
+}
+
+// ---------------------------------------------------------------------------
 // Audit ledger helpers
 // ---------------------------------------------------------------------------
 
@@ -723,28 +795,19 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
       }
 
       // Resolve any secret refs from the vault before writing.
-      const resolvedValues: Record<string, string> = {};
-      const resolvedRefKeys: string[] = [];
-      for (const [key, val] of Object.entries(args.values)) {
-        if (typeof val === 'string') {
-          resolvedValues[key] = val;
-        } else {
-          const secret = secretVault.get(val.secretRef);
-          if (secret === undefined) {
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: `Error: secret reference "${val.secretRef}" for key "${key}" is not known to the vault. The ref may have expired, been minted in a different run, or been mistyped.`,
-                },
-              ],
-              isError: true,
-            };
-          }
-          resolvedValues[key] = secret;
-          resolvedRefKeys.push(key);
-        }
+      const resolution = resolveEnvSecretRefs(args.values, secretVault);
+      if (!resolution.ok) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: secret reference "${resolution.secretRef}" for key "${resolution.key}" is not known to the vault. The ref may have expired, been minted in a different run, or been mistyped.`,
+            },
+          ],
+          isError: true,
+        };
       }
+      const { values: resolvedValues, refKeys: resolvedRefKeys } = resolution;
 
       const resolved = resolveEnvPath(workingDirectory, args.filePath);
       logToFile(
@@ -1228,35 +1291,12 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
           askCallCount -= 1;
         }
 
-        // For any question marked sensitive, move the raw answer into the
-        // vault and replace it with an opaque ref before returning to the
-        // agent — so the secret never enters the LLM conversation.
-        const sensitiveById = new Map(
-          args.questions
-            .filter((q) => q.sensitive)
-            .map((q) => [q.id, q.prompt]),
+        // Sensitive answers go to the vault; the agent sees an opaque ref.
+        const sanitised = vaultSensitiveAnswers(
+          args.questions,
+          answers,
+          secretVault,
         );
-        const sanitised: Record<
-          string,
-          string | string[] | { secretRef: string }
-        > = {};
-        for (const [id, answer] of Object.entries(answers)) {
-          const label = sensitiveById.get(id);
-          if (
-            label !== undefined &&
-            typeof answer === 'string' &&
-            answer !== '__cancelled__'
-          ) {
-            const ref = secretVault.put(answer, {
-              label,
-              source: 'wizard_ask',
-            });
-            sanitised[id] = { secretRef: ref };
-            logToFile(`wizard_ask: vaulted answer for "${id}" as ${ref}`);
-          } else {
-            sanitised[id] = answer;
-          }
-        }
 
         logToFile(
           `wizard_ask: resolved ${Object.keys(answers).length} answer(s) for ${

--- a/src/lib/wizard-tools/index.ts
+++ b/src/lib/wizard-tools/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Wizard tools — `./tools` is the shared behavior core, `./mcp` the MCP
+ * facade the anthropic harness mounts (pi's facade lives with its harness).
+ * Re-exported together so importers keep the `@lib/wizard-tools` path.
+ */
+export * from './tools';
+export * from './mcp';

--- a/src/lib/wizard-tools/mcp.ts
+++ b/src/lib/wizard-tools/mcp.ts
@@ -1,39 +1,67 @@
 /**
- * Unified in-process MCP server for the PostHog wizard.
+ * MCP facade over `./tools` — the unified in-process server the anthropic
+ * harness mounts. Declarations (zod schemas, descriptions) and the MCP result
+ * envelope live here; all behavior is imported from the shared core.
  *
- * Provides tools that run locally (secret values never leave the machine):
- * - check_env_keys: Check which env var keys exist in a .env file
- * - set_env_values: Create/update env vars in a .env file
- * - detect_package_manager: Detect the project's package manager(s)
- * - load_skill_menu / install_skill: Skill installation
- * - audit_seed_checks / audit_add_checks / audit_resolve_checks: Audit ledger ownership
+ * Provides: check_env_keys, set_env_values, detect_package_manager,
+ * load_skill_menu / install_skill, audit_* ledger tools, wizard_ask, and the
+ * orchestrator queue tools. Secret values never leave the machine.
  */
 
 import path from 'path';
 import fs from 'fs';
-import { unzipSync } from 'fflate';
 import { z } from 'zod';
 import { logToFile } from '@utils/debug';
 import { analytics } from '@utils/analytics';
-import { writeJsonAtomic, makeMutex } from '@utils/atomic-ledger';
-import type { PackageManagerDetector } from './detection/package-manager';
+import { makeMutex } from '@utils/atomic-ledger';
+import type { PackageManagerDetector } from '../detection/package-manager';
 import {
   AUDIT_CHECKS_FILE,
-  coerceAuditChecks,
   type AuditCheck,
   type AuditStatus,
-} from './programs/audit/types';
-import {
-  CANCELLED_SENTINEL,
-  type WizardAskBridge,
-  isFullyCancelled,
-} from './wizard-ask-bridge';
-import { createSecretVault, type SecretVault } from './secret-vault';
-import { fetchWithRetry, type RetryOpts } from './fetch-retry';
+} from '../programs/audit/types';
+import { type WizardAskBridge, isFullyCancelled } from '../wizard-ask-bridge';
+import { createSecretVault, type SecretVault } from '../secret-vault';
 import {
   buildOrchestratorTools,
   type OrchestratorToolsContext,
-} from './agent/runner/sequence/orchestrator/queue-tools';
+} from '../agent/runner/sequence/orchestrator/queue-tools';
+import {
+  DEFAULT_ASK_MAX_QUESTIONS,
+  ENV_FILE_PATH_DESCRIPTION,
+  SERVER_NAME,
+  appendAuditChecksToLedger,
+  applyAuditUpdates,
+  downloadSkill,
+  ensureGitignoreCoverage,
+  evaluateAskCap,
+  fetchSkillMenu,
+  mergeEnvValues,
+  parseEnvKeys,
+  readLedger,
+  resolveEnvPath,
+  resolveEnvSecretRefs,
+  vaultSensitiveAnswers,
+  writeLedgerAtomic,
+  type SkillEntry,
+  AUDIT_STATUSES,
+} from './tools';
+
+const auditCheckSchema = z.object({
+  id: z.string().min(1),
+  area: z.string().min(1),
+  label: z.string().min(1),
+  status: z.enum(AUDIT_STATUSES as [AuditStatus, ...AuditStatus[]]),
+  file: z.string().optional(),
+  details: z.string().optional(),
+});
+
+const auditUpdateSchema = z.object({
+  id: z.string().min(1),
+  status: z.enum(AUDIT_STATUSES as [AuditStatus, ...AuditStatus[]]),
+  file: z.string().optional(),
+  details: z.string().optional(),
+});
 
 // ---------------------------------------------------------------------------
 // SDK dynamic import (ESM module loaded once, cached)
@@ -45,251 +73,6 @@ async function getSDKModule(): Promise<any> {
     _sdkModule = await import('@anthropic-ai/claude-agent-sdk');
   }
   return _sdkModule;
-}
-
-// ---------------------------------------------------------------------------
-// Skill types
-// ---------------------------------------------------------------------------
-
-export type SkillEntry = {
-  id: string;
-  name: string;
-  downloadUrl: string;
-  /** The hyphenated skill-group prefix of `id` (e.g. `posthog-integration-install`). */
-  group?: string;
-  /** The detection id this variant serves (e.g. `rails`, `react-router`). */
-  framework?: string;
-  /** The variant a bare framework id resolves to when its family has several. */
-  default?: boolean;
-  /** This entry's download is a bundle JSON of every variant, not a single skill's zip. */
-  bundle?: boolean;
-  /** Menu-only: the variants inside a bundle, expanded into entries of their own on fetch. */
-  variants?: { id: string; framework?: string; default?: boolean }[];
-};
-
-/** A bundle's files, keyed by variant short id then path. */
-export type SkillBundle = {
-  id: string;
-  variants: Record<string, Record<string, string>>;
-};
-
-/**
- * Entry in the wizard's runtime CLI registry. Mirrors the shape context-mill
- * publishes under `cliEntries` inside `skill-menu.json`. The wizard uses these
- * to register skill-backed subcommands at runtime instead of from a baked
- * build-time snapshot.
- */
-export type CliEntry = {
-  skillId: string;
-  role: 'command' | 'skill' | 'internal';
-  command?: string;
-  parentCommand?: string;
-  default?: boolean;
-  displayName: string;
-  description: string;
-};
-
-export interface SkillMenu {
-  categories: Record<string, SkillEntry[]>;
-  /**
-   * Skills exposed as CLI commands. Optional because context-mill releases
-   * older than the runtime-resolver cutover don't emit this field.
-   */
-  cliEntries?: CliEntry[];
-}
-
-// ---------------------------------------------------------------------------
-// Standalone skill helpers (usable before the MCP server is created)
-// ---------------------------------------------------------------------------
-
-/** Expand a bundle entry into one entry per variant, so the menu reads the same whether a group ships bundled or as zips. */
-export function expandBundleEntry(entry: SkillEntry): SkillEntry[] {
-  if (!entry.bundle || !entry.variants) return [entry];
-  return entry.variants.map((variant) => ({
-    ...variant,
-    name: entry.name,
-    group: entry.group,
-    bundle: true,
-    downloadUrl: entry.downloadUrl,
-  }));
-}
-
-/**
- * Fetch the skill menu from the skills server.
- * Returns parsed data on success, `null` on failure.
- */
-export async function fetchSkillMenu(
-  skillsBaseUrl: string,
-  opts: RetryOpts = {},
-): Promise<SkillMenu | null> {
-  const menuUrl = `${skillsBaseUrl}/skill-menu.json`;
-  try {
-    logToFile(`fetchSkillMenu: fetching from ${menuUrl}`);
-    const resp = await fetchWithRetry(menuUrl, opts);
-    const data = (await resp.json()) as SkillMenu;
-    for (const [category, entries] of Object.entries(data.categories)) {
-      data.categories[category] = entries.flatMap(expandBundleEntry);
-    }
-    logToFile(
-      `fetchSkillMenu: loaded (${
-        Object.keys(data.categories).length
-      } categories)`,
-    );
-    return data;
-  } catch (err: any) {
-    logToFile(`fetchSkillMenu: error: ${err.message}`);
-    return null;
-  }
-}
-
-/** Extract a zip buffer, refusing entries that escape destDir (zip-slip). */
-function extractZipArchive(zip: Uint8Array, destDir: string): number {
-  const root = path.resolve(destDir);
-  let written = 0;
-  for (const [entryPath, data] of Object.entries(unzipSync(zip))) {
-    const target = path.resolve(root, entryPath);
-    if (target !== root && !target.startsWith(root + path.sep)) {
-      throw new Error(`zip entry escapes destination: ${entryPath}`);
-    }
-    if (entryPath.endsWith('/')) {
-      fs.mkdirSync(target, { recursive: true });
-      continue;
-    }
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, data);
-    written++;
-  }
-  return written;
-}
-
-/** Unpack the one variant this entry names out of a bundle; the rest is noise and never hits disk. */
-function extractBundle(
-  bundle: SkillBundle,
-  destDir: string,
-  entryId: string,
-): number {
-  if (
-    typeof bundle?.id !== 'string' ||
-    typeof bundle?.variants !== 'object' ||
-    bundle.variants === null
-  ) {
-    throw new Error('malformed bundle: expected { id, variants }');
-  }
-  const files = bundle.variants[entryId.slice(bundle.id.length + 1)];
-  if (!files) {
-    throw new Error(`bundle ${bundle.id} has no variant "${entryId}"`);
-  }
-  const root = path.resolve(destDir);
-  let written = 0;
-  for (const [entryPath, contents] of Object.entries(files)) {
-    const target = path.resolve(root, entryPath);
-    if (target !== root && !target.startsWith(root + path.sep)) {
-      throw new Error(`bundle entry escapes destination: ${entryPath}`);
-    }
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, contents);
-    written++;
-  }
-  return written;
-}
-
-/** Download a URL to a buffer, retrying transient failures with backoff. */
-async function downloadWithRetry(
-  url: string,
-  opts: RetryOpts = {},
-): Promise<Uint8Array> {
-  const resp = await fetchWithRetry(url, opts);
-  return new Uint8Array(await resp.arrayBuffer());
-}
-
-/**
- * Download and extract a skill.
- * By default installs to `<installDir>/.claude/skills/<id>/`.
- * Pass `skillsRoot` to override the base directory (e.g. `.posthog/skills`).
- */
-export async function downloadSkill(
-  skillEntry: SkillEntry,
-  installDir: string,
-  skillsRoot?: string,
-): Promise<{ success: boolean; error?: string }> {
-  const skillDir = skillsRoot
-    ? path.join(installDir, skillsRoot, skillEntry.id)
-    : path.join(installDir, '.claude', 'skills', skillEntry.id);
-  let step: 'download' | 'extract' = 'download';
-
-  try {
-    fs.mkdirSync(skillDir, { recursive: true });
-    const data = await downloadWithRetry(skillEntry.downloadUrl);
-    step = 'extract';
-    const fileCount = skillEntry.bundle
-      ? extractBundle(
-          JSON.parse(Buffer.from(data).toString('utf8')) as SkillBundle,
-          skillDir,
-          skillEntry.id,
-        )
-      : extractZipArchive(data, skillDir);
-    fs.writeFileSync(path.join(skillDir, '.posthog-wizard'), '');
-
-    logToFile(
-      `downloadSkill: installed ${skillEntry.id} from ${skillEntry.downloadUrl} (${fileCount} files)`,
-    );
-    return { success: true };
-  } catch (err: any) {
-    logToFile(`downloadSkill: error: ${err.message}`);
-    // A skill-less run still reports success — keep the failure visible.
-    analytics.wizardCapture('skill install failed', {
-      skill_id: skillEntry.id,
-      step,
-      platform: process.platform,
-      error: String(err.message).slice(0, 500),
-    });
-    return { success: false, error: err.message };
-  }
-}
-
-/**
- * Structured result for installSkillById.
- * - `ok`: the skill was fetched and extracted; `path` is where it lives
- *   relative to installDir.
- * - `menu-fetch-failed`: couldn't fetch or parse the skill menu.
- * - `skill-not-found`: the menu didn't contain a skill with this id.
- * - `download-failed`: found the skill but download/extract failed;
- *   `message` has the underlying error.
- */
-export type InstallSkillResult =
-  | { kind: 'ok'; path: string }
-  | { kind: 'menu-fetch-failed' }
-  | { kind: 'skill-not-found'; skillId: string }
-  | { kind: 'download-failed'; message: string };
-
-/**
- * High-level "install a skill by ID" helper. Fetches the skill menu,
- * finds the skill, downloads and extracts it. Programs should use this
- * instead of composing fetchSkillMenu + downloadSkill themselves.
- */
-export async function installSkillById(
-  skillId: string,
-  installDir: string,
-  skillsBaseUrl: string,
-  skillsRoot?: string,
-): Promise<InstallSkillResult> {
-  const menu = await fetchSkillMenu(skillsBaseUrl);
-  if (!menu) return { kind: 'menu-fetch-failed' };
-
-  const skill = Object.values(menu.categories)
-    .flat()
-    .find((s) => s.id === skillId);
-  if (!skill) return { kind: 'skill-not-found', skillId };
-
-  const result = await downloadSkill(skill, installDir, skillsRoot);
-  if (!result.success) {
-    return { kind: 'download-failed', message: result.error ?? 'unknown' };
-  }
-
-  const relPath = skillsRoot
-    ? `${skillsRoot}/${skillId}`
-    : `.claude/skills/${skillId}`;
-  return { kind: 'ok', path: relPath };
 }
 
 // ---------------------------------------------------------------------------
@@ -340,355 +123,9 @@ export interface WizardToolsOptions {
 }
 
 /** Default per-run cap on wizard_ask calls when no override is provided. */
-export const DEFAULT_ASK_MAX_QUESTIONS = 10;
-/** The call after this many returns a one-time batch-your-questions nudge. */
-export const ASK_BATCH_THRESHOLD = 3;
-
-export type AskCapDecision =
-  | { kind: 'ok' }
-  | {
-      kind: 'capped';
-      reason: 'max_questions' | 'adjacency';
-      message: string;
-    };
-
-/**
- * Pure decision function for the wizard_ask caps. Returns whether the
- * upcoming call should proceed and, if not, the error message to surface
- * to the agent. Extracted so the policy can be unit-tested without
- * spinning up an MCP server.
- *
- * The adjacency nudge fires exactly once per run (the caller records it
- * via `adjacencyNudged`) — flows that legitimately need several
- * sequential, answer-dependent asks then proceed up to `maxQuestions`.
- * Without the flag the rejected call would never advance the counter and
- * every later call would be rejected, making caps above the threshold
- * unreachable.
- */
-export function evaluateAskCap(
-  callCount: number,
-  maxQuestions: number,
-  adjacencyNudged = false,
-): AskCapDecision {
-  if (callCount >= maxQuestions) {
-    return {
-      kind: 'capped',
-      reason: 'max_questions',
-      message: `Error: wizard_ask cap reached (${maxQuestions} calls in this run). Proceed with sensible defaults using the answers you already have, or emit [ABORT] requirements-incomplete.`,
-    };
-  }
-  if (!adjacencyNudged && callCount >= ASK_BATCH_THRESHOLD) {
-    return {
-      kind: 'capped',
-      reason: 'adjacency',
-      message: `Error: too many wizard_ask calls in a row (${callCount} so far). Batch the remaining questions into a single call — the schema accepts up to 8 questions per invocation. If the remaining questions truly depend on earlier answers, ask again and they will go through.`,
-    };
-  }
-  return { kind: 'ok' };
-}
-
-// ---------------------------------------------------------------------------
-// Env file helpers
-// ---------------------------------------------------------------------------
-
-export const ENV_FILE_PATH_DESCRIPTION =
-  'Path to the .env file, relative to the wizard working directory. Pass ".env" for a file in that directory, or include the selected subproject path (for example, "packages/app/.env") for a nested project. Never prefix it with the wizard working directory\'s path inside an ancestor repository.';
-
-/**
- * Resolve filePath relative to workingDirectory, rejecting path traversal.
- */
-export function resolveEnvPath(
-  workingDirectory: string,
-  filePath: string,
-): string {
-  const resolved = path.resolve(workingDirectory, filePath);
-  if (
-    !resolved.startsWith(workingDirectory + path.sep) &&
-    resolved !== workingDirectory
-  ) {
-    throw new Error(
-      `Path traversal rejected: "${filePath}" resolves outside working directory`,
-    );
-  }
-  return resolved;
-}
-
-/**
- * Ensure the given env file basename is covered by .gitignore in the working directory.
- * Creates .gitignore if it doesn't exist; appends the entry if missing.
- */
-export function ensureGitignoreCoverage(
-  workingDirectory: string,
-  envFileName: string,
-): void {
-  const gitignorePath = path.join(workingDirectory, '.gitignore');
-
-  if (fs.existsSync(gitignorePath)) {
-    const content = fs.readFileSync(gitignorePath, 'utf8');
-    // Check if the file (or a glob covering it) is already listed
-    if (content.split('\n').some((line) => line.trim() === envFileName)) {
-      return;
-    }
-    const newContent = content.endsWith('\n')
-      ? `${content}${envFileName}\n`
-      : `${content}\n${envFileName}\n`;
-    fs.writeFileSync(gitignorePath, newContent, 'utf8');
-  } else {
-    fs.writeFileSync(gitignorePath, `${envFileName}\n`, 'utf8');
-  }
-}
-
-/**
- * Parse a .env file's content and return the set of defined key names.
- */
-export function parseEnvKeys(content: string): Set<string> {
-  const keys = new Set<string>();
-  for (const line of content.split('\n')) {
-    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
-    if (match) {
-      keys.add(match[1]);
-    }
-  }
-  return keys;
-}
-
-/**
- * Merge key-value pairs into existing .env content.
- * Updates existing keys in-place, appends new keys at the end.
- */
-export function mergeEnvValues(
-  content: string,
-  values: Record<string, string>,
-): string {
-  let result = content;
-  const updatedKeys = new Set<string>();
-
-  for (const [key, value] of Object.entries(values)) {
-    // Preserve the existing `KEY=` prefix exactly; only swap the value.
-    const regex = new RegExp(`^(\\s*${key}\\s*=).*$`, 'm');
-    if (regex.test(result)) {
-      result = result.replace(regex, `$1${value}`);
-      updatedKeys.add(key);
-    }
-  }
-
-  const newKeys = Object.entries(values).filter(
-    ([key]) => !updatedKeys.has(key),
-  );
-  if (newKeys.length > 0) {
-    if (result.length > 0 && !result.endsWith('\n')) {
-      result += '\n';
-    }
-    for (const [key, value] of newKeys) {
-      result += `${key}=${value}\n`;
-    }
-  }
-
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Secret-vault plumbing shared by the MCP server and the pi-native tools —
-// one implementation so the vault contract cannot drift between harnesses.
-// ---------------------------------------------------------------------------
-
-/**
- * Swap sensitive text answers for opaque vault refs before they return to
- * the agent — the raw value never enters the LLM conversation. Cancelled
- * answers pass through as the sentinel, unvaulted.
- */
-export function vaultSensitiveAnswers(
-  questions: readonly { id: string; prompt: string; sensitive?: boolean }[],
-  answers: Record<string, string | string[]>,
-  vault: SecretVault,
-): Record<string, string | string[] | { secretRef: string }> {
-  const sensitiveById = new Map(
-    questions.filter((q) => q.sensitive).map((q) => [q.id, q.prompt]),
-  );
-  const sanitised: Record<string, string | string[] | { secretRef: string }> =
-    {};
-  for (const [id, answer] of Object.entries(answers)) {
-    const label = sensitiveById.get(id);
-    if (
-      label !== undefined &&
-      typeof answer === 'string' &&
-      answer !== CANCELLED_SENTINEL
-    ) {
-      const ref = vault.put(answer, { label, source: 'wizard_ask' });
-      sanitised[id] = { secretRef: ref };
-      logToFile(`wizard_ask: vaulted answer for "${id}" as ${ref}`);
-    } else {
-      sanitised[id] = answer;
-    }
-  }
-  return sanitised;
-}
-
-/** Resolution of a values map that may carry `{secretRef}` entries. */
-export type ResolvedEnvValues =
-  | { ok: true; values: Record<string, string>; refKeys: string[] }
-  | { ok: false; key: string; secretRef: string };
-
-/**
- * Resolve `{secretRef}` entries host-side, so the value is written but never
- * returned to the agent. Callers format their own error envelope from the
- * failing key/ref.
- */
-export function resolveEnvSecretRefs(
-  values: Record<string, string | { secretRef: string }>,
-  vault: SecretVault,
-): ResolvedEnvValues {
-  const resolved: Record<string, string> = {};
-  const refKeys: string[] = [];
-  for (const [key, val] of Object.entries(values)) {
-    if (typeof val === 'string') {
-      resolved[key] = val;
-      continue;
-    }
-    const secret = vault.get(val.secretRef);
-    if (secret === undefined) {
-      return { ok: false, key, secretRef: val.secretRef };
-    }
-    resolved[key] = secret;
-    refKeys.push(key);
-  }
-  return { ok: true, values: resolved, refKeys };
-}
-
-// ---------------------------------------------------------------------------
-// Audit ledger helpers
-// ---------------------------------------------------------------------------
-
-const AUDIT_STATUSES: readonly AuditStatus[] = [
-  'pending',
-  'pass',
-  'error',
-  'warning',
-  'suggestion',
-];
-
-const auditCheckSchema = z.object({
-  id: z.string().min(1),
-  area: z.string().min(1),
-  label: z.string().min(1),
-  status: z.enum(AUDIT_STATUSES as [AuditStatus, ...AuditStatus[]]),
-  file: z.string().optional(),
-  details: z.string().optional(),
-});
-
-const auditUpdateSchema = z.object({
-  id: z.string().min(1),
-  status: z.enum(AUDIT_STATUSES as [AuditStatus, ...AuditStatus[]]),
-  file: z.string().optional(),
-  details: z.string().optional(),
-});
-
-/** Atomically write the audit ledger. Thin typed wrapper over writeJsonAtomic. */
-function writeLedgerAtomic(targetPath: string, checks: AuditCheck[]): void {
-  writeJsonAtomic(targetPath, checks);
-}
-
-/**
- * Apply a batch of patches to the ledger by id. Returns the new array and the
- * list of update ids that didn't match any existing check.
- */
-function applyAuditUpdates(
-  current: AuditCheck[],
-  updates: Array<{
-    id: string;
-    status: AuditStatus;
-    file?: string;
-    details?: string;
-  }>,
-): { next: AuditCheck[]; unknown: string[] } {
-  const byId = new Map(current.map((c) => [c.id, c]));
-  const unknown: string[] = [];
-
-  for (const u of updates) {
-    const existing = byId.get(u.id);
-    if (!existing) {
-      unknown.push(u.id);
-      continue;
-    }
-    byId.set(u.id, {
-      ...existing,
-      status: u.status,
-      ...(u.file !== undefined ? { file: u.file } : {}),
-      ...(u.details !== undefined ? { details: u.details } : {}),
-    });
-  }
-
-  return {
-    next: current.map((c) => byId.get(c.id) ?? c),
-    unknown,
-  };
-}
-
-/**
- * Append new checks to a seeded ledger. Duplicate ids are reported without
- * mutating the current ledger, including duplicates inside the additions.
- */
-function applyAuditAdditions(
-  current: AuditCheck[],
-  additions: AuditCheck[],
-): { next: AuditCheck[]; duplicates: string[] } {
-  const existingIds = new Set(current.map((c) => c.id));
-  const additionIds = new Set<string>();
-  const duplicates: string[] = [];
-
-  for (const check of additions) {
-    if (existingIds.has(check.id) || additionIds.has(check.id)) {
-      duplicates.push(check.id);
-      continue;
-    }
-    additionIds.add(check.id);
-  }
-
-  if (duplicates.length > 0) {
-    return { next: current, duplicates };
-  }
-
-  return { next: [...current, ...additions], duplicates: [] };
-}
-
-function readLedger(targetPath: string): AuditCheck[] {
-  if (!fs.existsSync(targetPath)) return [];
-  try {
-    const parsed = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
-    return coerceAuditChecks(parsed);
-  } catch {
-    return [];
-  }
-}
-
-type AppendAuditChecksResult =
-  | { ok: true; added: number }
-  | { ok: false; reason: 'missing-ledger' }
-  | { ok: false; reason: 'duplicate-ids'; ids: string[] };
-
-function appendAuditChecksToLedger(
-  targetPath: string,
-  additions: AuditCheck[],
-): AppendAuditChecksResult {
-  if (!fs.existsSync(targetPath)) {
-    return { ok: false, reason: 'missing-ledger' };
-  }
-
-  const current = readLedger(targetPath);
-  const { next, duplicates } = applyAuditAdditions(current, additions);
-  if (duplicates.length > 0) {
-    return { ok: false, reason: 'duplicate-ids', ids: duplicates };
-  }
-
-  writeLedgerAtomic(targetPath, next);
-  return { ok: true, added: additions.length };
-}
-
 // ---------------------------------------------------------------------------
 // Server factory
 // ---------------------------------------------------------------------------
-
-const SERVER_NAME = 'wizard-tools';
 
 /**
  * Create the unified in-process MCP server with all wizard tools.
@@ -1353,41 +790,3 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
     ],
   });
 }
-
-/** Tool names exposed by the wizard-tools server, keyed for selective use. */
-// SDK expects MCP tool names in allowedTools/disallowedTools to be the
-// fully-qualified `mcp__<server>__<tool>` form (sdk.d.ts: "Fully-qualified
-// MCP tool name, e.g. mcp__server__tool_name."). The colon form silently
-// fails to match, which made every program's `disallowedTools` entry a no-op.
-export const WIZARD_TOOL_NAMES = {
-  checkEnvKeys: `mcp__${SERVER_NAME}__check_env_keys`,
-  setEnvValues: `mcp__${SERVER_NAME}__set_env_values`,
-  detectPackageManager: `mcp__${SERVER_NAME}__detect_package_manager`,
-  loadSkillMenu: `mcp__${SERVER_NAME}__load_skill_menu`,
-  installSkill: `mcp__${SERVER_NAME}__install_skill`,
-  auditSeedChecks: `mcp__${SERVER_NAME}__audit_seed_checks`,
-  auditAddChecks: `mcp__${SERVER_NAME}__audit_add_checks`,
-  auditResolveChecks: `mcp__${SERVER_NAME}__audit_resolve_checks`,
-  wizardAsk: `mcp__${SERVER_NAME}__wizard_ask`,
-  enqueueTask: `mcp__${SERVER_NAME}__enqueue_task`,
-  completeTask: `mcp__${SERVER_NAME}__complete_task`,
-  readHandoffs: `mcp__${SERVER_NAME}__read_handoffs`,
-} as const;
-
-// ---------------------------------------------------------------------------
-// Test-only exports
-// ---------------------------------------------------------------------------
-
-export const __test = {
-  extractZipArchive,
-  extractBundle,
-  fetchWithRetry,
-  downloadWithRetry,
-  writeLedgerAtomic,
-  readLedger,
-  applyAuditAdditions,
-  appendAuditChecksToLedger,
-  applyAuditUpdates,
-  makeMutex,
-  AUDIT_CHECKS_FILE,
-};

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -1,0 +1,639 @@
+/**
+ * Shared wizard-tool behavior — skill discovery/install, env-file helpers,
+ * the wizard_ask cap policy, secret-vault plumbing, and the audit ledger.
+ * One implementation consumed by both protocol facades: the MCP server
+ * (`./mcp`) and the pi-native tools (`harness/pi/tools.ts`) — tool behavior
+ * cannot drift between harnesses.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { unzipSync } from 'fflate';
+import { logToFile } from '@utils/debug';
+import { analytics } from '@utils/analytics';
+import { writeJsonAtomic, makeMutex } from '@utils/atomic-ledger';
+import {
+  AUDIT_CHECKS_FILE,
+  coerceAuditChecks,
+  type AuditCheck,
+  type AuditStatus,
+} from '../programs/audit/types';
+import { CANCELLED_SENTINEL } from '../wizard-ask-bridge';
+import type { SecretVault } from '../secret-vault';
+import { fetchWithRetry, type RetryOpts } from '../fetch-retry';
+
+// ---------------------------------------------------------------------------
+// Skill types
+// ---------------------------------------------------------------------------
+
+export type SkillEntry = {
+  id: string;
+  name: string;
+  downloadUrl: string;
+  /** The hyphenated skill-group prefix of `id` (e.g. `posthog-integration-install`). */
+  group?: string;
+  /** The detection id this variant serves (e.g. `rails`, `react-router`). */
+  framework?: string;
+  /** The variant a bare framework id resolves to when its family has several. */
+  default?: boolean;
+  /** This entry's download is a bundle JSON of every variant, not a single skill's zip. */
+  bundle?: boolean;
+  /** Menu-only: the variants inside a bundle, expanded into entries of their own on fetch. */
+  variants?: { id: string; framework?: string; default?: boolean }[];
+};
+
+/** A bundle's files, keyed by variant short id then path. */
+export type SkillBundle = {
+  id: string;
+  variants: Record<string, Record<string, string>>;
+};
+
+/**
+ * Entry in the wizard's runtime CLI registry. Mirrors the shape context-mill
+ * publishes under `cliEntries` inside `skill-menu.json`. The wizard uses these
+ * to register skill-backed subcommands at runtime instead of from a baked
+ * build-time snapshot.
+ */
+export type CliEntry = {
+  skillId: string;
+  role: 'command' | 'skill' | 'internal';
+  command?: string;
+  parentCommand?: string;
+  default?: boolean;
+  displayName: string;
+  description: string;
+};
+
+export interface SkillMenu {
+  categories: Record<string, SkillEntry[]>;
+  /**
+   * Skills exposed as CLI commands. Optional because context-mill releases
+   * older than the runtime-resolver cutover don't emit this field.
+   */
+  cliEntries?: CliEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Standalone skill helpers (usable before the MCP server is created)
+// ---------------------------------------------------------------------------
+
+/** Expand a bundle entry into one entry per variant, so the menu reads the same whether a group ships bundled or as zips. */
+export function expandBundleEntry(entry: SkillEntry): SkillEntry[] {
+  if (!entry.bundle || !entry.variants) return [entry];
+  return entry.variants.map((variant) => ({
+    ...variant,
+    name: entry.name,
+    group: entry.group,
+    bundle: true,
+    downloadUrl: entry.downloadUrl,
+  }));
+}
+
+/**
+ * Fetch the skill menu from the skills server.
+ * Returns parsed data on success, `null` on failure.
+ */
+export async function fetchSkillMenu(
+  skillsBaseUrl: string,
+  opts: RetryOpts = {},
+): Promise<SkillMenu | null> {
+  const menuUrl = `${skillsBaseUrl}/skill-menu.json`;
+  try {
+    logToFile(`fetchSkillMenu: fetching from ${menuUrl}`);
+    const resp = await fetchWithRetry(menuUrl, opts);
+    const data = (await resp.json()) as SkillMenu;
+    for (const [category, entries] of Object.entries(data.categories)) {
+      data.categories[category] = entries.flatMap(expandBundleEntry);
+    }
+    logToFile(
+      `fetchSkillMenu: loaded (${
+        Object.keys(data.categories).length
+      } categories)`,
+    );
+    return data;
+  } catch (err: any) {
+    logToFile(`fetchSkillMenu: error: ${err.message}`);
+    return null;
+  }
+}
+
+/** Extract a zip buffer, refusing entries that escape destDir (zip-slip). */
+function extractZipArchive(zip: Uint8Array, destDir: string): number {
+  const root = path.resolve(destDir);
+  let written = 0;
+  for (const [entryPath, data] of Object.entries(unzipSync(zip))) {
+    const target = path.resolve(root, entryPath);
+    if (target !== root && !target.startsWith(root + path.sep)) {
+      throw new Error(`zip entry escapes destination: ${entryPath}`);
+    }
+    if (entryPath.endsWith('/')) {
+      fs.mkdirSync(target, { recursive: true });
+      continue;
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, data);
+    written++;
+  }
+  return written;
+}
+
+/** Unpack the one variant this entry names out of a bundle; the rest is noise and never hits disk. */
+function extractBundle(
+  bundle: SkillBundle,
+  destDir: string,
+  entryId: string,
+): number {
+  if (
+    typeof bundle?.id !== 'string' ||
+    typeof bundle?.variants !== 'object' ||
+    bundle.variants === null
+  ) {
+    throw new Error('malformed bundle: expected { id, variants }');
+  }
+  const files = bundle.variants[entryId.slice(bundle.id.length + 1)];
+  if (!files) {
+    throw new Error(`bundle ${bundle.id} has no variant "${entryId}"`);
+  }
+  const root = path.resolve(destDir);
+  let written = 0;
+  for (const [entryPath, contents] of Object.entries(files)) {
+    const target = path.resolve(root, entryPath);
+    if (target !== root && !target.startsWith(root + path.sep)) {
+      throw new Error(`bundle entry escapes destination: ${entryPath}`);
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, contents);
+    written++;
+  }
+  return written;
+}
+
+/** Download a URL to a buffer, retrying transient failures with backoff. */
+async function downloadWithRetry(
+  url: string,
+  opts: RetryOpts = {},
+): Promise<Uint8Array> {
+  const resp = await fetchWithRetry(url, opts);
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+/**
+ * Download and extract a skill.
+ * By default installs to `<installDir>/.claude/skills/<id>/`.
+ * Pass `skillsRoot` to override the base directory (e.g. `.posthog/skills`).
+ */
+export async function downloadSkill(
+  skillEntry: SkillEntry,
+  installDir: string,
+  skillsRoot?: string,
+): Promise<{ success: boolean; error?: string }> {
+  const skillDir = skillsRoot
+    ? path.join(installDir, skillsRoot, skillEntry.id)
+    : path.join(installDir, '.claude', 'skills', skillEntry.id);
+  let step: 'download' | 'extract' = 'download';
+
+  try {
+    fs.mkdirSync(skillDir, { recursive: true });
+    const data = await downloadWithRetry(skillEntry.downloadUrl);
+    step = 'extract';
+    const fileCount = skillEntry.bundle
+      ? extractBundle(
+          JSON.parse(Buffer.from(data).toString('utf8')) as SkillBundle,
+          skillDir,
+          skillEntry.id,
+        )
+      : extractZipArchive(data, skillDir);
+    fs.writeFileSync(path.join(skillDir, '.posthog-wizard'), '');
+
+    logToFile(
+      `downloadSkill: installed ${skillEntry.id} from ${skillEntry.downloadUrl} (${fileCount} files)`,
+    );
+    return { success: true };
+  } catch (err: any) {
+    logToFile(`downloadSkill: error: ${err.message}`);
+    // A skill-less run still reports success — keep the failure visible.
+    analytics.wizardCapture('skill install failed', {
+      skill_id: skillEntry.id,
+      step,
+      platform: process.platform,
+      error: String(err.message).slice(0, 500),
+    });
+    return { success: false, error: err.message };
+  }
+}
+
+/**
+ * Structured result for installSkillById.
+ * - `ok`: the skill was fetched and extracted; `path` is where it lives
+ *   relative to installDir.
+ * - `menu-fetch-failed`: couldn't fetch or parse the skill menu.
+ * - `skill-not-found`: the menu didn't contain a skill with this id.
+ * - `download-failed`: found the skill but download/extract failed;
+ *   `message` has the underlying error.
+ */
+export type InstallSkillResult =
+  | { kind: 'ok'; path: string }
+  | { kind: 'menu-fetch-failed' }
+  | { kind: 'skill-not-found'; skillId: string }
+  | { kind: 'download-failed'; message: string };
+
+/**
+ * High-level "install a skill by ID" helper. Fetches the skill menu,
+ * finds the skill, downloads and extracts it. Programs should use this
+ * instead of composing fetchSkillMenu + downloadSkill themselves.
+ */
+export async function installSkillById(
+  skillId: string,
+  installDir: string,
+  skillsBaseUrl: string,
+  skillsRoot?: string,
+): Promise<InstallSkillResult> {
+  const menu = await fetchSkillMenu(skillsBaseUrl);
+  if (!menu) return { kind: 'menu-fetch-failed' };
+
+  const skill = Object.values(menu.categories)
+    .flat()
+    .find((s) => s.id === skillId);
+  if (!skill) return { kind: 'skill-not-found', skillId };
+
+  const result = await downloadSkill(skill, installDir, skillsRoot);
+  if (!result.success) {
+    return { kind: 'download-failed', message: result.error ?? 'unknown' };
+  }
+
+  const relPath = skillsRoot
+    ? `${skillsRoot}/${skillId}`
+    : `.claude/skills/${skillId}`;
+  return { kind: 'ok', path: relPath };
+}
+
+export const DEFAULT_ASK_MAX_QUESTIONS = 10;
+/** The call after this many returns a one-time batch-your-questions nudge. */
+export const ASK_BATCH_THRESHOLD = 3;
+
+export type AskCapDecision =
+  | { kind: 'ok' }
+  | {
+      kind: 'capped';
+      reason: 'max_questions' | 'adjacency';
+      message: string;
+    };
+
+/**
+ * Pure decision function for the wizard_ask caps. Returns whether the
+ * upcoming call should proceed and, if not, the error message to surface
+ * to the agent. Extracted so the policy can be unit-tested without
+ * spinning up an MCP server.
+ *
+ * The adjacency nudge fires exactly once per run (the caller records it
+ * via `adjacencyNudged`) — flows that legitimately need several
+ * sequential, answer-dependent asks then proceed up to `maxQuestions`.
+ * Without the flag the rejected call would never advance the counter and
+ * every later call would be rejected, making caps above the threshold
+ * unreachable.
+ */
+export function evaluateAskCap(
+  callCount: number,
+  maxQuestions: number,
+  adjacencyNudged = false,
+): AskCapDecision {
+  if (callCount >= maxQuestions) {
+    return {
+      kind: 'capped',
+      reason: 'max_questions',
+      message: `Error: wizard_ask cap reached (${maxQuestions} calls in this run). Proceed with sensible defaults using the answers you already have, or emit [ABORT] requirements-incomplete.`,
+    };
+  }
+  if (!adjacencyNudged && callCount >= ASK_BATCH_THRESHOLD) {
+    return {
+      kind: 'capped',
+      reason: 'adjacency',
+      message: `Error: too many wizard_ask calls in a row (${callCount} so far). Batch the remaining questions into a single call — the schema accepts up to 8 questions per invocation. If the remaining questions truly depend on earlier answers, ask again and they will go through.`,
+    };
+  }
+  return { kind: 'ok' };
+}
+
+// ---------------------------------------------------------------------------
+// Env file helpers
+// ---------------------------------------------------------------------------
+
+export const ENV_FILE_PATH_DESCRIPTION =
+  'Path to the .env file, relative to the wizard working directory. Pass ".env" for a file in that directory, or include the selected subproject path (for example, "packages/app/.env") for a nested project. Never prefix it with the wizard working directory\'s path inside an ancestor repository.';
+
+/**
+ * Resolve filePath relative to workingDirectory, rejecting path traversal.
+ */
+export function resolveEnvPath(
+  workingDirectory: string,
+  filePath: string,
+): string {
+  const resolved = path.resolve(workingDirectory, filePath);
+  if (
+    !resolved.startsWith(workingDirectory + path.sep) &&
+    resolved !== workingDirectory
+  ) {
+    throw new Error(
+      `Path traversal rejected: "${filePath}" resolves outside working directory`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Ensure the given env file basename is covered by .gitignore in the working directory.
+ * Creates .gitignore if it doesn't exist; appends the entry if missing.
+ */
+export function ensureGitignoreCoverage(
+  workingDirectory: string,
+  envFileName: string,
+): void {
+  const gitignorePath = path.join(workingDirectory, '.gitignore');
+
+  if (fs.existsSync(gitignorePath)) {
+    const content = fs.readFileSync(gitignorePath, 'utf8');
+    // Check if the file (or a glob covering it) is already listed
+    if (content.split('\n').some((line) => line.trim() === envFileName)) {
+      return;
+    }
+    const newContent = content.endsWith('\n')
+      ? `${content}${envFileName}\n`
+      : `${content}\n${envFileName}\n`;
+    fs.writeFileSync(gitignorePath, newContent, 'utf8');
+  } else {
+    fs.writeFileSync(gitignorePath, `${envFileName}\n`, 'utf8');
+  }
+}
+
+/**
+ * Parse a .env file's content and return the set of defined key names.
+ */
+export function parseEnvKeys(content: string): Set<string> {
+  const keys = new Set<string>();
+  for (const line of content.split('\n')) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+    if (match) {
+      keys.add(match[1]);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Merge key-value pairs into existing .env content.
+ * Updates existing keys in-place, appends new keys at the end.
+ */
+export function mergeEnvValues(
+  content: string,
+  values: Record<string, string>,
+): string {
+  let result = content;
+  const updatedKeys = new Set<string>();
+
+  for (const [key, value] of Object.entries(values)) {
+    // Preserve the existing `KEY=` prefix exactly; only swap the value.
+    const regex = new RegExp(`^(\\s*${key}\\s*=).*$`, 'm');
+    if (regex.test(result)) {
+      result = result.replace(regex, `$1${value}`);
+      updatedKeys.add(key);
+    }
+  }
+
+  const newKeys = Object.entries(values).filter(
+    ([key]) => !updatedKeys.has(key),
+  );
+  if (newKeys.length > 0) {
+    if (result.length > 0 && !result.endsWith('\n')) {
+      result += '\n';
+    }
+    for (const [key, value] of newKeys) {
+      result += `${key}=${value}\n`;
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Secret-vault plumbing shared by the MCP server and the pi-native tools —
+// one implementation so the vault contract cannot drift between harnesses.
+// ---------------------------------------------------------------------------
+
+/**
+ * Swap sensitive text answers for opaque vault refs before they return to
+ * the agent — the raw value never enters the LLM conversation. Cancelled
+ * answers pass through as the sentinel, unvaulted.
+ */
+export function vaultSensitiveAnswers(
+  questions: readonly { id: string; prompt: string; sensitive?: boolean }[],
+  answers: Record<string, string | string[]>,
+  vault: SecretVault,
+): Record<string, string | string[] | { secretRef: string }> {
+  const sensitiveById = new Map(
+    questions.filter((q) => q.sensitive).map((q) => [q.id, q.prompt]),
+  );
+  const sanitised: Record<string, string | string[] | { secretRef: string }> =
+    {};
+  for (const [id, answer] of Object.entries(answers)) {
+    const label = sensitiveById.get(id);
+    if (
+      label !== undefined &&
+      typeof answer === 'string' &&
+      answer !== CANCELLED_SENTINEL
+    ) {
+      const ref = vault.put(answer, { label, source: 'wizard_ask' });
+      sanitised[id] = { secretRef: ref };
+      logToFile(`wizard_ask: vaulted answer for "${id}" as ${ref}`);
+    } else {
+      sanitised[id] = answer;
+    }
+  }
+  return sanitised;
+}
+
+/** Resolution of a values map that may carry `{secretRef}` entries. */
+export type ResolvedEnvValues =
+  | { ok: true; values: Record<string, string>; refKeys: string[] }
+  | { ok: false; key: string; secretRef: string };
+
+/**
+ * Resolve `{secretRef}` entries host-side, so the value is written but never
+ * returned to the agent. Callers format their own error envelope from the
+ * failing key/ref.
+ */
+export function resolveEnvSecretRefs(
+  values: Record<string, string | { secretRef: string }>,
+  vault: SecretVault,
+): ResolvedEnvValues {
+  const resolved: Record<string, string> = {};
+  const refKeys: string[] = [];
+  for (const [key, val] of Object.entries(values)) {
+    if (typeof val === 'string') {
+      resolved[key] = val;
+      continue;
+    }
+    const secret = vault.get(val.secretRef);
+    if (secret === undefined) {
+      return { ok: false, key, secretRef: val.secretRef };
+    }
+    resolved[key] = secret;
+    refKeys.push(key);
+  }
+  return { ok: true, values: resolved, refKeys };
+}
+
+// ---------------------------------------------------------------------------
+// Audit ledger helpers
+// ---------------------------------------------------------------------------
+
+export const AUDIT_STATUSES: readonly AuditStatus[] = [
+  'pending',
+  'pass',
+  'error',
+  'warning',
+  'suggestion',
+];
+
+/** Atomically write the audit ledger. Thin typed wrapper over writeJsonAtomic. */
+export function writeLedgerAtomic(
+  targetPath: string,
+  checks: AuditCheck[],
+): void {
+  writeJsonAtomic(targetPath, checks);
+}
+
+/**
+ * Apply a batch of patches to the ledger by id. Returns the new array and the
+ * list of update ids that didn't match any existing check.
+ */
+export function applyAuditUpdates(
+  current: AuditCheck[],
+  updates: Array<{
+    id: string;
+    status: AuditStatus;
+    file?: string;
+    details?: string;
+  }>,
+): { next: AuditCheck[]; unknown: string[] } {
+  const byId = new Map(current.map((c) => [c.id, c]));
+  const unknown: string[] = [];
+
+  for (const u of updates) {
+    const existing = byId.get(u.id);
+    if (!existing) {
+      unknown.push(u.id);
+      continue;
+    }
+    byId.set(u.id, {
+      ...existing,
+      status: u.status,
+      ...(u.file !== undefined ? { file: u.file } : {}),
+      ...(u.details !== undefined ? { details: u.details } : {}),
+    });
+  }
+
+  return {
+    next: current.map((c) => byId.get(c.id) ?? c),
+    unknown,
+  };
+}
+
+/**
+ * Append new checks to a seeded ledger. Duplicate ids are reported without
+ * mutating the current ledger, including duplicates inside the additions.
+ */
+function applyAuditAdditions(
+  current: AuditCheck[],
+  additions: AuditCheck[],
+): { next: AuditCheck[]; duplicates: string[] } {
+  const existingIds = new Set(current.map((c) => c.id));
+  const additionIds = new Set<string>();
+  const duplicates: string[] = [];
+
+  for (const check of additions) {
+    if (existingIds.has(check.id) || additionIds.has(check.id)) {
+      duplicates.push(check.id);
+      continue;
+    }
+    additionIds.add(check.id);
+  }
+
+  if (duplicates.length > 0) {
+    return { next: current, duplicates };
+  }
+
+  return { next: [...current, ...additions], duplicates: [] };
+}
+
+export function readLedger(targetPath: string): AuditCheck[] {
+  if (!fs.existsSync(targetPath)) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
+    return coerceAuditChecks(parsed);
+  } catch {
+    return [];
+  }
+}
+
+export type AppendAuditChecksResult =
+  | { ok: true; added: number }
+  | { ok: false; reason: 'missing-ledger' }
+  | { ok: false; reason: 'duplicate-ids'; ids: string[] };
+
+export function appendAuditChecksToLedger(
+  targetPath: string,
+  additions: AuditCheck[],
+): AppendAuditChecksResult {
+  if (!fs.existsSync(targetPath)) {
+    return { ok: false, reason: 'missing-ledger' };
+  }
+
+  const current = readLedger(targetPath);
+  const { next, duplicates } = applyAuditAdditions(current, additions);
+  if (duplicates.length > 0) {
+    return { ok: false, reason: 'duplicate-ids', ids: duplicates };
+  }
+
+  writeLedgerAtomic(targetPath, next);
+  return { ok: true, added: additions.length };
+}
+
+export const SERVER_NAME = 'wizard-tools';
+
+/** Tool names exposed by the wizard-tools server, keyed for selective use. */
+// SDK expects MCP tool names in allowedTools/disallowedTools to be the
+// fully-qualified `mcp__<server>__<tool>` form (sdk.d.ts: "Fully-qualified
+// MCP tool name, e.g. mcp__server__tool_name."). The colon form silently
+// fails to match, which made every program's `disallowedTools` entry a no-op.
+export const WIZARD_TOOL_NAMES = {
+  checkEnvKeys: `mcp__${SERVER_NAME}__check_env_keys`,
+  setEnvValues: `mcp__${SERVER_NAME}__set_env_values`,
+  detectPackageManager: `mcp__${SERVER_NAME}__detect_package_manager`,
+  loadSkillMenu: `mcp__${SERVER_NAME}__load_skill_menu`,
+  installSkill: `mcp__${SERVER_NAME}__install_skill`,
+  auditSeedChecks: `mcp__${SERVER_NAME}__audit_seed_checks`,
+  auditAddChecks: `mcp__${SERVER_NAME}__audit_add_checks`,
+  auditResolveChecks: `mcp__${SERVER_NAME}__audit_resolve_checks`,
+  wizardAsk: `mcp__${SERVER_NAME}__wizard_ask`,
+  enqueueTask: `mcp__${SERVER_NAME}__enqueue_task`,
+  completeTask: `mcp__${SERVER_NAME}__complete_task`,
+  readHandoffs: `mcp__${SERVER_NAME}__read_handoffs`,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Test-only exports
+// ---------------------------------------------------------------------------
+
+export const __test = {
+  extractZipArchive,
+  extractBundle,
+  fetchWithRetry,
+  downloadWithRetry,
+  writeLedgerAtomic,
+  readLedger,
+  applyAuditAdditions,
+  appendAuditChecksToLedger,
+  applyAuditUpdates,
+  makeMutex,
+  AUDIT_CHECKS_FILE,
+};


### PR DESCRIPTION
Wires the session secret vault into pi's `wizard_ask` and `set_env_values` — same contract as the MCP server.

Sensitive text answers are vaulted and returned to the agent as `{"secretRef": "secret:..."}`; `set_env_values` accepts `string | {secretRef}` and resolves refs host-side, so the credential lands in `.env` without ever entering the model conversation. Refs are session-scoped (cross-run refs error), cancelled answers are never vaulted, and `sensitive` on non-text kinds is still rejected. First commit hardened by rejecting `sensitive` outright; this replaces it with the real fix. Addresses Sarah's review comment on #902.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
