### PR TITLE
fix(agent): thread gateway auth explicitly on anthropic triage path

### DIFF
--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -33,7 +33,10 @@ import {
   createPostToolUseYaraHooks,
   prewarmYaraScanner,
 } from '@lib/yara-hooks';
-import { createTriageLLMProvider } from './triage-provider';
+import {
+  createTriageLLMProvider,
+  type TriageGatewayAuth,
+} from './triage-provider';
 import { getWizardCommandments } from './commandments';
 import { classifyToolToStage } from './agent-phase';
 import type { PackageManagerDetector } from '@lib/detection/package-manager';
@@ -298,6 +301,8 @@ type AgentRunConfig = {
   getPendingQuestion?: () =>
     | import('@lib/wizard-session').PendingQuestion
     | null;
+  /** Gateway auth for warlock triage LLM (anthropic path). */
+  triageAuth?: TriageGatewayAuth;
 };
 
 /**
@@ -579,6 +584,7 @@ export async function initializeAgent(
       allowedTools: config.allowedTools,
       disallowedTools: config.disallowedTools,
       getPendingQuestion: config.getPendingQuestion,
+      triageAuth: { baseURL: gatewayUrl, authToken: config.posthogApiKey },
     };
 
     logToFile('Agent config:', {
@@ -800,10 +806,10 @@ export async function runAgent(
     // each string against the parent's mcpServers map.
     const inheritedMcpServerNames = Object.keys(agentConfig.mcpServers);
 
-    // LLM provider for warlock triage (reuses the gateway auth set on
-    // process.env by initializeAgent). Undefined if auth is missing — hooks
-    // then skip triage and fail closed.
-    const triageProvider = createTriageLLMProvider();
+    // LLM provider for warlock triage (reuses the gateway auth threaded
+    // through AgentRunConfig.triageAuth by initializeAgent). Undefined if auth
+    // is missing — hooks then skip triage and fail closed.
+    const triageProvider = createTriageLLMProvider(agentConfig.triageAuth);
 
     // Actually stop the run when a YARA hook hits a terminal violation. The SDK
     // ignores `stopReason` from PostToolUse hooks, so we abort the query (like

--- a/src/lib/agent/triage-provider.test.ts
+++ b/src/lib/agent/triage-provider.test.ts
@@ -1,0 +1,53 @@
+import { createTriageLLMProvider } from './triage-provider';
+
+vi.mock('@utils/debug', () => ({
+  logToFile: vi.fn(),
+}));
+
+// Mock axios so the returned provider doesn't hit the network; we never call
+// the returned function in these tests so the mock body is inert.
+vi.mock('axios');
+
+describe('createTriageLLMProvider', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('returns a provider function when explicit auth is given', () => {
+    const provider = createTriageLLMProvider({
+      baseURL: 'https://gateway.example.com',
+      authToken: 'tok_abc123',
+    });
+
+    expect(provider).toBeTruthy();
+    expect(typeof provider).toBe('function');
+  });
+
+  it('returns undefined when no auth arg is passed (fail-closed)', () => {
+    const provider = createTriageLLMProvider();
+
+    expect(provider).toBeUndefined();
+  });
+
+  it('returns undefined when auth arg is empty object (env is no longer consulted)', () => {
+    // Stub the env vars that the old code used to read — the current code
+    // must NOT fall back to them.
+    process.env.ANTHROPIC_BASE_URL = 'https://stale-env.example.com';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'tok_stale_env';
+
+    // Cast through any to test the runtime env-is-no-longer-read path
+    // (the call at L52-53 used to fall back to process.env when auth.baseURL
+    // was undefined — we're proving that fallback is gone).
+    const provider = createTriageLLMProvider({} as any);
+
+    expect(provider).toBeUndefined();
+  });
+});

--- a/src/lib/agent/triage-provider.ts
+++ b/src/lib/agent/triage-provider.ts
@@ -36,11 +36,11 @@ export interface TriageGatewayAuth {
 
 /**
  * Build the triage LLM provider. Auth comes from the explicit `auth` param
- * when given (the pi harness — it auths the gateway programmatically and never
- * sets the env vars), otherwise from the gateway auth on process.env (set by
- * initializeAgent on the anthropic path). Returns undefined if neither is
- * configured — callers then skip triage and fail closed (act on every flagged
- * match), so a missing key never silently disables the scanner.
+ * when given (the pi harness passes it from ToolGateContext.triageAuth, the
+ * anthropic harness passes it from AgentRunConfig.triageAuth). Returns
+ * undefined if auth is absent — callers then skip triage and fail closed
+ * (act on every flagged match), so a missing key never silently disables the
+ * scanner.
  *
  * The triage model is independent of the agent's model: it is a classifier
  * judging scan matches, and the gateway routes it by model id regardless of
@@ -49,8 +49,8 @@ export interface TriageGatewayAuth {
 export function createTriageLLMProvider(
   auth?: TriageGatewayAuth,
 ): LLMProvider | undefined {
-  const baseURL = auth?.baseURL ?? process.env.ANTHROPIC_BASE_URL;
-  const authToken = auth?.authToken ?? process.env.ANTHROPIC_AUTH_TOKEN;
+  const baseURL = auth?.baseURL;
+  const authToken = auth?.authToken;
 
   if (!baseURL || !authToken) {
     logToFile(


### PR DESCRIPTION
## Problem

Warlock's triage LLM provider has its gateway auth wired two different ways
depending on the harness:

- **pi path** passes it explicitly via `ToolGateContext.triageAuth`.
- **anthropic path** relies on an implicit `process.env` fallback:
  `createTriageLLMProvider()` is called with no args and reads
  `process.env.ANTHROPIC_BASE_URL` / `process.env.ANTHROPIC_AUTH_TOKEN`, which
  `initializeAgent` mutated earlier in the run.

The env fallback works, but it's a fragile side-channel: `runAgent` doesn't
actually have the gateway creds in scope — it depends on `initializeAgent`
having mutated `process.env` first. It also reads as "triage talks to Anthropic
directly" to anyone skimming the code. This is a documented follow-up to #804
(the pi → warlock migration), which deliberately scoped its auth change to the
pi path.

Closes #825. Depends on #804 (already landed — commit 383ac5d).

## Changes

Thread the gateway auth explicitly on the anthropic path, then drop the
`process.env` fallback so **neither** harness depends on the env side-channel.

- `src/lib/agent/triage-provider.ts` — removed the
  `?? process.env.ANTHROPIC_BASE_URL` / `?? process.env.ANTHROPIC_AUTH_TOKEN`
  fallback. Auth now comes only from the `auth` param. Missing auth still returns
  `undefined` → hooks skip triage and fail closed (act on every flagged match).
- `src/lib/agent/agent-interface.ts`
  - import `TriageGatewayAuth`
  - add optional `triageAuth?: TriageGatewayAuth` to the internal `AgentRunConfig`
  - set it in `initializeAgent` from `gatewayUrl` (already computed) +
    `config.posthogApiKey` (already in scope)
  - pass it at the `runAgent` call site:
    `createTriageLLMProvider(agentConfig.triageAuth)`

**Deliberately left unchanged** (per issue scope): the pi path
(`pi/index.ts`, `pi/task.ts`), `initializeAgent`'s `process.env` writes (the
Claude Agent SDK subprocess still needs them for the agent's own model calls),
and `src/lib/agent/mcp-prompt-streaming.ts`.

## Test plan

`pnpm build && pnpm test && pnpm fix` all green (build=0, fix=0, test=1445
passed across 106 files).

New unit tests in `src/lib/agent/triage-provider.test.ts` cover the changed
behavior with explicit edge cases:
- explicit `{ baseURL, authToken }` → returns a provider function
- no arg → `undefined` (fail-closed)
- empty object **with stale `process.env.ANTHROPIC_*` stubbed** → still
  `undefined` (proves the env fallback is gone, not just unused)

Edge cases considered: if `triageAuth` is ever absent on the anthropic path,
`createTriageLLMProvider` returns `undefined` and Warlock fails closed (every
flagged match acted on) — same as today's missing-key path, so no security
regression. Verified by grep that `authToken` is never interpolated into a log
line or request URL (boolean `apiKeyPresent` pattern preserved). Existing
`pi/__tests__/security.test.ts` (46 tests) confirms the pi path is unchanged.

## LLM context

This PR was produced with AI assistance, disclosed per PostHog's AI contributions
policy and the wizard PR template's Agent context section.

- An AFK implementation agent (Hermes, in an isolated git worktree on branch
  `fix/825-anthropic-triage-explicit-auth`) wrote the code + new test via TDD.
- Two independent adversarial review agents (CTO = code/arch lens, COO =
  scope/process lens) reviewed the diff; both returned APPROVED. One
  false-positive (a "literal `***` instead of `Bearer`" claim) was caught and
  refuted by byte-level `xxd` verification — the file correctly contains
  `` `Bearer ${authToken}` ``.
- The parent session (human-in-the-loop) independently re-ran the verify gate
  (`pnpm build && pnpm test && pnpm fix`) and confirmed the diff scope before
  this description was written.

The human author understands and owns the change: it threads gateway auth
explicitly on the anthropic triage path and removes the implicit `process.env`
fallback, with fail-closed behavior preserved.