### PR TITLE
fix(auth): honor --region on the interactive path and log region-probe failures

### DIFF
--- a/src/lib/runners/run-wizard.ts
+++ b/src/lib/runners/run-wizard.ts
@@ -4,6 +4,7 @@ import { runAgent } from '@lib/agent/agent-runner';
 import { authenticate } from '@lib/agent/runner/shared/authenticate';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { Harness, Sequence } from '@lib/constants';
+import type { CloudRegion } from '@utils/types';
 import type { startTUI as StartTUIFn } from '@ui/tui/start-tui';
 import type { WizardStore } from '@ui/tui/store';
 import type { WizardSession } from '@lib/wizard-session';
@@ -94,6 +95,7 @@ export function runWizard(
         apiKey: options.apiKey as string | undefined,
         projectId: options.projectId as string | undefined,
         email: options.email as string | undefined,
+        region: options.region as CloudRegion | undefined,
         baseUrl: options.baseUrl as string | undefined,
         benchmark: options.benchmark as boolean | undefined,
         yaraReport: options.yaraReport as boolean | undefined,

--- a/src/utils/__tests__/ci-region.test.ts
+++ b/src/utils/__tests__/ci-region.test.ts
@@ -1,6 +1,7 @@
 import { getOrAskForProjectData } from '@utils/setup-utils';
 import { detectRegion } from '@utils/urls';
-import { fetchProjectData } from '@lib/api';
+import { fetchProjectData, fetchUserData } from '@lib/api';
+import { performOAuthFlow } from '@utils/oauth';
 
 vi.mock('@ui', () => ({
   getUI: () => ({
@@ -26,11 +27,16 @@ vi.mock('@utils/analytics', () => ({
     setTag: vi.fn(),
   },
 }));
+vi.mock('@utils/oauth', () => ({
+  performOAuthFlow: vi.fn(),
+}));
 
 const mockedDetect = detectRegion as unknown as ReturnType<typeof vi.fn>;
 const mockedFetchProject = fetchProjectData as unknown as ReturnType<
   typeof vi.fn
 >;
+const mockedFetchUser = fetchUserData as unknown as ReturnType<typeof vi.fn>;
+const mockedOAuthFlow = performOAuthFlow as unknown as ReturnType<typeof vi.fn>;
 
 const project = {
   id: 123,
@@ -75,5 +81,51 @@ describe('getOrAskForProjectData CI region', () => {
     });
 
     expect(mockedDetect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getOrAskForProjectData OAuth login region', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFetchProject.mockResolvedValue(project);
+    mockedFetchUser.mockResolvedValue({
+      distinct_id: 'user-1',
+      role_at_organization: null,
+    });
+    mockedOAuthFlow.mockResolvedValue({
+      access_token: 'pha_test',
+      scoped_teams: [123],
+    });
+  });
+
+  it('uses the provided region and never probes @me for it', async () => {
+    const result = await getOrAskForProjectData({
+      ci: false,
+      signup: false,
+      projectId: 123,
+      region: 'eu',
+    });
+
+    // Same contract as CI mode: a provided region skips the us/eu probe.
+    expect(mockedDetect).not.toHaveBeenCalled();
+    expect(mockedFetchProject).toHaveBeenCalledWith(
+      'pha_test',
+      123,
+      'https://eu.posthog.com',
+    );
+    expect(result.host.region).toBe('eu');
+  });
+
+  it('falls back to detection only when no region is provided', async () => {
+    mockedDetect.mockResolvedValue('eu');
+
+    await getOrAskForProjectData({ ci: false, signup: false, projectId: 123 });
+
+    expect(mockedDetect).toHaveBeenCalledTimes(1);
+    expect(mockedFetchProject).toHaveBeenCalledWith(
+      'pha_test',
+      123,
+      'https://eu.posthog.com',
+    );
   });
 });

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -615,6 +615,7 @@ async function askForWizardLogin(options: {
   const host = await HostResolution.fromAccessToken(
     tokenResponse.access_token,
     {
+      region: options.region,
       localMcp: options.localMcp,
       baseUrl: options.baseUrl,
     },
@@ -695,7 +696,7 @@ async function askForProvisioningSignup(
         'This email already has a PostHog account. Switching to login flow...',
       );
 
-      return askForWizardLogin({ signup: false, baseUrl, localMcp });
+      return askForWizardLogin({ signup: false, region, baseUrl, localMcp });
     }
 
     getUI().log.error(`Failed to create account: ${message}`);

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { IS_DEV, WIZARD_USER_AGENT } from '@lib/constants';
+import { logToFile } from './debug';
 import type { CloudRegion } from './types';
 
 /**
@@ -83,6 +84,17 @@ export async function detectRegion(
 
   if (usResult.status === 'fulfilled') return 'us';
   if (euResult.status === 'fulfilled') return 'eu';
+
+  // Log why each probe failed — otherwise network-level failures are
+  // indistinguishable from a genuinely bad token.
+  const describeProbeFailure = ({ reason }: PromiseRejectedResult): string =>
+    axios.isAxiosError(reason)
+      ? `code=${reason.code ?? 'none'} status=${
+          reason.response?.status ?? 'none'
+        } ${reason.message}`
+      : String(reason);
+  logToFile('[detect-region] us probe failed:', describeProbeFailure(usResult));
+  logToFile('[detect-region] eu probe failed:', describeProbeFailure(euResult));
 
   throw new Error(
     'Could not determine cloud region from access token. Please check your PostHog account.',


### PR DESCRIPTION
## Problem

The self-driving wizard has been crashing for me for weeks, at the accept-the-callback-URL step right after authenticating with PostHog EU Cloud:

```
❯ npx -y @posthog/wizard@latest self-driving
Wizard run failed: Error: Could not determine cloud region from access token. Please check your PostHog account.
    at detectRegion (...)
```

The log shows login actually succeeds:

```
[oauth] callback received with authorization code
[oauth] token exchange succeeded, granted scopes: ... scoped_teams: [123898]
[run-wizard] FATAL: Error: Could not determine cloud region from access token.
```

The OAuth response doesn't include the account's region, so the wizard guesses it by hitting both clouds' `/api/users/@me/` with the token. I'm in Sydney: Node aborts each connect attempt after 250ms (the `autoSelectFamilyAttemptTimeout` default), eu-central-1 is a ~300ms round trip, so both probes time out and the wizard decides the token is bad seconds after issuing it. us-east-1 (~220ms) barely fits under the limit, so US users rarely see this.

`--region eu` should skip the probe and is in the self-driving help output, but it only works in CI mode: the interactive path drops it in `runWizard`'s `buildSession` call and again in `askForWizardLogin`. And `detectRegion` swallows the network errors, so the failure reads as an account problem.

## Changes

- Thread `region` through the interactive path (`runWizard` into the session, `askForWizardLogin` into `HostResolution.fromAccessToken`), matching CI. `--region eu` now skips the probe.
- Forward `region` on the signup-to-login fallback too.
- Log each probe's failure reason (axios code, status, message) before throwing the generic error.

Default behavior is unchanged: without `--region`, detection runs exactly as today.

## Test plan

- Two new tests in `ci-region.test.ts`: the OAuth path with a region never calls `detectRegion`; without one it falls back to detection.
- `vitest run`: 1444 tests pass. `pnpm lint` passes.
- Verified on my machine: `self-driving --region eu` gets past region detection (the crash point); without the flag, the log now shows `[detect-region] eu probe failed: code=ETIMEDOUT ...` instead of nothing. Note the 250ms connect abort also affects the wizard's subsequent API calls to the far cloud, so fully completing a run on an affected machine additionally needs `NODE_OPTIONS="--network-family-autoselection-attempt-timeout=2000"`; details in comments.

## LLM context

Debugged and authored with Claude Code by replaying the wizard's axios calls with forced address family and attempt timeouts to isolate the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
