### PR TITLE
feat(data-warehouse): expand warehouse-source detection registry

### DIFF
--- a/src/lib/warehouse-sources/__tests__/detect.test.ts
+++ b/src/lib/warehouse-sources/__tests__/detect.test.ts
@@ -117,6 +117,47 @@ describe('detectWarehouseSources', () => {
     expect(byKind.Github).toBe('deep-link');
   });
 
+  it('detects LLM/AI SaaS sources by their SDK package as in-cli', () => {
+    writePackageJson(tmpDir, {
+      openai: '^4.0.0',
+      '@anthropic-ai/sdk': '^0.30.0',
+      'groq-sdk': '^0.9.0',
+    });
+    const byKind = Object.fromEntries(
+      detectWarehouseSources(tmpDir).map((s) => [s.kind, s.mode]),
+    );
+    expect(byKind.OpenAI).toBe('in-cli');
+    expect(byKind.Anthropic).toBe('in-cli');
+    expect(byKind.Groq).toBe('in-cli');
+  });
+
+  it('detects ad-platform sources as deep-link OAuth sources', () => {
+    writePackageJson(tmpDir, {
+      'google-ads-api': '^17.0.0',
+      'facebook-nodejs-business-sdk': '^20.0.0',
+    });
+    const byKind = Object.fromEntries(
+      detectWarehouseSources(tmpDir).map((s) => [s.kind, s.mode]),
+    );
+    expect(byKind.GoogleAds).toBe('deep-link');
+    expect(byKind.MetaAds).toBe('deep-link');
+  });
+
+  it('detects newly added sources from Python, Ruby, and env signals', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'requirements.txt'),
+      'python-gitlab==4.0.0\n',
+    );
+    fs.writeFileSync(path.join(tmpDir, 'Gemfile'), "gem 'newrelic_rpm'\n");
+    fs.writeFileSync(
+      path.join(tmpDir, '.env'),
+      'DATADOG_API_KEY=x\nSTYTCH_SECRET=y\n',
+    );
+    expect(kinds(tmpDir)).toEqual(
+      ['Datadog', 'GitLab', 'NewRelic', 'Stytch'].sort(),
+    );
+  });
+
   it('detects sources from Python and Ruby deps and env keys', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'requirements.txt'),

--- a/src/lib/warehouse-sources/registry.ts
+++ b/src/lib/warehouse-sources/registry.ts
@@ -612,4 +612,1241 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
       ruby: ['octokit'],
     },
   },
+
+  // ============================================================
+  // Additional released source types (see PostHog data-warehouse
+  // source catalog). Detected by SDK package or .env key convention.
+  // ============================================================
+  // ---- LLM / AI ----
+  {
+    kind: 'OpenAI',
+    label: 'OpenAI',
+    mode: 'in-cli',
+    signals: {
+      npm: ['openai'],
+      python: ['openai'],
+      envKeys: [/^OPENAI_/],
+    },
+  },
+  {
+    kind: 'Anthropic',
+    label: 'Anthropic',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@anthropic-ai/sdk'],
+      python: ['anthropic'],
+      envKeys: [/^ANTHROPIC_/],
+    },
+  },
+  {
+    kind: 'Cohere',
+    label: 'Cohere',
+    mode: 'in-cli',
+    signals: {
+      npm: ['cohere-ai'],
+      python: ['cohere'],
+      envKeys: [/^COHERE_/],
+    },
+  },
+  {
+    kind: 'MistralAI',
+    label: 'Mistral AI',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@mistralai/mistralai'],
+      python: ['mistralai'],
+      envKeys: [/^MISTRAL_/],
+    },
+  },
+  {
+    kind: 'Groq',
+    label: 'Groq',
+    mode: 'in-cli',
+    signals: {
+      npm: ['groq-sdk'],
+      python: ['groq'],
+      envKeys: [/^GROQ_/],
+    },
+  },
+  {
+    kind: 'TogetherAI',
+    label: 'Together AI',
+    mode: 'in-cli',
+    signals: {
+      npm: ['together-ai'],
+      python: ['together'],
+      envKeys: [/^TOGETHER_/],
+    },
+  },
+  {
+    kind: 'FireworksAI',
+    label: 'Fireworks AI',
+    mode: 'in-cli',
+    signals: {
+      python: ['fireworks-ai'],
+      envKeys: [/^FIREWORKS_/],
+    },
+  },
+  {
+    kind: 'Replicate',
+    label: 'Replicate',
+    mode: 'in-cli',
+    signals: {
+      npm: ['replicate'],
+      python: ['replicate'],
+      envKeys: [/^REPLICATE_/],
+    },
+  },
+  {
+    kind: 'HuggingFace',
+    label: 'Hugging Face',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@huggingface/inference'],
+      python: ['huggingface-hub'],
+      envKeys: [/^HUGGINGFACE_/, /^HF_TOKEN$/],
+    },
+  },
+  {
+    kind: 'ElevenLabs',
+    label: 'ElevenLabs',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@elevenlabs/elevenlabs-js', 'elevenlabs'],
+      python: ['elevenlabs'],
+      envKeys: [/^ELEVENLABS_/, /^ELEVEN_LABS_/],
+    },
+  },
+  {
+    kind: 'Deepgram',
+    label: 'Deepgram',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@deepgram/sdk'],
+      python: ['deepgram-sdk'],
+      envKeys: [/^DEEPGRAM_/],
+    },
+  },
+  {
+    kind: 'AssemblyAI',
+    label: 'AssemblyAI',
+    mode: 'in-cli',
+    signals: {
+      npm: ['assemblyai'],
+      python: ['assemblyai'],
+      envKeys: [/^ASSEMBLYAI_/],
+    },
+  },
+  {
+    kind: 'Langfuse',
+    label: 'Langfuse',
+    mode: 'in-cli',
+    signals: {
+      npm: ['langfuse'],
+      python: ['langfuse'],
+      envKeys: [/^LANGFUSE_/],
+    },
+  },
+  {
+    kind: 'LangSmith',
+    label: 'LangSmith',
+    mode: 'in-cli',
+    signals: {
+      npm: ['langsmith'],
+      python: ['langsmith'],
+      envKeys: [/^LANGSMITH_/, /^LANGCHAIN_API_KEY$/],
+    },
+  },
+  {
+    kind: 'Firecrawl',
+    label: 'Firecrawl',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@mendable/firecrawl-js'],
+      python: ['firecrawl-py'],
+      envKeys: [/^FIRECRAWL_/],
+    },
+  },
+  {
+    kind: 'Mem0',
+    label: 'Mem0',
+    mode: 'in-cli',
+    signals: {
+      npm: ['mem0ai'],
+      python: ['mem0ai'],
+      envKeys: [/^MEM0_/],
+    },
+  },
+  {
+    kind: 'Vellum',
+    label: 'Vellum',
+    mode: 'in-cli',
+    signals: {
+      npm: ['vellum-ai'],
+      python: ['vellum-ai'],
+      envKeys: [/^VELLUM_/],
+    },
+  },
+  {
+    kind: 'Helicone',
+    label: 'Helicone',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@helicone/helpers'],
+      envKeys: [/^HELICONE_/],
+    },
+  },
+  {
+    kind: 'OpenRouter',
+    label: 'OpenRouter',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@openrouter/ai-sdk-provider'],
+      envKeys: [/^OPENROUTER_/],
+    },
+  },
+  // ---- Payments / billing ----
+  {
+    kind: 'Paystack',
+    label: 'Paystack',
+    mode: 'in-cli',
+    signals: {
+      python: ['paystackapi'],
+      envKeys: [/^PAYSTACK_/],
+    },
+  },
+  {
+    kind: 'Orb',
+    label: 'Orb',
+    mode: 'in-cli',
+    signals: {
+      npm: ['orb-billing'],
+      python: ['orb-billing'],
+      envKeys: [/^ORB_/],
+    },
+  },
+  {
+    kind: 'Lago',
+    label: 'Lago',
+    mode: 'in-cli',
+    signals: {
+      npm: ['lago-javascript-client'],
+      python: ['lago-python-client'],
+      envKeys: [/^LAGO_/],
+    },
+  },
+  {
+    kind: 'Zuora',
+    label: 'Zuora',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^ZUORA_/],
+    },
+  },
+  {
+    kind: 'Stigg',
+    label: 'Stigg',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@stigg/node-server-sdk'],
+      envKeys: [/^STIGG_/],
+    },
+  },
+  {
+    kind: 'Ramp',
+    label: 'Ramp',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^RAMP_/],
+    },
+  },
+  {
+    kind: 'Brex',
+    label: 'Brex',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^BREX_/],
+    },
+  },
+  {
+    kind: 'Tremendous',
+    label: 'Tremendous',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^TREMENDOUS_/],
+    },
+  },
+  {
+    kind: 'Maxio',
+    label: 'Maxio',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^MAXIO_/],
+    },
+  },
+  {
+    kind: 'Chargify',
+    label: 'Chargify',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CHARGIFY_/],
+    },
+  },
+  {
+    kind: 'Invoiced',
+    label: 'Invoiced',
+    mode: 'in-cli',
+    signals: {
+      npm: ['invoiced'],
+      python: ['invoiced'],
+      envKeys: [/^INVOICED_/],
+    },
+  },
+  // ---- Email / marketing ----
+  {
+    kind: 'SparkPost',
+    label: 'SparkPost',
+    mode: 'in-cli',
+    signals: {
+      npm: ['sparkpost'],
+      python: ['sparkpost'],
+      envKeys: [/^SPARKPOST_/],
+    },
+  },
+  {
+    kind: 'MailerSend',
+    label: 'MailerSend',
+    mode: 'in-cli',
+    signals: {
+      npm: ['mailersend'],
+      python: ['mailersend'],
+      envKeys: [/^MAILERSEND_/],
+    },
+  },
+  {
+    kind: 'Iterable',
+    label: 'Iterable',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^ITERABLE_/],
+    },
+  },
+  {
+    kind: 'ConvertKit',
+    label: 'ConvertKit',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CONVERTKIT_/],
+    },
+  },
+  {
+    kind: 'Drip',
+    label: 'Drip',
+    mode: 'in-cli',
+    signals: {
+      npm: ['drip-nodejs'],
+      envKeys: [/^DRIP_/],
+    },
+  },
+  {
+    kind: 'Omnisend',
+    label: 'Omnisend',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^OMNISEND_/],
+    },
+  },
+  {
+    kind: 'EmailOctopus',
+    label: 'EmailOctopus',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^EMAILOCTOPUS_/, /^EMAIL_OCTOPUS_/],
+    },
+  },
+  {
+    kind: 'Elasticemail',
+    label: 'Elastic Email',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^ELASTICEMAIL_/, /^ELASTIC_EMAIL_/],
+    },
+  },
+  {
+    kind: 'CampaignMonitor',
+    label: 'Campaign Monitor',
+    mode: 'in-cli',
+    signals: {
+      npm: ['createsend-node'],
+      envKeys: [/^CAMPAIGN_MONITOR_/, /^CREATESEND_/],
+    },
+  },
+  {
+    kind: 'Lemlist',
+    label: 'Lemlist',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^LEMLIST_/],
+    },
+  },
+  // ---- Product analytics / CDP ----
+  {
+    kind: 'Segment',
+    label: 'Segment',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@segment/analytics-node', 'analytics-node'],
+      python: ['segment-analytics-python', 'analytics-python'],
+      envKeys: [/^SEGMENT_/],
+    },
+  },
+  {
+    kind: 'Snowplow',
+    label: 'Snowplow Analytics',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@snowplow/node-tracker'],
+      python: ['snowplow-tracker'],
+      envKeys: [/^SNOWPLOW_/],
+    },
+  },
+  {
+    kind: 'Matomo',
+    label: 'Matomo',
+    mode: 'in-cli',
+    signals: {
+      npm: ['matomo-tracker'],
+      envKeys: [/^MATOMO_/],
+    },
+  },
+  {
+    kind: 'Plausible',
+    label: 'Plausible',
+    mode: 'in-cli',
+    signals: {
+      npm: ['plausible-tracker'],
+      envKeys: [/^PLAUSIBLE_/],
+    },
+  },
+  // ---- Feature flags / experimentation ----
+  {
+    kind: 'ConfigCat',
+    label: 'ConfigCat',
+    mode: 'in-cli',
+    signals: {
+      npm: ['configcat-node', 'configcat-js'],
+      python: ['configcat-client'],
+      envKeys: [/^CONFIGCAT_/],
+    },
+  },
+  {
+    kind: 'Flagsmith',
+    label: 'Flagsmith',
+    mode: 'in-cli',
+    signals: {
+      npm: ['flagsmith-nodejs', 'flagsmith'],
+      python: ['flagsmith'],
+      envKeys: [/^FLAGSMITH_/],
+    },
+  },
+  {
+    kind: 'Unleash',
+    label: 'Unleash',
+    mode: 'in-cli',
+    signals: {
+      npm: ['unleash-client'],
+      python: ['unleashclient'],
+      envKeys: [/^UNLEASH_/],
+    },
+  },
+  {
+    kind: 'SplitIo',
+    label: 'Split.io',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@splitsoftware/splitio'],
+      python: ['splitio-client'],
+      envKeys: [/^SPLITIO_/, /^SPLIT_IO_/],
+    },
+  },
+  // ---- Auth / secrets ----
+  {
+    kind: 'Stytch',
+    label: 'Stytch',
+    mode: 'in-cli',
+    signals: {
+      npm: ['stytch'],
+      python: ['stytch'],
+      envKeys: [/^STYTCH_/],
+    },
+  },
+  {
+    kind: 'Doppler',
+    label: 'Doppler',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@dopplerhq/node-sdk'],
+      envKeys: [/^DOPPLER_/],
+    },
+  },
+  {
+    kind: 'Infisical',
+    label: 'Infisical',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@infisical/sdk'],
+      python: ['infisicalsdk'],
+      envKeys: [/^INFISICAL_/],
+    },
+  },
+  {
+    kind: 'OnePassword',
+    label: '1Password',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@1password/sdk'],
+      python: ['onepassword-sdk'],
+      envKeys: [/^ONEPASSWORD_/, /^OP_SERVICE_ACCOUNT_TOKEN$/],
+    },
+  },
+  {
+    kind: 'Persona',
+    label: 'Persona',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^PERSONA_/],
+    },
+  },
+  // ---- Comms / webhooks / voice ----
+  {
+    kind: 'Svix',
+    label: 'Svix',
+    mode: 'in-cli',
+    signals: {
+      npm: ['svix'],
+      python: ['svix'],
+      envKeys: [/^SVIX_/],
+    },
+  },
+  {
+    kind: 'Mux',
+    label: 'Mux',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@mux/mux-node'],
+      python: ['mux-python'],
+      envKeys: [/^MUX_/],
+    },
+  },
+  {
+    kind: 'Vapi',
+    label: 'Vapi',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@vapi-ai/server-sdk'],
+      python: ['vapi-server-sdk'],
+      envKeys: [/^VAPI_/],
+    },
+  },
+  {
+    kind: 'Aircall',
+    label: 'Aircall',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^AIRCALL_/],
+    },
+  },
+  {
+    kind: 'JustCall',
+    label: 'JustCall',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^JUSTCALL_/],
+    },
+  },
+  // ---- E-commerce / logistics ----
+  {
+    kind: 'WooCommerce',
+    label: 'WooCommerce',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@woocommerce/woocommerce-rest-api'],
+      python: ['woocommerce'],
+      envKeys: [/^WOOCOMMERCE_/],
+    },
+  },
+  {
+    kind: 'Recharge',
+    label: 'Recharge',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^RECHARGE_/],
+    },
+  },
+  {
+    kind: 'Commercetools',
+    label: 'commercetools',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@commercetools/platform-sdk'],
+      python: ['commercetools'],
+      envKeys: [/^CTP_/, /^COMMERCETOOLS_/],
+    },
+  },
+  {
+    kind: 'Webflow',
+    label: 'Webflow',
+    mode: 'in-cli',
+    signals: {
+      npm: ['webflow-api'],
+      envKeys: [/^WEBFLOW_/],
+    },
+  },
+  {
+    kind: 'Easypost',
+    label: 'EasyPost',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@easypost/api'],
+      python: ['easypost'],
+      envKeys: [/^EASYPOST_/],
+    },
+  },
+  {
+    kind: 'Shippo',
+    label: 'Shippo',
+    mode: 'in-cli',
+    signals: {
+      npm: ['shippo'],
+      python: ['shippo'],
+      envKeys: [/^SHIPPO_/],
+    },
+  },
+  {
+    kind: 'ShipStation',
+    label: 'ShipStation',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^SHIPSTATION_/],
+    },
+  },
+  {
+    kind: 'Squarespace',
+    label: 'Squarespace',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^SQUARESPACE_/],
+    },
+  },
+  {
+    kind: 'Printify',
+    label: 'Printify',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^PRINTIFY_/],
+    },
+  },
+  // ---- Support / helpdesk ----
+  {
+    kind: 'Freshdesk',
+    label: 'Freshdesk',
+    mode: 'in-cli',
+    signals: {
+      python: ['python-freshdesk'],
+      envKeys: [/^FRESHDESK_/],
+    },
+  },
+  {
+    kind: 'Front',
+    label: 'Front',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^FRONTAPP_/, /^FRONT_API_/],
+    },
+  },
+  {
+    kind: 'Gorgias',
+    label: 'Gorgias',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^GORGIAS_/],
+    },
+  },
+  {
+    kind: 'Chatwoot',
+    label: 'Chatwoot',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CHATWOOT_/],
+    },
+  },
+  {
+    kind: 'Kustomer',
+    label: 'Kustomer',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^KUSTOMER_/],
+    },
+  },
+  {
+    kind: 'Plain',
+    label: 'Plain',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@team-plain/typescript-sdk'],
+      envKeys: [/^PLAIN_/],
+    },
+  },
+  {
+    kind: 'Canny',
+    label: 'Canny',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CANNY_/],
+    },
+  },
+  {
+    kind: 'Pylon',
+    label: 'Pylon',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^PYLON_/],
+    },
+  },
+  // ---- Dev / infra / observability ----
+  {
+    kind: 'GitLab',
+    label: 'GitLab',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@gitbeaker/rest'],
+      python: ['python-gitlab'],
+      ruby: ['gitlab'],
+      envKeys: [/^GITLAB_/],
+    },
+  },
+  {
+    kind: 'Bitbucket',
+    label: 'Atlassian Bitbucket Cloud',
+    mode: 'in-cli',
+    signals: {
+      npm: ['bitbucket'],
+      envKeys: [/^BITBUCKET_/],
+    },
+  },
+  {
+    kind: 'Gitea',
+    label: 'Gitea',
+    mode: 'in-cli',
+    signals: {
+      npm: ['gitea-js'],
+      envKeys: [/^GITEA_/],
+    },
+  },
+  {
+    kind: 'Datadog',
+    label: 'Datadog',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@datadog/datadog-api-client', 'dd-trace'],
+      python: ['datadog', 'datadog-api-client'],
+      ruby: ['dogapi'],
+      envKeys: [/^DATADOG_/, /^DD_API_KEY$/, /^DD_APP_KEY$/],
+    },
+  },
+  {
+    kind: 'NewRelic',
+    label: 'New Relic',
+    mode: 'in-cli',
+    signals: {
+      npm: ['newrelic'],
+      python: ['newrelic'],
+      ruby: ['newrelic_rpm'],
+      envKeys: [/^NEW_RELIC_/, /^NEWRELIC_/],
+    },
+  },
+  {
+    kind: 'Cloudflare',
+    label: 'Cloudflare',
+    mode: 'in-cli',
+    signals: {
+      npm: ['cloudflare'],
+      python: ['cloudflare'],
+      envKeys: [/^CLOUDFLARE_/, /^CF_API_TOKEN$/],
+    },
+  },
+  {
+    kind: 'Elasticsearch',
+    label: 'Elasticsearch',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@elastic/elasticsearch'],
+      python: ['elasticsearch'],
+      ruby: ['elasticsearch'],
+      envKeys: [/^ELASTICSEARCH_/],
+    },
+  },
+  {
+    kind: 'Snyk',
+    label: 'Snyk',
+    mode: 'in-cli',
+    signals: {
+      npm: ['snyk'],
+      python: ['pysnyk'],
+      envKeys: [/^SNYK_/],
+    },
+  },
+  {
+    kind: 'PagerDuty',
+    label: 'PagerDuty',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@pagerduty/pdjs'],
+      python: ['pdpyras'],
+      envKeys: [/^PAGERDUTY_/, /^PD_API_KEY$/],
+    },
+  },
+  {
+    kind: 'Opsgenie',
+    label: 'Opsgenie',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^OPSGENIE_/],
+    },
+  },
+  {
+    kind: 'IncidentIo',
+    label: 'incident.io',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^INCIDENT_IO_/, /^INCIDENTIO_/],
+    },
+  },
+  {
+    kind: 'Bugsnag',
+    label: 'Bugsnag',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@bugsnag/js'],
+      python: ['bugsnag'],
+      ruby: ['bugsnag'],
+      envKeys: [/^BUGSNAG_/],
+    },
+  },
+  {
+    kind: 'Honeybadger',
+    label: 'Honeybadger',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@honeybadger-io/js'],
+      python: ['honeybadger'],
+      ruby: ['honeybadger'],
+      envKeys: [/^HONEYBADGER_/],
+    },
+  },
+  {
+    kind: 'Raygun',
+    label: 'Raygun',
+    mode: 'in-cli',
+    signals: {
+      npm: ['raygun'],
+      python: ['raygun4py'],
+      ruby: ['raygun4ruby'],
+      envKeys: [/^RAYGUN_/],
+    },
+  },
+  {
+    kind: 'CircleCI',
+    label: 'CircleCI',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CIRCLECI_/, /^CIRCLE_TOKEN$/],
+    },
+  },
+  {
+    kind: 'Upstash',
+    label: 'Upstash',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@upstash/redis'],
+      python: ['upstash-redis'],
+      envKeys: [/^UPSTASH_/],
+    },
+  },
+  {
+    kind: 'Vercel',
+    label: 'Vercel',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@vercel/sdk'],
+      envKeys: [/^VERCEL_API_TOKEN$/],
+    },
+  },
+  // ---- CRM / sales ----
+  {
+    kind: 'Pipedrive',
+    label: 'Pipedrive',
+    mode: 'in-cli',
+    signals: {
+      npm: ['pipedrive'],
+      envKeys: [/^PIPEDRIVE_/],
+    },
+  },
+  {
+    kind: 'Close',
+    label: 'Close',
+    mode: 'in-cli',
+    signals: {
+      python: ['closeio'],
+      envKeys: [/^CLOSE_API_KEY$/],
+    },
+  },
+  {
+    kind: 'Copper',
+    label: 'Copper',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^COPPER_/],
+    },
+  },
+  {
+    kind: 'Insightly',
+    label: 'Insightly',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^INSIGHTLY_/],
+    },
+  },
+  {
+    kind: 'Salesflare',
+    label: 'Salesflare',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^SALESFLARE_/],
+    },
+  },
+  {
+    kind: 'SalesLoft',
+    label: 'Salesloft',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^SALESLOFT_/],
+    },
+  },
+  {
+    kind: 'Attio',
+    label: 'Attio',
+    mode: 'in-cli',
+    signals: {
+      npm: ['attio'],
+      envKeys: [/^ATTIO_/],
+    },
+  },
+  {
+    kind: 'ActiveCampaign',
+    label: 'ActiveCampaign',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^ACTIVECAMPAIGN_/, /^ACTIVE_CAMPAIGN_/],
+    },
+  },
+  {
+    kind: 'Vitally',
+    label: 'Vitally',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^VITALLY_/],
+    },
+  },
+  // ---- PM / productivity ----
+  {
+    kind: 'Asana',
+    label: 'Asana',
+    mode: 'in-cli',
+    signals: {
+      npm: ['asana'],
+      python: ['asana'],
+      envKeys: [/^ASANA_/],
+    },
+  },
+  {
+    kind: 'Trello',
+    label: 'Trello',
+    mode: 'in-cli',
+    signals: {
+      npm: ['trello'],
+      envKeys: [/^TRELLO_/],
+    },
+  },
+  {
+    kind: 'Todoist',
+    label: 'Todoist',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@doist/todoist-api-typescript'],
+      python: ['todoist-api-python'],
+      envKeys: [/^TODOIST_/],
+    },
+  },
+  {
+    kind: 'Monday',
+    label: 'monday.com',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@mondaydotcomorg/api'],
+      envKeys: [/^MONDAY_/],
+    },
+  },
+  {
+    kind: 'ClickUp',
+    label: 'ClickUp',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CLICKUP_/],
+    },
+  },
+  {
+    kind: 'Height',
+    label: 'Height',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^HEIGHT_API_KEY$/],
+    },
+  },
+  {
+    kind: 'Shortcut',
+    label: 'Shortcut',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@shortcut/client'],
+      envKeys: [/^SHORTCUT_/],
+    },
+  },
+  {
+    kind: 'Jira',
+    label: 'Jira',
+    mode: 'in-cli',
+    signals: {
+      npm: ['jira-client'],
+      python: ['jira', 'atlassian-python-api'],
+      envKeys: [/^JIRA_/],
+    },
+  },
+  {
+    kind: 'Confluence',
+    label: 'Confluence',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CONFLUENCE_/],
+    },
+  },
+  {
+    kind: 'Airtable',
+    label: 'Airtable',
+    mode: 'in-cli',
+    signals: {
+      npm: ['airtable'],
+      python: ['pyairtable'],
+      envKeys: [/^AIRTABLE_/],
+    },
+  },
+  {
+    kind: 'Smartsheet',
+    label: 'Smartsheet',
+    mode: 'in-cli',
+    signals: {
+      npm: ['smartsheet'],
+      python: ['smartsheet-python-sdk'],
+      envKeys: [/^SMARTSHEET_/],
+    },
+  },
+  {
+    kind: 'Coda',
+    label: 'Coda',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CODA_API_/],
+    },
+  },
+  {
+    kind: 'Productboard',
+    label: 'Productboard',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^PRODUCTBOARD_/],
+    },
+  },
+  // ---- Scheduling / events ----
+  {
+    kind: 'Calendly',
+    label: 'Calendly',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CALENDLY_/],
+    },
+  },
+  {
+    kind: 'CalCom',
+    label: 'Cal.com',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CALCOM_/, /^CAL_API_KEY$/],
+    },
+  },
+  {
+    kind: 'Eventbrite',
+    label: 'Eventbrite',
+    mode: 'in-cli',
+    signals: {
+      python: ['eventbrite'],
+      envKeys: [/^EVENTBRITE_/],
+    },
+  },
+  // ---- HR / people ----
+  {
+    kind: 'BambooHR',
+    label: 'BambooHR',
+    mode: 'in-cli',
+    signals: {
+      python: ['pybamboohr'],
+      envKeys: [/^BAMBOOHR_/, /^BAMBOO_HR_/],
+    },
+  },
+  {
+    kind: 'Personio',
+    label: 'Personio',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^PERSONIO_/],
+    },
+  },
+  {
+    kind: 'Rippling',
+    label: 'Rippling',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^RIPPLING_/],
+    },
+  },
+  {
+    kind: 'Greenhouse',
+    label: 'Greenhouse',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^GREENHOUSE_/],
+    },
+  },
+  {
+    kind: 'Ashby',
+    label: 'Ashby',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^ASHBY_/],
+    },
+  },
+  {
+    kind: 'Workable',
+    label: 'Workable',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^WORKABLE_/],
+    },
+  },
+  // ---- Ads / marketing analytics (OAuth-first -> deep-link) ----
+  {
+    kind: 'GoogleAds',
+    label: 'Google Ads',
+    mode: 'deep-link',
+    signals: {
+      npm: ['google-ads-api'],
+      python: ['google-ads'],
+      envKeys: [/^GOOGLE_ADS_/],
+    },
+  },
+  {
+    kind: 'MetaAds',
+    label: 'Meta Ads',
+    mode: 'deep-link',
+    signals: {
+      npm: ['facebook-nodejs-business-sdk'],
+      python: ['facebook-business'],
+      envKeys: [/^META_ADS_/, /^FACEBOOK_ADS_/],
+    },
+  },
+  {
+    kind: 'LinkedinAds',
+    label: 'LinkedIn Ads',
+    mode: 'deep-link',
+    signals: {
+      envKeys: [/^LINKEDIN_ADS_/],
+    },
+  },
+  {
+    kind: 'TikTokAds',
+    label: 'TikTok Ads',
+    mode: 'deep-link',
+    signals: {
+      envKeys: [/^TIKTOK_ADS_/],
+    },
+  },
+  {
+    kind: 'RedditAds',
+    label: 'Reddit Ads',
+    mode: 'deep-link',
+    signals: {
+      envKeys: [/^REDDIT_ADS_/],
+    },
+  },
+  {
+    kind: 'PinterestAds',
+    label: 'Pinterest Ads',
+    mode: 'deep-link',
+    signals: {
+      envKeys: [/^PINTEREST_ADS_/],
+    },
+  },
+  {
+    kind: 'BingAds',
+    label: 'Bing Ads',
+    mode: 'deep-link',
+    signals: {
+      python: ['bingads'],
+      envKeys: [/^BING_ADS_/, /^MICROSOFT_ADS_/],
+    },
+  },
+  {
+    kind: 'AmazonAds',
+    label: 'Amazon Ads',
+    mode: 'deep-link',
+    signals: {
+      envKeys: [/^AMAZON_ADS_/],
+    },
+  },
+  {
+    kind: 'GoogleAnalytics',
+    label: 'Google Analytics',
+    mode: 'deep-link',
+    signals: {
+      npm: ['react-ga4'],
+      python: ['google-analytics-data'],
+      envKeys: [/^GOOGLE_ANALYTICS_/, /^GA4_/],
+    },
+  },
+  {
+    kind: 'GoogleSearchConsole',
+    label: 'Google Search Console',
+    mode: 'deep-link',
+    signals: {
+      envKeys: [/^SEARCH_CONSOLE_/, /^GSC_/],
+    },
+  },
+  {
+    kind: 'AppsFlyer',
+    label: 'AppsFlyer',
+    mode: 'in-cli',
+    signals: {
+      npm: ['react-native-appsflyer'],
+      envKeys: [/^APPSFLYER_/],
+    },
+  },
 ];


### PR DESCRIPTION
## Problem

The wizard's `warehouse-source` program nudges users to connect data-warehouse sources it
finds in their codebase, driven by the `SOURCE_DETECTORS` registry
(`src/lib/warehouse-sources/registry.ts`). That registry had **55** detectors, but PostHog
now ships **529 released + implemented** warehouse source types — so the wizard was silent
about the large majority of sources a user might already have wired into their app.

## Changes

Add **134** new detectors for released + implemented PostHog source types that have a
reliable codebase footprint (registry now 55 → 189). Categories: LLM/AI, payments &
billing, email & marketing, product analytics/CDP, feature flags, auth & secrets,
comms/webhooks, e-commerce & logistics, support, dev/infra & observability, CRM & sales,
project management, scheduling, HR, and ad platforms.

How each entry was derived and kept trustworthy:

- **Sources**: enumerated PostHog's live `SourceRegistry`, keeping only source types that
  are released (`unreleasedSource=false`) *and* implemented (the source overrides
  `get_schemas`). Every `kind` string is an exact match for a released `ExternalDataSourceType`.
- **Signals**: each detector maps a codebase footprint to a source — an npm/PyPI/gem SDK
  package and/or a distinctive `.env` key prefix. Env prefixes are kept specific to avoid
  false positives (no generic `API_KEY`/`TOKEN`).
- **Verification**: every package name was checked to exist against the npm, PyPI, and
  RubyGems registries; non-existent or placeholder packages (e.g. a security-holding npm
  stub) were dropped. Python names are normalized to the parser's form (lowercase, `_`→`-`).
- **Mode**: OAuth-first sources (ad platforms, etc.) use `deep-link`; database and API-key
  sources use `in-cli`, matching the existing convention.

No changes to detection mechanics — `detect.ts`/`types.ts` are untouched; this is config only.

## Test plan

- `pnpm exec vitest run src/lib/warehouse-sources` — 20/20 pass, including new cases for
  in-cli SDK detection (OpenAI/Anthropic/Groq), deep-link ad platforms (Google/Meta Ads),
  and combined Python/Ruby/env detection (GitLab/New Relic/Datadog/Stytch).
- `pnpm exec tsc --noEmit` — no new type errors introduced (pre-existing errors on `master`
  are in unrelated files).
- `eslint` + `prettier --check` clean on both changed files.
