### PR TITLE
feat: automate Android source-map (mapping) upload

### DIFF
--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -14,11 +14,17 @@ describe('SOURCE_MAPS_TARGETS precedence', () => {
     }
   });
 
-  it('ranks unsupported native guards ahead of the iOS target', () => {
+  it('ranks unsupported native guards ahead of the native targets', () => {
+    expect(SOURCE_MAPS_TARGETS).toContainEqual({
+      id: 'android',
+      name: 'Android',
+    });
     expect(SOURCE_MAPS_TARGETS).toContainEqual({ id: 'ios', name: 'iOS' });
-    for (const nativeGuard of ['react-native', 'flutter', 'android']) {
+    for (const nativeGuard of ['react-native', 'flutter']) {
+      expect(rank(nativeGuard)).toBeLessThan(rank('android'));
       expect(rank(nativeGuard)).toBeLessThan(rank('ios'));
     }
+    expect(rank('android')).toBeLessThan(rank('nextjs'));
     expect(rank('ios')).toBeLessThan(rank('nextjs'));
   });
 
@@ -111,7 +117,7 @@ describe('coerceReport', () => {
     );
   });
 
-  it.each(['React Native', 'Expo', 'Flutter', 'Android'])(
+  it.each(['React Native', 'Expo', 'Flutter'])(
     'blocks a native %s project misclassified as iOS',
     (framework) => {
       const report = coerceReport({
@@ -121,6 +127,76 @@ describe('coerceReport', () => {
             path: '.',
             framework,
             targetId: 'ios',
+            hasPostHog: true,
+          },
+        ],
+      });
+
+      expect(report.projects[0]).toEqual(
+        expect.objectContaining({
+          variant: null,
+          instrumentable: false,
+          reason: expect.stringMatching(/isn't supported/i),
+        }),
+      );
+    },
+  );
+
+  it('retains an Android project with PostHog as instrumentable', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Android',
+          targetId: 'android',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual({
+      path: '.',
+      framework: 'Android',
+      variant: 'android',
+      hasPostHog: true,
+      instrumentable: true,
+    });
+  });
+
+  it('blocks an Android project that has no PostHog SDK yet', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Android',
+          targetId: 'android',
+          hasPostHog: false,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: 'android',
+        hasPostHog: false,
+        instrumentable: false,
+        reason: expect.stringMatching(/no posthog sdk/i),
+      }),
+    );
+  });
+
+  it.each(['React Native', 'Expo', 'Flutter'])(
+    'blocks a native %s project misclassified as Android',
+    (framework) => {
+      const report = coerceReport({
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework,
+            targetId: 'android',
             hasPostHog: true,
           },
         ],

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -47,19 +47,19 @@ export type DetectionReport = {
 /**
  * Variant precedence for the agentic picker (most specific first). The detector
  * keeps the EARLIEST matching target. Unsupported native targets are included
- * as guards before iOS so React Native, Flutter, and Android projects with
- * nested Xcode manifests are not misclassified as instrumentable iOS apps.
- * JS ordering mirrors `pickJsVariant` in detect.ts: opinionated frameworks →
- * bundlers → bare React → Node → generic web.
+ * as guards before Android and iOS so React Native and Flutter projects with
+ * nested Gradle or Xcode manifests are not misclassified as instrumentable
+ * native apps. JS ordering mirrors `pickJsVariant` in detect.ts: opinionated
+ * frameworks → bundlers → bare React → Node → generic web.
  */
 const NON_AUTOMATABLE_NATIVE_VARIANTS: readonly SkillVariant[] = [
   'react-native',
   'flutter',
-  'android',
 ];
 
 const VARIANT_PRECEDENCE: readonly SkillVariant[] = [
   ...NON_AUTOMATABLE_NATIVE_VARIANTS,
+  'android',
   'ios',
   'nextjs',
   'nuxt',
@@ -119,7 +119,7 @@ function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
     projects: report.projects.map((p) => {
       const variant =
         isAutomatableVariant(p.targetId) &&
-        !/\b(?:react[\s-]*native|expo|flutter|android)\b/i.test(p.framework)
+        !/\b(?:react[\s-]*native|expo|flutter)\b/i.test(p.framework)
           ? p.targetId
           : null;
       return {

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -52,10 +52,11 @@ const DISPLAY_NAME: Record<SkillVariant, string> = {
 
 /**
  * Variants the wizard can wire up source-map upload for automatically. The
- * native variants (react-native, android, flutter) are recognised but not yet
+ * native variants (react-native, flutter) are recognised but not yet
  * automatable, so the agentic picker treats them as non-instrumentable.
  */
 export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
+  'android',
   'ios',
   'web',
   'nextjs',
@@ -73,7 +74,7 @@ export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
  * build shells out to it with no npx / local-dep fallback. JS variants stay out.
  */
 export const VARIANTS_REQUIRING_POSTHOG_CLI: ReadonlySet<SkillVariant> =
-  new Set(['ios']);
+  new Set(['ios', 'android']);
 
 const POSTHOG_SDKS = [
   'posthog-js',

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -44,8 +44,8 @@ function ensurePostHogCli(variant: SkillVariant): void {
       { source: 'source_maps_cli_preinstall', variant },
     );
     getUI().log.warn(
-      `Could not pre-install posthog-cli (${result.error}). Your Xcode build ` +
-        `will fail to upload dSYMs until it's installed: npm install -g @posthog/cli@latest`,
+      `Could not pre-install posthog-cli (${result.error}). Your release build ` +
+        `will fail to upload debug symbols until it's installed: npm install -g @posthog/cli@latest`,
     );
   }
 }


### PR DESCRIPTION
Related PRs:
- context-mill: https://github.com/PostHog/context-mill/pull/253
- wizard-workbench: https://github.com/PostHog/wizard-workbench/pull/2906

Adds Android support to the `upload-source-maps` program.

<img width="1704" height="635" alt="CleanShot 2026-07-20 at 17 23 40" src="https://github.com/user-attachments/assets/7df0de07-7943-4ddc-ad16-5403aea05323" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)