### PR TITLE
fix(auth): read posthog_region from the OAuth token response

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -202,9 +202,9 @@ describe('CLI argument parsing', () => {
     return calls[calls.length - 1][0];
   }
 
-  // Note: --region is a yargs option that doesn't flow through buildSession in
-  // the non-CI path, so it's tested indirectly (no errors) rather than by
-  // inspecting values.
+  // Note: --region flows through buildSession only on the non-interactive
+  // paths; interactively it's ignored (OAuth reads the region off the token
+  // response), so the non-CI cases just assert parsing succeeds.
 
   describe('--region flag', () => {
     test.each(['us', 'eu'])(
@@ -309,6 +309,34 @@ describe('CLI argument parsing', () => {
 
       const args = getLastBuildSessionArgs();
       expect(args.apiKey).toBe('phx_test_key');
+    });
+
+    test('passes --region through to buildSession', async () => {
+      await runCLI([
+        '--ci',
+        '--region',
+        'eu',
+        '--api-key',
+        'phx_test',
+        '--install-dir',
+        '/tmp/test',
+      ]);
+
+      const args = getLastBuildSessionArgs();
+      expect(args.region).toBe('eu');
+    });
+
+    test('leaves region unset when --region is not passed', async () => {
+      await runCLI([
+        '--ci',
+        '--api-key',
+        'phx_test',
+        '--install-dir',
+        '/tmp/test',
+      ]);
+
+      const args = getLastBuildSessionArgs();
+      expect(args.region).toBeUndefined();
     });
 
     test("tags the build as 'ci'", async () => {
@@ -466,6 +494,7 @@ describe('CLI argument parsing', () => {
 
       const args = getLastBuildSessionArgs();
       expect(args.apiKey).toBe('phx_cli_key');
+      expect(args.region).toBe('eu');
     });
   });
 

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -217,14 +217,14 @@ describe('yargs parsing for the audit family', () => {
   test('accepts upload-source-maps and legacy upload-sourcemaps alias', async () => {
     const canonical = await parseCommand(
       uploadSourcemapsCommand,
-      'upload-source-maps --region eu',
+      'upload-source-maps --debug',
     );
     const legacy = await parseCommand(
       uploadSourcemapsCommand,
-      'upload-sourcemaps --region eu',
+      'upload-sourcemaps --debug',
     );
-    expect(canonical.region).toBe('eu');
-    expect(legacy.region).toBe('eu');
+    expect(canonical.debug).toBe(true);
+    expect(legacy.debug).toBe(true);
   });
 });
 

--- a/src/commands/basic-integration/index.ts
+++ b/src/commands/basic-integration/index.ts
@@ -1,6 +1,6 @@
 import { isNonInteractiveEnvironment } from '@utils/environment';
 import { setEntryCommand } from '@utils/links';
-import { headlessOption, isHeadless } from '@lib/headless-mode';
+import { headlessOption, isHeadless, regionOption } from '@lib/headless-mode';
 import { provisionCommand } from '../provision';
 import type { Command } from '../command';
 
@@ -32,6 +32,7 @@ export const basicIntegrationCommand: Command = {
     // The experimental headless flag — declared here (and on `audit`) rather
     // than globally. Routed by this command's handler via runHeadlessInstall.
     ...headlessOption,
+    ...regionOption,
   },
   check: (argv) => {
     // --playground is the standalone TUI demo; it can't combine with a

--- a/src/lib/headless-mode.ts
+++ b/src/lib/headless-mode.ts
@@ -50,3 +50,15 @@ export const headlessOption: Record<string, Options> = {
 export function isHeadless(options: Record<string, unknown>): boolean {
   return options[HEADLESS_FLAG] === true;
 }
+
+// `--region` only means something non-interactively (API-key auth has no OAuth
+// token response to read `posthog_region` from), so only headless-capable
+// commands declare it.
+export const regionOption: Record<string, Options> = {
+  region: {
+    describe: 'PostHog cloud region\nenv: POSTHOG_WIZARD_REGION',
+    choices: ['us', 'eu'],
+    type: 'string',
+    hidden: true,
+  },
+};

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -7,7 +7,7 @@ import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { WizardSession } from '@lib/wizard-session';
 import { OutroKind } from '@lib/wizard-session';
 import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
-import { headlessOption } from '@lib/headless-mode';
+import { headlessOption, regionOption } from '@lib/headless-mode';
 import { AUDIT_ABORT_CASES } from './detect.js';
 import { AUDIT_CHECKS_KEY, AUDIT_REPORT_FILE } from './types.js';
 import { AUDIT_SEED_CHECKS, seedAuditLedger } from './seed.js';
@@ -102,5 +102,5 @@ export const auditConfig: ProgramConfig = {
   // The experimental headless flag — declared on `audit` (and basic
   // integration) rather than globally. mergeCommandOptions lands it on the
   // `wizard audit` command; dispatchProgram routes it to runWizardHeadless.
-  cliOptions: { ...headlessOption },
+  cliOptions: { ...headlessOption, ...regionOption },
 };

--- a/src/lib/runners/run-non-interactive.ts
+++ b/src/lib/runners/run-non-interactive.ts
@@ -1,4 +1,5 @@
 import { POSTHOG_DOCS_URL, type Harness, type Sequence } from '@lib/constants';
+import type { CloudRegion } from '@utils/types';
 import { getUI, setUI } from '@ui';
 import { LoggingUI } from '@ui/logging-ui';
 import type { ProgramConfig } from '@lib/programs/program-step';
@@ -25,8 +26,8 @@ function modeLabel(mode: NonInteractiveMode): string {
 }
 
 /**
- * The single non-interactive validation layer: defaults region and requires
- * api-key and install-dir. Every non-interactive entry point routes through
+ * The single non-interactive validation layer: requires api-key and
+ * install-dir. Every non-interactive entry point routes through
  * `runNonInteractive`, so this is the one place these checks live. UI must be
  * initialized before calling.
  */
@@ -39,7 +40,6 @@ export function validateNonInteractiveOptions(
     mode === 'headless'
       ? 'personal API key phx_xxx or pha_ OAuth access token'
       : 'personal API key phx_xxx';
-  if (!options.region) options.region = 'us';
   if (!options.apiKey) {
     getUI().intro('PostHog Wizard');
     getUI().log.error(`${label} mode requires --api-key (${keyHint})`);
@@ -119,6 +119,9 @@ export function runNonInteractive(
       sequence: options.sequence as Sequence | undefined,
       model: options.model as string | undefined,
       ...env,
+      // After the spread: yargs already resolves flag-over-env for --region,
+      // so the parsed value must win over the raw env bag.
+      region: (options.region ?? env.region) as CloudRegion | undefined,
     });
     session.programLabel = config.id;
     if (config.skillId) {

--- a/src/utils/__tests__/ci-region.test.ts
+++ b/src/utils/__tests__/ci-region.test.ts
@@ -1,6 +1,7 @@
 import { getOrAskForProjectData } from '@utils/setup-utils';
 import { detectRegion } from '@utils/urls';
-import { fetchProjectData } from '@lib/api';
+import { fetchProjectData, fetchUserData } from '@lib/api';
+import { performOAuthFlow } from '@utils/oauth';
 
 vi.mock('@ui', () => ({
   getUI: () => ({
@@ -26,11 +27,17 @@ vi.mock('@utils/analytics', () => ({
     setTag: vi.fn(),
   },
 }));
+vi.mock('@utils/oauth', () => ({
+  performOAuthFlow: vi.fn(),
+  assertWizardCompletionScope: vi.fn(),
+}));
 
 const mockedDetect = detectRegion as unknown as ReturnType<typeof vi.fn>;
 const mockedFetchProject = fetchProjectData as unknown as ReturnType<
   typeof vi.fn
 >;
+const mockedFetchUser = fetchUserData as unknown as ReturnType<typeof vi.fn>;
+const mockedOAuthFlow = performOAuthFlow as unknown as ReturnType<typeof vi.fn>;
 
 const project = {
   id: 123,
@@ -75,5 +82,57 @@ describe('getOrAskForProjectData CI region', () => {
     });
 
     expect(mockedDetect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getOrAskForProjectData OAuth login region', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFetchProject.mockResolvedValue(project);
+    mockedFetchUser.mockResolvedValue({
+      distinct_id: 'user-1',
+      role_at_organization: null,
+    });
+  });
+
+  it('uses posthog_region from the token response and never probes @me', async () => {
+    mockedOAuthFlow.mockResolvedValue({
+      access_token: 'pha_test',
+      scope: 'event_definition:write',
+      scoped_teams: [123],
+      posthog_region: 'eu',
+    });
+
+    const result = await getOrAskForProjectData({
+      ci: false,
+      signup: false,
+      projectId: 123,
+    });
+
+    expect(mockedDetect).not.toHaveBeenCalled();
+    expect(mockedFetchProject).toHaveBeenCalledWith(
+      'pha_test',
+      123,
+      'https://eu.posthog.com',
+    );
+    expect(result.host.region).toBe('eu');
+  });
+
+  it('falls back to detection when the token response has no region', async () => {
+    mockedOAuthFlow.mockResolvedValue({
+      access_token: 'pha_test',
+      scope: 'event_definition:write',
+      scoped_teams: [123],
+    });
+    mockedDetect.mockResolvedValue('eu');
+
+    await getOrAskForProjectData({ ci: false, signup: false, projectId: 123 });
+
+    expect(mockedDetect).toHaveBeenCalledTimes(1);
+    expect(mockedFetchProject).toHaveBeenCalledWith(
+      'pha_test',
+      123,
+      'https://eu.posthog.com',
+    );
   });
 });

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -2,6 +2,7 @@ import {
   assertWizardCompletionScope,
   extractOAuthCode,
   isAuthorizationTimeout,
+  OAuthTokenResponseSchema,
   parseOAuthScopes,
 } from '@utils/oauth';
 import {
@@ -117,5 +118,38 @@ describe('wizard OAuth scopes', () => {
       'wizard_session:write',
       'event_definition:write',
     ]);
+  });
+});
+
+describe('OAuthTokenResponseSchema posthog_region', () => {
+  const base = {
+    access_token: 'pha_test',
+    expires_in: 3600,
+    token_type: 'Bearer',
+    scope: 'event_definition:write',
+  };
+
+  it('passes a recognized region through', () => {
+    const token = OAuthTokenResponseSchema.parse({
+      ...base,
+      posthog_region: 'eu',
+      posthog_base_url: 'https://eu.posthog.com',
+    });
+    expect(token.posthog_region).toBe('eu');
+    expect(token.posthog_base_url).toBe('https://eu.posthog.com');
+  });
+
+  it('degrades an unrecognized region to undefined instead of failing login', () => {
+    const token = OAuthTokenResponseSchema.parse({
+      ...base,
+      posthog_region: 'apac',
+    });
+    expect(token.access_token).toBe('pha_test');
+    expect(token.posthog_region).toBeUndefined();
+  });
+
+  it('parses responses without region fields (self-hosted)', () => {
+    const token = OAuthTokenResponseSchema.parse(base);
+    expect(token.posthog_region).toBeUndefined();
   });
 });

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -55,6 +55,9 @@ const OAuthTokenResponseSchema = z.object({
   refresh_token: z.string().optional(),
   scoped_teams: z.array(z.number()).optional(),
   scoped_organizations: z.array(z.string()).optional(),
+  // Sent by PostHog Cloud (and passed through the oauth.posthog.com proxy); absent on self-hosted.
+  posthog_region: z.enum(['us', 'eu']).optional(),
+  posthog_base_url: z.string().optional(),
 });
 
 export type OAuthTokenResponse = z.infer<typeof OAuthTokenResponseSchema>;
@@ -376,6 +379,7 @@ async function exchangeCodeForToken(
   const token = OAuthTokenResponseSchema.parse(response.data);
   logToFile(
     `[oauth] token exchange succeeded, granted scopes: ${token.scope}` +
+      `${token.posthog_region ? `, region: ${token.posthog_region}` : ''}` +
       `${
         token.scoped_teams
           ? `, scoped_teams: [${token.scoped_teams.join(', ')}]`

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -47,7 +47,7 @@ const OAUTH_CALLBACK_STYLES = `
   </style>
 `;
 
-const OAuthTokenResponseSchema = z.object({
+export const OAuthTokenResponseSchema = z.object({
   access_token: z.string(),
   expires_in: z.number(),
   token_type: z.string(),
@@ -55,9 +55,11 @@ const OAuthTokenResponseSchema = z.object({
   refresh_token: z.string().optional(),
   scoped_teams: z.array(z.number()).optional(),
   scoped_organizations: z.array(z.string()).optional(),
-  // Sent by PostHog Cloud (and passed through the oauth.posthog.com proxy); absent on self-hosted.
-  posthog_region: z.enum(['us', 'eu']).optional(),
-  posthog_base_url: z.string().optional(),
+  // Sent by PostHog Cloud (and passed through the oauth.posthog.com proxy); absent on
+  // self-hosted. `.catch(undefined)` so an unrecognized value degrades to the probe
+  // fallback instead of failing the whole login.
+  posthog_region: z.enum(['us', 'eu']).optional().catch(undefined),
+  posthog_base_url: z.string().optional().catch(undefined),
 });
 
 export type OAuthTokenResponse = z.infer<typeof OAuthTokenResponseSchema>;

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -625,9 +625,11 @@ async function askForWizardLogin(options: {
     await abort();
   }
 
+  // The issuing region comes with the token; the us/eu @me probe only runs when omitted.
   const host = await HostResolution.fromAccessToken(
     tokenResponse.access_token,
     {
+      region: tokenResponse.posthog_region,
       localMcp: options.localMcp,
       baseUrl: options.baseUrl,
     },

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -19,11 +19,6 @@ export const GLOBAL_OPTIONS = {
     describe: 'Enable verbose logging\nenv: POSTHOG_WIZARD_DEBUG',
     type: 'boolean' as const,
   },
-  region: {
-    describe: 'PostHog cloud region\nenv: POSTHOG_WIZARD_REGION',
-    choices: ['us', 'eu'] as const,
-    type: 'string' as const,
-  },
   signup: {
     default: false,
     describe:


### PR DESCRIPTION
Read `posthog_region` from the OAuth token response (sent by PostHog Cloud since PostHog/posthog#53272) instead of racing both clouds' `/api/users/@me/` after login — the probe times out on high-latency connections and has failed ~430 valid logins since March. `detectRegion` stays as a fallback for instances that omit the field. `--region` is now declared only on the headless-capable commands (API-key auth has no token response) and `provision`; the OAuth path ignores it entirely.

Context: #926.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*