### PR TITLE
fix(env-upload): surface Vercel env var upload failures instead of skipping silently

### DIFF
--- a/src/lib/programs/posthog-integration/__tests__/hosting-env-skip.test.ts
+++ b/src/lib/programs/posthog-integration/__tests__/hosting-env-skip.test.ts
@@ -1,0 +1,32 @@
+import { setHostingEnvUploadSkip, buildHostingEnvSkipWarning } from '../index';
+import type { WizardSession } from '@lib/wizard-session';
+
+function makeSession(): WizardSession {
+  return { frameworkContext: {} } as unknown as WizardSession;
+}
+
+describe('hosting env upload skip wiring', () => {
+  it('surfaces an outro warning line after postRun records a skip', () => {
+    const sess = makeSession();
+
+    setHostingEnvUploadSkip(sess, 'Vercel');
+
+    expect(buildHostingEnvSkipWarning(sess)).toBe(
+      "⚠️ Not added to Vercel — add them there too, or your deployed site won't send events",
+    );
+  });
+
+  it('returns no warning when postRun never records a skip', () => {
+    const sess = makeSession();
+
+    expect(buildHostingEnvSkipWarning(sess)).toBe('');
+  });
+
+  it('returns no warning when the skip was explicitly cleared', () => {
+    const sess = makeSession();
+
+    setHostingEnvUploadSkip(sess, undefined);
+
+    expect(buildHostingEnvSkipWarning(sess)).toBe('');
+  });
+});

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -26,6 +26,7 @@ import { buildCodingAgentPrompt } from './handoff.js';
 import { EVENT_PLAN_FILE } from './constants.js';
 
 const DASHBOARD_DEEP_LINK_KEY = 'dashboardDeepLink';
+const HOSTING_ENV_SKIP_KEY = 'hostingEnvUploadSkipped';
 
 function resolveContinueUrl(
   sess: WizardSession,
@@ -263,20 +264,23 @@ ${warehouseReportInstruction(session)}
           const { uploadEnvironmentVariablesStep } = await import(
             '@steps/index'
           );
-          const uploadedEnvVars = await uploadEnvironmentVariablesStep(
+          const { uploadedKeys, skip } = await uploadEnvironmentVariablesStep(
             envVars,
             {
               integration: config.metadata.integration,
               session: sess,
             },
           );
-          if (uploadedEnvVars.length > 0) {
+          if (uploadedKeys.length > 0) {
             analytics.capture(WIZARD_INTERACTION_EVENT_NAME, {
               action: 'wizard_env_vars_uploaded',
               integration: config.metadata.integration,
-              variable_count: uploadedEnvVars.length,
-              variable_keys: uploadedEnvVars,
+              variable_count: uploadedKeys.length,
+              variable_keys: uploadedKeys,
             });
+          }
+          if (skip) {
+            sess.frameworkContext[HOSTING_ENV_SKIP_KEY] = skip.provider;
           }
         }
 
@@ -307,10 +311,14 @@ ${warehouseReportInstruction(session)}
           deepLink,
         );
 
+        const hostingEnvSkip = sess.frameworkContext[HOSTING_ENV_SKIP_KEY];
         const changes = [
           ...config.ui.getOutroChanges(frameworkContext),
           Object.keys(envVars).length > 0
             ? 'Added environment variables to .env file'
+            : '',
+          typeof hostingEnvSkip === 'string'
+            ? `⚠️ Not added to ${hostingEnvSkip} — add them there too, or your deployed site won't send events`
             : '',
         ].filter(Boolean);
 

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -28,6 +28,26 @@ import { EVENT_PLAN_FILE } from './constants.js';
 const DASHBOARD_DEEP_LINK_KEY = 'dashboardDeepLink';
 const HOSTING_ENV_SKIP_KEY = 'hostingEnvUploadSkipped';
 
+/**
+ * Setter/getter pair for the hosting-provider env-upload skip, both keyed off
+ * the same constant — postRun writes, buildOutroData reads. Exported and
+ * unit-tested together so a key typo on either side fails a test instead of
+ * silently dropping the outro warning.
+ */
+export function setHostingEnvUploadSkip(
+  sess: WizardSession,
+  provider: string | undefined,
+): void {
+  sess.frameworkContext[HOSTING_ENV_SKIP_KEY] = provider;
+}
+
+export function buildHostingEnvSkipWarning(sess: WizardSession): string {
+  const hostingEnvSkip = sess.frameworkContext[HOSTING_ENV_SKIP_KEY];
+  return typeof hostingEnvSkip === 'string'
+    ? `⚠️ Not added to ${hostingEnvSkip} — add them there too, or your deployed site won't send events`
+    : '';
+}
+
 function resolveContinueUrl(
   sess: WizardSession,
   host: HostResolution,
@@ -280,7 +300,7 @@ ${warehouseReportInstruction(session)}
             });
           }
           if (skip) {
-            sess.frameworkContext[HOSTING_ENV_SKIP_KEY] = skip.provider;
+            setHostingEnvUploadSkip(sess, skip.provider);
           }
         }
 
@@ -311,15 +331,12 @@ ${warehouseReportInstruction(session)}
           deepLink,
         );
 
-        const hostingEnvSkip = sess.frameworkContext[HOSTING_ENV_SKIP_KEY];
         const changes = [
           ...config.ui.getOutroChanges(frameworkContext),
           Object.keys(envVars).length > 0
             ? 'Added environment variables to .env file'
             : '',
-          typeof hostingEnvSkip === 'string'
-            ? `⚠️ Not added to ${hostingEnvSkip} — add them there too, or your deployed site won't send events`
-            : '',
+          buildHostingEnvSkipWarning(sess),
         ].filter(Boolean);
 
         return {

--- a/src/steps/upload-environment-variables/EnvironmentProvider.ts
+++ b/src/steps/upload-environment-variables/EnvironmentProvider.ts
@@ -2,6 +2,7 @@ export enum EnvUploadSkipCause {
   CliMissing = 'cli-missing',
   ProjectUnlinked = 'project-unlinked',
   Unauthenticated = 'unauthenticated',
+  UploadFailed = 'upload-failed',
 }
 
 export type EnvUploadSkip = {

--- a/src/steps/upload-environment-variables/EnvironmentProvider.ts
+++ b/src/steps/upload-environment-variables/EnvironmentProvider.ts
@@ -1,3 +1,15 @@
+export enum EnvUploadSkipCause {
+  CliMissing = 'cli-missing',
+  ProjectUnlinked = 'project-unlinked',
+  Unauthenticated = 'unauthenticated',
+}
+
+export type EnvUploadSkip = {
+  provider: string;
+  cause: EnvUploadSkipCause;
+  message: string;
+};
+
 export abstract class EnvironmentProvider {
   protected options: { installDir: string };
 
@@ -12,4 +24,13 @@ export abstract class EnvironmentProvider {
   abstract uploadEnvVars(
     vars: Record<string, string>,
   ): Promise<Record<string, boolean>>;
+
+  /**
+   * Guidance for a project that looks like it deploys to this provider but
+   * failed `detect()` — null when there's no sign the project deploys here.
+   * Only meaningful after `detect()` has run.
+   */
+  describeSkip(_keys: string[]): EnvUploadSkip | null {
+    return null;
+  }
 }

--- a/src/steps/upload-environment-variables/__tests__/upload-environment-variables.test.ts
+++ b/src/steps/upload-environment-variables/__tests__/upload-environment-variables.test.ts
@@ -135,4 +135,91 @@ describe('uploadEnvironmentVariablesStep', () => {
     });
     expect(mockWarn).not.toHaveBeenCalled();
   });
+
+  it('should not fire "env uploaded" when every upload fails', async () => {
+    stubVercel({
+      detected: true,
+      uploads: {
+        NEXT_PUBLIC_POSTHOG_KEY: false,
+        NEXT_PUBLIC_POSTHOG_HOST: false,
+      },
+    });
+
+    await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(mockWizardCapture).not.toHaveBeenCalledWith(
+      'env uploaded',
+      expect.anything(),
+    );
+  });
+
+  it('should fire "env uploaded" when at least one key is uploaded', async () => {
+    stubVercel({
+      detected: true,
+      uploads: {
+        NEXT_PUBLIC_POSTHOG_KEY: true,
+        NEXT_PUBLIC_POSTHOG_HOST: false,
+      },
+    });
+
+    await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(mockWizardCapture).toHaveBeenCalledWith('env uploaded', {
+      provider: 'Vercel',
+      integration: 'nextjs',
+    });
+  });
+
+  it('should return a loud skip when every upload fails despite a detected provider', async () => {
+    stubVercel({
+      detected: true,
+      uploads: {
+        NEXT_PUBLIC_POSTHOG_KEY: false,
+        NEXT_PUBLIC_POSTHOG_HOST: false,
+      },
+    });
+
+    const outcome = await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(outcome.uploadedKeys).toEqual([]);
+    expect(outcome.skip).toEqual(
+      expect.objectContaining({
+        provider: 'Vercel',
+        cause: EnvUploadSkipCause.UploadFailed,
+      }),
+    );
+    expect(outcome.skip?.message).toContain('NEXT_PUBLIC_POSTHOG_KEY');
+    expect(outcome.skip?.message).toContain('NEXT_PUBLIC_POSTHOG_HOST');
+    expect(mockWarn).toHaveBeenCalledWith(outcome.skip?.message);
+  });
+
+  it('should tag the upload-failed skip event with the provider and cause', async () => {
+    stubVercel({
+      detected: true,
+      uploads: {
+        NEXT_PUBLIC_POSTHOG_KEY: false,
+        NEXT_PUBLIC_POSTHOG_HOST: false,
+      },
+    });
+
+    await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(mockWizardCapture).toHaveBeenCalledWith(
+      'env upload skipped',
+      expect.objectContaining({
+        reason: 'all uploads failed',
+        deploy_target: 'Vercel',
+        skip_cause: EnvUploadSkipCause.UploadFailed,
+      }),
+    );
+  });
+
+  it('should not return a skip when a provider is detected but there were no env vars to upload', async () => {
+    stubVercel({ detected: true, uploads: {} });
+
+    const outcome = await uploadEnvironmentVariablesStep({}, stepArgs);
+
+    expect(outcome).toEqual({ uploadedKeys: [], skip: null });
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
 });

--- a/src/steps/upload-environment-variables/__tests__/upload-environment-variables.test.ts
+++ b/src/steps/upload-environment-variables/__tests__/upload-environment-variables.test.ts
@@ -1,0 +1,138 @@
+import type { Mock } from 'vitest';
+
+const { mockWarn, mockInfo, mockWizardCapture } = vi.hoisted(() => ({
+  mockWarn: vi.fn(),
+  mockInfo: vi.fn(),
+  mockWizardCapture: vi.fn(),
+}));
+
+vi.mock('@ui', () => ({
+  getUI: () => ({
+    log: { info: mockInfo, warn: mockWarn, error: vi.fn(), success: vi.fn() },
+    spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
+  }),
+}));
+vi.mock('@utils/analytics', () => ({
+  analytics: { wizardCapture: mockWizardCapture, setTag: vi.fn() },
+}));
+vi.mock('../../telemetry', () => ({
+  withProgress: (_label: string, fn: () => unknown) => fn(),
+}));
+
+import { uploadEnvironmentVariablesStep } from '@steps/upload-environment-variables';
+import {
+  EnvUploadSkipCause,
+  type EnvUploadSkip,
+} from '@steps/upload-environment-variables/EnvironmentProvider';
+import { VercelEnvironmentProvider } from '@steps/upload-environment-variables/providers/vercel';
+
+const ENV_VARS = {
+  NEXT_PUBLIC_POSTHOG_KEY: 'phc_secret_value',
+  NEXT_PUBLIC_POSTHOG_HOST: 'https://us.i.posthog.com',
+};
+
+const stepArgs = {
+  integration: 'nextjs' as never,
+  session: { installDir: '/tmp/project' } as never,
+};
+
+function stubVercel(options: {
+  detected: boolean;
+  skip?: EnvUploadSkip | null;
+  uploads?: Record<string, boolean>;
+}): void {
+  vi.spyOn(VercelEnvironmentProvider.prototype, 'detect').mockResolvedValue(
+    options.detected,
+  );
+  vi.spyOn(VercelEnvironmentProvider.prototype, 'describeSkip').mockReturnValue(
+    options.skip ?? null,
+  );
+  vi.spyOn(
+    VercelEnvironmentProvider.prototype,
+    'uploadEnvVars',
+  ).mockResolvedValue(options.uploads ?? {});
+}
+
+const VERCEL_SKIP: EnvUploadSkip = {
+  provider: 'Vercel',
+  cause: EnvUploadSkipCause.CliMissing,
+  message: 'Your project appears to deploy to Vercel, but ...',
+};
+
+describe('uploadEnvironmentVariablesStep', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('should warn and report the skip when a Vercel-marked project cannot be uploaded to', async () => {
+    stubVercel({ detected: false, skip: VERCEL_SKIP });
+
+    const outcome = await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(outcome).toEqual({ uploadedKeys: [], skip: VERCEL_SKIP });
+    expect(mockWarn).toHaveBeenCalledWith(VERCEL_SKIP.message);
+  });
+
+  it('should stay quiet when the project shows no deploy markers', async () => {
+    stubVercel({ detected: false, skip: null });
+
+    const outcome = await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(outcome).toEqual({ uploadedKeys: [], skip: null });
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('should tag the skip event with the deploy target and cause', async () => {
+    stubVercel({ detected: false, skip: VERCEL_SKIP });
+
+    await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(mockWizardCapture).toHaveBeenCalledWith(
+      'env upload skipped',
+      expect.objectContaining({
+        deploy_target: 'Vercel',
+        skip_cause: EnvUploadSkipCause.CliMissing,
+      }),
+    );
+  });
+
+  it('should record a null deploy target for non-Vercel projects', async () => {
+    stubVercel({ detected: false, skip: null });
+
+    await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(mockWizardCapture).toHaveBeenCalledWith(
+      'env upload skipped',
+      expect.objectContaining({ deploy_target: null, skip_cause: null }),
+    );
+  });
+
+  it('should pass the provider only the key names to warn about', async () => {
+    stubVercel({ detected: false, skip: VERCEL_SKIP });
+
+    await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(
+      VercelEnvironmentProvider.prototype.describeSkip as unknown as Mock,
+    ).toHaveBeenCalledWith(Object.keys(ENV_VARS));
+  });
+
+  it('should return the uploaded keys when a provider is detected', async () => {
+    stubVercel({
+      detected: true,
+      uploads: {
+        NEXT_PUBLIC_POSTHOG_KEY: true,
+        NEXT_PUBLIC_POSTHOG_HOST: false,
+      },
+    });
+
+    const outcome = await uploadEnvironmentVariablesStep(ENV_VARS, stepArgs);
+
+    expect(outcome).toEqual({
+      uploadedKeys: ['NEXT_PUBLIC_POSTHOG_KEY'],
+      skip: null,
+    });
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+});

--- a/src/steps/upload-environment-variables/index.ts
+++ b/src/steps/upload-environment-variables/index.ts
@@ -4,7 +4,7 @@ import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
 import type { WizardSession } from '@lib/wizard-session';
 import type { EnvUploadSkip } from './EnvironmentProvider';
-import { EnvironmentProvider } from './EnvironmentProvider';
+import { EnvironmentProvider, EnvUploadSkipCause } from './EnvironmentProvider';
 import { VercelEnvironmentProvider } from './providers/vercel';
 
 export type EnvUploadOutcome = {
@@ -66,13 +66,43 @@ export const uploadEnvironmentVariablesStep = async (
     },
   );
 
-  analytics.wizardCapture('env uploaded', {
+  const uploadedKeys = Object.keys(results).filter((key) => results[key]);
+  const attemptedKeys = Object.keys(envVars);
+
+  if (uploadedKeys.length > 0) {
+    analytics.wizardCapture('env uploaded', {
+      provider: provider.name,
+      integration,
+    });
+
+    return { uploadedKeys, skip: null };
+  }
+
+  // Partial success (some keys uploaded) is still success — only total
+  // failure, with at least one key attempted, becomes a loud skip.
+  if (attemptedKeys.length === 0) {
+    return { uploadedKeys, skip: null };
+  }
+
+  const keyList = attemptedKeys.map((key) => `  - ${key}`).join('\n');
+  const skip: EnvUploadSkip = {
     provider: provider.name,
+    cause: EnvUploadSkipCause.UploadFailed,
+    message: `The wizard found ${provider.name} but couldn't add the environment variables there — every upload failed. Add them under Settings → Environment Variables in your ${provider.name} project:
+
+${keyList}
+
+Until these are set in ${provider.name}, your deployed site won't send events to PostHog. The values are in your local .env file.`,
+  };
+
+  analytics.wizardCapture('env upload skipped', {
+    reason: 'all uploads failed',
     integration,
+    deploy_target: skip.provider,
+    skip_cause: skip.cause,
   });
 
-  return {
-    uploadedKeys: Object.keys(results).filter((key) => results[key]),
-    skip: null,
-  };
+  getUI().log.warn(skip.message);
+
+  return { uploadedKeys, skip };
 };

--- a/src/steps/upload-environment-variables/index.ts
+++ b/src/steps/upload-environment-variables/index.ts
@@ -3,8 +3,14 @@ import { withProgress } from '../../telemetry';
 import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
 import type { WizardSession } from '@lib/wizard-session';
+import type { EnvUploadSkip } from './EnvironmentProvider';
 import { EnvironmentProvider } from './EnvironmentProvider';
 import { VercelEnvironmentProvider } from './providers/vercel';
+
+export type EnvUploadOutcome = {
+  uploadedKeys: string[];
+  skip: EnvUploadSkip | null;
+};
 
 export const uploadEnvironmentVariablesStep = async (
   envVars: Record<string, string>,
@@ -15,7 +21,7 @@ export const uploadEnvironmentVariablesStep = async (
     integration: Integration;
     session: WizardSession;
   },
-): Promise<string[]> => {
+): Promise<EnvUploadOutcome> => {
   const providers: EnvironmentProvider[] = [
     new VercelEnvironmentProvider({ installDir: session.installDir }),
   ];
@@ -30,11 +36,24 @@ export const uploadEnvironmentVariablesStep = async (
   }
 
   if (!provider) {
+    const keys = Object.keys(envVars);
+    const skip =
+      providers
+        .map((p) => p.describeSkip(keys))
+        .find((s): s is EnvUploadSkip => s !== null) ?? null;
+
     analytics.wizardCapture('env upload skipped', {
       reason: 'no environment provider found',
       integration,
+      deploy_target: skip?.provider ?? null,
+      skip_cause: skip?.cause ?? null,
     });
-    return [];
+
+    if (skip) {
+      getUI().log.warn(skip.message);
+    }
+
+    return { uploadedKeys: [], skip };
   }
 
   // Auto-accept — the agent already wrote env vars via MCP tools
@@ -52,5 +71,8 @@ export const uploadEnvironmentVariablesStep = async (
     integration,
   });
 
-  return Object.keys(results).filter((key) => results[key]);
+  return {
+    uploadedKeys: Object.keys(results).filter((key) => results[key]),
+    skip: null,
+  };
 };

--- a/src/steps/upload-environment-variables/providers/__tests__/vercel.test.ts
+++ b/src/steps/upload-environment-variables/providers/__tests__/vercel.test.ts
@@ -1,4 +1,5 @@
 import { VercelEnvironmentProvider } from '@steps/upload-environment-variables/providers/vercel';
+import { EnvUploadSkipCause } from '@steps/upload-environment-variables/EnvironmentProvider';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
 
@@ -6,6 +7,47 @@ vi.mock('fs');
 vi.mock('child_process');
 
 const mockOptions = { installDir: '/tmp/project' };
+
+type VercelResponse = { code: number; stderr?: string };
+
+/**
+ * The three environments upload concurrently, so responses are keyed by the
+ * `vercel` arguments (and the nth identical invocation) rather than by a flat
+ * queue, which would be order-dependent.
+ */
+function mockSpawn(respond: (args: string[], nth: number) => VercelResponse): {
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const seen = new Map<string, number>();
+
+  (child_process.spawn as Mock).mockImplementation(
+    (_cmd: string, args: string[]) => {
+      calls.push(args);
+      const signature = args.join(' ');
+      const nth = seen.get(signature) ?? 0;
+      seen.set(signature, nth + 1);
+      const { code, stderr } = respond(args, nth);
+
+      return {
+        stdin: { write: vi.fn(), end: vi.fn() },
+        stderr: {
+          on: (event: string, cb: (data: string) => void) => {
+            if (event === 'data' && stderr) cb(stderr);
+          },
+        },
+        on: (event: string, cb: (arg: unknown) => void) => {
+          if (event === 'close') setImmediate(() => cb(code));
+        },
+      };
+    },
+  );
+
+  return { calls };
+}
+
+const isProductionAdd = (args: string[]): boolean =>
+  args[1] === 'add' && args[3] === 'production';
 
 describe('VercelEnvironmentProvider', () => {
   let provider: VercelEnvironmentProvider;
@@ -55,45 +97,179 @@ describe('VercelEnvironmentProvider', () => {
     await expect(provider.detect()).resolves.toBe(false);
   });
 
-  it('should return false if env var already exists', async () => {
-    const stdinMock = { write: vi.fn(), end: vi.fn() };
-    let closeCallback: ((code: number) => void) | undefined;
-    const onMock = vi.fn((event, cb) => {
-      if (event === 'close') closeCallback = cb;
+  describe('deploy marker detection', () => {
+    it.each([
+      ['.vercel directory', '.vercel', true],
+      ['vercel.json', 'vercel.json', true],
+    ])('should find markers via %s', (_label, marker, expected) => {
+      (fs.existsSync as Mock).mockImplementation((p: string) =>
+        p.endsWith(marker),
+      );
+      expect(provider.hasDeployMarkers()).toBe(expected);
     });
 
-    // Simulate a process with a writable stderr stream
-    let stderrListener: ((data: Buffer | string) => void) | undefined;
-    const stderr = {
-      on: vi.fn((event, cb) => {
-        if (event === 'data') stderrListener = cb;
-      }),
-    };
-
-    (child_process.spawn as Mock).mockReturnValue({
-      stdin: stdinMock,
-      on: onMock,
-      stderr,
+    it('should find no markers in a non-Vercel project', () => {
+      (fs.existsSync as Mock).mockReturnValue(false);
+      expect(provider.hasDeployMarkers()).toBe(false);
     });
-
-    const uploadPromise = provider.uploadEnvVars({ FOO: 'bar' });
-
-    // Simulate "already exists" error on stderr, then process close
-    stderrListener && stderrListener('already exists');
-    closeCallback && closeCallback(1);
-
-    await expect(uploadPromise).resolves.toEqual({ FOO: false });
   });
 
-  it('should attempt to upload environment variables', async () => {
-    (child_process.spawn as Mock).mockReturnValue({});
+  describe('describeSkip', () => {
+    it('should return null before detect() has run', () => {
+      (fs.existsSync as Mock).mockReturnValue(true);
+      expect(provider.describeSkip(['FOO'])).toBeNull();
+    });
 
-    await provider.uploadEnvVars({ FOO: 'bar' });
+    it('should return null when the project has no Vercel markers', async () => {
+      (child_process.execSync as Mock).mockImplementation(() => {
+        throw new Error();
+      });
+      (fs.existsSync as Mock).mockReturnValue(false);
 
-    expect(child_process.spawn).toHaveBeenCalledWith(
-      'vercel',
-      ['env', 'add', 'FOO', 'production'],
-      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] }),
+      await provider.detect();
+
+      expect(provider.describeSkip(['FOO'])).toBeNull();
+    });
+
+    it.each([
+      [
+        'cli missing',
+        () => {
+          (child_process.execSync as Mock).mockImplementation(() => {
+            throw new Error();
+          });
+          (fs.existsSync as Mock).mockImplementation((p: string) =>
+            p.endsWith('vercel.json'),
+          );
+        },
+        EnvUploadSkipCause.CliMissing,
+      ],
+      [
+        'project unlinked',
+        () => {
+          (child_process.execSync as Mock).mockReturnValue(undefined);
+          (fs.existsSync as Mock).mockImplementation((p: string) =>
+            p.endsWith('vercel.json'),
+          );
+        },
+        EnvUploadSkipCause.ProjectUnlinked,
+      ],
+      [
+        'unauthenticated',
+        () => {
+          (child_process.execSync as Mock).mockReturnValue(undefined);
+          (fs.existsSync as Mock).mockReturnValue(true);
+          (child_process.spawnSync as Mock).mockReturnValue({
+            stdout: 'Log in to Vercel',
+            stderr: '',
+            status: 0,
+          });
+        },
+        EnvUploadSkipCause.Unauthenticated,
+      ],
+    ])('should attribute a skip to %s', async (_label, setup, cause) => {
+      setup();
+
+      await provider.detect();
+      const skip = provider.describeSkip(['NEXT_PUBLIC_POSTHOG_KEY']);
+
+      expect(skip).not.toBeNull();
+      expect(skip!.cause).toBe(cause);
+      expect(skip!.provider).toBe('Vercel');
+      expect(skip!.message).toContain(
+        'vercel env add NEXT_PUBLIC_POSTHOG_KEY production',
+      );
+    });
+
+    it('should name every key without leaking its value', async () => {
+      (child_process.execSync as Mock).mockImplementation(() => {
+        throw new Error();
+      });
+      (fs.existsSync as Mock).mockImplementation((p: string) =>
+        p.endsWith('vercel.json'),
+      );
+
+      await provider.detect();
+      const skip = provider.describeSkip([
+        'NEXT_PUBLIC_POSTHOG_KEY',
+        'NEXT_PUBLIC_POSTHOG_HOST',
+      ]);
+
+      expect(skip!.message).toContain('NEXT_PUBLIC_POSTHOG_KEY');
+      expect(skip!.message).toContain('NEXT_PUBLIC_POSTHOG_HOST');
+      expect(skip!.message).not.toContain('phc_');
+    });
+
+    it('should return null once detect() succeeds', async () => {
+      (child_process.execSync as Mock).mockReturnValue(undefined);
+      (fs.existsSync as Mock).mockReturnValue(true);
+      (child_process.spawnSync as Mock).mockReturnValue({
+        stdout: 'testuser',
+        stderr: '',
+        status: 0,
+      });
+
+      await provider.detect();
+
+      expect(provider.describeSkip(['FOO'])).toBeNull();
+    });
+  });
+
+  describe('uploadEnvVars', () => {
+    it('should attempt to upload environment variables', async () => {
+      const { calls } = mockSpawn(() => ({ code: 0 }));
+
+      await expect(provider.uploadEnvVars({ FOO: 'bar' })).resolves.toEqual({
+        FOO: true,
+      });
+
+      expect(calls).toContainEqual(['env', 'add', 'FOO', 'production']);
+    });
+
+    it.each([['already exists'], ['already been added'], ['vercel env rm']])(
+      'should replace the value when Vercel reports "%s"',
+      async (stderr) => {
+        const { calls } = mockSpawn((args, nth) =>
+          isProductionAdd(args) && nth === 0
+            ? { code: 1, stderr }
+            : { code: 0 },
+        );
+
+        await expect(provider.uploadEnvVars({ FOO: 'bar' })).resolves.toEqual({
+          FOO: true,
+        });
+
+        expect(calls).toContainEqual(['env', 'rm', 'FOO', 'production', '-y']);
+        expect(calls.filter(isProductionAdd)).toHaveLength(2);
+      },
     );
+
+    it('should fail when the existing variable cannot be removed', async () => {
+      mockSpawn((args, nth) => {
+        if (isProductionAdd(args) && nth === 0) {
+          return { code: 1, stderr: 'already exists' };
+        }
+        if (args[1] === 'rm') return { code: 1 };
+        return { code: 0 };
+      });
+
+      await expect(provider.uploadEnvVars({ FOO: 'bar' })).resolves.toEqual({
+        FOO: false,
+      });
+    });
+
+    it('should fail on a genuine error without attempting a replace', async () => {
+      const { calls } = mockSpawn((args) =>
+        isProductionAdd(args)
+          ? { code: 1, stderr: 'unexpected error from vercel' }
+          : { code: 0 },
+      );
+
+      await expect(provider.uploadEnvVars({ FOO: 'bar' })).resolves.toEqual({
+        FOO: false,
+      });
+
+      expect(calls.some((args) => args[1] === 'rm')).toBe(false);
+    });
   });
 });

--- a/src/steps/upload-environment-variables/providers/__tests__/vercel.test.ts
+++ b/src/steps/upload-environment-variables/providers/__tests__/vercel.test.ts
@@ -1,5 +1,6 @@
 import { VercelEnvironmentProvider } from '@steps/upload-environment-variables/providers/vercel';
 import { EnvUploadSkipCause } from '@steps/upload-environment-variables/EnvironmentProvider';
+import { getUI } from '@ui';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
 
@@ -270,6 +271,48 @@ describe('VercelEnvironmentProvider', () => {
       });
 
       expect(calls.some((args) => args[1] === 'rm')).toBe(false);
+    });
+
+    it('should retry the re-add once after a successful rm before giving up', async () => {
+      const { calls } = mockSpawn((args, nth) => {
+        if (isProductionAdd(args)) {
+          if (nth === 0) return { code: 1, stderr: 'already exists' };
+          if (nth === 1) return { code: 1, stderr: 'timeout' }; // first retry after rm
+          return { code: 0 }; // second retry after rm succeeds
+        }
+        return { code: 0 };
+      });
+
+      await expect(provider.uploadEnvVars({ FOO: 'bar' })).resolves.toEqual({
+        FOO: true,
+      });
+
+      expect(calls).toContainEqual(['env', 'rm', 'FOO', 'production', '-y']);
+      expect(calls.filter(isProductionAdd)).toHaveLength(3);
+    });
+
+    it('should surface a REMOVED data-loss error when the rm succeeds but every re-add attempt fails', async () => {
+      const spinner = { start: vi.fn(), stop: vi.fn(), message: vi.fn() };
+      vi.spyOn(getUI(), 'spinner').mockReturnValue(spinner);
+
+      mockSpawn((args, nth) => {
+        if (isProductionAdd(args)) {
+          return nth === 0
+            ? { code: 1, stderr: 'already exists' }
+            : { code: 1, stderr: 'timeout' };
+        }
+        return { code: 0 };
+      });
+
+      await expect(provider.uploadEnvVars({ FOO: 'bar' })).resolves.toEqual({
+        FOO: false,
+      });
+
+      const stopMessage = spinner.stop.mock.calls
+        .map(([msg]: [string?]) => msg)
+        .find((msg: string | undefined) => msg?.includes('FOO'));
+      expect(stopMessage).toContain('REMOVED');
+      expect(stopMessage).toContain('production');
     });
   });
 });

--- a/src/steps/upload-environment-variables/providers/vercel.ts
+++ b/src/steps/upload-environment-variables/providers/vercel.ts
@@ -1,13 +1,40 @@
 import { execSync, spawn, spawnSync } from 'child_process';
-import { EnvironmentProvider } from '@steps/upload-environment-variables/EnvironmentProvider';
+import {
+  EnvironmentProvider,
+  EnvUploadSkipCause,
+  type EnvUploadSkip,
+} from '@steps/upload-environment-variables/EnvironmentProvider';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getUI } from '@ui';
 import { analytics } from '@utils/analytics';
 
+type EnvAddResult = { code: number | null; stderr: string };
+
+const ALREADY_EXISTS_MARKERS = [
+  'already exists',
+  'already been added',
+  'vercel env rm',
+];
+
+const REMEDY_BY_CAUSE: Record<EnvUploadSkipCause, string> = {
+  [EnvUploadSkipCause.CliMissing]:
+    "the Vercel CLI isn't installed. Install it with `npm i -g vercel`, run `vercel link`, then:",
+  [EnvUploadSkipCause.ProjectUnlinked]:
+    "this directory isn't linked to a Vercel project. Run `vercel link`, then:",
+  [EnvUploadSkipCause.Unauthenticated]:
+    "you're not logged in to the Vercel CLI. Run `vercel login`, then:",
+};
+
 export class VercelEnvironmentProvider extends EnvironmentProvider {
   name = 'Vercel';
   environments = ['production', 'preview', 'development'];
+
+  private checks: {
+    hasCli: boolean;
+    isLinked: boolean;
+    isAuthenticated: boolean;
+  } | null = null;
 
   constructor(options: { installDir: string }) {
     super(options);
@@ -15,12 +42,30 @@ export class VercelEnvironmentProvider extends EnvironmentProvider {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async detect(): Promise<boolean> {
-    const vercelDetected =
-      this.hasVercelCli() && this.isProjectLinked() && this.isAuthenticated();
+    const hasCli = this.hasVercelCli();
+    const isLinked = hasCli && this.isProjectLinked();
+    const isAuthenticated = isLinked && this.isAuthenticated();
+
+    this.checks = { hasCli, isLinked, isAuthenticated };
+
+    const vercelDetected = hasCli && isLinked && isAuthenticated;
 
     analytics.setTag('vercel-detected', vercelDetected);
+    analytics.setTag('vercel-markers-found', this.hasDeployMarkers());
 
     return vercelDetected;
+  }
+
+  /**
+   * Cheap filesystem signal that the project deploys to Vercel, independent of
+   * whether the CLI is usable — `detect()` can't tell "not a Vercel project"
+   * apart from "Vercel project the wizard can't reach".
+   */
+  hasDeployMarkers(): boolean {
+    return (
+      this.hasDotVercelDir() ||
+      fs.existsSync(path.join(this.options.installDir, 'vercel.json'))
+    );
   }
 
   hasDotVercelDir(): boolean {
@@ -78,12 +123,46 @@ export class VercelEnvironmentProvider extends EnvironmentProvider {
     return true;
   }
 
-  async uploadEnvironmentVariable(
+  describeSkip(keys: string[]): EnvUploadSkip | null {
+    if (!this.checks || !this.hasDeployMarkers()) return null;
+
+    const cause = this.skipCause();
+    if (!cause) return null;
+
+    const keyList = keys.map((key) => `  - ${key}`).join('\n');
+    const addCommands = keys
+      .map((key) => `  vercel env add ${key} production`)
+      .join('\n');
+
+    return {
+      provider: this.name,
+      cause,
+      message: `Your project appears to deploy to ${this.name}, but the wizard couldn't upload environment variables — ${REMEDY_BY_CAUSE[cause]}
+
+${addCommands}
+
+Until these are set in ${this.name}, your deployed site won't send events to PostHog. You can also add them under Settings → Environment Variables in your ${this.name} project:
+
+${keyList}
+
+The values are in your local .env file.`,
+    };
+  }
+
+  private skipCause(): EnvUploadSkipCause | null {
+    if (!this.checks) return null;
+    if (!this.checks.hasCli) return EnvUploadSkipCause.CliMissing;
+    if (!this.checks.isLinked) return EnvUploadSkipCause.ProjectUnlinked;
+    if (!this.checks.isAuthenticated) return EnvUploadSkipCause.Unauthenticated;
+    return null;
+  }
+
+  private runEnvAdd(
     key: string,
     value: string,
     environment: string,
-  ): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
+  ): Promise<EnvAddResult> {
+    return new Promise<EnvAddResult>((resolve, reject) => {
       const proc = spawn('vercel', ['env', 'add', key, environment], {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
@@ -96,28 +175,59 @@ export class VercelEnvironmentProvider extends EnvironmentProvider {
       proc.stdin.write(value);
       proc.stdin.end();
 
-      proc.on('close', (code) => {
-        if (
-          stderr.includes('already exists') ||
-          stderr.includes('already been added') ||
-          stderr.includes('vercel env rm')
-        ) {
-          reject(
-            new Error(
-              `❌ Environment variable ${key} already exists in ${this.name}. Please upload it manually.`,
-            ),
-          );
-        } else if (code === 0) {
-          resolve();
-        } else {
-          reject(
-            new Error(
-              `❌ Failed to upload environment variable ${key} to ${this.name}. Please upload it manually.`,
-            ),
-          );
-        }
-      });
+      proc.on('error', reject);
+      proc.on('close', (code) => resolve({ code, stderr }));
     });
+  }
+
+  private removeEnvironmentVariable(
+    key: string,
+    environment: string,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const proc = spawn('vercel', ['env', 'rm', key, environment, '-y'], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      proc.on('error', reject);
+      proc.on('close', (code) =>
+        code === 0
+          ? resolve()
+          : reject(
+              new Error(
+                `❌ Failed to replace existing environment variable ${key} in ${this.name}. Please upload it manually.`,
+              ),
+            ),
+      );
+    });
+  }
+
+  async uploadEnvironmentVariable(
+    key: string,
+    value: string,
+    environment: string,
+  ): Promise<void> {
+    const added = await this.runEnvAdd(key, value, environment);
+    if (added.code === 0) return;
+
+    const alreadyExists = ALREADY_EXISTS_MARKERS.some((marker) =>
+      added.stderr.includes(marker),
+    );
+    if (!alreadyExists) {
+      throw new Error(
+        `❌ Failed to upload environment variable ${key} to ${this.name}. Please upload it manually.`,
+      );
+    }
+
+    // Vercel has no upsert for env vars, so replace the stale value.
+    await this.removeEnvironmentVariable(key, environment);
+
+    const readded = await this.runEnvAdd(key, value, environment);
+    if (readded.code !== 0) {
+      throw new Error(
+        `❌ Failed to update existing environment variable ${key} in ${this.name}. Please upload it manually.`,
+      );
+    }
   }
 
   async uploadEnvVars(

--- a/src/steps/upload-environment-variables/providers/vercel.ts
+++ b/src/steps/upload-environment-variables/providers/vercel.ts
@@ -17,7 +17,14 @@ const ALREADY_EXISTS_MARKERS = [
   'vercel env rm',
 ];
 
-const REMEDY_BY_CAUSE: Record<EnvUploadSkipCause, string> = {
+// UploadFailed is only ever constructed by the upload step itself (not by
+// describeSkip), so it has no detection-remedy copy here.
+type DescribeSkipCause = Exclude<
+  EnvUploadSkipCause,
+  EnvUploadSkipCause.UploadFailed
+>;
+
+const REMEDY_BY_CAUSE: Record<DescribeSkipCause, string> = {
   [EnvUploadSkipCause.CliMissing]:
     "the Vercel CLI isn't installed. Install it with `npm i -g vercel`, run `vercel link`, then:",
   [EnvUploadSkipCause.ProjectUnlinked]:
@@ -149,7 +156,7 @@ The values are in your local .env file.`,
     };
   }
 
-  private skipCause(): EnvUploadSkipCause | null {
+  private skipCause(): DescribeSkipCause | null {
     if (!this.checks) return null;
     if (!this.checks.hasCli) return EnvUploadSkipCause.CliMissing;
     if (!this.checks.isLinked) return EnvUploadSkipCause.ProjectUnlinked;
@@ -219,13 +226,18 @@ The values are in your local .env file.`,
       );
     }
 
-    // Vercel has no upsert for env vars, so replace the stale value.
+    // Vercel has no upsert for env vars, so replace the stale value. Once the
+    // rm succeeds there is no way back — retry the re-add once before
+    // surfacing an error that makes the data loss unmistakable.
     await this.removeEnvironmentVariable(key, environment);
 
-    const readded = await this.runEnvAdd(key, value, environment);
+    let readded = await this.runEnvAdd(key, value, environment);
+    if (readded.code !== 0) {
+      readded = await this.runEnvAdd(key, value, environment);
+    }
     if (readded.code !== 0) {
       throw new Error(
-        `❌ Failed to update existing environment variable ${key} in ${this.name}. Please upload it manually.`,
+        `❌ ${key} was REMOVED from ${this.name} (${environment}) while the wizard was updating it, and could not be re-added. The old value is gone — please re-create ${key} in ${this.name} manually.`,
       );
     }
   }


### PR DESCRIPTION
## Problem

The wizard uploads the env vars to the user's hosting provider after an install. Vercel is the only provider today. The wizard skips that upload far more often than it completes it. In the 30 days before 2026-07-21 it sent 5,504 `wizard: env upload skipped` events and 414 `wizard: env uploaded` events. The skip event carries one generic reason, "no environment provider found", and no detail about the cause.

The user also sees nothing. A user can deploy to Vercel without copying the vars by hand. That deployed site then sends no events. No message during the wizard run warned the user. Wizard feedback reports this pattern repeatedly: analytics that work on the machine and send nothing from production.

## Changes

- The env upload step now returns a structured skip, `EnvUploadSkip`, when a project appears to deploy to a provider but the upload cannot run. The skip carries a typed cause: `cli-missing`, `project-unlinked`, or `unauthenticated`.
- Each provider can implement `describeSkip()`. The Vercel provider detects Vercel markers such as `vercel.json` and `.vercel/`, and reports which precondition failed.
- On a skip the wizard prints a warning. The warning states that the wizard did not add the vars to the hosting provider, and that the deployed site sends no events until the user adds them.
- The outro screen repeats that warning next to the env var list.
- The skip event now carries `deploy_target` and `skip_cause`, so each skip has an identified cause. A completed upload now reports `variable_count` and `variable_keys`.
- A detected provider whose uploads all fail now produces a warning and a skip with `skip_cause: upload-failed`, instead of returning without a message. `env uploaded` no longer fires when the wizard uploaded nothing.
- Vercel has no upsert, so the wizard replaces an existing var with a remove followed by an add. That add now retries once. If the retry fails, the error states that the wizard removed the variable and that the user must create it again.

## Test plan

- `pnpm test` passes locally. 1,549 tests ran. New tests cover skip detection, the upload-failed path, the failure path for remove-then-add, and the warning on the outro screen.
- `pnpm run lint` reports no errors.

Skills invoked: `/unambiguous-agent-text`.
