### PR TITLE
fix(pi): terminate on critical/block YARA matches only

### DIFF
--- a/src/lib/__tests__/yara-policy.test.ts
+++ b/src/lib/__tests__/yara-policy.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest';
+import type { ScanMatch } from '@posthog/warlock';
+import { isTerminalMatch, scanVerdict } from '../yara-policy';
+
+function match(
+  severity: string,
+  action: string,
+  rule = `rule_${severity}_${action}`,
+): ScanMatch {
+  return {
+    rule,
+    metadata: {
+      description: `${severity} / ${action}`,
+      severity,
+      category: 'prompt_injection',
+      action,
+      scan_context: 'input',
+    },
+    matchedStrings: ['x'],
+  } as ScanMatch;
+}
+
+describe('yara-policy: terminate-or-warn', () => {
+  test('critical severity terminates whatever the rule asks for', () => {
+    expect(isTerminalMatch(match('critical', 'remediate'))).toBe(true);
+  });
+
+  test('a rule asking to block terminates at any severity', () => {
+    expect(isTerminalMatch(match('low', 'block'))).toBe(true);
+  });
+
+  test('a high-severity rule that only asks to remediate warns', () => {
+    expect(isTerminalMatch(match('high', 'remediate'))).toBe(false);
+  });
+
+  test('the medium-severity integration-attack heuristic warns, never aborts', () => {
+    // The false positive that killed real runs: a commandment phrased as
+    // "remove this error" tripped this rule and pi treated it as fatal.
+    const heuristic = match(
+      'medium',
+      'unknown',
+      'prompt_injection_posthog_integration_attack',
+    );
+    expect(isTerminalMatch(heuristic)).toBe(false);
+    expect(scanVerdict([heuristic])).toMatchObject({
+      terminal: false,
+      action: 'warned',
+    });
+  });
+});
+
+describe('yara-policy: scanVerdict', () => {
+  test('no matches is no verdict', () => {
+    expect(scanVerdict([])).toBeNull();
+  });
+
+  test('reports the highest-severity match, not the first', () => {
+    const verdict = scanVerdict([
+      match('low', 'remediate'),
+      match('high', 'remediate'),
+    ]);
+    expect(verdict?.match.metadata.severity).toBe('high');
+  });
+
+  test('a terminal match is recorded as aborted', () => {
+    expect(scanVerdict([match('critical', 'block')])).toMatchObject({
+      terminal: true,
+      action: 'aborted',
+    });
+  });
+
+  test('an unranked severity does not outrank a known one', () => {
+    const verdict = scanVerdict([
+      match('medium', 'remediate'),
+      match('unknown', 'remediate'),
+    ]);
+    expect(verdict?.match.metadata.severity).toBe('medium');
+  });
+});

--- a/src/lib/agent/runner/harness/pi/__tests__/security.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/security.test.ts
@@ -279,6 +279,26 @@ describe('pi-security: extension state machine (fail-closed + runaway + latch)',
     });
   });
 
+  test('a non-critical, non-block post-scan match warns without terminating', async () => {
+    const { factory, state } = createSecurityExtension();
+    const { pi, handlers } = fakePi();
+    factory(pi);
+    // piiMatch is severity: 'high', action: 'remediate' — below the terminate
+    // gate (critical severity OR action: 'block'), so it should only warn.
+    mockedScan.mockResolvedValueOnce({ matched: true, matches: [piiMatch] });
+    await handlers.tool_result({
+      toolName: 'read',
+      content: [{ type: 'text', text: 'some file content' }],
+    });
+    expect(state.criticalViolation).toBe(false);
+    expect(
+      await handlers.tool_call({
+        toolName: 'bash',
+        input: { command: 'npm install' },
+      }),
+    ).toEqual({});
+  });
+
   test('with triageAuth, a triage false_positive verdict unblocks the write', async () => {
     const { factory, state } = createSecurityExtension({
       triageAuth: { baseURL: 'https://gw.example', authToken: 'tok' },

--- a/src/lib/agent/runner/harness/pi/security.ts
+++ b/src/lib/agent/runner/harness/pi/security.ts
@@ -423,16 +423,27 @@ export function createSecurityExtension(ctx: ToolGateContext = {}): {
         // 'input'-context rules (prompt injection in read content), with
         // triage — same policy as the anthropic PostToolUse Read hook.
         const matches = await scanAndTriage(text, 'input', llmProvider);
+        // Critical severity or a rule asking us to block => terminate; the
+        // same gate the anthropic harness applies (yara-hooks.ts). Anything
+        // below that (e.g. a medium-severity heuristic hit) is a warning —
+        // recorded, not fatal, so a false positive doesn't kill the run.
+        const worst = matches.find(
+          (m) => m.metadata.severity === 'critical' || m.metadata.action === 'block',
+        );
         recordExternalScan(
           'PostToolUse',
           event.toolName === 'read' ? 'Read' : 'Bash',
           matches.map(toReportViolation),
-          'aborted',
+          worst ? 'aborted' : 'warned',
         );
-        if (matches.length > 0) {
+        if (worst) {
           state.criticalViolation = true;
           logToFile(
-            `[pi-security] POST-SCAN VIOLATION ${event.toolName}: ${matches[0].rule}`,
+            `[pi-security] POST-SCAN VIOLATION ${event.toolName}: ${worst.rule}`,
+          );
+        } else if (matches.length > 0) {
+          logToFile(
+            `[pi-security] POST-SCAN WARNING ${event.toolName}: ${matches[0].rule} (severity: ${matches[0].metadata.severity ?? 'unknown'})`,
           );
         }
       } catch (err) {

--- a/src/lib/agent/runner/harness/pi/security.ts
+++ b/src/lib/agent/runner/harness/pi/security.ts
@@ -23,14 +23,13 @@ import type { LLMProvider, ScanMatch } from '@posthog/warlock';
 import { wizardCanUseTool } from '@lib/agent/agent-interface';
 import {
   createRepeatBlockTracker,
-  isTerminalMatch,
   isWizardDocumentationPath,
   recordExternalScan,
   repeatBlockReason,
   scanAndTriage,
   type RepeatBlockTracker,
-  type ScanContext,
 } from '@lib/yara-hooks';
+import { scanVerdict, type ScanContext } from '@lib/yara-policy';
 import {
   createTriageLLMProvider,
   type TriageGatewayAuth,
@@ -424,21 +423,25 @@ export function createSecurityExtension(ctx: ToolGateContext = {}): {
         // 'input'-context rules (prompt injection in read content), with
         // triage — same policy as the anthropic PostToolUse Read hook.
         const matches = await scanAndTriage(text, 'input', llmProvider);
-        const worst = matches.find(isTerminalMatch);
+        const verdict = scanVerdict(matches);
+        if (!verdict) return {};
+
         recordExternalScan(
           'PostToolUse',
           event.toolName === 'read' ? 'Read' : 'Bash',
           matches.map(toReportViolation),
-          worst ? 'aborted' : 'warned',
+          verdict.action,
         );
-        if (worst) {
+        if (verdict.terminal) {
           state.criticalViolation = true;
           logToFile(
-            `[pi-security] POST-SCAN VIOLATION ${event.toolName}: ${worst.rule}`,
+            `[pi-security] POST-SCAN VIOLATION ${event.toolName}: ${verdict.match.rule}`,
           );
-        } else if (matches.length > 0) {
+        } else {
           logToFile(
-            `[pi-security] POST-SCAN WARNING ${event.toolName}: ${matches[0].rule} (severity: ${matches[0].metadata.severity ?? 'unknown'})`,
+            `[pi-security] POST-SCAN WARNING ${event.toolName}: ${
+              verdict.match.rule
+            } (severity: ${verdict.match.metadata.severity ?? 'unknown'})`,
           );
         }
       } catch (err) {

--- a/src/lib/agent/runner/harness/pi/security.ts
+++ b/src/lib/agent/runner/harness/pi/security.ts
@@ -424,14 +424,14 @@ export function createSecurityExtension(ctx: ToolGateContext = {}): {
         // triage — same policy as the anthropic PostToolUse Read hook.
         const matches = await scanAndTriage(text, 'input', llmProvider);
         const verdict = scanVerdict(matches);
-        if (!verdict) return {};
-
+        // Count the scan even when clean, like the anthropic hooks do.
         recordExternalScan(
           'PostToolUse',
           event.toolName === 'read' ? 'Read' : 'Bash',
           matches.map(toReportViolation),
-          verdict.action,
+          verdict?.action ?? 'warned',
         );
+        if (!verdict) return {};
         if (verdict.terminal) {
           state.criticalViolation = true;
           logToFile(

--- a/src/lib/agent/runner/harness/pi/security.ts
+++ b/src/lib/agent/runner/harness/pi/security.ts
@@ -23,6 +23,7 @@ import type { LLMProvider, ScanMatch } from '@posthog/warlock';
 import { wizardCanUseTool } from '@lib/agent/agent-interface';
 import {
   createRepeatBlockTracker,
+  isTerminalMatch,
   isWizardDocumentationPath,
   recordExternalScan,
   repeatBlockReason,
@@ -423,13 +424,7 @@ export function createSecurityExtension(ctx: ToolGateContext = {}): {
         // 'input'-context rules (prompt injection in read content), with
         // triage — same policy as the anthropic PostToolUse Read hook.
         const matches = await scanAndTriage(text, 'input', llmProvider);
-        // Critical severity or a rule asking us to block => terminate; the
-        // same gate the anthropic harness applies (yara-hooks.ts). Anything
-        // below that (e.g. a medium-severity heuristic hit) is a warning —
-        // recorded, not fatal, so a false positive doesn't kill the run.
-        const worst = matches.find(
-          (m) => m.metadata.severity === 'critical' || m.metadata.action === 'block',
-        );
+        const worst = matches.find(isTerminalMatch);
         recordExternalScan(
           'PostToolUse',
           event.toolName === 'read' ? 'Read' : 'Bash',

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -37,6 +37,8 @@ import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
 import type { WizardSession } from '@lib/wizard-session';
 import { isSkillInstallCommand } from './skill-install';
+import { highestSeverityMatch, scanVerdict } from './yara-policy';
+import type { ScanAction, ScanContext } from './yara-policy';
 import { WIZARD_YARA_REPORT_FILE } from '@utils/paths';
 // TODO(wizard#594): invert this dependency.
 // L2 infra (yara-hooks) imports product-specific filename constants from
@@ -113,12 +115,9 @@ export interface HookCallbackMatcher {
   timeout?: number;
 }
 
-/** Which content surface a warlock rule applies to (from rule `scan_context`). */
-export type ScanContext = 'command' | 'input' | 'output';
+export type { ScanAction, ScanContext } from './yara-policy';
 
 // ─── Scan Report Accumulator ─────────────────────────────────────
-
-export type ScanAction = 'blocked' | 'reverted' | 'warned' | 'aborted';
 
 interface ScanReportEntry {
   rule: string;
@@ -531,34 +530,7 @@ export function repeatBlockReason(
 }
 
 // ─── Severity helpers ────────────────────────────────────────────
-
-const SEVERITY_RANK: Record<string, number> = {
-  critical: 4,
-  high: 3,
-  medium: 2,
-  low: 1,
-};
-
-/** Severities that terminate the session outright, not just warn. */
-const TERMINAL_SEVERITIES = new Set(['critical']);
-
-/** A match that terminates the session rather than just warning. */
-export function isTerminalMatch(match: ScanMatch): boolean {
-  return (
-    TERMINAL_SEVERITIES.has(match.metadata.severity ?? '') ||
-    match.metadata.action === 'block'
-  );
-}
-
-/** Return the highest-severity match from a list of matches. */
-function highestSeverityMatch(matches: ScanMatch[]): ScanMatch {
-  return matches.reduce((worst, m) =>
-    (SEVERITY_RANK[m.metadata.severity ?? ''] ?? 0) >
-    (SEVERITY_RANK[worst.metadata.severity ?? ''] ?? 0)
-      ? m
-      : worst,
-  );
-}
+// Severity vocabulary and the terminate-or-warn decision live in yara-policy.
 
 // ─── Scan + triage core ──────────────────────────────────────────
 
@@ -934,12 +906,13 @@ export function createPostToolUseYaraHooks(
 
             recordScan();
             const matches = await scanAndTriage(content, 'input', llmProvider);
-            if (matches.length === 0) return {};
+            const verdict = scanVerdict(matches);
+            if (!verdict) return {};
 
-            const match = highestSeverityMatch(matches);
+            const { match } = verdict;
+            recordMatch('PostToolUse', toolName, match, verdict.action);
 
-            if (isTerminalMatch(match)) {
-              recordMatch('PostToolUse', toolName, match, 'aborted');
+            if (verdict.terminal) {
               const reason =
                 `[YARA CRITICAL] ${match.rule}: Prompt injection detected in file content. ` +
                 `Agent context is potentially poisoned. Session terminated for safety.`;
@@ -947,7 +920,6 @@ export function createPostToolUseYaraHooks(
               return { stopReason: reason };
             }
 
-            recordMatch('PostToolUse', toolName, match, 'warned');
             return {
               hookSpecificOutput: {
                 hookEventName: 'PostToolUse',

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -539,6 +539,17 @@ const SEVERITY_RANK: Record<string, number> = {
   low: 1,
 };
 
+/** Severities that terminate the session outright, not just warn. */
+const TERMINAL_SEVERITIES = new Set(['critical']);
+
+/** A match that terminates the session rather than just warning. */
+export function isTerminalMatch(match: ScanMatch): boolean {
+  return (
+    TERMINAL_SEVERITIES.has(match.metadata.severity ?? '') ||
+    match.metadata.action === 'block'
+  );
+}
+
 /** Return the highest-severity match from a list of matches. */
 function highestSeverityMatch(matches: ScanMatch[]): ScanMatch {
   return matches.reduce((worst, m) =>
@@ -927,13 +938,7 @@ export function createPostToolUseYaraHooks(
 
             const match = highestSeverityMatch(matches);
 
-            // Critical severity or a rule asking us to block => terminate; the
-            // agent's context may be poisoned by injected instructions.
-            const isTerminal =
-              match.metadata.severity === 'critical' ||
-              match.metadata.action === 'block';
-
-            if (isTerminal) {
+            if (isTerminalMatch(match)) {
               recordMatch('PostToolUse', toolName, match, 'aborted');
               const reason =
                 `[YARA CRITICAL] ${match.rule}: Prompt injection detected in file content. ` +

--- a/src/lib/yara-policy.ts
+++ b/src/lib/yara-policy.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared YARA scan policy: the vocabulary every scan surface speaks, and the
+ * one decision they all make — does a set of matches terminate the session, or
+ * only warn. Both fences (the anthropic PostToolUse hooks in `yara-hooks.ts`
+ * and the pi tool_result extension in `harness/pi/security.ts`) resolve a
+ * verdict here rather than each re-deriving it from severity and action.
+ */
+
+import type { ScanMatch } from '@posthog/warlock';
+
+/** Which content surface a warlock rule applies to (from rule `scan_context`). */
+export type ScanContext = 'command' | 'input' | 'output';
+
+/** What a fence did about a match, as recorded in the scan report. */
+export type ScanAction = 'blocked' | 'reverted' | 'warned' | 'aborted';
+
+/** Severity order, highest first, for picking the match worth reporting. */
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+/** Severities that end the session on their own, whatever the rule asks for. */
+const TERMINAL_SEVERITIES = new Set(['critical']);
+
+/** The match that ends the session rather than just warning. */
+export function isTerminalMatch(match: ScanMatch): boolean {
+  return (
+    TERMINAL_SEVERITIES.has(match.metadata.severity ?? '') ||
+    match.metadata.action === 'block'
+  );
+}
+
+/** Return the highest-severity match from a list of matches. */
+export function highestSeverityMatch(matches: ScanMatch[]): ScanMatch {
+  return matches.reduce((worst, m) =>
+    (SEVERITY_RANK[m.metadata.severity ?? ''] ?? 0) >
+    (SEVERITY_RANK[worst.metadata.severity ?? ''] ?? 0)
+      ? m
+      : worst,
+  );
+}
+
+export interface ScanVerdict {
+  /** The match worth reporting: the highest-severity one. */
+  match: ScanMatch;
+  /** Session ends now; anything else is advisory. */
+  terminal: boolean;
+  /** How the scan report records it. */
+  action: ScanAction;
+}
+
+/** Resolve what a fence should do about a set of matches. Null when clean. */
+export function scanVerdict(matches: ScanMatch[]): ScanVerdict | null {
+  if (matches.length === 0) return null;
+  const match = highestSeverityMatch(matches);
+  const terminal = isTerminalMatch(match);
+  return { match, terminal, action: terminal ? 'aborted' : 'warned' };
+}


### PR DESCRIPTION
pi terminated on any post-scan match; anthropic only terminates on severity=critical or action=block. This aligns pi with that gate.