### PR TITLE
feat: automate Rust debug-symbol upload in upload-source-maps

### DIFF
--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -588,4 +588,20 @@ describe('rustSdkVerifier', () => {
   it('returns false when the manifest is missing', () => {
     expect(rustSdkVerifier(tmpDir)('.')).toBe(false);
   });
+
+  it('ignores a commented-out dependency', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'Cargo.toml'),
+      '[package]\nname = "svc"\n\n[dependencies]\n# posthog-rs = "0.20"\nserde = "1"\n',
+    );
+    expect(rustSdkVerifier(tmpDir)('.')).toBe(false);
+  });
+
+  it('accepts a renamed dependency on the crate', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'Cargo.toml'),
+      '[package]\nname = "svc"\n\n[dependencies]\nposthog = { package = "posthog-rs", version = "0.20" }\n',
+    );
+    expect(rustSdkVerifier(tmpDir)('.')).toBe(true);
+  });
 });

--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -1,5 +1,9 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   coerceReport,
+  rustSdkVerifier,
   SOURCE_MAPS_TARGETS,
 } from '@lib/programs/error-tracking-upload-source-maps/detect-agentic';
 import { AUTOMATABLE_VARIANTS } from '@lib/programs/error-tracking-upload-source-maps/detect';
@@ -52,6 +56,15 @@ describe('SOURCE_MAPS_TARGETS precedence', () => {
   it('ranks the generic web fallback last among JS targets', () => {
     for (const other of ['react', 'node', 'vite']) {
       expect(rank(other)).toBeLessThan(rank('web'));
+    }
+  });
+
+  it('ranks native binaries after JS targets but ahead of the web fallback', () => {
+    expect(SOURCE_MAPS_TARGETS).toContainEqual({ id: 'rust', name: 'Rust' });
+    expect(SOURCE_MAPS_TARGETS).toContainEqual({ id: 'go', name: 'Go' });
+    for (const native of ['go', 'rust']) {
+      expect(rank('node')).toBeLessThan(rank(native));
+      expect(rank(native)).toBeLessThan(rank('web'));
     }
   });
 });
@@ -476,5 +489,103 @@ describe('coerceReport', () => {
   it('returns an empty report when projects is absent', () => {
     expect(coerceReport({}).projects).toEqual([]);
     expect(coerceReport(null).projects).toEqual([]);
+  });
+
+  it('retains a Rust project with PostHog as instrumentable', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Rust (Axum)',
+          targetId: 'rust',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual({
+      path: '.',
+      framework: 'Rust (Axum)',
+      variant: 'rust',
+      hasPostHog: true,
+      instrumentable: true,
+    });
+  });
+
+  it('points a Rust project without the SDK at a manual crate install', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Rust',
+          targetId: 'rust',
+          hasPostHog: false,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: 'rust',
+        instrumentable: false,
+        reason: expect.stringMatching(/add the posthog-rs crate/i),
+      }),
+    );
+  });
+
+  it('recognises Go but blocks it as not yet supported', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Go',
+          targetId: 'go',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: null,
+        instrumentable: false,
+        reason: expect.stringMatching(/isn't supported/i),
+      }),
+    );
+  });
+});
+
+describe('rustSdkVerifier', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wizard-rust-detect-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('confirms the SDK from the project Cargo.toml, root or nested', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'Cargo.toml'),
+      '[package]\nname = "svc"\n\n[dependencies]\nposthog-rs = "0.20"\n',
+    );
+    fs.mkdirSync(path.join(tmpDir, 'crates', 'api'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'crates', 'api', 'Cargo.toml'),
+      '[package]\nname = "api"\n\n[dependencies]\nserde = "1"\n',
+    );
+
+    const verify = rustSdkVerifier(tmpDir);
+    expect(verify('.')).toBe(true);
+    expect(verify('crates/api')).toBe(false);
+  });
+
+  it('returns false when the manifest is missing', () => {
+    expect(rustSdkVerifier(tmpDir)('.')).toBe(false);
   });
 });

--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -589,6 +589,38 @@ describe('rustSdkVerifier', () => {
     expect(rustSdkVerifier(tmpDir)('.')).toBe(false);
   });
 
+  it('finds the SDK in a member when the workspace root manifest is virtual', () => {
+    // The rust-workspace fixture shape: the root Cargo.toml has no
+    // [dependencies] at all, only [workspace] — the SDK lives in a member.
+    fs.writeFileSync(
+      path.join(tmpDir, 'Cargo.toml'),
+      '[workspace]\nresolver = "2"\nmembers = ["crates/api"]\n',
+    );
+    fs.mkdirSync(path.join(tmpDir, 'crates', 'api'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'crates', 'api', 'Cargo.toml'),
+      '[package]\nname = "api"\n\n[dependencies]\nposthog-rs = "0.20"\n',
+    );
+
+    expect(rustSdkVerifier(tmpDir)('.')).toBe(true);
+  });
+
+  it('ignores manifests under target/ when scanning members', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'Cargo.toml'),
+      '[workspace]\nmembers = ["crates/api"]\n',
+    );
+    fs.mkdirSync(path.join(tmpDir, 'target', 'package', 'dep'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'target', 'package', 'dep', 'Cargo.toml'),
+      '[package]\nname = "dep"\n\n[dependencies]\nposthog-rs = "0.20"\n',
+    );
+
+    expect(rustSdkVerifier(tmpDir)('.')).toBe(false);
+  });
+
   it('ignores a commented-out dependency', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'Cargo.toml'),

--- a/src/lib/programs/__tests__/source-maps-prompt.test.ts
+++ b/src/lib/programs/__tests__/source-maps-prompt.test.ts
@@ -75,6 +75,11 @@ describe('buildSourceMapsUploadPrompt rust workspace scope', () => {
 
     expect(prompt).toContain('Cargo workspace exception');
     expect(prompt).toContain('cargo locate-project --workspace');
+    // The env-path rule must carry the same exception, or STEP 5 writes the
+    // key into the member while the workspace upload reads the root .env.
+    expect(prompt).toContain(
+      'when the skill places the env file at the workspace root',
+    );
   });
 
   it('omits the workspace exception for root-scoped rust projects', () => {

--- a/src/lib/programs/__tests__/source-maps-prompt.test.ts
+++ b/src/lib/programs/__tests__/source-maps-prompt.test.ts
@@ -58,3 +58,40 @@ describe('buildSourceMapsUploadPrompt env file paths', () => {
     },
   );
 });
+
+describe('buildSourceMapsUploadPrompt rust workspace scope', () => {
+  const rustParams = {
+    ...baseParams,
+    displayName: 'Rust',
+    variant: 'rust' as const,
+    skillId: 'error-tracking-upload-source-maps-rust',
+  };
+
+  it('exempts the Cargo workspace root when a member project is selected', () => {
+    const prompt = buildSourceMapsUploadPrompt({
+      ...rustParams,
+      projectPath: 'rust/cymbal',
+    });
+
+    expect(prompt).toContain('Cargo workspace exception');
+    expect(prompt).toContain('cargo locate-project --workspace');
+  });
+
+  it('omits the workspace exception for root-scoped rust projects', () => {
+    const prompt = buildSourceMapsUploadPrompt({
+      ...rustParams,
+      projectPath: '.',
+    });
+
+    expect(prompt).not.toContain('Cargo workspace exception');
+  });
+
+  it('omits the workspace exception for non-rust monorepo projects', () => {
+    const prompt = buildSourceMapsUploadPrompt({
+      ...baseParams,
+      projectPath: 'backend',
+    });
+
+    expect(prompt).not.toContain('Cargo workspace exception');
+  });
+});

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -20,6 +20,8 @@ import type { WizardSession } from '@lib/wizard-session';
 import {
   VARIANT_DISPLAY_NAME,
   AUTOMATABLE_VARIANTS,
+  MANUAL_SDK_VARIANTS,
+  RUST_SDK_CRATE,
   type SkillVariant,
 } from './detect.js';
 
@@ -47,6 +49,14 @@ export type DetectionReport = {
 };
 
 /**
+ * Variants the detector recognises so the picker can name and block them,
+ * without a shipped skill behind them yet. They rank LOW — a go.mod signal
+ * must not shadow a real JS/native target in the same directory, it only
+ * needs to beat the generic web fallback.
+ */
+const DETECTION_ONLY_VARIANTS: readonly SkillVariant[] = ['go'];
+
+/**
  * Variant precedence for the agentic picker (most specific first). The detector
  * keeps the EARLIEST matching target. React Native and Flutter both outrank
  * Android and iOS: their repos carry `android/` and `ios/` folders with real
@@ -67,6 +77,15 @@ const VARIANT_PRECEDENCE: readonly SkillVariant[] = [
   'rollup',
   'react',
   'node',
+  // Native binaries: only chosen when no JS target matches the project, but
+  // ahead of the generic web fallback so a go.mod / Cargo.toml project
+  // resolves to its debug-symbols variant instead of `web`. Deliberate
+  // tradeoff for the same-directory mixed case: a Go/Rust project with a
+  // tooling-only package.json (common) beats a root-level JS app sharing a
+  // directory with go.mod / Cargo.toml (rare — frontends usually live in a
+  // subdirectory, which classifies as its own project).
+  'go',
+  'rust',
   'web',
 ];
 
@@ -75,10 +94,40 @@ const precedenceRank = (v: SkillVariant): number => {
   return i === -1 ? Number.MAX_SAFE_INTEGER : i;
 };
 
-/** Source-map detection targets, ordered by VARIANT_PRECEDENCE. */
-export const SOURCE_MAPS_TARGETS: DetectTarget[] = [...AUTOMATABLE_VARIANTS]
+/**
+ * Source-map detection targets, ordered by VARIANT_PRECEDENCE. Detection-only
+ * variants stay in the target list so the detector can identify and block
+ * them instead of falling through to a JS target or the web fallback.
+ */
+export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
+  ...DETECTION_ONLY_VARIANTS,
+  ...AUTOMATABLE_VARIANTS,
+]
   .sort((a, b) => precedenceRank(a) - precedenceRank(b))
   .map((v) => ({ id: v, name: VARIANT_DISPLAY_NAME[v] }));
+
+/**
+ * Checks a project's own Cargo.toml for the Rust SDK. The agentic detector
+ * reports a single `hasPostHog` boolean for ANY PostHog dependency in the
+ * project — for `rust` that could be satisfied by an unrelated JS SDK in the
+ * same directory, so the deterministic manifest read is authoritative.
+ * Exported for testing.
+ */
+export function rustSdkVerifier(
+  installDir: string,
+): (projectPath: string) => boolean {
+  return (projectPath) => {
+    const dir =
+      projectPath === '.' ? installDir : join(installDir, projectPath);
+    try {
+      return readFileSync(join(dir, 'Cargo.toml'), 'utf-8').includes(
+        RUST_SDK_CRATE,
+      );
+    } catch {
+      return false;
+    }
+  };
+}
 
 function isAutomatableVariant(value: string | null): value is SkillVariant {
   return value !== null && AUTOMATABLE_VARIANTS.includes(value as SkillVariant);
@@ -104,6 +153,13 @@ export type ProjectProbes = {
   hasBuildTarget: (path: string) => boolean;
   /** React Native: is the `expo` package installed in the project? */
   isExpoProject: (path: string) => boolean;
+  /**
+   * Rust: does the project's Cargo manifest tree carry the posthog-rs crate?
+   * Unlike the gate probes above, absence means "trust the agent's
+   * `hasPostHog`", not `false` — the probe REPLACES the agent's boolean when
+   * present, because any unrelated PostHog dependency can satisfy it.
+   */
+  verifyRustSdk?: (path: string) => boolean;
 };
 
 const NO_PROBES: ProjectProbes = {
@@ -152,10 +208,16 @@ function classifyProject(
   p: AgenticDetectionReport['projects'][number],
   probes: ProjectProbes,
 ): DetectedProject {
+  // For rust the deterministic Cargo.toml read overrides the agent's single
+  // hasPostHog boolean, which any unrelated PostHog dependency can satisfy.
+  const hasPostHog =
+    p.targetId === 'rust' && probes.verifyRustSdk
+      ? probes.verifyRustSdk(p.path)
+      : p.hasPostHog;
   const base = {
     path: p.path,
     framework: p.framework,
-    hasPostHog: p.hasPostHog,
+    hasPostHog,
   };
 
   // A React Native or Flutter labelled project only counts when it resolved to
@@ -196,12 +258,17 @@ function classifyProject(
     };
   }
 
-  if (!p.hasPostHog) {
+  if (!hasPostHog) {
+    // The wizard's default flow can't install the Rust SDK, so don't point
+    // users at it for that stack.
+    const install = MANUAL_SDK_VARIANTS.includes(p.targetId)
+      ? 'add the posthog-rs crate first'
+      : 'run `npx @posthog/wizard` first';
     return {
       ...base,
       variant: p.targetId,
       instrumentable: false,
-      reason: 'No PostHog SDK installed yet — run `npx @posthog/wizard` first',
+      reason: `No PostHog SDK installed yet — ${install}`,
     };
   }
 
@@ -252,5 +319,6 @@ export async function detectSourceMapsProjects(
   return toSourceMapsReport(report, {
     hasBuildTarget: (path) => projectHasBuildTarget(session.installDir, path),
     isExpoProject: (path) => projectHasExpo(session.installDir, path),
+    verifyRustSdk: rustSdkVerifier(session.installDir),
   });
 }

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -113,7 +113,11 @@ export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
  * same directory, so the deterministic manifest read is authoritative.
  * Comment-stripped substring matching, not TOML parsing: it still catches
  * renamed (`package = "posthog-rs"`) and workspace-inherited deps, while a
- * commented-out dependency no longer counts. Exported for testing.
+ * commented-out dependency no longer counts. Known miss: a member manifest
+ * whose dep is aliased at the workspace root (`posthog.workspace = true`
+ * with the `package = "posthog-rs"` mapping only in the root manifest) —
+ * accepted; resolving that needs full workspace metadata. Exported for
+ * testing.
  */
 export function rustSdkVerifier(
   installDir: string,

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -7,8 +7,9 @@
  * instruments the chosen project.
  */
 
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { IGNORED_DIRS } from '@utils/bounded-fs';
 import {
   detectProjectsWithAgent,
   coerceAgenticReport,
@@ -106,18 +107,57 @@ export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
   .sort((a, b) => precedenceRank(a) - precedenceRank(b))
   .map((v) => ({ id: v, name: VARIANT_DISPLAY_NAME[v] }));
 
+/** Comment-stripped substring check for the Rust SDK in one manifest. */
+function manifestMentionsSdk(manifestPath: string): boolean {
+  try {
+    return readFileSync(manifestPath, 'utf-8')
+      .split('\n')
+      .some((line) => {
+        const code = line.split('#', 1)[0];
+        return code.includes(RUST_SDK_CRATE);
+      });
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Checks a project's own Cargo.toml for the Rust SDK. The agentic detector
+ * A workspace root is often a virtual manifest (`[workspace]` only, no
+ * `[dependencies]`) — the SDK then lives in a member crate's manifest, so a
+ * miss on the root must fall through to a bounded walk over nested
+ * manifests. Depth 3 covers the common `crates/<name>/` layouts.
+ */
+function anyNestedManifestMentionsSdk(dir: string, depth: number): boolean {
+  if (depth > 3) return false;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('.')) continue;
+    if (IGNORED_DIRS.has(entry.name) || entry.name === 'target') continue;
+    const child = join(dir, entry.name);
+    if (manifestMentionsSdk(join(child, 'Cargo.toml'))) return true;
+    if (anyNestedManifestMentionsSdk(child, depth + 1)) return true;
+  }
+  return false;
+}
+
+/**
+ * Checks a project's Cargo manifests for the Rust SDK. The agentic detector
  * reports a single `hasPostHog` boolean for ANY PostHog dependency in the
  * project — for `rust` that could be satisfied by an unrelated JS SDK in the
  * same directory, so the deterministic manifest read is authoritative.
  * Comment-stripped substring matching, not TOML parsing: it still catches
  * renamed (`package = "posthog-rs"`) and workspace-inherited deps, while a
- * commented-out dependency no longer counts. Known miss: a member manifest
- * whose dep is aliased at the workspace root (`posthog.workspace = true`
- * with the `package = "posthog-rs"` mapping only in the root manifest) —
- * accepted; resolving that needs full workspace metadata. Exported for
- * testing.
+ * commented-out dependency no longer counts. Known miss: selecting a
+ * workspace MEMBER whose dep is aliased at the workspace root
+ * (`posthog.workspace = true` with the `package = "posthog-rs"` mapping only
+ * in the root manifest, which sits above the member) — accepted; resolving
+ * that needs full workspace metadata. Exported for testing.
  */
 export function rustSdkVerifier(
   installDir: string,
@@ -125,16 +165,10 @@ export function rustSdkVerifier(
   return (projectPath) => {
     const dir =
       projectPath === '.' ? installDir : join(installDir, projectPath);
-    try {
-      return readFileSync(join(dir, 'Cargo.toml'), 'utf-8')
-        .split('\n')
-        .some((line) => {
-          const code = line.split('#', 1)[0];
-          return code.includes(RUST_SDK_CRATE);
-        });
-    } catch {
-      return false;
-    }
+    return (
+      manifestMentionsSdk(join(dir, 'Cargo.toml')) ||
+      anyNestedManifestMentionsSdk(dir, 0)
+    );
   };
 }
 

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -111,7 +111,9 @@ export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
  * reports a single `hasPostHog` boolean for ANY PostHog dependency in the
  * project — for `rust` that could be satisfied by an unrelated JS SDK in the
  * same directory, so the deterministic manifest read is authoritative.
- * Exported for testing.
+ * Comment-stripped substring matching, not TOML parsing: it still catches
+ * renamed (`package = "posthog-rs"`) and workspace-inherited deps, while a
+ * commented-out dependency no longer counts. Exported for testing.
  */
 export function rustSdkVerifier(
   installDir: string,
@@ -120,9 +122,12 @@ export function rustSdkVerifier(
     const dir =
       projectPath === '.' ? installDir : join(installDir, projectPath);
     try {
-      return readFileSync(join(dir, 'Cargo.toml'), 'utf-8').includes(
-        RUST_SDK_CRATE,
-      );
+      return readFileSync(join(dir, 'Cargo.toml'), 'utf-8')
+        .split('\n')
+        .some((line) => {
+          const code = line.split('#', 1)[0];
+          return code.includes(RUST_SDK_CRATE);
+        });
     } catch {
       return false;
     }

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -37,7 +37,9 @@ export type SkillVariant =
   | 'ios'
   | 'vite'
   | 'webpack'
-  | 'rollup';
+  | 'rollup'
+  | 'go'
+  | 'rust';
 
 const DISPLAY_NAME: Record<SkillVariant, string> = {
   web: 'Web (JavaScript)',
@@ -53,16 +55,28 @@ const DISPLAY_NAME: Record<SkillVariant, string> = {
   vite: 'Vite',
   webpack: 'Webpack',
   rollup: 'Rollup',
+  go: 'Go',
+  rust: 'Rust',
 };
 
 /**
- * Variants the wizard can wire up source-map upload for automatically.
+ * Variants the wizard can wire up source-map upload for automatically. Go is
+ * recognised but not yet automatable, so the agentic picker treats it as
+ * non-instrumentable. Rust uploads native debug symbols
+ * (`posthog-cli symbol-sets upload`) instead of source maps, but the wiring
+ * is the same shape.
+ *
+ * Invariant: every variant listed here must have a published
+ * `error-tracking-upload-source-maps-<variant>` skill in context-mill —
+ * STEP 2 of the run installs that exact id, so an entry without a shipped
+ * skill fails every run for that stack.
  */
 export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
   'android',
   'ios',
   'react-native',
   'flutter',
+  'rust',
   'web',
   'nextjs',
   'node',
@@ -83,7 +97,17 @@ export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
  * or local dependency to fall back to when the post-build step invokes the CLI.
  */
 export const VARIANTS_REQUIRING_POSTHOG_CLI: ReadonlySet<SkillVariant> =
-  new Set(['ios', 'android', 'react-native', 'flutter']);
+  new Set(['ios', 'android', 'react-native', 'flutter', 'rust']);
+
+/**
+ * Automatable variants whose SDK the wizard's default flow cannot install —
+ * remediation for a missing SDK is a manual install (posthog-rs), not
+ * `npx @posthog/wizard`. Drives the missing-SDK copy in the picker.
+ */
+export const MANUAL_SDK_VARIANTS: readonly SkillVariant[] = ['rust'];
+
+/** Dependency string that identifies the Rust SDK in Cargo.toml. */
+export const RUST_SDK_CRATE = 'posthog-rs';
 
 const POSTHOG_SDKS = new Set([
   'posthog-js',
@@ -122,7 +146,9 @@ export const SOURCE_MAPS_ABORT_CASES: AbortCase[] = [
     body:
       'The agent could not find a PostHog SDK in your project. ' +
       'Source map upload requires the SDK to already be installed so it can ' +
-      'report errors. Run `npx @posthog/wizard` first to install the SDK.',
+      'report errors. Run `npx @posthog/wizard` first to install the SDK ' +
+      '(for Rust, add the posthog-rs crate by hand first — the wizard ' +
+      'cannot install it for that stack yet).',
     docsUrl: 'https://posthog.com/docs/error-tracking',
   },
   {

--- a/src/lib/programs/error-tracking-upload-source-maps/index.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/index.ts
@@ -153,6 +153,7 @@ export {
   SOURCE_MAPS_ABORT_CASES,
   SOURCE_MAPS_CONTEXT_KEYS,
   VARIANT_DISPLAY_NAME,
+  MANUAL_SDK_VARIANTS,
   type SkillVariant,
   type SourceMapsDetectError,
 } from './detect.js';

--- a/src/lib/programs/error-tracking-upload-source-maps/prompt.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/prompt.ts
@@ -39,7 +39,11 @@ export function buildSourceMapsUploadPrompt(
     ? `- Project directory (relative to the wizard's working directory): ${projectPath}`
     : "- Project directory: the wizard's working directory (even when it sits inside a larger git repo, this directory is the project root)";
   const envFilePathGuidance = inSubproject
-    ? `Tool filePaths are relative to the wizard's working directory, not the selected project directory. Treat the skill's env path as relative to the selected project and prefix it with \`${projectPath}/\` when calling the tools: for example, pass \`${projectPath}/.env\`, not \`.env\` (which would target the wizard's working directory).`
+    ? `Tool filePaths are relative to the wizard's working directory, not the selected project directory. Treat the skill's env path as relative to the selected project and prefix it with \`${projectPath}/\` when calling the tools: for example, pass \`${projectPath}/.env\`, not \`.env\` (which would target the wizard's working directory).${
+        variant === 'rust'
+          ? ` Cargo workspace exception: when the skill places the env file at the workspace root instead, pass the path of the ROOT manifest's directory relative to the wizard's working directory (e.g. \`rust/.env\` for a workspace root at \`rust/\`, or plain \`.env\` when the workspace root IS the working directory) — not the member path.`
+          : ''
+      }`
     : `Tool filePaths are relative to the wizard's working directory. For an env file at this project root, pass \`.env\`; never prefix it with this directory's path inside an ancestor repository.`;
 
   const credentialSteps = `STEP 4 — Make the credentials readable at build time. (skill: "Make credentials available at build time")

--- a/src/lib/programs/error-tracking-upload-source-maps/prompt.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/prompt.ts
@@ -78,7 +78,18 @@ All file changes, build/run commands, and config edits target the project direct
     inSubproject
       ? ` — this is a monorepo, so scope your work to \`${projectPath}\` and do not touch other packages`
       : ''
-  }.
+  }.${
+    variant === 'rust' && inSubproject
+      ? `
+Cargo workspace exception: if the selected project is a member of a Cargo
+workspace (resolve the root with \`cargo locate-project --workspace
+--message-format plain\`), the workspace root's Cargo.toml (for \`[profile.*]\`
+edits), the workspace-level \`target/\` directory, and a \`.env\` next to the
+root manifest are IN SCOPE — treat them as part of the selected project, and
+follow the skill's workspace guidance for which paths to use. Every other
+package stays off-limits.`
+      : ''
+  }
 
 The skill you install in STEP 2 is the source of truth for the HOW of every
 step: its "## Steps" section has an overview, tips and per-technology

--- a/src/ui/tui/screens/SourceMapsDetectScreen.tsx
+++ b/src/ui/tui/screens/SourceMapsDetectScreen.tsx
@@ -15,6 +15,7 @@ import { Colors, Icons } from '@ui/tui/styles';
 import {
   SOURCE_MAPS_CONTEXT_KEYS,
   VARIANT_DISPLAY_NAME,
+  MANUAL_SDK_VARIANTS,
 } from '@lib/programs/error-tracking-upload-source-maps/index';
 import {
   detectSourceMapsProjects,
@@ -214,7 +215,12 @@ export const SourceMapsDetectScreen = ({
  */
 const BlockedSummary = ({ blocked }: { blocked: DetectedProject[] }) => {
   const unsupported = blocked.filter((p) => p.variant == null).length;
-  const missingSdk = blocked.length - unsupported;
+  // The wizard can't install the Rust SDK, so its missing-SDK remediation is
+  // a manual install, not `npx @posthog/wizard`.
+  const manualSdk = blocked.filter(
+    (p) => p.variant != null && MANUAL_SDK_VARIANTS.includes(p.variant),
+  ).length;
+  const missingSdk = blocked.length - unsupported - manualSdk;
   if (blocked.length === 0) return null;
   return (
     <Box flexDirection="column">
@@ -228,6 +234,12 @@ const BlockedSummary = ({ blocked }: { blocked: DetectedProject[] }) => {
         <Text dimColor>
           (… {missingSdk} supported but missing the PostHog SDK — install it
           first with `npx @posthog/wizard`)
+        </Text>
+      )}
+      {manualSdk > 0 && (
+        <Text dimColor>
+          (… {manualSdk} supported but missing the PostHog SDK — add the
+          posthog-rs crate to the project first, then re-run)
         </Text>
       )}
     </Box>


### PR DESCRIPTION
Related PRs:
- context-mill: https://github.com/PostHog/context-mill/pull/262
- docs (merged, page live): https://github.com/PostHog/posthog.com/pull/18705
- wizard-workbench: rust fixture app, follows this PR

Adds Rust support to the `upload-source-maps` program, mirroring the Android/iOS pattern:

- `rust` joins `AUTOMATABLE_VARIANTS` and `VARIANTS_REQUIRING_POSTHOG_CLI` (the upload shells out to a PATH `posthog-cli symbol-sets upload`, so the wizard pre-installs it).
- `go` is recognized-but-blocked (like react-native/flutter): the picker names Go projects and shows "not supported yet" instead of letting them fall through to the `web` variant. It flips to automatable when posthog-go ships its native-frames release.
- Precedence: `go`/`rust` rank after every JS target but ahead of the `web` fallback, so a native project with a tooling-only `package.json` resolves correctly.
- Deterministic `hasPostHog` for rust: the agent reports one boolean for any PostHog dependency in a project, which a stray JS SDK could satisfy — a comment-stripped read of the project's Cargo manifests for `posthog-rs` is authoritative instead. When the project manifest misses (a workspace root is often a virtual manifest with no `[dependencies]`), a bounded walk checks member manifests — caught by devbox testing against the `rust-workspace` fixture, which previously reported "missing the PostHog SDK" for the root selection.
- Missing-SDK remediation copy for rust points at a manual crate install (the wizard can't install posthog-rs).

> [!WARNING]
> **Merge gate:** STEP 2 installs `error-tracking-upload-source-maps-rust`, which ships with context-mill PR #262 — release that first or every Rust run fails with `ERROR_RESOURCE_MISSING`. Old wizards are unaffected by the skill releasing first (they never resolve a `rust` variant).

Tests: full suite green (113 files / 1534+ tests), new coverage for target precedence, rust retained/blocked classification, go blocked classification, and the Cargo verifier (commented-out dep ignored, renamed dep accepted).

Review notes (codex, 2 rounds): fixed comment-stripped Cargo matching. Rejected: full TOML/workspace-inheritance parsing for the picker hint (documented looseness; the skill agent owns workspace mechanics — a workspace profile/target gotcha was added to the skill in #262 instead), and gating rust on the local OS for the Windows-PDB gap (production builds usually run on Linux CI regardless of the dev's OS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

