### PR TITLE
feat: automate React Native source-map upload

### DIFF
--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -16,6 +16,10 @@ describe('SOURCE_MAPS_TARGETS precedence', () => {
 
   it('ranks the cross-platform targets ahead of the native targets', () => {
     expect(SOURCE_MAPS_TARGETS).toContainEqual({
+      id: 'react-native',
+      name: 'React Native',
+    });
+    expect(SOURCE_MAPS_TARGETS).toContainEqual({
       id: 'android',
       name: 'Android',
     });
@@ -239,6 +243,28 @@ describe('coerceReport', () => {
     });
   });
 
+  it('retains a React Native project with PostHog as instrumentable', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'React Native',
+          targetId: 'react-native',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual({
+      path: '.',
+      framework: 'React Native',
+      variant: 'react-native',
+      hasPostHog: true,
+      instrumentable: true,
+    });
+  });
+
   it('blocks a Flutter project with no platform targets at all', () => {
     // A pure Dart package or plugin has no web/, android/ or ios/ directory,
     // so it never produces an app build with symbols to upload.
@@ -262,6 +288,27 @@ describe('coerceReport', () => {
         variant: null,
         instrumentable: false,
         reason: expect.stringMatching(/no web, android or ios target/i),
+      }),
+    );
+  });
+
+  it('retains an Expo-labelled project resolved to react-native as instrumentable', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Expo (React Native)',
+          targetId: 'react-native',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: 'react-native',
+        instrumentable: true,
       }),
     );
   });
@@ -292,6 +339,51 @@ describe('coerceReport', () => {
     );
   });
 
+  it('blocks a React Native project that has no PostHog SDK yet', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'React Native',
+          targetId: 'react-native',
+          hasPostHog: false,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: 'react-native',
+        hasPostHog: false,
+        instrumentable: false,
+        reason: expect.stringMatching(/no posthog sdk/i),
+      }),
+    );
+  });
+
+  it('blocks a Flutter project misclassified as React Native', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Flutter',
+          targetId: 'react-native',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: null,
+        instrumentable: false,
+        reason: expect.stringMatching(/isn't supported/i),
+      }),
+    );
+  });
+
   it('blocks a supported project that has no PostHog SDK yet', () => {
     const report = coerceReport({
       repoType: 'single',
@@ -314,11 +406,11 @@ describe('coerceReport', () => {
     const report = coerceReport({
       repoType: 'monorepo',
       projects: [
-        // not in the automatable set
+        // no variant covers this stack
         {
-          path: 'apps/mobile',
-          framework: 'React Native',
-          targetId: 'react-native',
+          path: 'apps/desktop',
+          framework: 'Qt',
+          targetId: 'qt',
           hasPostHog: true,
         },
         // garbage value

--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -231,7 +231,7 @@ describe('coerceReport', () => {
           },
         ],
       },
-      () => true,
+      { hasBuildTarget: () => true },
     );
 
     expect(report.projects[0]).toEqual({
@@ -243,18 +243,21 @@ describe('coerceReport', () => {
     });
   });
 
-  it('retains a React Native project with PostHog as instrumentable', () => {
-    const report = coerceReport({
-      repoType: 'single',
-      projects: [
-        {
-          path: '.',
-          framework: 'React Native',
-          targetId: 'react-native',
-          hasPostHog: true,
-        },
-      ],
-    });
+  it('retains an Expo React Native project with PostHog as instrumentable', () => {
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'React Native',
+            targetId: 'react-native',
+            hasPostHog: true,
+          },
+        ],
+      },
+      { isExpoProject: () => true },
+    );
 
     expect(report.projects[0]).toEqual({
       path: '.',
@@ -280,7 +283,7 @@ describe('coerceReport', () => {
           },
         ],
       },
-      () => false,
+      { hasBuildTarget: () => false },
     );
 
     expect(report.projects[0]).toEqual(
@@ -293,17 +296,20 @@ describe('coerceReport', () => {
   });
 
   it('retains an Expo-labelled project resolved to react-native as instrumentable', () => {
-    const report = coerceReport({
-      repoType: 'single',
-      projects: [
-        {
-          path: '.',
-          framework: 'Expo (React Native)',
-          targetId: 'react-native',
-          hasPostHog: true,
-        },
-      ],
-    });
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'Expo (React Native)',
+            targetId: 'react-native',
+            hasPostHog: true,
+          },
+        ],
+      },
+      { isExpoProject: () => true },
+    );
 
     expect(report.projects[0]).toEqual(
       expect.objectContaining({
@@ -326,7 +332,7 @@ describe('coerceReport', () => {
           },
         ],
       },
-      () => true,
+      { hasBuildTarget: () => true },
     );
 
     expect(report.projects[0]).toEqual(
@@ -339,7 +345,7 @@ describe('coerceReport', () => {
     );
   });
 
-  it('blocks a React Native project that has no PostHog SDK yet', () => {
+  it('blocks a bare React Native project (no expo package)', () => {
     const report = coerceReport({
       repoType: 'single',
       projects: [
@@ -347,10 +353,35 @@ describe('coerceReport', () => {
           path: '.',
           framework: 'React Native',
           targetId: 'react-native',
-          hasPostHog: false,
+          hasPostHog: true,
         },
       ],
     });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: null,
+        instrumentable: false,
+        reason: expect.stringMatching(/bare react native/i),
+      }),
+    );
+  });
+
+  it('blocks an Expo React Native project that has no PostHog SDK yet', () => {
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'React Native',
+            targetId: 'react-native',
+            hasPostHog: false,
+          },
+        ],
+      },
+      { isExpoProject: () => true },
+    );
 
     expect(report.projects[0]).toEqual(
       expect.objectContaining({

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -7,7 +7,7 @@
  * instruments the chosen project.
  */
 
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import {
   detectProjectsWithAgent,
@@ -87,12 +87,35 @@ function isAutomatableVariant(value: string | null): value is SkillVariant {
 export const FLUTTER_NO_BUILD_TARGET_REASON =
   'Flutter project has no web, android or ios target — nothing to upload symbols for';
 
+export const BARE_REACT_NATIVE_REASON =
+  'Bare React Native (without Expo) is not supported — source-map upload needs the Expo build pipeline';
+
+/**
+ * Filesystem probes the classifier needs on top of what the agent reports.
+ * Injected so `coerceReport` stays testable without touching disk. A missing
+ * probe answers `false`, which blocks the variant it guards.
+ */
+export type ProjectProbes = {
+  /**
+   * Flutter: does the project have at least one platform target the wizard can
+   * wire uploads into — web (dart2js source maps), android (R8 mapping files)
+   * or ios (dSYMs)?
+   */
+  hasBuildTarget: (path: string) => boolean;
+  /** React Native: is the `expo` package installed in the project? */
+  isExpoProject: (path: string) => boolean;
+};
+
+const NO_PROBES: ProjectProbes = {
+  hasBuildTarget: () => false,
+  isExpoProject: () => false,
+};
+
 /**
  * True when the Flutter project at `projectPath` has at least one platform
- * target the wizard can wire uploads into: web (dart2js source maps), android
- * (R8 mapping files) or ios (dSYMs). `flutter create` scaffolds a directory per
- * enabled platform, so their absence means this is a pure Dart package or
- * plugin — it produces no app build, and there is nothing to upload.
+ * target. `flutter create` scaffolds a directory per enabled platform, so their
+ * absence means this is a pure Dart package or plugin — it produces no app
+ * build, and there is nothing to upload.
  */
 function projectHasBuildTarget(
   installDir: string,
@@ -106,10 +129,28 @@ function projectHasBuildTarget(
   );
 }
 
+/** True when the project at `projectPath` has the `expo` package installed. */
+function projectHasExpo(installDir: string, projectPath: string): boolean {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(installDir, projectPath, 'package.json'), 'utf-8'),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    return (
+      pkg.dependencies?.['expo'] != null ||
+      pkg.devDependencies?.['expo'] != null
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Classify one agent-detected project for source-map upload. */
 function classifyProject(
   p: AgenticDetectionReport['projects'][number],
-  hasBuildTarget: (path: string) => boolean,
+  probes: ProjectProbes,
 ): DetectedProject {
   const base = {
     path: p.path,
@@ -135,12 +176,23 @@ function classifyProject(
 
   // A Flutter package or plugin has no platform directories and never produces
   // an app build, so there are no symbols to upload for it.
-  if (p.targetId === 'flutter' && !hasBuildTarget(p.path)) {
+  if (p.targetId === 'flutter' && !probes.hasBuildTarget(p.path)) {
     return {
       ...base,
       variant: null,
       instrumentable: false,
       reason: FLUTTER_NO_BUILD_TARGET_REASON,
+    };
+  }
+
+  // Bare React Native (no expo package) is not supported: its Metro pipeline
+  // can't inject chunk IDs, so uploads would never resolve.
+  if (p.targetId === 'react-native' && !probes.isExpoProject(p.path)) {
+    return {
+      ...base,
+      variant: null,
+      instrumentable: false,
+      reason: BARE_REACT_NATIVE_REASON,
     };
   }
 
@@ -159,30 +211,31 @@ function classifyProject(
 /** Map a generic detection report into source-maps projects. */
 function toSourceMapsReport(
   report: AgenticDetectionReport,
-  hasBuildTarget: (path: string) => boolean,
+  probes: ProjectProbes,
 ): DetectionReport {
   return {
     repoType: report.repoType,
-    projects: report.projects.map((p) => classifyProject(p, hasBuildTarget)),
+    projects: report.projects.map((p) => classifyProject(p, probes)),
   };
 }
 
 /**
  * Validate the agent's raw JSON into a source-maps detection report. Exported
  * for testing — clamps projects the wizard cannot wire up to
- * non-instrumentable. Without a `hasBuildTarget` predicate every Flutter
- * project is treated as target-less (blocked).
+ * non-instrumentable. Probes left out of `probes` answer `false`, so every
+ * Flutter project is treated as target-less and every React Native project as
+ * bare (both blocked).
  */
 export function coerceReport(
   parsed: unknown,
-  hasBuildTarget: (path: string) => boolean = () => false,
+  probes: Partial<ProjectProbes> = {},
 ): DetectionReport {
   return toSourceMapsReport(
     coerceAgenticReport(
       parsed,
       SOURCE_MAPS_TARGETS.map((target) => target.id),
     ),
-    hasBuildTarget,
+    { ...NO_PROBES, ...probes },
   );
 }
 
@@ -196,7 +249,8 @@ export async function detectSourceMapsProjects(
     purpose: 'set up PostHog Error Tracking source-map upload',
     onEvent,
   });
-  return toSourceMapsReport(report, (path) =>
-    projectHasBuildTarget(session.installDir, path),
-  );
+  return toSourceMapsReport(report, {
+    hasBuildTarget: (path) => projectHasBuildTarget(session.installDir, path),
+    isExpoProject: (path) => projectHasExpo(session.installDir, path),
+  });
 }

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -48,20 +48,14 @@ export type DetectionReport = {
 
 /**
  * Variant precedence for the agentic picker (most specific first). The detector
- * keeps the EARLIEST matching target. Unsupported native targets are included
- * as guards before Android and iOS so React Native projects with nested Gradle
- * or Xcode manifests are not misclassified as instrumentable native apps. JS
- * ordering mirrors `pickJsVariant` in detect.ts: opinionated frameworks →
- * bundlers → bare React → Node → generic web.
+ * keeps the EARLIEST matching target. React Native and Flutter both outrank
+ * Android and iOS: their repos carry `android/` and `ios/` folders with real
+ * Gradle and Xcode manifests inside them, and must not be misclassified as
+ * plain native apps. JS ordering mirrors `pickJsVariant` in detect.ts:
+ * opinionated frameworks → bundlers → bare React → Node → generic web.
  */
-const NON_AUTOMATABLE_NATIVE_VARIANTS: readonly SkillVariant[] = [
-  'react-native',
-];
-
 const VARIANT_PRECEDENCE: readonly SkillVariant[] = [
-  ...NON_AUTOMATABLE_NATIVE_VARIANTS,
-  // Flutter outranks android/ios: a Flutter repo carries `android/` and
-  // `ios/` folders with real Gradle and Xcode manifests inside it.
+  'react-native',
   'flutter',
   'android',
   'ios',
@@ -81,15 +75,8 @@ const precedenceRank = (v: SkillVariant): number => {
   return i === -1 ? Number.MAX_SAFE_INTEGER : i;
 };
 
-/**
- * Source-map detection targets, ordered by VARIANT_PRECEDENCE. Unsupported
- * native variants remain in the target list so the detector can identify and
- * block them instead of falling through to iOS or a JS target.
- */
-export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
-  ...NON_AUTOMATABLE_NATIVE_VARIANTS,
-  ...AUTOMATABLE_VARIANTS,
-]
+/** Source-map detection targets, ordered by VARIANT_PRECEDENCE. */
+export const SOURCE_MAPS_TARGETS: DetectTarget[] = [...AUTOMATABLE_VARIANTS]
   .sort((a, b) => precedenceRank(a) - precedenceRank(b))
   .map((v) => ({ id: v, name: VARIANT_DISPLAY_NAME[v] }));
 
@@ -130,11 +117,12 @@ function classifyProject(
     hasPostHog: p.hasPostHog,
   };
 
-  // React Native is not automatable at all; a Flutter-labelled project only
-  // counts when it resolved to the flutter target — the nested Gradle and
-  // Xcode manifests inside a Flutter repo must not claim android or ios.
+  // A React Native or Flutter labelled project only counts when it resolved to
+  // its own target — the nested Gradle and Xcode manifests inside those repos
+  // must not claim android or ios.
   const namesForeignNativePlatform =
-    /\b(?:react[\s-]*native|expo)\b/i.test(p.framework) ||
+    (/\b(?:react[\s-]*native|expo)\b/i.test(p.framework) &&
+      p.targetId !== 'react-native') ||
     (/\bflutter\b/i.test(p.framework) && p.targetId !== 'flutter');
   if (!isAutomatableVariant(p.targetId) || namesForeignNativePlatform) {
     return {
@@ -181,9 +169,9 @@ function toSourceMapsReport(
 
 /**
  * Validate the agent's raw JSON into a source-maps detection report. Exported
- * for testing — recognises detection-only native targets, then clamps them to
- * non-instrumentable projects. Without a `hasBuildTarget` predicate every
- * Flutter project is treated as target-less (blocked).
+ * for testing — clamps projects the wizard cannot wire up to
+ * non-instrumentable. Without a `hasBuildTarget` predicate every Flutter
+ * project is treated as target-less (blocked).
  */
 export function coerceReport(
   parsed: unknown,

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -134,6 +134,16 @@ export const SOURCE_MAPS_ABORT_CASES: AbortCase[] = [
       'your project and run this wizard again.',
     docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
   },
+  {
+    match: /^bare react native not supported$/i,
+    message: 'Bare React Native is not supported',
+    body:
+      'Source-map upload for React Native requires Expo, and this project ' +
+      'has no `expo` package. Bare React Native builds cannot inject the ' +
+      'chunk IDs PostHog needs to resolve stack traces.',
+    docsUrl:
+      'https://posthog.com/docs/error-tracking/upload-source-maps/react-native',
+  },
 ];
 
 // ── File / dependency probes ─────────────────────────────────────────

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -56,13 +56,12 @@ const DISPLAY_NAME: Record<SkillVariant, string> = {
 };
 
 /**
- * Variants the wizard can wire up source-map upload for automatically. React
- * Native is recognised but not yet automatable, so the agentic picker treats
- * it as non-instrumentable.
+ * Variants the wizard can wire up source-map upload for automatically.
  */
 export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
   'android',
   'ios',
+  'react-native',
   'flutter',
   'web',
   'nextjs',
@@ -77,13 +76,14 @@ export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
 
 /**
  * Variants the wizard pre-installs a machine-global `posthog-cli` for — their
- * build shells out to it with no npx / local-dep fallback. JS variants stay
- * out. Flutter counts here despite emitting plain `.js.map` files: a Flutter
- * project has no `package.json`, so there is no npx or local dependency to
- * fall back to when the post-build step invokes the CLI.
+ * build shells out to it with no npx / local-dep fallback. Web JS variants stay
+ * out. React Native counts as native here — its Xcode build phases and Gradle
+ * tasks invoke the global CLI. Flutter counts too despite emitting plain
+ * `.js.map` files: a Flutter project has no `package.json`, so there is no npx
+ * or local dependency to fall back to when the post-build step invokes the CLI.
  */
 export const VARIANTS_REQUIRING_POSTHOG_CLI: ReadonlySet<SkillVariant> =
-  new Set(['ios', 'android', 'flutter']);
+  new Set(['ios', 'android', 'react-native', 'flutter']);
 
 const POSTHOG_SDKS = new Set([
   'posthog-js',


### PR DESCRIPTION
## Related PRs

Part of the React Native source-map upload rollout:

- PostHog/context-mill#263 — skill: React Native (Expo) upload guidance for the wizard agent
- PostHog/wizard-workbench#2960 — workbench: real React Native test apps (bare + Expo)

---

## What

There were some changes we had to do in our expo plugin to inject path to an env file so then it's injected into the native technology which then loads it and calls upload of dsyms/proguard.

Had to do:
- this https://github.com/PostHog/posthog-android/pull/651
- and this https://github.com/PostHog/posthog-js/pull/4219

| Test screen in the wizard |
|--------|
| <img width="1134" height="754" alt="CleanShot 2026-07-24 at 12 44 51@2x" src="https://github.com/user-attachments/assets/e6898625-b575-4ce3-8ce7-c607f37b4850" /> | 

### Expo iOS

| JS crash [view in PostHog](https://us.posthog.com/project/89529/error_tracking/019f89d9-2b9f-7a43-8e41-87a37c7121ed?timestamp=2026-07-24%2010%3A55%3A51.559000%2B00%3A00&dateRange=%7B%22date_from%22%3A%22-1h%22%2C%22date_to%22%3Anull%7D) | Native crash [view in PostHog](https://us.posthog.com/project/89529/error_tracking/019f8e0e-e740-7113-a004-ce05e36a4217?timestamp=2026-07-24%2010%3A51%3A58.091000%2B00%3A00&dateRange=%7B%22date_from%22%3A%22-1h%22%2C%22date_to%22%3Anull%7D) |
|--------|--------|
| <img width="1706" height="956" alt="CleanShot 2026-07-22 at 14 43 10" src="https://github.com/user-attachments/assets/b83fb1d2-4d9e-46e9-b43b-8e861e4927a7" /> | <img width="1706" height="913" alt="CleanShot 2026-07-23 at 10 22 33" src="https://github.com/user-attachments/assets/e97ad608-a1ac-4e49-9dbb-a32404fc1ec6" /> | 


### Expo Android

JS crash got grouped to the same issue as iOS one on the same build (as expected).
In android native crash we've got clean deminification (we don't have source context because we don't support that for android)

| JS crash [view in PostHog](https://us.posthog.com/project/89529/error_tracking/019f89d9-2b9f-7a43-8e41-87a37c7121ed?timestamp=2026-07-24%2010%3A55%3A51.559000%2B00%3A00&dateRange=%7B%22date_from%22%3A%22-1h%22%2C%22date_to%22%3Anull%7D) | Native crash [view in PostHog](https://us.posthog.com/project/89529/error_tracking/019f8e1b-18c3-7472-a114-368e1c9e7d2d?timestamp=2026-07-24%2010%3A55%3A54.643000%2B00%3A00&dateRange=%7B%22date_from%22%3A%22-1h%22%2C%22date_to%22%3Anull%7D) |
|--------|--------|
<img width="1703" height="914" alt="CleanShot 2026-07-23 at 10 29 57" src="https://github.com/user-attachments/assets/7672a61a-6fac-4eee-bc90-7cd1d913681e" /> | <img width="1703" height="914" alt="CleanShot 2026-07-23 at 10 33 30" src="https://github.com/user-attachments/assets/f9156037-cabd-4bc9-975c-842c34a20545" /> | 



### Bare RN iOS & Android

Made a decision to no support this right now. Wasted a lot of time trying to make that work. It seems that expo is the standard recommended by the RN itself. On top of that wizard was extremely slow because changes required to make this work are extremely complex. Maybe I will revisit this in the future. For now we display this:

| Bare react native error message |
|--------|
| <img width="1782" height="306" alt="CleanShot 2026-07-23 at 15 24 32@2x" src="https://github.com/user-attachments/assets/cad97d81-4025-4cd6-84eb-3de15220a076" /> | 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
