### PR TITLE
fix(e2e): honor POSTHOG_REGION in the TUI host

### DIFF
--- a/scripts/tui-host.no-jest.ts
+++ b/scripts/tui-host.no-jest.ts
@@ -58,7 +58,7 @@ async function main() {
     ci: true,
     apiKey,
     projectId,
-    region: 'us',
+    region: process.env.POSTHOG_REGION === 'eu' ? 'eu' : 'us',
     // Local skills + MCP (context-mill dev server on :8765, MCP on :8787) —
     // same env-backed flag the bin's --local-mcp reads.
     localMcp: process.env.POSTHOG_WIZARD_LOCAL_MCP === 'true',


### PR DESCRIPTION
The wizard-ci MCP server passes POSTHOG_REGION from open_app's region param, but the TUI host hardcodes region: 'us' — every harness run with an EU key fails with 'Authentication failed while trying to fetch project data' regardless of the region passed. Found while e2e-testing #942 against an EU project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)