### PR TITLE
fix(data-warehouse): stop reporting benign fs errors during source detection

### DIFF
--- a/src/utils/__tests__/file-utils.test.ts
+++ b/src/utils/__tests__/file-utils.test.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import { walkProjectFiles, safeReadFile } from '@utils/file-utils';
+import { analytics } from '@utils/analytics';
+import { logToFile } from '@utils/debug';
+
+vi.mock('../analytics', () => ({
+  analytics: { captureException: vi.fn() },
+}));
+vi.mock('../debug', () => ({ logToFile: vi.fn() }));
+
+const captureException = analytics.captureException as ReturnType<typeof vi.fn>;
+const mockLogToFile = logToFile as ReturnType<typeof vi.fn>;
+
+function errnoError(code: string): NodeJS.ErrnoException {
+  const err = new Error(`${code}: mock`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+describe('reportFsError (via walkProjectFiles / safeReadFile)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  // Benign codes are expected while scanning arbitrary trees (protected dirs,
+  // races, symlink loops) — they must be logged, not captured as exceptions.
+  it.each(['EACCES', 'EPERM', 'ENOENT', 'ENOTDIR', 'ELOOP', 'EMFILE'])(
+    'does not capture an exception for benign fs error %s',
+    (code) => {
+      vi.spyOn(fs, 'realpathSync').mockImplementation(() => {
+        throw errnoError(code);
+      });
+
+      walkProjectFiles('/some/dir', vi.fn());
+
+      expect(captureException).not.toHaveBeenCalled();
+      expect(mockLogToFile).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('captures an exception for an unexpected fs error code', () => {
+    vi.spyOn(fs, 'realpathSync').mockImplementation(() => {
+      throw errnoError('EUNEXPECTED');
+    });
+
+    walkProjectFiles('/some/dir', vi.fn());
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(mockLogToFile).not.toHaveBeenCalled();
+  });
+
+  it('captures an exception for an error with no errno code', () => {
+    vi.spyOn(fs, 'realpathSync').mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    walkProjectFiles('/some/dir', vi.fn());
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('safeReadFile swallows benign read errors without capturing', () => {
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw errnoError('EACCES');
+    });
+
+    expect(safeReadFile('/some/file')).toBeNull();
+    expect(captureException).not.toHaveBeenCalled();
+    expect(mockLogToFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -2,15 +2,40 @@ import path from 'path';
 import fs from 'fs';
 import type { Dirent } from 'fs';
 import { analytics } from './analytics';
+import { logToFile } from './debug';
 import type { WizardRunOptions } from './types';
 
 /**
- * Report a swallowed filesystem error to error tracking. Traversal stays
- * best-effort — the caller still skips the failing entry — but the failure is
- * no longer silent. Preserves the original Error (and its `code`, e.g. EACCES
- * / ENOENT) when available.
+ * Errno codes that are expected while walking an arbitrary tree and mean
+ * "skip this entry", not "something is broken". Scanning from a broad dir
+ * (e.g. `~`) routinely hits OS-protected paths (macOS `Library/Group
+ * Containers/group.com.apple.*`) that throw EPERM/EACCES per entry — capturing
+ * each as an exception buried real errors under thousands of noise events.
+ */
+const BENIGN_FS_ERROR_CODES = new Set<string>([
+  'EACCES', // permission denied
+  'EPERM', // operation not permitted (macOS-protected dirs)
+  'ENOENT', // entry vanished mid-walk
+  'ENOTDIR', // path component isn't a directory
+  'ELOOP', // symlink loop
+  'ENAMETOOLONG', // path too long
+  'EMFILE', // too many open files (environmental, not a wizard bug)
+  'ENFILE',
+]);
+
+/**
+ * Report a swallowed filesystem error. Traversal stays best-effort — the caller
+ * still skips the failing entry. Expected errno codes (permission denied, entry
+ * vanished, symlink loops…) are logged to the debug file only; anything else is
+ * genuinely unexpected and gets captured to error tracking. Preserves the
+ * original Error (and its `code`, e.g. EACCES / ENOENT) when available.
  */
 function reportFsError(step: string, path: string, error: unknown): void {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  if (code && BENIGN_FS_ERROR_CODES.has(code)) {
+    logToFile(`[file-utils] skipped ${step} (${code}): ${path}`);
+    return;
+  }
   analytics.captureException(
     error instanceof Error ? error : new Error(String(error)),
     { step, path },


### PR DESCRIPTION
## Problem

Warehouse-source detection (shipped Jul 21) walks the install dir 3 levels deep on every wizard run. When the wizard is run from a broad directory (e.g. `~`), the walk hits OS-protected paths — macOS `Library/Group Containers/group.com.apple.*` (Reminders, Siri, chronod…) and similar — that throw `EPERM`/`EACCES` per entry.

`reportFsError` captured each swallowed error as a `$exception`, so a handful of users produced 1000+ noise exception events, burying real errors and setting off a wizard-error spike alert.

## Changes

`reportFsError` now distinguishes expected errno codes from genuinely unexpected ones:

- Benign codes (`EACCES`, `EPERM`, `ENOENT`, `ENOTDIR`, `ELOOP`, `ENAMETOOLONG`, `EMFILE`, `ENFILE`) — routine while scanning an arbitrary tree — are logged to the debug file and skipped, not captured.
- Anything else still goes to error tracking.

Traversal stays best-effort either way — the caller already skips the failing entry. This covers both `walkProjectFiles` (realpath/readdir/stat) and `safeReadFile`.

## Test plan

New `src/utils/__tests__/file-utils.test.ts`:
- benign codes (parameterized) → no exception captured, logged instead
- unexpected code / no errno code → exception captured
- `safeReadFile` benign read error → returns null, no capture

`vitest`, `tsc --noEmit`, eslint and prettier all clean on the changed files.