### PR TITLE
feat(source-maps): require Expo for React Native projects

### DIFF
--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -15,7 +15,6 @@ import { runtimeEnv } from '@env';
 import {
   WIZARD_REMARK_EVENT_NAME,
   POSTHOG_PROPERTY_HEADER_PREFIX,
-  WIZARD_ORCHESTRATOR_FLAG_KEY,
   wizardUserAgentForProgram,
   DEFAULT_AGENT_MODEL,
 } from '@lib/constants';
@@ -298,6 +297,16 @@ type AgentRunConfig = {
   getPendingQuestion?: () =>
     | import('@lib/wizard-session').PendingQuestion
     | null;
+  /**
+   * Orchestrator queue context, propagated from `AgentConfig`. Present ONLY on
+   * runs the orchestrator actually drives (seed + per-task). Used as the
+   * suppress-task-render signal: when set, the orchestrator owns the TUI queue
+   * panel, so the sub-agent's own TaskCreate/TaskUpdate must not render. When
+   * absent (linear / top-level runs), the agent renders its own todos — never
+   * key this off the raw `wizard-orchestrator` flag, which is on account-wide
+   * and does not mean this particular run is orchestrated.
+   */
+  orchestrator?: import('@lib/agent/runner/sequence/orchestrator/queue-tools').OrchestratorToolsContext;
 };
 
 /**
@@ -579,6 +588,7 @@ export async function initializeAgent(
       allowedTools: config.allowedTools,
       disallowedTools: config.disallowedTools,
       getPendingQuestion: config.getPendingQuestion,
+      orchestrator: config.orchestrator,
     };
 
     logToFile('Agent config:', {
@@ -1027,8 +1037,13 @@ export async function runAgent(
         signals,
         receivedSuccessResult,
         tasks,
-        (agentConfig.wizardFlags ?? {})[WIZARD_ORCHESTRATOR_FLAG_KEY] ===
-          'true',
+        // Suppress the agent's own task rendering ONLY when the orchestrator is
+        // actually driving this run (it owns the TUI queue panel and repaints
+        // via renderQueue). Keyed on the threaded orchestrator context, NOT the
+        // raw `wizard-orchestrator` flag: that flag is on account-wide but the
+        // orchestrator only routes `posthog-integration` — every other program
+        // runs linear, where suppressing would leave the todo panel empty.
+        !!agentConfig.orchestrator,
         emitStepEvents,
       );
 

--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -220,18 +220,21 @@ describe('coerceReport', () => {
     },
   );
 
-  it('retains a React Native project with PostHog as instrumentable', () => {
-    const report = coerceReport({
-      repoType: 'single',
-      projects: [
-        {
-          path: '.',
-          framework: 'React Native',
-          targetId: 'react-native',
-          hasPostHog: true,
-        },
-      ],
-    });
+  it('retains an Expo React Native project with PostHog as instrumentable', () => {
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'React Native',
+            targetId: 'react-native',
+            hasPostHog: true,
+          },
+        ],
+      },
+      () => true,
+    );
 
     expect(report.projects[0]).toEqual({
       path: '.',
@@ -243,17 +246,20 @@ describe('coerceReport', () => {
   });
 
   it('retains an Expo-labelled project resolved to react-native as instrumentable', () => {
-    const report = coerceReport({
-      repoType: 'single',
-      projects: [
-        {
-          path: '.',
-          framework: 'Expo (React Native)',
-          targetId: 'react-native',
-          hasPostHog: true,
-        },
-      ],
-    });
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'Expo (React Native)',
+            targetId: 'react-native',
+            hasPostHog: true,
+          },
+        ],
+      },
+      () => true,
+    );
 
     expect(report.projects[0]).toEqual(
       expect.objectContaining({
@@ -263,7 +269,7 @@ describe('coerceReport', () => {
     );
   });
 
-  it('blocks a React Native project that has no PostHog SDK yet', () => {
+  it('blocks a bare React Native project (no expo package)', () => {
     const report = coerceReport({
       repoType: 'single',
       projects: [
@@ -271,10 +277,35 @@ describe('coerceReport', () => {
           path: '.',
           framework: 'React Native',
           targetId: 'react-native',
-          hasPostHog: false,
+          hasPostHog: true,
         },
       ],
     });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: null,
+        instrumentable: false,
+        reason: expect.stringMatching(/bare react native/i),
+      }),
+    );
+  });
+
+  it('blocks an Expo React Native project that has no PostHog SDK yet', () => {
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'React Native',
+            targetId: 'react-native',
+            hasPostHog: false,
+          },
+        ],
+      },
+      () => true,
+    );
 
     expect(report.projects[0]).toEqual(
       expect.objectContaining({

--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -14,16 +14,24 @@ describe('SOURCE_MAPS_TARGETS precedence', () => {
     }
   });
 
-  it('ranks unsupported native guards ahead of the native targets', () => {
+  it('ranks the unsupported flutter guard ahead of the native targets', () => {
+    for (const native of ['react-native', 'android', 'ios']) {
+      expect(rank('flutter')).toBeLessThan(rank(native));
+    }
+  });
+
+  it('ranks React Native ahead of Android and iOS', () => {
+    expect(SOURCE_MAPS_TARGETS).toContainEqual({
+      id: 'react-native',
+      name: 'React Native',
+    });
     expect(SOURCE_MAPS_TARGETS).toContainEqual({
       id: 'android',
       name: 'Android',
     });
     expect(SOURCE_MAPS_TARGETS).toContainEqual({ id: 'ios', name: 'iOS' });
-    for (const nativeGuard of ['react-native', 'flutter']) {
-      expect(rank(nativeGuard)).toBeLessThan(rank('android'));
-      expect(rank(nativeGuard)).toBeLessThan(rank('ios'));
-    }
+    expect(rank('react-native')).toBeLessThan(rank('android'));
+    expect(rank('react-native')).toBeLessThan(rank('ios'));
     expect(rank('android')).toBeLessThan(rank('nextjs'));
     expect(rank('ios')).toBeLessThan(rank('nextjs'));
   });
@@ -212,6 +220,94 @@ describe('coerceReport', () => {
     },
   );
 
+  it('retains a React Native project with PostHog as instrumentable', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'React Native',
+          targetId: 'react-native',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual({
+      path: '.',
+      framework: 'React Native',
+      variant: 'react-native',
+      hasPostHog: true,
+      instrumentable: true,
+    });
+  });
+
+  it('retains an Expo-labelled project resolved to react-native as instrumentable', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Expo (React Native)',
+          targetId: 'react-native',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: 'react-native',
+        instrumentable: true,
+      }),
+    );
+  });
+
+  it('blocks a React Native project that has no PostHog SDK yet', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'React Native',
+          targetId: 'react-native',
+          hasPostHog: false,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: 'react-native',
+        hasPostHog: false,
+        instrumentable: false,
+        reason: expect.stringMatching(/no posthog sdk/i),
+      }),
+    );
+  });
+
+  it('blocks a Flutter project misclassified as React Native', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Flutter',
+          targetId: 'react-native',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: null,
+        instrumentable: false,
+        reason: expect.stringMatching(/isn't supported/i),
+      }),
+    );
+  });
+
   it('blocks a supported project that has no PostHog SDK yet', () => {
     const report = coerceReport({
       repoType: 'single',
@@ -237,8 +333,8 @@ describe('coerceReport', () => {
         // not in the automatable set
         {
           path: 'apps/mobile',
-          framework: 'React Native',
-          targetId: 'react-native',
+          framework: 'Flutter',
+          targetId: 'flutter',
           hasPostHog: true,
         },
         // garbage value

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -7,6 +7,8 @@
  * instruments the chosen project.
  */
 
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import {
   detectProjectsWithAgent,
   coerceAgenticReport,
@@ -90,11 +92,14 @@ export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
 function classify(
   variant: SkillVariant | null,
   hasPostHog: boolean,
+  reasonWhenNoVariant?: string,
 ): { instrumentable: boolean; reason?: string } {
   if (variant == null) {
     return {
       instrumentable: false,
-      reason: "Source-map upload isn't supported for this stack yet",
+      reason:
+        reasonWhenNoVariant ??
+        "Source-map upload isn't supported for this stack yet",
     };
   }
   if (!hasPostHog) {
@@ -110,8 +115,32 @@ function isAutomatableVariant(value: string | null): value is SkillVariant {
   return value !== null && AUTOMATABLE_VARIANTS.includes(value as SkillVariant);
 }
 
+export const BARE_REACT_NATIVE_REASON =
+  'Bare React Native (without Expo) is not supported — source-map upload needs the Expo build pipeline';
+
+/** True when the project at `path` has the `expo` package installed. */
+function projectHasExpo(installDir: string, projectPath: string): boolean {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(installDir, projectPath, 'package.json'), 'utf-8'),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    return (
+      pkg.dependencies?.['expo'] != null ||
+      pkg.devDependencies?.['expo'] != null
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Map a generic detection report into source-maps projects. */
-function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
+function toSourceMapsReport(
+  report: AgenticDetectionReport,
+  isExpoProject: (path: string) => boolean,
+): DetectionReport {
   return {
     repoType: report.repoType,
     projects: report.projects.map((p) => {
@@ -122,8 +151,16 @@ function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
         /\bflutter\b/i.test(p.framework) ||
         (/\b(?:react[\s-]*native|expo)\b/i.test(p.framework) &&
           p.targetId !== 'react-native');
+      // Bare React Native (no expo package) is not supported: its Metro
+      // pipeline can't inject chunk IDs, so uploads would never resolve.
+      const isBareReactNative =
+        p.targetId === 'react-native' &&
+        !namesForeignNativePlatform &&
+        !isExpoProject(p.path);
       const variant =
-        isAutomatableVariant(p.targetId) && !namesForeignNativePlatform
+        isAutomatableVariant(p.targetId) &&
+        !namesForeignNativePlatform &&
+        !isBareReactNative
           ? p.targetId
           : null;
       return {
@@ -131,7 +168,11 @@ function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
         framework: p.framework,
         variant,
         hasPostHog: p.hasPostHog,
-        ...classify(variant, p.hasPostHog),
+        ...classify(
+          variant,
+          p.hasPostHog,
+          isBareReactNative ? BARE_REACT_NATIVE_REASON : undefined,
+        ),
       };
     }),
   };
@@ -140,14 +181,19 @@ function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
 /**
  * Validate the agent's raw JSON into a source-maps detection report. Exported
  * for testing — recognises detection-only native targets, then clamps them to
- * non-instrumentable projects.
+ * non-instrumentable projects. Without an `isExpoProject` predicate every
+ * react-native project is treated as bare (blocked).
  */
-export function coerceReport(parsed: unknown): DetectionReport {
+export function coerceReport(
+  parsed: unknown,
+  isExpoProject: (path: string) => boolean = () => false,
+): DetectionReport {
   return toSourceMapsReport(
     coerceAgenticReport(
       parsed,
       SOURCE_MAPS_TARGETS.map((target) => target.id),
     ),
+    isExpoProject,
   );
 }
 
@@ -161,5 +207,7 @@ export async function detectSourceMapsProjects(
     purpose: 'set up PostHog Error Tracking source-map upload',
     onEvent,
   });
-  return toSourceMapsReport(report);
+  return toSourceMapsReport(report, (path) =>
+    projectHasExpo(session.installDir, path),
+  );
 }

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -46,19 +46,17 @@ export type DetectionReport = {
 
 /**
  * Variant precedence for the agentic picker (most specific first). The detector
- * keeps the EARLIEST matching target. Unsupported native targets are included
- * as guards before Android and iOS so React Native and Flutter projects with
- * nested Gradle or Xcode manifests are not misclassified as instrumentable
- * native apps. JS ordering mirrors `pickJsVariant` in detect.ts: opinionated
- * frameworks → bundlers → bare React → Node → generic web.
+ * keeps the EARLIEST matching target. The unsupported Flutter target stays in
+ * the list as a guard, and React Native ranks ahead of Android and iOS, so
+ * projects with nested Gradle or Xcode manifests are not misclassified as
+ * plain native apps. JS ordering mirrors `pickJsVariant` in detect.ts:
+ * opinionated frameworks → bundlers → bare React → Node → generic web.
  */
-const NON_AUTOMATABLE_NATIVE_VARIANTS: readonly SkillVariant[] = [
-  'react-native',
-  'flutter',
-];
+const NON_AUTOMATABLE_NATIVE_VARIANTS: readonly SkillVariant[] = ['flutter'];
 
 const VARIANT_PRECEDENCE: readonly SkillVariant[] = [
   ...NON_AUTOMATABLE_NATIVE_VARIANTS,
+  'react-native',
   'android',
   'ios',
   'nextjs',
@@ -117,9 +115,15 @@ function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
   return {
     repoType: report.repoType,
     projects: report.projects.map((p) => {
+      // Flutter is never automatable; an RN/Expo-labelled project only counts
+      // when it resolved to the react-native target — nested Gradle/Xcode
+      // manifests inside an RN repo must not claim android or ios.
+      const namesForeignNativePlatform =
+        /\bflutter\b/i.test(p.framework) ||
+        (/\b(?:react[\s-]*native|expo)\b/i.test(p.framework) &&
+          p.targetId !== 'react-native');
       const variant =
-        isAutomatableVariant(p.targetId) &&
-        !/\b(?:react[\s-]*native|expo|flutter)\b/i.test(p.framework)
+        isAutomatableVariant(p.targetId) && !namesForeignNativePlatform
           ? p.targetId
           : null;
       return {

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -121,6 +121,16 @@ export const SOURCE_MAPS_ABORT_CASES: AbortCase[] = [
       'your project and run this wizard again.',
     docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
   },
+  {
+    match: /^bare react native not supported$/i,
+    message: 'Bare React Native is not supported',
+    body:
+      'Source-map upload for React Native requires Expo, and this project ' +
+      'has no `expo` package. Bare React Native builds cannot inject the ' +
+      'chunk IDs PostHog needs to resolve stack traces.',
+    docsUrl:
+      'https://posthog.com/docs/error-tracking/upload-source-maps/react-native',
+  },
 ];
 
 // ── File / dependency probes ─────────────────────────────────────────

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -51,13 +51,14 @@ const DISPLAY_NAME: Record<SkillVariant, string> = {
 };
 
 /**
- * Variants the wizard can wire up source-map upload for automatically. The
- * native variants (react-native, flutter) are recognised but not yet
- * automatable, so the agentic picker treats them as non-instrumentable.
+ * Variants the wizard can wire up source-map upload for automatically. Flutter
+ * is recognised but not yet automatable, so the agentic picker treats it as
+ * non-instrumentable.
  */
 export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
   'android',
   'ios',
+  'react-native',
   'web',
   'nextjs',
   'node',
@@ -71,10 +72,12 @@ export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
 
 /**
  * Variants the wizard pre-installs a machine-global `posthog-cli` for — their
- * build shells out to it with no npx / local-dep fallback. JS variants stay out.
+ * build shells out to it with no npx / local-dep fallback. Web JS variants stay
+ * out; React Native counts as native here — its Xcode build phases and Gradle
+ * tasks invoke the global CLI.
  */
 export const VARIANTS_REQUIRING_POSTHOG_CLI: ReadonlySet<SkillVariant> =
-  new Set(['ios', 'android']);
+  new Set(['ios', 'android', 'react-native']);
 
 const POSTHOG_SDKS = [
   'posthog-js',


### PR DESCRIPTION
## Why

Bare React Native (no `expo` package) cannot inject the chunk IDs PostHog needs to resolve stack traces: the SDK's Metro serializer path outside Expo never replaces the `__POSTHOG_CHUNK_ID__` placeholder, so the native build hooks upload symbol sets that can never match a runtime frame — every exception comes back "No chunk id sent with frame". Rather than shipping a wiring that silently produces unresolvable frames, source-map upload for React Native is now Expo-only.

## What

- The agentic source-maps picker checks the detected react-native project's `package.json` for the `expo` dependency. Without it the project is classified non-instrumentable with an explicit reason ("Bare React Native (without Expo) is not supported — source-map upload needs the Expo build pipeline").
- New abort case: the skill can emit `[ABORT] bare react native not supported`, rendered with a docs link.
- Tests cover the bare-blocked case, the Expo-instrumentable case, and reason precedence against the Flutter-mislabel guard.

Companion change: the `error-tracking-upload-source-maps` skill in context-mill (PR #263) drops its bare-RN wiring instructions and tells the agent to abort instead.

## Test plan

- `pnpm build && pnpm test && pnpm lint` — 1535 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)