### PR TITLE
feat: Lock the wizard to a model allow-list; purge retired openai models

### DIFF
--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -13,10 +13,6 @@ import { describe, it, expect } from 'vitest';
 import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
 import {
   DEFAULT_AGENT_MODEL,
-  GPT5_MINI_MODEL,
-  GPT5_MODEL,
-  GPT5_4_MODEL,
-  GPT5_5_MODEL,
   GPT5_6_LUNA_MODEL,
   GPT5_6_SOL_MODEL,
   GPT5_6_TERRA_MODEL,
@@ -32,7 +28,11 @@ import {
   resolveBinding,
   type SwitchboardCtx,
 } from '@lib/agent/runner/switchboard';
-import { modelCapabilities } from '@lib/agent/runner/switchboard/models';
+import {
+  modelCapabilities,
+  isValidModel,
+  requireKnownModel,
+} from '@lib/agent/runner/switchboard/models';
 import { runBindingCases } from '@lib/agent/runner/switchboard/flags/__tests__/binding-cases';
 
 const PROGRAM_IDS = PROGRAM_REGISTRY.map((c) => c.id);
@@ -165,7 +165,7 @@ describe('switchboard decision trace', () => {
       binding: {
         sequence: Sequence.linear,
         harness: Harness.pi,
-        model: GPT5_4_MODEL,
+        model: GPT5_6_TERRA_MODEL,
         thinkingLevel: undefined,
       },
       trace: { harness: 'flag', model: 'flag', sequence: 'binding' },
@@ -182,7 +182,7 @@ describe('switchboard decision trace', () => {
       binding: {
         sequence: Sequence.orchestrator,
         harness: Harness.pi,
-        model: GPT5_4_MODEL,
+        model: GPT5_6_TERRA_MODEL,
         thinkingLevel: undefined,
       },
       trace: { harness: 'flag', model: 'flag', sequence: 'flag' },
@@ -236,7 +236,7 @@ describe('switchboard composed clamp', () => {
       binding: {
         sequence: Sequence.linear,
         harness: Harness.pi,
-        model: GPT5_4_MODEL,
+        model: GPT5_6_TERRA_MODEL,
         thinkingLevel: undefined,
       },
       trace: { harness: 'flag', model: 'flag', sequence: 'composed' },
@@ -250,7 +250,7 @@ describe('switchboard modelCapabilities (stage 2: effective effort)', () => {
       'claude-sonnet-4-6',
       'claude-opus-4-8',
       'claude-haiku-4-5-20251001',
-      'openai/gpt-5',
+      'openai/gpt-5.6-terra',
     ]) {
       expect(modelCapabilities(m).reasoning).toBe(true);
     }
@@ -262,23 +262,15 @@ describe('switchboard modelCapabilities (stage 2: effective effort)', () => {
     expect(modelCapabilities('openai/gpt-4o').reasoning).toBe(false);
   });
 
-  it('sets reasoning effort per model: gpt-5 low (fast flagship), gpt-5-mini medium', () => {
-    expect(modelCapabilities(GPT5_MODEL).thinkingLevel).toBe('low');
-    expect(modelCapabilities(GPT5_MINI_MODEL).thinkingLevel).toBe('medium');
-    // The gpt-5.6 line + gpt-5.5 are reasoning models despite the openai/ prefix; they opt in past the default-off.
-    for (const m of [
-      GPT5_6_LUNA_MODEL,
-      GPT5_6_TERRA_MODEL,
-      GPT5_6_SOL_MODEL,
-      GPT5_5_MODEL,
-    ]) {
+  it('sets reasoning effort per model across the gpt-5.6 line', () => {
+    // The gpt-5.6 line are reasoning models despite the openai/ prefix; they opt in past the default-off.
+    for (const m of [GPT5_6_LUNA_MODEL, GPT5_6_TERRA_MODEL, GPT5_6_SOL_MODEL]) {
       expect(modelCapabilities(m).reasoning).toBe(true);
     }
-    // luna/sol/5.5 stay low (fast); terra runs medium as the sonnet-tier parallel.
+    // luna/sol stay low (fast); terra runs medium as the sonnet-tier parallel.
     expect(modelCapabilities(GPT5_6_LUNA_MODEL).thinkingLevel).toBe('low');
     expect(modelCapabilities(GPT5_6_TERRA_MODEL).thinkingLevel).toBe('medium');
     expect(modelCapabilities(GPT5_6_SOL_MODEL).thinkingLevel).toBe('low');
-    expect(modelCapabilities(GPT5_5_MODEL).thinkingLevel).toBe('low');
     // Anthropic default carries no explicit effort — the harness default stands.
     expect(
       modelCapabilities(DEFAULT_AGENT_MODEL).thinkingLevel,
@@ -291,10 +283,48 @@ describe('switchboard modelCapabilities (stage 2: effective effort)', () => {
   });
 
   it('a binding thinkingLevel override rides only a reasoning model', () => {
-    expect(modelCapabilities(GPT5_4_MODEL, 'high').thinkingLevel).toBe('high');
-    expect(modelCapabilities(GPT5_4_MODEL).thinkingLevel).toBe('low');
+    expect(modelCapabilities(GPT5_6_TERRA_MODEL, 'high').thinkingLevel).toBe(
+      'high',
+    );
+    expect(modelCapabilities(GPT5_6_TERRA_MODEL).thinkingLevel).toBe('medium');
     expect(
       modelCapabilities('openai/gpt-4o', 'high').thinkingLevel,
     ).toBeUndefined();
+  });
+});
+
+describe('switchboard model allow-list', () => {
+  it('allow-lists the sonnets and the gpt-5.6 line, nothing older', () => {
+    for (const m of [
+      DEFAULT_AGENT_MODEL,
+      SONNET_5_MODEL,
+      GPT5_6_LUNA_MODEL,
+      GPT5_6_TERRA_MODEL,
+      GPT5_6_SOL_MODEL,
+    ]) {
+      expect(isValidModel(m)).toBe(true);
+    }
+    // The retired openai ids are gone — no longer valid to dispatch on.
+    for (const m of ['openai/gpt-5', 'openai/gpt-5.4', 'openai/gpt-5.5']) {
+      expect(isValidModel(m)).toBe(false);
+    }
+    expect(isValidModel('')).toBe(false);
+    expect(isValidModel(undefined)).toBe(false);
+  });
+
+  it('requireKnownModel takes the first allow-listed candidate', () => {
+    expect(requireKnownModel(undefined, GPT5_6_TERRA_MODEL)).toBe(
+      GPT5_6_TERRA_MODEL,
+    );
+    expect(requireKnownModel('openai/gpt-5', GPT5_6_TERRA_MODEL)).toBe(
+      GPT5_6_TERRA_MODEL,
+    );
+  });
+
+  it('requireKnownModel throws loud when no candidate is allow-listed', () => {
+    // A dead/empty id must fail here, not reach the gateway.
+    expect(() => requireKnownModel(undefined, '', 'openai/gpt-5')).toThrow(
+      /No valid model/,
+    );
   });
 });

--- a/src/lib/agent/runner/harness/anthropic/README.md
+++ b/src/lib/agent/runner/harness/anthropic/README.md
@@ -28,7 +28,7 @@ Both entry points are implemented:
 - **Custom headers:** wizard flags (`X-POSTHOG-FLAG-*`) and metadata
   (`X-POSTHOG-PROPERTY-*`) piggyback on every gateway request for tracing.
 - **Model routing:** `AgentConfig.modelOverride` accepts any gateway model id
-  (`DEFAULT_AGENT_MODEL`, `HAIKU_MODEL`, `OPUS_MODEL`, `GPT5_MODEL`), so
+  (`DEFAULT_AGENT_MODEL`, `HAIKU_MODEL`, `OPUS_MODEL`, `GPT5_6_TERRA_MODEL`), so
   mechanical work (repo classification, source-map detection) can route to
   `HAIKU_MODEL` while integration work stays on Sonnet.
 

--- a/src/lib/agent/runner/harness/pi/README.md
+++ b/src/lib/agent/runner/harness/pi/README.md
@@ -27,8 +27,8 @@ Entry points:
   `anthropic-messages` provider on pi's in-memory `ModelRegistry`, authed
   bearer-style with the user's OAuth token. Same Bedrock fallback +
   wizard-flag/metadata headers as the anthropic path. OpenAI-class models (e.g.
-  `GPT5_MODEL`) route to `/v1/chat/completions` via `openai-completions` shape
-  automatically.
+  `GPT5_6_TERRA_MODEL`) route to `/v1/chat/completions` via `openai-completions`
+  shape automatically.
 - **Context window:** 1M-context beta enabled
   (`anthropic-beta: context-1m-2025-08-07`) — otherwise runs at 200k and
   compaction fails on larger projects.

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/queue-tools.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/queue-tools.test.ts
@@ -63,6 +63,28 @@ describe('checkEnqueueGuards', () => {
     expect(r).toEqual({ ok: true });
   });
 
+  it('rejects an enqueue that pins a non-allow-listed model', () => {
+    const r = checkEnqueueGuards(ctx, {
+      type: 'init',
+      reason: 'x',
+      model: 'openai/gpt-5',
+    });
+    expect(r).toMatchObject({ ok: false, guard: 'invalid-model' });
+  });
+
+  it('allows an allow-listed model override and an omitted model', () => {
+    expect(
+      checkEnqueueGuards(ctx, {
+        type: 'init',
+        reason: 'x',
+        model: 'openai/gpt-5.6-terra',
+      }),
+    ).toEqual({ ok: true });
+    expect(checkEnqueueGuards(ctx, { type: 'capture', reason: 'x' })).toEqual({
+      ok: true,
+    });
+  });
+
   it('refuses to grow the queue past the runaway cap', () => {
     for (let i = 0; i < 30; i++) {
       store.enqueue({ type: 'capture', inputs: { i } });

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -44,6 +44,7 @@ import {
   resolveHarness,
   type HarnessPick,
 } from '../../switchboard';
+import { requireKnownModel } from '../../switchboard/models';
 import type { AgentHarness } from '../../harness/types';
 import {
   QueueStore,
@@ -405,7 +406,7 @@ export async function runOrchestrator(
     boot,
     prompt: assembleSeedPrompt(promptContext, seedPrompt.body),
     spinner,
-    model: seedModel.model ?? seedPick.model,
+    model: requireKnownModel(seedModel.model, seedPick.model),
     effort: seedModel.effort,
     ...agentRunTools(seedPrompt),
     orchestrator: orchestratorCtx(),
@@ -495,7 +496,7 @@ export async function runOrchestrator(
         boot,
         prompt: assembleTaskPrompt(promptContext, resolved.prompt, skillPaths),
         spinner,
-        model: taskModel.model ?? taskPick.model,
+        model: requireKnownModel(taskModel.model, taskPick.model),
         effort: taskModel.effort,
         allowedTools: resolved.allowedTools,
         disallowedTools: resolved.disallowedTools,

--- a/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
@@ -9,6 +9,10 @@
 import { z } from 'zod';
 import { analytics } from '@utils/analytics';
 import {
+  isValidModel,
+  VALID_MODELS,
+} from '@lib/agent/runner/switchboard/models';
+import {
   TaskStatus,
   type QueueStore,
   type QueuedTask,
@@ -93,6 +97,19 @@ export function checkEnqueueGuards(
       message: `Unknown task type "${
         args.type
       }". Valid types: ${ctx.validTypes.join(', ')}.`,
+    };
+  }
+
+  // Reject an agent pinning a task to a non-allow-listed model.
+  if (args.model !== undefined && !isValidModel(args.model)) {
+    return {
+      ok: false,
+      guard: 'invalid-model',
+      message: `Model "${
+        args.model
+      }" is not allowed. Omit model to use the task default, or pick one of: ${[
+        ...VALID_MODELS,
+      ].join(', ')}.`,
     };
   }
 

--- a/src/lib/agent/runner/switchboard/flags/__tests__/basic-integration.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/basic-integration.test.ts
@@ -6,13 +6,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
 import {
   DEFAULT_AGENT_MODEL,
-  GPT5_4_MODEL,
-  GPT5_5_MODEL,
   GPT5_6_LUNA_MODEL,
   GPT5_6_SOL_MODEL,
   GPT5_6_TERRA_MODEL,
-  GPT5_MINI_MODEL,
-  GPT5_MODEL,
   Harness,
   Sequence,
   SONNET_5_MODEL,
@@ -48,7 +44,7 @@ const integration = (flags: Record<string, string>): BindingCase['ctx'] => ({
 const PI_ON = { [WIZARD_USE_PI_HARNESS_FLAG_KEY]: 'true' };
 const TRIO_ON = {
   ...PI_ON,
-  [WIZARD_PI_MODEL_FLAG_KEY]: 'gpt-5-4',
+  [WIZARD_PI_MODEL_FLAG_KEY]: 'gpt-5-6-terra',
   [WIZARD_PI_EFFORT_FLAG_KEY]: 'high',
 };
 
@@ -76,15 +72,15 @@ describe('basic-integration experiment — flags in, binding out', () => {
   runBindingCases(
     [
       {
-        name: 'use flag alone → pi + gpt-5.4, linear, table-default effort',
+        name: 'use flag alone → pi + gpt-5.6-terra fallback, linear, table-default effort',
         ctx: integration(PI_ON),
-        binding: PI_LINEAR(GPT5_4_MODEL),
+        binding: PI_LINEAR(GPT5_6_TERRA_MODEL),
         trace: { harness: 'flag', model: 'flag', sequence: 'binding' },
       },
       {
         name: 'full trio → pi + selected model + effort override, still linear',
         ctx: integration(TRIO_ON),
-        binding: PI_LINEAR(GPT5_4_MODEL, 'high'),
+        binding: PI_LINEAR(GPT5_6_TERRA_MODEL, 'high'),
       },
       {
         name: "use flag 'false' → the non-flagged binding, whole shape",
@@ -99,7 +95,7 @@ describe('basic-integration experiment — flags in, binding out', () => {
       {
         name: 'invalid effort variant → table default, pi routing intact',
         ctx: integration({ ...PI_ON, [WIZARD_PI_EFFORT_FLAG_KEY]: 'banana' }),
-        binding: PI_LINEAR(GPT5_4_MODEL),
+        binding: PI_LINEAR(GPT5_6_TERRA_MODEL),
       },
       {
         name: 'effort flag without the use flag → inert, non-flagged binding',
@@ -116,21 +112,19 @@ describe('basic-integration experiment — flags in, binding out', () => {
     setSurface,
   );
 
-  // Variant key → gateway model, unknown/missing → gpt-5.4 fallback.
+  // Variant key → gateway model, unknown/retired → the fallback.
   runBindingCases(
     (
       [
-        ['gpt-5', GPT5_MODEL],
-        ['gpt-5-4', GPT5_4_MODEL],
-        ['gpt-5-mini', GPT5_MINI_MODEL],
         ['gpt-5-6-luna', GPT5_6_LUNA_MODEL],
         ['gpt-5-6-terra', GPT5_6_TERRA_MODEL],
         ['gpt-5-6-sol', GPT5_6_SOL_MODEL],
-        ['gpt-5-5', GPT5_5_MODEL],
         ['sonnet-4-6', DEFAULT_AGENT_MODEL],
         ['sonnet-5', SONNET_5_MODEL],
-        ['banana', GPT5_4_MODEL],
-        [undefined, GPT5_4_MODEL],
+        ['gpt-5', GPT5_6_TERRA_MODEL],
+        ['gpt-5-4', GPT5_6_TERRA_MODEL],
+        ['banana', GPT5_6_TERRA_MODEL],
+        [undefined, GPT5_6_TERRA_MODEL],
       ] as const
     ).map(([variant, model]) => ({
       name: `model variant ${variant ?? '(missing)'} → ${model}`,

--- a/src/lib/agent/runner/switchboard/flags/__tests__/scoping.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/scoping.test.ts
@@ -40,11 +40,11 @@ const maxFlagsFor = (exp: (typeof HARNESS_EXPERIMENTS)[number]) => {
   const flags: Record<string, string> = { [exp.flags.useFlag]: 'true' };
   const payloads: Record<string, unknown> = {};
   if (exp.flags.modelFlag) {
-    flags[exp.flags.modelFlag] = 'gpt-5-4';
+    flags[exp.flags.modelFlag] = 'gpt-5-6-terra';
     flags[exp.flags.effortFlag] = 'high';
   } else {
     payloads[exp.flags.useFlag] = {
-      model: 'gpt-5-4',
+      model: 'gpt-5-6-terra',
       effort: 'high',
       harness: 'pi',
       sequence: 'orchestrator',
@@ -108,7 +108,7 @@ describe('flag scoping — the pinned effect matrix', () => {
       ALL_FLAG_KEYS.map((k) => [
         k,
         {
-          model: 'gpt-5-4',
+          model: 'gpt-5-6-terra',
           effort: 'high',
           harness: 'pi',
           sequence: 'orchestrator',
@@ -138,7 +138,7 @@ describe('flag scoping — the pinned effect matrix', () => {
     ).toEqual({
       sequence: constants.Sequence.orchestrator,
       harness: constants.Harness.pi,
-      model: constants.GPT5_4_MODEL, // 'true' is no variant → fallback
+      model: constants.GPT5_6_TERRA_MODEL, // 'true' is no variant → fallback
       thinkingLevel: undefined, // 'true' is no effort level → table default
     });
     expect(
@@ -146,7 +146,7 @@ describe('flag scoping — the pinned effect matrix', () => {
     ).toEqual({
       sequence: constants.Sequence.orchestrator, // from its own payload only
       harness: constants.Harness.pi,
-      model: constants.GPT5_4_MODEL,
+      model: constants.GPT5_6_TERRA_MODEL,
       thinkingLevel: 'high',
     });
   });

--- a/src/lib/agent/runner/switchboard/flags/__tests__/self-driving.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/self-driving.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, vi } from 'vitest';
 import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
 import {
   DEFAULT_AGENT_MODEL,
-  GPT5_4_MODEL,
   GPT5_6_TERRA_MODEL,
   Harness,
   Sequence,
@@ -121,11 +120,11 @@ describe('self-driving experiment — payload in, binding out', () => {
       },
       {
         name: 'JSON-string payload parses',
-        ctx: sd('{"model": "gpt-5-4", "effort": "low"}'),
+        ctx: sd('{"model": "gpt-5-6-terra", "effort": "low"}'),
         binding: {
           sequence: Sequence.linear,
           harness: Harness.pi,
-          model: GPT5_4_MODEL,
+          model: GPT5_6_TERRA_MODEL,
           thinkingLevel: 'low',
         },
       },
@@ -192,7 +191,7 @@ describe('self-driving experiment — fail-closed payload', () => {
 describe('self-driving experiment — isolation', () => {
   it('flag + maximal payload leave every other registry program exactly as unflagged', () => {
     const flagged = sd({
-      model: 'gpt-5-4',
+      model: 'gpt-5-6-terra',
       effort: 'high',
       harness: 'pi',
       sequence: 'orchestrator',

--- a/src/lib/agent/runner/switchboard/flags/basic-integration.ts
+++ b/src/lib/agent/runner/switchboard/flags/basic-integration.ts
@@ -5,7 +5,7 @@
  * Routes: ONLY `posthog-integration` — harness, model, and effort axes.
  */
 import {
-  GPT5_4_MODEL,
+  GPT5_6_TERRA_MODEL,
   WIZARD_PI_EFFORT_FLAG_KEY,
   WIZARD_PI_MODEL_FLAG_KEY,
   WIZARD_USE_PI_HARNESS_FLAG_KEY,
@@ -18,6 +18,7 @@ export const BASIC_INTEGRATION_EXPERIMENT: HarnessExperiment = {
     useFlag: WIZARD_USE_PI_HARNESS_FLAG_KEY,
     modelFlag: WIZARD_PI_MODEL_FLAG_KEY,
     effortFlag: WIZARD_PI_EFFORT_FLAG_KEY,
-    fallbackModel: GPT5_4_MODEL,
+    // Where an unknown model variant lands.
+    fallbackModel: GPT5_6_TERRA_MODEL,
   },
 };

--- a/src/lib/agent/runner/switchboard/flags/schemes.ts
+++ b/src/lib/agent/runner/switchboard/flags/schemes.ts
@@ -7,13 +7,9 @@
 import { z } from 'zod';
 import {
   DEFAULT_AGENT_MODEL,
-  GPT5_4_MODEL,
-  GPT5_5_MODEL,
   GPT5_6_LUNA_MODEL,
   GPT5_6_SOL_MODEL,
   GPT5_6_TERRA_MODEL,
-  GPT5_MINI_MODEL,
-  GPT5_MODEL,
   Harness,
   Sequence,
   SONNET_5_MODEL,
@@ -24,12 +20,8 @@ import type { EffortLevel } from '../models';
 
 // ── Shared vocabulary ─────────────────────────────────────────────────────
 
-/** Model variant key → gateway id (variant keys can't carry `/` or `.`). */
+/** Model variant key → gateway id. */
 const MODEL_FLAG_VARIANTS: Record<string, string> = {
-  'gpt-5': GPT5_MODEL,
-  'gpt-5-4': GPT5_4_MODEL,
-  'gpt-5-mini': GPT5_MINI_MODEL,
-  'gpt-5-5': GPT5_5_MODEL,
   'gpt-5-6-luna': GPT5_6_LUNA_MODEL,
   'gpt-5-6-terra': GPT5_6_TERRA_MODEL,
   'gpt-5-6-sol': GPT5_6_SOL_MODEL,

--- a/src/lib/agent/runner/switchboard/models.ts
+++ b/src/lib/agent/runner/switchboard/models.ts
@@ -14,13 +14,9 @@ import {
   SONNET_5_MODEL,
   OPUS_MODEL,
   HAIKU_MODEL,
-  GPT5_MODEL,
-  GPT5_4_MODEL,
-  GPT5_5_MODEL,
   GPT5_6_LUNA_MODEL,
   GPT5_6_SOL_MODEL,
   GPT5_6_TERRA_MODEL,
-  GPT5_MINI_MODEL,
 } from '@lib/constants';
 
 /** Reasoning effort. pi maps it to `reasoning_effort` for openai-completions. */
@@ -58,23 +54,35 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
   [SONNET_5_MODEL]: { reasoning: true },
   [OPUS_MODEL]: { reasoning: true },
   [HAIKU_MODEL]: { reasoning: true },
-  // Flagship openai reasoning model at low effort: capable but kept fast, so a
-  // run finishes in a few minutes instead of the long high-effort default.
-  [GPT5_MODEL]: { reasoning: true, thinkingLevel: 'low' },
-  [GPT5_4_MODEL]: { reasoning: true, thinkingLevel: 'low' },
-  // Latest openai flagship line; all reasoning models, so they must opt in past
-  // the openai-completions default (reasoning off). Luna stays low for cheap,
+  // The openai 5.6 line; all reasoning models, so they must opt in past the
+  // openai-completions default (reasoning off). Luna stays low for cheap,
   // short-context mechanical work; terra runs medium as the sonnet-tier parallel
   // — enough reasoning depth for the judgment tasks without high's latency blowup.
   [GPT5_6_LUNA_MODEL]: { reasoning: true, thinkingLevel: 'low' },
   [GPT5_6_TERRA_MODEL]: { reasoning: true, thinkingLevel: 'medium' },
   [GPT5_6_SOL_MODEL]: { reasoning: true, thinkingLevel: 'low' },
-  [GPT5_5_MODEL]: { reasoning: true, thinkingLevel: 'low' },
-  // The pi runner's paired model — a smaller openai reasoning model. Medium
-  // effort: enough to follow the skill's setup completely, still fast.
-  [GPT5_MINI_MODEL]: { reasoning: true, thinkingLevel: 'medium' },
-  'openai/o4-mini': { reasoning: true },
 };
+
+/** The only models the wizard may dispatch on. */
+export const VALID_MODELS: ReadonlySet<string> = new Set(
+  Object.keys(MODEL_CAPABILITIES),
+);
+
+/** Whether the value is an allow-listed model. */
+export function isValidModel(model: unknown): model is string {
+  return typeof model === 'string' && VALID_MODELS.has(model);
+}
+
+/** First allow-listed candidate, else throw so a bad id fails loud. */
+export function requireKnownModel(
+  ...candidates: (string | undefined)[]
+): string {
+  for (const c of candidates) if (isValidModel(c)) return c;
+  throw new Error(
+    `No valid model to dispatch on (tried ${JSON.stringify(candidates)}). ` +
+      `Allowed: ${[...VALID_MODELS].join(', ')}.`,
+  );
+}
 
 /**
  * Default for a model not in the table: reasoning on for anthropic-messages

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -27,31 +27,10 @@ export const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
  */
 export const OPUS_MODEL = 'claude-opus-4-8';
 
-/**
- * OpenAI-class peer of sonnet, served by the LLM gateway over OpenAI
- * completions. Enables cross-provider A/B without a wizard release.
- */
-export const GPT5_MODEL = 'openai/gpt-5';
-
-/** Newer sonnet-class openai flagship (list: $2.50/$15 per MTok). */
-export const GPT5_4_MODEL = 'openai/gpt-5.4';
-
-/**
- * Smaller, faster, cheaper openai reasoning model. The pi runner is paired with
- * this (a reasoning model follows the integration skill; the mini tier keeps a
- * run to a few minutes where flagship gpt-5 takes far longer). Reasoning effort
- * is set per-model in the switchboard capability matrix.
- */
-export const GPT5_MINI_MODEL = 'openai/gpt-5-mini';
-
-// Latest openai flagship generation. The 5.6 line ships tiered variants —
-// `luna` (fast/cheap: $1/$6 per MTok), `terra` (mid: $2.50/$15), `sol` (top:
-// $5/$30) — plus the `gpt-5.5` flagship. All are `wizard-pi-model` options for
-// cross-provider A/B; gateway ids carry no `/` or `.` in the variant keys.
+// The only openai models the wizard runs.
 export const GPT5_6_LUNA_MODEL = 'openai/gpt-5.6-luna';
 export const GPT5_6_TERRA_MODEL = 'openai/gpt-5.6-terra';
 export const GPT5_6_SOL_MODEL = 'openai/gpt-5.6-sol';
-export const GPT5_5_MODEL = 'openai/gpt-5.5';
 
 // ── Agent runner routing axes ────────────────────────────────────────
 


### PR DESCRIPTION
Removes gpt-5/gpt-5.4/gpt-5.5/gpt-5-mini/o4-mini from the wizard and adds a VALID_MODELS allow-list enforced on the seed agent's enqueue_task tool and at every dispatch site (requireKnownModel), so a task can never silently run on a dead or empty gateway id — the zero-token capture-step failure the benchmark surfaced.