### PR TITLE
fix(switchboard): review-model effort comes from the flag, not a code literal

### DIFF
--- a/src/lib/agent/runner/harness/pi/task.ts
+++ b/src/lib/agent/runner/harness/pi/task.ts
@@ -424,7 +424,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
         ? (analyticsProperties as { task_type: string }).task_type
         : modelId;
     logToFile(
-      `[pi-task] usage task=${taskType} model=${modelId} dur=${durations.duration_seconds}s turns=${assistantTurns} in=${stats.tokens.input} out=${stats.tokens.output} cacheR=${stats.tokens.cacheRead} cacheW=${stats.tokens.cacheWrite}`,
+      `[pi-task] usage task=${taskType} model=${modelId} effort=${caps.thinkingLevel} dur=${durations.duration_seconds}s turns=${assistantTurns} in=${stats.tokens.input} out=${stats.tokens.output} cacheR=${stats.tokens.cacheRead} cacheW=${stats.tokens.cacheWrite}`,
     );
     if (successMessage) spinner.stop(successMessage);
     return {};

--- a/src/lib/agent/runner/switchboard/flags/__tests__/review-model.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/review-model.test.ts
@@ -24,9 +24,10 @@ vi.mock('@env', async (importOriginal) => ({
   },
 }));
 
-const ARM_FLAGS = (variant: string) => ({
+const ARM_FLAGS = (variant: string, effort?: string) => ({
   [WIZARD_USE_PI_HARNESS_FLAG_KEY]: 'true',
   [WIZARD_PI_MODEL_FLAG_KEY]: variant,
+  ...(effort ? { [WIZARD_PI_EFFORT_FLAG_KEY]: effort } : {}),
 });
 
 describe('review-model experiment — scope declaration', () => {
@@ -34,17 +35,17 @@ describe('review-model experiment — scope declaration', () => {
     expect(ROLE_EXPERIMENTS).toEqual([REVIEW_MODEL_EXPERIMENT]);
   });
 
-  it('declares the posthog-integration program (exists in the registry), the review role, and exactly the sol/terra arms at medium', () => {
+  it('declares the posthog-integration program (exists in the registry), the review role, the effort flag, and exactly the sol/terra arms', () => {
     expect(REVIEW_MODEL_EXPERIMENT.program).toBe('posthog-integration');
     expect(PROGRAM_REGISTRY.map((c) => c.id)).toContain(
       REVIEW_MODEL_EXPERIMENT.program,
     );
     expect(REVIEW_MODEL_EXPERIMENT.role).toBe('review');
+    expect(REVIEW_MODEL_EXPERIMENT.effortFlag).toBe(WIZARD_PI_EFFORT_FLAG_KEY);
     expect(REVIEW_MODEL_EXPERIMENT.arms).toEqual([
       'gpt-5-6-sol',
       'gpt-5-6-terra',
     ]);
-    expect(REVIEW_MODEL_EXPERIMENT.effort).toBe('medium');
   });
 });
 
@@ -52,20 +53,41 @@ describe('review-model experiment — arms route', () => {
   it.each([
     ['gpt-5-6-sol', GPT5_6_SOL_MODEL],
     ['gpt-5-6-terra', GPT5_6_TERRA_MODEL],
-  ] as const)('%s → %s at medium', (variant, model) => {
+  ] as const)('%s + effort flag medium → %s at medium', (variant, model) => {
     expect(
-      resolveRoleRoute('posthog-integration', 'review', ARM_FLAGS(variant)),
+      resolveRoleRoute(
+        'posthog-integration',
+        'review',
+        ARM_FLAGS(variant, 'medium'),
+      ),
     ).toEqual({ model, effort: 'medium' });
   });
 
-  it('an effort flag cannot move the pinned effort (arms must not diverge)', () => {
+  it('the effort flag rides the arm (high → high)', () => {
     expect(
-      resolveRoleRoute('posthog-integration', 'review', {
-        ...ARM_FLAGS('gpt-5-6-sol'),
-        [WIZARD_PI_EFFORT_FLAG_KEY]: 'high',
-      }),
-    ).toEqual({ model: GPT5_6_SOL_MODEL, effort: 'medium' });
+      resolveRoleRoute(
+        'posthog-integration',
+        'review',
+        ARM_FLAGS('gpt-5-6-sol', 'high'),
+      ),
+    ).toEqual({ model: GPT5_6_SOL_MODEL, effort: 'high' });
   });
+
+  it.each([
+    ['missing', undefined],
+    ['invalid (banana)', 'banana'],
+  ])(
+    'effort flag %s → effort undefined, the frontmatter effort governs',
+    (_name, effort) => {
+      expect(
+        resolveRoleRoute(
+          'posthog-integration',
+          'review',
+          ARM_FLAGS('gpt-5-6-terra', effort),
+        ),
+      ).toEqual({ model: GPT5_6_TERRA_MODEL, effort: undefined });
+    },
+  );
 });
 
 describe('review-model experiment — fail closed', () => {

--- a/src/lib/agent/runner/switchboard/flags/review-model.ts
+++ b/src/lib/agent/runner/switchboard/flags/review-model.ts
@@ -1,5 +1,6 @@
-/** Review-model experiment: wizard-pi-model routes sol|terra (at medium) for posthog-integration's review role only — outranks prompt frontmatter there, fails closed everywhere else. */
+/** Review-model experiment: wizard-pi-model routes sol|terra (effort from wizard-pi-effort, else frontmatter) for posthog-integration's review role only — outranks prompt frontmatter there, fails closed everywhere else. */
 import {
+  WIZARD_PI_EFFORT_FLAG_KEY,
   WIZARD_PI_MODEL_FLAG_KEY,
   WIZARD_USE_PI_HARNESS_FLAG_KEY,
 } from '@lib/constants';
@@ -10,6 +11,6 @@ export const REVIEW_MODEL_EXPERIMENT: RoleExperiment = {
   role: 'review',
   useFlag: WIZARD_USE_PI_HARNESS_FLAG_KEY,
   modelFlag: WIZARD_PI_MODEL_FLAG_KEY,
+  effortFlag: WIZARD_PI_EFFORT_FLAG_KEY,
   arms: ['gpt-5-6-sol', 'gpt-5-6-terra'],
-  effort: 'medium',
 };

--- a/src/lib/agent/runner/switchboard/flags/schemes.ts
+++ b/src/lib/agent/runner/switchboard/flags/schemes.ts
@@ -91,10 +91,10 @@ export interface RoleExperiment {
   role: string;
   useFlag: string;
   modelFlag: string;
+  /** Multivariate flag: reasoning-effort override riding the arm; invalid/missing → the role's frontmatter effort. */
+  effortFlag: string;
   /** Variant keys (`MODEL_FLAG_VARIANTS`) the experiment may route. */
   arms: readonly string[];
-  /** Effort pinned for every arm, so arms never diverge onto per-model table defaults. */
-  effort: EffortLevel;
 }
 
 /** `{model, effort?, harness?, sequence?}` payload shape; extra keys tolerated for forward compat. */
@@ -154,10 +154,15 @@ export function routeFromConfigFlag(
 export function routeFromRoleFlag(
   exp: RoleExperiment,
   flags: Record<string, string>,
-): { model: string; effort: EffortLevel } | undefined {
+): { model: string; effort?: EffortLevel } | undefined {
   if (flags[exp.useFlag] !== 'true') return undefined;
   const variant = flags[exp.modelFlag] ?? '';
   if (!exp.arms.includes(variant)) return undefined;
   const model = MODEL_FLAG_VARIANTS[variant];
-  return model ? { model, effort: exp.effort } : undefined;
+  if (!model) return undefined;
+  const effort = flags[exp.effortFlag] as EffortLevel;
+  return {
+    model,
+    effort: EFFORT_FLAG_VARIANTS.includes(effort) ? effort : undefined,
+  };
 }


### PR DESCRIPTION
Restores wizard-pi-effort as the effort source for the review-model experiment arms.

The experiment declaration had effort hardcoded to medium, so the effort flag was routing-dead and changing effort meant a wizard release. Now a valid wizard-pi-effort variant rides the arm; invalid/missing falls back to the role's frontmatter effort_pi. Also prints effort in the pi usage log line.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*