### PR TITLE
fix(host): MCP_URL override wins even under --local-mcp

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -28,7 +28,7 @@ node --input-type=module -e "import '$DIST_BIN'" 2>&1 | head -5 | grep -q 'PostH
 # builds and tsdown strips it; its env var name appearing in dist/*.js means
 # dead-code elimination regressed and a prod surface leaked. Sourcemaps keep
 # the original source, so only .js output counts.
-OVERRIDE_MARKERS='WIZARD_CI_FLAG_OVERRIDES WIZARD_CI_EXCLUDE_TASKS'
+OVERRIDE_MARKERS='WIZARD_CI_FLAG_OVERRIDES WIZARD_CI_EXCLUDE_TASKS MCP_URL'
 if [ "${WIZARD_BUILD_NODE_ENV:-production}" = "ci" ]; then
   # CI builds must keep the paths — their absence means the overrides silently
   # stopped working and CI is back to testing live behavior.

--- a/src/lib/__tests__/host-resolution.test.ts
+++ b/src/lib/__tests__/host-resolution.test.ts
@@ -86,11 +86,12 @@ describe('mcpUrlFor', () => {
     expect(mcpUrlFor(true)).toBe('http://localhost:8787/mcp');
   });
 
-  it('takes an MCP_URL override verbatim', () => {
+  it('takes an MCP_URL override verbatim, even under --local-mcp', () => {
     const prev = process.env.MCP_URL;
     process.env.MCP_URL = 'https://mcp.example.com/mcp?mode=cli';
     try {
       expect(mcpUrlFor(false)).toBe('https://mcp.example.com/mcp?mode=cli');
+      expect(mcpUrlFor(true)).toBe('https://mcp.example.com/mcp?mode=cli');
     } finally {
       if (prev === undefined) delete process.env.MCP_URL;
       else process.env.MCP_URL = prev;

--- a/src/lib/__tests__/host-resolution.test.ts
+++ b/src/lib/__tests__/host-resolution.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { HostResolution, mcpUrlFor } from '@lib/host-resolution';
 
 /**
@@ -95,6 +95,24 @@ describe('mcpUrlFor', () => {
     } finally {
       if (prev === undefined) delete process.env.MCP_URL;
       else process.env.MCP_URL = prev;
+    }
+  });
+
+  it('ignores MCP_URL entirely in production builds', async () => {
+    const prevEnv = process.env.NODE_ENV;
+    const prevUrl = process.env.MCP_URL;
+    process.env.NODE_ENV = 'production';
+    process.env.MCP_URL = 'https://evil.example.com/mcp';
+    try {
+      vi.resetModules();
+      const fresh = await import('@lib/host-resolution');
+      expect(fresh.mcpUrlFor(false)).toBe('https://mcp.posthog.com/mcp');
+      expect(fresh.mcpUrlFor(true)).toBe('http://localhost:8787/mcp');
+    } finally {
+      process.env.NODE_ENV = prevEnv;
+      if (prevUrl === undefined) delete process.env.MCP_URL;
+      else process.env.MCP_URL = prevUrl;
+      vi.resetModules();
     }
   });
 });

--- a/src/lib/host-resolution.ts
+++ b/src/lib/host-resolution.ts
@@ -24,13 +24,13 @@ import {
   detectRegion,
   resolveBaseUrl,
 } from '@utils/urls';
-import { runtimeEnv } from '@env';
+import { IS_PRODUCTION_BUILD, runtimeEnv } from '@env';
 import type { CloudRegion } from '@utils/types';
 
 // The wizard's client gets CLI mode (a single `exec` tool) by server default,
-// so no mode is pinned; an `MCP_URL` override is taken verbatim.
-const LOCAL_MCP_URL = 'http://localhost:8787/mcp';
-const PROD_MCP_URL = 'https://mcp.posthog.com/mcp';
+// so no mode is pinned; the dev env override (see env.ts) is taken verbatim.
+const MCP_LOCAL_URL = 'http://localhost:8787/mcp';
+const MCP_PROD_URL = 'https://mcp.posthog.com/mcp';
 
 /** Construction-time inputs that aren't implied by the region. */
 export interface HostResolutionOptions {
@@ -60,11 +60,11 @@ function assetHostFromApiHost(apiHost: string): string {
   return apiHost;
 }
 
-/** MCP_URL wins even under --local-mcp, so CI can pair local skills with the prod MCP. */
+/** Dev/CI only: the env override (see env.ts) wins even under --local-mcp, so CI pairs local skills with the prod MCP; published builds strip the read. */
 export function mcpUrlFor(localMcp: boolean): string {
-  const override = runtimeEnv('MCP_URL');
+  const override = IS_PRODUCTION_BUILD ? undefined : runtimeEnv('MCP_URL');
   if (override) return override;
-  return localMcp ? LOCAL_MCP_URL : PROD_MCP_URL;
+  return localMcp ? MCP_LOCAL_URL : MCP_PROD_URL;
 }
 
 export class HostResolution {
@@ -89,7 +89,7 @@ export class HostResolution {
   /**
    * PostHog MCP server URL the agent connects to. Region-independent — the
    * server resolves the user's region from the bearer token — so this is driven
-   * only by `--local-mcp` and the `MCP_URL` override, not by region/base-url.
+   * only by `--local-mcp` and the dev env override, not by region/base-url.
    */
   readonly mcpUrl: string;
 

--- a/src/lib/host-resolution.ts
+++ b/src/lib/host-resolution.ts
@@ -60,9 +60,11 @@ function assetHostFromApiHost(apiHost: string): string {
   return apiHost;
 }
 
+/** MCP_URL wins even under --local-mcp, so CI can pair local skills with the prod MCP. */
 export function mcpUrlFor(localMcp: boolean): string {
-  if (localMcp) return LOCAL_MCP_URL;
-  return runtimeEnv('MCP_URL') || PROD_MCP_URL;
+  const override = runtimeEnv('MCP_URL');
+  if (override) return override;
+  return localMcp ? LOCAL_MCP_URL : PROD_MCP_URL;
 }
 
 export class HostResolution {


### PR DESCRIPTION
mcpUrlFor keyed both the skills source and the MCP URL off the single localMcp bool, and MCP_URL only applied on the non-local path — so a run could not use local context-mill skills with the prod MCP. Now an explicit MCP_URL wins on both paths.

Unblocks wizard-workbench dropping its per-run posthog-master MCP server (currently broken on master's new hard Redis dependency): CI sets MCP_URL=https://mcp.posthog.com/mcp alongside --local-mcp and hits the same hosted MCP every real user does.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*