### PR TITLE
Add WordPress framework support

### DIFF
--- a/src/frameworks/wordpress/utils.ts
+++ b/src/frameworks/wordpress/utils.ts
@@ -1,0 +1,174 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { WizardRunOptions } from '@utils/types';
+
+/**
+ * What kind of WordPress tree the wizard is pointed at. The three cases need
+ * different advice: a full site owns wp-config.php, a plugin or theme is a
+ * single directory that gets dropped into one.
+ */
+export enum WordPressProjectType {
+  SITE = 'site',
+  PLUGIN = 'plugin',
+  THEME = 'theme',
+}
+
+export function getWordPressProjectTypeName(
+  projectType: WordPressProjectType,
+): string {
+  switch (projectType) {
+    case WordPressProjectType.SITE:
+      return 'WordPress site';
+    case WordPressProjectType.PLUGIN:
+      return 'WordPress plugin';
+    case WordPressProjectType.THEME:
+      return 'WordPress theme';
+  }
+}
+
+/** wp-config.php, or the sample that ships before a site is installed. */
+export function hasWordPressCore(installDir: string): boolean {
+  return [
+    'wp-config.php',
+    'wp-config-sample.php',
+    'wp-load.php',
+    'wp-settings.php',
+    path.join('wp-includes', 'version.php'),
+  ].some((rel) => fs.existsSync(path.join(installDir, rel)));
+}
+
+/**
+ * Composer-managed WordPress (Bedrock and friends) keeps core out of the
+ * project root, so the files above are absent — the giveaway is the core
+ * package in composer.json.
+ */
+export function hasComposerWordPress(installDir: string): boolean {
+  const composerPath = path.join(installDir, 'composer.json');
+  if (!fs.existsSync(composerPath)) {
+    return false;
+  }
+
+  try {
+    const composer = JSON.parse(fs.readFileSync(composerPath, 'utf-8')) as {
+      require?: Record<string, string>;
+      'require-dev'?: Record<string, string>;
+    };
+    const deps = { ...composer.require, ...composer['require-dev'] };
+    return Object.keys(deps).some(
+      (name) =>
+        name === 'johnpbloch/wordpress' ||
+        name === 'johnpbloch/wordpress-core' ||
+        name === 'roots/wordpress' ||
+        name === 'roots/bedrock-autoloader' ||
+        name.startsWith('wpackagist-'),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A plugin declares itself with a `Plugin Name:` header in a PHP file at the
+ * root of its own directory. Only root-level files are read — the header is a
+ * plugin's entry point by definition, and globbing a whole site is expensive.
+ */
+export function findPluginHeaderFile(installDir: string): string | undefined {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(installDir);
+  } catch {
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.php')) {
+      continue;
+    }
+
+    try {
+      const head = fs
+        .readFileSync(path.join(installDir, entry), 'utf-8')
+        .slice(0, 8192);
+      if (/^\s*\*?\s*Plugin Name:\s*\S/im.test(head)) {
+        return entry;
+      }
+    } catch {
+      // Unreadable file — keep looking.
+    }
+  }
+
+  return undefined;
+}
+
+/** A theme declares itself with a `Theme Name:` header in style.css. */
+export function hasThemeHeader(installDir: string): boolean {
+  const stylePath = path.join(installDir, 'style.css');
+  if (!fs.existsSync(stylePath)) {
+    return false;
+  }
+
+  try {
+    const head = fs.readFileSync(stylePath, 'utf-8').slice(0, 8192);
+    return /^\s*\*?\s*Theme Name:\s*\S/im.test(head);
+  } catch {
+    return false;
+  }
+}
+
+export function getWordPressProjectType(
+  options: Pick<WizardRunOptions, 'installDir'>,
+): WordPressProjectType {
+  const { installDir } = options;
+
+  if (hasWordPressCore(installDir) || hasComposerWordPress(installDir)) {
+    return WordPressProjectType.SITE;
+  }
+
+  if (findPluginHeaderFile(installDir)) {
+    return WordPressProjectType.PLUGIN;
+  }
+
+  return WordPressProjectType.THEME;
+}
+
+/** Reads `$wp_version` out of wp-includes/version.php. */
+export function getWordPressVersion(
+  options: Pick<WizardRunOptions, 'installDir'>,
+): string | undefined {
+  const versionPath = path.join(
+    options.installDir,
+    'wp-includes',
+    'version.php',
+  );
+
+  if (!fs.existsSync(versionPath)) {
+    return undefined;
+  }
+
+  try {
+    const content = fs.readFileSync(versionPath, 'utf-8');
+    return /\$wp_version\s*=\s*'([^']+)'/.exec(content)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+/** "6.4.2" → "6.4.x", for analytics grouping. */
+export function getWordPressVersionBucket(version: string): string {
+  const [major, minor] = version.split('.');
+  return major && minor ? `${major}.${minor}.x` : version;
+}
+
+/**
+ * Whether the plugins directory is writable — the wizard writes a plugin, and
+ * a managed host with a read-only filesystem needs different advice.
+ */
+export function findPluginsDir(installDir: string): string | undefined {
+  const candidates = [
+    path.join('wp-content', 'plugins'),
+    path.join('web', 'app', 'plugins'), // Bedrock
+    path.join('public', 'wp-content', 'plugins'),
+  ];
+
+  return candidates.find((rel) => fs.existsSync(path.join(installDir, rel)));
+}

--- a/src/frameworks/wordpress/utils.ts
+++ b/src/frameworks/wordpress/utils.ts
@@ -2,30 +2,6 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { WizardRunOptions } from '@utils/types';
 
-/**
- * What kind of WordPress tree the wizard is pointed at. The three cases need
- * different advice: a full site owns wp-config.php, a plugin or theme is a
- * single directory that gets dropped into one.
- */
-export enum WordPressProjectType {
-  SITE = 'site',
-  PLUGIN = 'plugin',
-  THEME = 'theme',
-}
-
-export function getWordPressProjectTypeName(
-  projectType: WordPressProjectType,
-): string {
-  switch (projectType) {
-    case WordPressProjectType.SITE:
-      return 'WordPress site';
-    case WordPressProjectType.PLUGIN:
-      return 'WordPress plugin';
-    case WordPressProjectType.THEME:
-      return 'WordPress theme';
-  }
-}
-
 /** wp-config.php, or the sample that ships before a site is installed. */
 export function hasWordPressCore(installDir: string): boolean {
   return [
@@ -40,7 +16,8 @@ export function hasWordPressCore(installDir: string): boolean {
 /**
  * Composer-managed WordPress (Bedrock and friends) keeps core out of the
  * project root, so the files above are absent — the giveaway is the core
- * package in composer.json.
+ * package in composer.json. Only core packages count: wpackagist plugin/theme
+ * dependencies also appear in standalone plugin projects, which are not sites.
  */
 export function hasComposerWordPress(installDir: string): boolean {
   const composerPath = path.join(installDir, 'composer.json');
@@ -59,76 +36,11 @@ export function hasComposerWordPress(installDir: string): boolean {
         name === 'johnpbloch/wordpress' ||
         name === 'johnpbloch/wordpress-core' ||
         name === 'roots/wordpress' ||
-        name === 'roots/bedrock-autoloader' ||
-        name.startsWith('wpackagist-'),
+        name === 'roots/bedrock-autoloader',
     );
   } catch {
     return false;
   }
-}
-
-/**
- * A plugin declares itself with a `Plugin Name:` header in a PHP file at the
- * root of its own directory. Only root-level files are read — the header is a
- * plugin's entry point by definition, and globbing a whole site is expensive.
- */
-export function findPluginHeaderFile(installDir: string): string | undefined {
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(installDir);
-  } catch {
-    return undefined;
-  }
-
-  for (const entry of entries) {
-    if (!entry.endsWith('.php')) {
-      continue;
-    }
-
-    try {
-      const head = fs
-        .readFileSync(path.join(installDir, entry), 'utf-8')
-        .slice(0, 8192);
-      if (/^\s*\*?\s*Plugin Name:\s*\S/im.test(head)) {
-        return entry;
-      }
-    } catch {
-      // Unreadable file — keep looking.
-    }
-  }
-
-  return undefined;
-}
-
-/** A theme declares itself with a `Theme Name:` header in style.css. */
-export function hasThemeHeader(installDir: string): boolean {
-  const stylePath = path.join(installDir, 'style.css');
-  if (!fs.existsSync(stylePath)) {
-    return false;
-  }
-
-  try {
-    const head = fs.readFileSync(stylePath, 'utf-8').slice(0, 8192);
-    return /^\s*\*?\s*Theme Name:\s*\S/im.test(head);
-  } catch {
-    return false;
-  }
-}
-
-export function getWordPressProjectType(
-  options: Pick<WizardRunOptions, 'installDir'>,
-): WordPressProjectType {
-  const { installDir } = options;
-
-  if (hasWordPressCore(installDir) || hasComposerWordPress(installDir)) {
-    return WordPressProjectType.SITE;
-  }
-
-  if (findPluginHeaderFile(installDir)) {
-    return WordPressProjectType.PLUGIN;
-  }
-
-  return WordPressProjectType.THEME;
 }
 
 /** Reads `$wp_version` out of wp-includes/version.php. */
@@ -160,8 +72,8 @@ export function getWordPressVersionBucket(version: string): string {
 }
 
 /**
- * Whether the plugins directory is writable — the wizard writes a plugin, and
- * a managed host with a read-only filesystem needs different advice.
+ * The plugins directory the wizard's plugin will be written into — classic
+ * root, Bedrock, and public/ layouts each keep it somewhere different.
  */
 export function findPluginsDir(installDir: string): string | undefined {
   const candidates = [

--- a/src/frameworks/wordpress/wordpress-wizard-agent.ts
+++ b/src/frameworks/wordpress/wordpress-wizard-agent.ts
@@ -4,22 +4,17 @@ import type { FrameworkConfig } from '@lib/framework-config';
 import { composerPackageManager } from '@lib/detection/package-manager';
 import { Integration } from '@lib/constants';
 import {
-  WordPressProjectType,
-  findPluginHeaderFile,
   findPluginsDir,
-  getWordPressProjectType,
-  getWordPressProjectTypeName,
   getWordPressVersion,
   getWordPressVersionBucket,
   hasComposerWordPress,
-  hasThemeHeader,
   hasWordPressCore,
 } from './utils';
 
 type WordPressContext = {
-  projectType?: WordPressProjectType;
+  /** Classic install owns core at the root; Bedrock manages it via Composer. */
+  installKind?: 'classic' | 'composer';
   pluginsDir?: string;
-  pluginHeaderFile?: string;
 };
 
 export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
@@ -28,15 +23,13 @@ export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
     integration: Integration.wordpress,
     docsUrl: 'https://posthog.com/docs/libraries/wordpress',
     unsupportedVersionDocsUrl: 'https://posthog.com/docs/libraries/php',
-    gatherContext: (options: WizardRunOptions) => {
-      const projectType = getWordPressProjectType(options);
-
-      return Promise.resolve({
-        projectType,
+    gatherContext: (options: WizardRunOptions) =>
+      Promise.resolve({
+        installKind: hasWordPressCore(options.installDir)
+          ? ('classic' as const)
+          : ('composer' as const),
         pluginsDir: findPluginsDir(options.installDir),
-        pluginHeaderFile: findPluginHeaderFile(options.installDir),
-      });
-    },
+      }),
   },
 
   detection: {
@@ -50,17 +43,13 @@ export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
     detect: (options) => {
       const { installDir } = options;
 
-      // A full site: wp-config.php and friends, or Composer-managed core.
-      if (hasWordPressCore(installDir) || hasComposerWordPress(installDir)) {
-        return Promise.resolve(true);
-      }
-
-      // A single plugin or theme directory, worked on outside a site tree.
-      if (findPluginHeaderFile(installDir) || hasThemeHeader(installDir)) {
-        return Promise.resolve(true);
-      }
-
-      return Promise.resolve(false);
+      // Only a full site is claimed: wp-config.php and friends at the root,
+      // or Composer-managed core (Bedrock). A standalone plugin or theme
+      // directory is deliberately not — the integration writes a plugin into
+      // a site tree, so it needs one to exist.
+      return Promise.resolve(
+        hasWordPressCore(installDir) || hasComposerWordPress(installDir),
+      );
     },
     detectPackageManager: composerPackageManager,
   },
@@ -75,42 +64,28 @@ export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
 
   analytics: {
     getTags: (context) => ({
-      projectType: context.projectType || 'unknown',
+      installKind: context.installKind || 'unknown',
     }),
   },
 
   prompts: {
     projectTypeDetection:
-      'This is a WordPress project. Look for wp-config.php, wp-content/, or a PHP file with a `Plugin Name:` header to confirm. Composer-managed installs (Bedrock) keep core out of the root — check composer.json for johnpbloch/wordpress or roots/wordpress.',
+      'This is a WordPress site. Look for wp-config.php, wp-load.php, and the wp-includes/ directory to confirm. Composer-managed installs (Bedrock) keep core out of the root — check composer.json for johnpbloch/wordpress or roots/wordpress.',
     packageInstallation:
       'Use Composer to install packages. Run `composer require posthog/posthog-php` without pinning a specific version, from inside the plugin directory that will own the dependency — not the site root.',
     getAdditionalContextLines: (context) => {
-      const projectTypeName = context.projectType
-        ? getWordPressProjectTypeName(context.projectType)
-        : 'unknown';
-
       // Integration rules (plugin over functions.php, ABSPATH, esc_js, flush)
       // live in context-mill's wordpress commandments and reach the agent with
       // the skill. Only project-shape facts the skill cannot know belong here.
       const lines = [
-        `Project type: ${projectTypeName}`,
+        `Project type: WordPress site (${
+          context.installKind ?? 'classic'
+        } install)`,
         `Framework docs ID: php (use posthog://docs/frameworks/php for documentation)`,
       ];
 
       if (context.pluginsDir) {
         lines.push(`Plugins directory: ${context.pluginsDir}`);
-      }
-
-      if (context.pluginHeaderFile) {
-        lines.push(
-          `Existing plugin entry file: ${context.pluginHeaderFile} (add to this plugin rather than creating a new one)`,
-        );
-      }
-
-      if (context.projectType === WordPressProjectType.THEME) {
-        lines.push(
-          'This directory is a theme. Prefer creating a companion plugin next to it so tracking survives a theme change; only fall back to the theme if the user insists.',
-        );
       }
 
       return lines;
@@ -120,28 +95,14 @@ export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
   ui: {
     successMessage: 'PostHog integration complete',
     estimatedDurationMinutes: 5,
-    getOutroChanges: (context) => {
-      const projectTypeName = context.projectType
-        ? getWordPressProjectTypeName(context.projectType)
-        : 'WordPress project';
-
-      const changes = [
-        `Analyzed your ${projectTypeName}`,
-        'Installed the PostHog PHP package via Composer',
-      ];
-
-      if (context.projectType === WordPressProjectType.SITE) {
-        changes.push('Added a PostHog plugin under wp-content/plugins');
-      } else {
-        changes.push('Added PostHog initialization to your plugin entry file');
-      }
-
-      changes.push(
-        'Wired client-side autocapture on wp_head and a server-side capture on a WordPress action',
-      );
-
-      return changes;
-    },
+    getOutroChanges: (context) => [
+      'Analyzed your WordPress site',
+      'Installed the PostHog PHP package via Composer',
+      `Added a PostHog plugin under ${
+        context.pluginsDir ?? 'wp-content/plugins'
+      }`,
+      'Wired client-side autocapture on wp_head and a server-side capture on a WordPress action',
+    ],
     getOutroNextSteps: () => [
       'Activate the PostHog plugin from Plugins in wp-admin',
       'Load any page on the site, then check your PostHog dashboard for incoming events',

--- a/src/frameworks/wordpress/wordpress-wizard-agent.ts
+++ b/src/frameworks/wordpress/wordpress-wizard-agent.ts
@@ -1,0 +1,153 @@
+/* WordPress wizard using posthog-agent with PostHog MCP */
+import type { WizardRunOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { composerPackageManager } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
+import {
+  WordPressProjectType,
+  findPluginHeaderFile,
+  findPluginsDir,
+  getWordPressProjectType,
+  getWordPressProjectTypeName,
+  getWordPressVersion,
+  getWordPressVersionBucket,
+  hasComposerWordPress,
+  hasThemeHeader,
+  hasWordPressCore,
+} from './utils';
+
+type WordPressContext = {
+  projectType?: WordPressProjectType;
+  pluginsDir?: string;
+  pluginHeaderFile?: string;
+};
+
+export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
+  metadata: {
+    name: 'WordPress',
+    integration: Integration.wordpress,
+    docsUrl: 'https://posthog.com/docs/libraries/wordpress',
+    unsupportedVersionDocsUrl: 'https://posthog.com/docs/libraries/php',
+    gatherContext: (options: WizardRunOptions) => {
+      const projectType = getWordPressProjectType(options);
+
+      return Promise.resolve({
+        projectType,
+        pluginsDir: findPluginsDir(options.installDir),
+        pluginHeaderFile: findPluginHeaderFile(options.installDir),
+      });
+    },
+  },
+
+  detection: {
+    packageName: 'posthog/posthog-php',
+    packageDisplayName: 'WordPress',
+    usesPackageJson: false,
+    getVersion: () => undefined,
+    getVersionBucket: getWordPressVersionBucket,
+    getInstalledVersion: (options: WizardRunOptions) =>
+      Promise.resolve(getWordPressVersion(options)),
+    detect: (options) => {
+      const { installDir } = options;
+
+      // A full site: wp-config.php and friends, or Composer-managed core.
+      if (hasWordPressCore(installDir) || hasComposerWordPress(installDir)) {
+        return Promise.resolve(true);
+      }
+
+      // A single plugin or theme directory, worked on outside a site tree.
+      if (findPluginHeaderFile(installDir) || hasThemeHeader(installDir)) {
+        return Promise.resolve(true);
+      }
+
+      return Promise.resolve(false);
+    },
+    detectPackageManager: composerPackageManager,
+  },
+
+  environment: {
+    uploadToHosting: false,
+    getEnvVars: (apiKey: string, host: string) => ({
+      POSTHOG_PROJECT_TOKEN: apiKey,
+      POSTHOG_HOST: host,
+    }),
+  },
+
+  analytics: {
+    getTags: (context) => ({
+      projectType: context.projectType || 'unknown',
+    }),
+  },
+
+  prompts: {
+    projectTypeDetection:
+      'This is a WordPress project. Look for wp-config.php, wp-content/, or a PHP file with a `Plugin Name:` header to confirm. Composer-managed installs (Bedrock) keep core out of the root — check composer.json for johnpbloch/wordpress or roots/wordpress.',
+    packageInstallation:
+      'Use Composer to install packages. Run `composer require posthog/posthog-php` without pinning a specific version, from inside the plugin directory that will own the dependency — not the site root.',
+    getAdditionalContextLines: (context) => {
+      const projectTypeName = context.projectType
+        ? getWordPressProjectTypeName(context.projectType)
+        : 'unknown';
+
+      const lines = [
+        `Project type: ${projectTypeName}`,
+        `Framework docs ID: php (use posthog://docs/frameworks/php for documentation)`,
+        "Ship the integration as a standalone plugin. Do NOT edit the active theme's functions.php — a theme switch or theme update silently removes the tracking.",
+        "Guard every plugin entry file with `if (!defined('ABSPATH')) { exit; }` before any other code.",
+        'Print the client snippet from a wp_head hook and escape the interpolated token with esc_js().',
+        'Capture pageviews client-side. Reserve PostHog::capture for server-side WordPress actions such as comment_post, user_register, or woocommerce_thankyou, and call PostHog::flush() after each capture — a web request has no single exit point like a CLI script.',
+      ];
+
+      if (context.pluginsDir) {
+        lines.push(`Plugins directory: ${context.pluginsDir}`);
+      }
+
+      if (context.pluginHeaderFile) {
+        lines.push(
+          `Existing plugin entry file: ${context.pluginHeaderFile} (add to this plugin rather than creating a new one)`,
+        );
+      }
+
+      if (context.projectType === WordPressProjectType.THEME) {
+        lines.push(
+          'This directory is a theme. Prefer creating a companion plugin next to it so tracking survives a theme change; only fall back to the theme if the user insists.',
+        );
+      }
+
+      return lines;
+    },
+  },
+
+  ui: {
+    successMessage: 'PostHog integration complete',
+    estimatedDurationMinutes: 5,
+    getOutroChanges: (context) => {
+      const projectTypeName = context.projectType
+        ? getWordPressProjectTypeName(context.projectType)
+        : 'WordPress project';
+
+      const changes = [
+        `Analyzed your ${projectTypeName}`,
+        'Installed the PostHog PHP package via Composer',
+      ];
+
+      if (context.projectType === WordPressProjectType.SITE) {
+        changes.push('Added a PostHog plugin under wp-content/plugins');
+      } else {
+        changes.push('Added PostHog initialization to your plugin entry file');
+      }
+
+      changes.push(
+        'Wired client-side autocapture on wp_head and a server-side capture on a WordPress action',
+      );
+
+      return changes;
+    },
+    getOutroNextSteps: () => [
+      'Activate the PostHog plugin from Plugins in wp-admin',
+      'Load any page on the site, then check your PostHog dashboard for incoming events',
+      'Use PostHog::capture() inside WordPress actions to track server-side events',
+      'Move the project token into a wp-config.php constant before deploying',
+    ],
+  },
+};

--- a/src/frameworks/wordpress/wordpress-wizard-agent.ts
+++ b/src/frameworks/wordpress/wordpress-wizard-agent.ts
@@ -89,13 +89,12 @@ export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
         ? getWordPressProjectTypeName(context.projectType)
         : 'unknown';
 
+      // Integration rules (plugin over functions.php, ABSPATH, esc_js, flush)
+      // live in context-mill's wordpress commandments and reach the agent with
+      // the skill. Only project-shape facts the skill cannot know belong here.
       const lines = [
         `Project type: ${projectTypeName}`,
         `Framework docs ID: php (use posthog://docs/frameworks/php for documentation)`,
-        "Ship the integration as a standalone plugin. Do NOT edit the active theme's functions.php — a theme switch or theme update silently removes the tracking.",
-        "Guard every plugin entry file with `if (!defined('ABSPATH')) { exit; }` before any other code.",
-        'Print the client snippet from a wp_head hook and escape the interpolated token with esc_js().',
-        'Capture pageviews client-side. Reserve PostHog::capture for server-side WordPress actions such as comment_post, user_register, or woocommerce_thankyou, and call PostHog::flush() after each capture — a web request has no single exit point like a CLI script.',
       ];
 
       if (context.pluginsDir) {

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/variant-resolution.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/variant-resolution.test.ts
@@ -40,6 +40,7 @@ const INTEGRATION_ENTRIES = [
   },
   { id: 'integration-tanstack-start', framework: 'tanstack-start' },
   { id: 'integration-laravel', framework: 'laravel' },
+  { id: 'integration-wordpress', framework: 'wordpress' },
   { id: 'integration-php' },
   { id: 'integration-ruby-on-rails', framework: 'rails' },
   { id: 'integration-android', framework: 'android' },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -77,6 +77,7 @@ export enum Integration {
   flask = 'flask',
   fastapi = 'fastapi',
   laravel = 'laravel',
+  wordpress = 'wordpress',
   sveltekit = 'sveltekit',
   flutter = 'flutter',
   kmp = 'kmp',

--- a/src/lib/detection/__tests__/framework.test.ts
+++ b/src/lib/detection/__tests__/framework.test.ts
@@ -292,19 +292,29 @@ describe('wordpress detect', () => {
     await expect(detect(opts)).resolves.toBe(true);
   });
 
-  test('claims a standalone plugin directory by its Plugin Name header', async () => {
+  test('does not claim a standalone plugin directory — only full sites', async () => {
     const opts = project({
       'my-plugin.php': '<?php\n/**\n * Plugin Name: My Plugin\n */\n',
     });
-    await expect(detect(opts)).resolves.toBe(true);
+    await expect(detect(opts)).resolves.toBe(false);
   });
 
-  test('claims a standalone theme directory by its Theme Name header', async () => {
+  test('does not claim a standalone theme directory — only full sites', async () => {
     const opts = project({
       'style.css': '/*\nTheme Name: My Theme\n*/\n',
       'index.php': '<?php',
     });
-    await expect(detect(opts)).resolves.toBe(true);
+    await expect(detect(opts)).resolves.toBe(false);
+  });
+
+  test('does not claim a plugin that pulls wpackagist dependencies via Composer', async () => {
+    const opts = project({
+      'my-plugin.php': '<?php\n/**\n * Plugin Name: My Plugin\n */\n',
+      'composer.json': JSON.stringify({
+        require: { 'wpackagist-plugin/woocommerce': '^9.0' },
+      }),
+    });
+    await expect(detect(opts)).resolves.toBe(false);
   });
 
   test('does not claim a Laravel project that merely has composer.json', async () => {

--- a/src/lib/detection/__tests__/framework.test.ts
+++ b/src/lib/detection/__tests__/framework.test.ts
@@ -6,6 +6,7 @@ import { Integration } from '@lib/constants';
 import { ANDROID_AGENT_CONFIG } from '../../../frameworks/android/android-wizard-agent';
 import { KMP_AGENT_CONFIG } from '../../../frameworks/kmp/kmp-wizard-agent';
 import { FLUTTER_AGENT_CONFIG } from '../../../frameworks/flutter/flutter-wizard-agent';
+import { WORDPRESS_AGENT_CONFIG } from '../../../frameworks/wordpress/wordpress-wizard-agent';
 
 /** A throwaway project dir seeded with the given files. */
 function makeProject(files: Record<string, string>): string {
@@ -260,5 +261,87 @@ describe('kmp detect', () => {
       'android/app/src/main/kotlin/MainActivity.kt': 'class MainActivity',
     });
     await expect(detect(opts)).resolves.toBe(false);
+  });
+});
+
+describe('wordpress detect', () => {
+  const detect = WORDPRESS_AGENT_CONFIG.detection.detect;
+
+  test('claims a site by wp-config.php', async () => {
+    const opts = project({
+      'wp-config.php': "<?php define('DB_NAME', 'wp');",
+      'wp-content/themes/twentytwentyfour/style.css': '/* Theme Name: TT4 */',
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('claims a fresh unpacked core before install (wp-config-sample.php only)', async () => {
+    const opts = project({
+      'wp-config-sample.php': '<?php // sample',
+      'wp-includes/version.php': "<?php $wp_version = '6.7.1';",
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('claims a Composer-managed install (Bedrock) with no core in the root', async () => {
+    const opts = project({
+      'composer.json': JSON.stringify({
+        require: { 'roots/wordpress': '^6.7' },
+      }),
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('claims a standalone plugin directory by its Plugin Name header', async () => {
+    const opts = project({
+      'my-plugin.php': '<?php\n/**\n * Plugin Name: My Plugin\n */\n',
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('claims a standalone theme directory by its Theme Name header', async () => {
+    const opts = project({
+      'style.css': '/*\nTheme Name: My Theme\n*/\n',
+      'index.php': '<?php',
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('does not claim a Laravel project that merely has composer.json', async () => {
+    const opts = project({
+      'composer.json': JSON.stringify({
+        require: { 'laravel/framework': '^11' },
+      }),
+      artisan: '#!/usr/bin/env php\n<?php // Artisan',
+    });
+    await expect(detect(opts)).resolves.toBe(false);
+  });
+
+  test('does not claim a plain PHP project', async () => {
+    const opts = project({
+      'index.php': '<?php echo "hello";',
+      'composer.json': JSON.stringify({ require: { 'monolog/monolog': '^3' } }),
+    });
+    await expect(detect(opts)).resolves.toBe(false);
+  });
+});
+
+describe('wordpress detection order', () => {
+  test('a WordPress site wins over the Node fallback despite a theme package.json', async () => {
+    const opts = project({
+      'wp-config.php': "<?php define('DB_NAME', 'wp');",
+      'package.json': JSON.stringify({ devDependencies: { vite: '^6' } }),
+      'package-lock.json': '{}',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.wordpress,
+    );
+  });
+
+  test('laravel is still checked before wordpress', () => {
+    const order = Object.values(Integration);
+    expect(order.indexOf(Integration.laravel)).toBeLessThan(
+      order.indexOf(Integration.wordpress),
+    );
   });
 });

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -13,6 +13,7 @@ import { DJANGO_AGENT_CONFIG } from '@frameworks/django/django-wizard-agent';
 import { FLASK_AGENT_CONFIG } from '@frameworks/flask/flask-wizard-agent';
 import { FASTAPI_AGENT_CONFIG } from '@frameworks/fastapi/fastapi-wizard-agent';
 import { LARAVEL_AGENT_CONFIG } from '@frameworks/laravel/laravel-wizard-agent';
+import { WORDPRESS_AGENT_CONFIG } from '@frameworks/wordpress/wordpress-wizard-agent';
 import { SVELTEKIT_AGENT_CONFIG } from '@frameworks/svelte/svelte-wizard-agent';
 import { FLUTTER_AGENT_CONFIG } from '@frameworks/flutter/flutter-wizard-agent';
 import { SWIFT_AGENT_CONFIG } from '@frameworks/swift/swift-wizard-agent';
@@ -38,6 +39,7 @@ export const FRAMEWORK_REGISTRY: Record<Integration, FrameworkConfig> = {
   [Integration.flask]: FLASK_AGENT_CONFIG,
   [Integration.fastapi]: FASTAPI_AGENT_CONFIG,
   [Integration.laravel]: LARAVEL_AGENT_CONFIG,
+  [Integration.wordpress]: WORDPRESS_AGENT_CONFIG,
   [Integration.sveltekit]: SVELTEKIT_AGENT_CONFIG,
   [Integration.flutter]: FLUTTER_AGENT_CONFIG,
   [Integration.kmp]: KMP_AGENT_CONFIG,


### PR DESCRIPTION
> **Ready for review** — PostHog/context-mill#279 (the skill-side half) merged on 2026-07-27, so the cross-repo contract this PR pins now holds. Rebased on main; all tests pass.

## Problem

The wizard has no way to recognize a WordPress project. `npx @posthog/wizard` in a WordPress directory detects nothing — and when a theme build has left a `package.json` behind, detection falls through to the generic Node integration and gives advice that doesn't apply.

WordPress is already a PostHog product surface: there are [WordPress library docs](https://posthog.com/docs/libraries/wordpress), and WooCommerce is a supported data-warehouse source. The wizard just hadn't been told.

## What this adds

Followed `.claude/skills/adding-framework-support/SKILL.md` step by step.

- **`Integration.wordpress`** — ordered after `laravel` and before the language fallbacks, so a site whose theme carries a `package.json` still resolves to WordPress rather than `javascript_node`.
- **`src/frameworks/wordpress/`** — a `FrameworkConfig` modelled on the Laravel one: `usesPackageJson: false`, `composerPackageManager`, version read from `$wp_version` in `wp-includes/version.php` and bucketed as `6.4.x`.
- **Detection claims full sites only**, in the three shapes a real site tree takes:
  1. an installed site — `wp-config.php`, `wp-load.php`, `wp-settings.php`, `wp-includes/version.php`
  2. unpacked core before install — `wp-config-sample.php` only
  3. a Composer-managed install where core is not in the root — `roots/wordpress`, `johnpbloch/wordpress` (Bedrock)

  A standalone plugin or theme directory is deliberately **not** claimed: the integration writes a plugin into a site tree, so it needs one to exist. For the same reason, `wpackagist-*` packages don't count as a site signal — a standalone plugin pulling wpackagist dependencies via Composer must not be mistaken for a site. Both boundaries are pinned as negative detection tests.
- **Context gathering** reports the install kind (classic vs Composer-managed) and the plugins directory (including Bedrock's `web/app/plugins`), so the agent writes the plugin where this particular site keeps them.

## Where the WordPress rules live

Not here. An earlier commit had `getAdditionalContextLines` carrying the integration rules — plugin over `functions.php`, the `ABSPATH` guard, `esc_js()` on the token, flush after capture. That was wrong: those are integration knowledge, which AGENTS.md places in context-mill, and they already exist in the `wordpress` block of `commandments.yaml` in #279. Carrying them in both places would have drifted the first time either side was edited. They've been removed, and this config now passes only what the skill cannot know — the shape of the project this run is pointed at.

## Telemetry

`analytics.getTags` reports `installKind`: `classic` or `composer`. WordPress is the first CMS in the registry, and that split is the useful operational signal — a Bedrock-style site keeps core and plugins in different places than a classic install, so it's the axis integrations succeed or fail along. It surfaces alongside `detected_framework` with no extra wiring.

## Cross-repo contract

`variant-resolution.test.ts` asserts every framework in the `Integration` enum resolves to a context-mill variant. Adding `Integration.wordpress` fails that test until context-mill ships an `integration-wordpress` variant carrying `framework: wordpress` — which is exactly what PostHog/context-mill#279 adds. The pinned `skill-menu.json` fixture here is updated to match.

That test is why this PR waited in draft: merge order was context-mill#279 first, then this. #279 is now merged, so the order is satisfied.

## Tests

10 detection tests, including the negatives that matter — a Laravel project, a plain Composer PHP project, and standalone plugin/theme directories must not be claimed by WordPress — plus an ordering test asserting a WordPress site beats the Node fallback.

```
pnpm build   ✅
pnpm test    ✅ 1726 passing
pnpm fix     ✅ no new errors
```

## Not included

No `wizard-workbench` test app yet. The handbook's worked example for `wizard mcp-analytics` puts test fixtures in the canonical set, so happy to add one there if you'd like this to go through the same end-to-end evaluation the other frameworks get.
