### PR TITLE
feat(source-maps): automate Flutter source-map upload

### DIFF
--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -14,15 +14,17 @@ describe('SOURCE_MAPS_TARGETS precedence', () => {
     }
   });
 
-  it('ranks unsupported native guards ahead of the native targets', () => {
+  it('ranks the cross-platform targets ahead of the native targets', () => {
     expect(SOURCE_MAPS_TARGETS).toContainEqual({
       id: 'android',
       name: 'Android',
     });
     expect(SOURCE_MAPS_TARGETS).toContainEqual({ id: 'ios', name: 'iOS' });
-    for (const nativeGuard of ['react-native', 'flutter']) {
-      expect(rank(nativeGuard)).toBeLessThan(rank('android'));
-      expect(rank(nativeGuard)).toBeLessThan(rank('ios'));
+    // React Native and Flutter repos both carry Gradle and Xcode manifests
+    // inside them, so they must win over the bare native targets.
+    for (const crossPlatform of ['react-native', 'flutter']) {
+      expect(rank(crossPlatform)).toBeLessThan(rank('android'));
+      expect(rank(crossPlatform)).toBeLessThan(rank('ios'));
     }
     expect(rank('android')).toBeLessThan(rank('nextjs'));
     expect(rank('ios')).toBeLessThan(rank('nextjs'));
@@ -211,6 +213,84 @@ describe('coerceReport', () => {
       );
     },
   );
+
+  it('retains a Flutter project with a platform target and PostHog as instrumentable', () => {
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'Flutter',
+            targetId: 'flutter',
+            hasPostHog: true,
+          },
+        ],
+      },
+      () => true,
+    );
+
+    expect(report.projects[0]).toEqual({
+      path: '.',
+      framework: 'Flutter',
+      variant: 'flutter',
+      hasPostHog: true,
+      instrumentable: true,
+    });
+  });
+
+  it('blocks a Flutter project with no platform targets at all', () => {
+    // A pure Dart package or plugin has no web/, android/ or ios/ directory,
+    // so it never produces an app build with symbols to upload.
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'Flutter',
+            targetId: 'flutter',
+            hasPostHog: true,
+          },
+        ],
+      },
+      () => false,
+    );
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: null,
+        instrumentable: false,
+        reason: expect.stringMatching(/no web, android or ios target/i),
+      }),
+    );
+  });
+
+  it('blocks a Flutter project with a platform target but no PostHog SDK yet', () => {
+    const report = coerceReport(
+      {
+        repoType: 'single',
+        projects: [
+          {
+            path: '.',
+            framework: 'Flutter',
+            targetId: 'flutter',
+            hasPostHog: false,
+          },
+        ],
+      },
+      () => true,
+    );
+
+    expect(report.projects[0]).toEqual(
+      expect.objectContaining({
+        variant: 'flutter',
+        hasPostHog: false,
+        instrumentable: false,
+        reason: expect.stringMatching(/no posthog sdk/i),
+      }),
+    );
+  });
 
   it('blocks a supported project that has no PostHog SDK yet', () => {
     const report = coerceReport({

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -7,6 +7,8 @@
  * instruments the chosen project.
  */
 
+import { existsSync } from 'fs';
+import { join } from 'path';
 import {
   detectProjectsWithAgent,
   coerceAgenticReport,
@@ -47,18 +49,20 @@ export type DetectionReport = {
 /**
  * Variant precedence for the agentic picker (most specific first). The detector
  * keeps the EARLIEST matching target. Unsupported native targets are included
- * as guards before Android and iOS so React Native and Flutter projects with
- * nested Gradle or Xcode manifests are not misclassified as instrumentable
- * native apps. JS ordering mirrors `pickJsVariant` in detect.ts: opinionated
- * frameworks → bundlers → bare React → Node → generic web.
+ * as guards before Android and iOS so React Native projects with nested Gradle
+ * or Xcode manifests are not misclassified as instrumentable native apps. JS
+ * ordering mirrors `pickJsVariant` in detect.ts: opinionated frameworks →
+ * bundlers → bare React → Node → generic web.
  */
 const NON_AUTOMATABLE_NATIVE_VARIANTS: readonly SkillVariant[] = [
   'react-native',
-  'flutter',
 ];
 
 const VARIANT_PRECEDENCE: readonly SkillVariant[] = [
   ...NON_AUTOMATABLE_NATIVE_VARIANTS,
+  // Flutter outranks android/ios: a Flutter repo carries `android/` and
+  // `ios/` folders with real Gradle and Xcode manifests inside it.
+  'flutter',
   'android',
   'ios',
   'nextjs',
@@ -89,61 +93,108 @@ export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
   .sort((a, b) => precedenceRank(a) - precedenceRank(b))
   .map((v) => ({ id: v, name: VARIANT_DISPLAY_NAME[v] }));
 
-function classify(
-  variant: SkillVariant | null,
-  hasPostHog: boolean,
-): { instrumentable: boolean; reason?: string } {
-  if (variant == null) {
-    return {
-      instrumentable: false,
-      reason: "Source-map upload isn't supported for this stack yet",
-    };
-  }
-  if (!hasPostHog) {
-    return {
-      instrumentable: false,
-      reason: 'No PostHog SDK installed yet — run `npx @posthog/wizard` first',
-    };
-  }
-  return { instrumentable: true };
-}
-
 function isAutomatableVariant(value: string | null): value is SkillVariant {
   return value !== null && AUTOMATABLE_VARIANTS.includes(value as SkillVariant);
 }
 
+export const FLUTTER_NO_BUILD_TARGET_REASON =
+  'Flutter project has no web, android or ios target — nothing to upload symbols for';
+
+/**
+ * True when the Flutter project at `projectPath` has at least one platform
+ * target the wizard can wire uploads into: web (dart2js source maps), android
+ * (R8 mapping files) or ios (dSYMs). `flutter create` scaffolds a directory per
+ * enabled platform, so their absence means this is a pure Dart package or
+ * plugin — it produces no app build, and there is nothing to upload.
+ */
+function projectHasBuildTarget(
+  installDir: string,
+  projectPath: string,
+): boolean {
+  const root = join(installDir, projectPath);
+  return (
+    existsSync(join(root, 'web', 'index.html')) ||
+    existsSync(join(root, 'android')) ||
+    existsSync(join(root, 'ios'))
+  );
+}
+
+/** Classify one agent-detected project for source-map upload. */
+function classifyProject(
+  p: AgenticDetectionReport['projects'][number],
+  hasBuildTarget: (path: string) => boolean,
+): DetectedProject {
+  const base = {
+    path: p.path,
+    framework: p.framework,
+    hasPostHog: p.hasPostHog,
+  };
+
+  // React Native is not automatable at all; a Flutter-labelled project only
+  // counts when it resolved to the flutter target — the nested Gradle and
+  // Xcode manifests inside a Flutter repo must not claim android or ios.
+  const namesForeignNativePlatform =
+    /\b(?:react[\s-]*native|expo)\b/i.test(p.framework) ||
+    (/\bflutter\b/i.test(p.framework) && p.targetId !== 'flutter');
+  if (!isAutomatableVariant(p.targetId) || namesForeignNativePlatform) {
+    return {
+      ...base,
+      variant: null,
+      instrumentable: false,
+      reason: "Source-map upload isn't supported for this stack yet",
+    };
+  }
+
+  // A Flutter package or plugin has no platform directories and never produces
+  // an app build, so there are no symbols to upload for it.
+  if (p.targetId === 'flutter' && !hasBuildTarget(p.path)) {
+    return {
+      ...base,
+      variant: null,
+      instrumentable: false,
+      reason: FLUTTER_NO_BUILD_TARGET_REASON,
+    };
+  }
+
+  if (!p.hasPostHog) {
+    return {
+      ...base,
+      variant: p.targetId,
+      instrumentable: false,
+      reason: 'No PostHog SDK installed yet — run `npx @posthog/wizard` first',
+    };
+  }
+
+  return { ...base, variant: p.targetId, instrumentable: true };
+}
+
 /** Map a generic detection report into source-maps projects. */
-function toSourceMapsReport(report: AgenticDetectionReport): DetectionReport {
+function toSourceMapsReport(
+  report: AgenticDetectionReport,
+  hasBuildTarget: (path: string) => boolean,
+): DetectionReport {
   return {
     repoType: report.repoType,
-    projects: report.projects.map((p) => {
-      const variant =
-        isAutomatableVariant(p.targetId) &&
-        !/\b(?:react[\s-]*native|expo|flutter)\b/i.test(p.framework)
-          ? p.targetId
-          : null;
-      return {
-        path: p.path,
-        framework: p.framework,
-        variant,
-        hasPostHog: p.hasPostHog,
-        ...classify(variant, p.hasPostHog),
-      };
-    }),
+    projects: report.projects.map((p) => classifyProject(p, hasBuildTarget)),
   };
 }
 
 /**
  * Validate the agent's raw JSON into a source-maps detection report. Exported
  * for testing — recognises detection-only native targets, then clamps them to
- * non-instrumentable projects.
+ * non-instrumentable projects. Without a `hasBuildTarget` predicate every
+ * Flutter project is treated as target-less (blocked).
  */
-export function coerceReport(parsed: unknown): DetectionReport {
+export function coerceReport(
+  parsed: unknown,
+  hasBuildTarget: (path: string) => boolean = () => false,
+): DetectionReport {
   return toSourceMapsReport(
     coerceAgenticReport(
       parsed,
       SOURCE_MAPS_TARGETS.map((target) => target.id),
     ),
+    hasBuildTarget,
   );
 }
 
@@ -157,5 +208,7 @@ export async function detectSourceMapsProjects(
     purpose: 'set up PostHog Error Tracking source-map upload',
     onEvent,
   });
-  return toSourceMapsReport(report);
+  return toSourceMapsReport(report, (path) =>
+    projectHasBuildTarget(session.installDir, path),
+  );
 }

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -56,13 +56,14 @@ const DISPLAY_NAME: Record<SkillVariant, string> = {
 };
 
 /**
- * Variants the wizard can wire up source-map upload for automatically. The
- * native variants (react-native, flutter) are recognised but not yet
- * automatable, so the agentic picker treats them as non-instrumentable.
+ * Variants the wizard can wire up source-map upload for automatically. React
+ * Native is recognised but not yet automatable, so the agentic picker treats
+ * it as non-instrumentable.
  */
 export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
   'android',
   'ios',
+  'flutter',
   'web',
   'nextjs',
   'node',
@@ -76,10 +77,13 @@ export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
 
 /**
  * Variants the wizard pre-installs a machine-global `posthog-cli` for — their
- * build shells out to it with no npx / local-dep fallback. JS variants stay out.
+ * build shells out to it with no npx / local-dep fallback. JS variants stay
+ * out. Flutter counts here despite emitting plain `.js.map` files: a Flutter
+ * project has no `package.json`, so there is no npx or local dependency to
+ * fall back to when the post-build step invokes the CLI.
  */
 export const VARIANTS_REQUIRING_POSTHOG_CLI: ReadonlySet<SkillVariant> =
-  new Set(['ios', 'android']);
+  new Set(['ios', 'android', 'flutter']);
 
 const POSTHOG_SDKS = new Set([
   'posthog-js',


### PR DESCRIPTION
## Related PRs

Part of the Flutter source-map upload rollout:

- PostHog/context-mill#281 — skill: Flutter upload guidance for the wizard agent
- PostHog/wizard-workbench#3120 — workbench: real Flutter test app

---

## What

Flutter support. Didn't test native crash on ios as I wasn't able to run this in emulator and it required code signing on top of everything. It works in the same way native ios app works so I'm assuming it works. I did a visual check and compared what it changes vs native ios and it's just the same - also ran the build and it produced symbols as expected

# JS

| Web | Android | iOS |
|--------|--------|--------|
| <img width="779" height="366" alt="CleanShot 2026-07-27 at 13 00 19" src="https://github.com/user-attachments/assets/e8e2c58d-d82b-4f54-b2e5-592cf3f86b8e" /> | <img width="779" height="366" alt="CleanShot 2026-07-27 at 14 11 06" src="https://github.com/user-attachments/assets/a54deb52-4d22-4d49-aff1-c15025d836ba" /> | <img width="812" height="717" alt="CleanShot 2026-07-27 at 14 23 45" src="https://github.com/user-attachments/assets/29526ca8-26ba-4278-8da6-af965781dc52" /> | 


# Native

| ios | android |
|--------|--------|
| Haven't tested. Assuming it works | <img width="812" height="717" alt="CleanShot 2026-07-27 at 14 16 38" src="https://github.com/user-attachments/assets/bf44be3f-a50c-4c13-a09c-a9f1ff80c17d" /> | 


🤖 Generated with [Claude Code](https://claude.com/claude-code)