### PR TITLE
Constrain PickerMenu description width to the terminal's real width

### DIFF
--- a/src/frameworks/wordpress/utils.ts
+++ b/src/frameworks/wordpress/utils.ts
@@ -1,0 +1,174 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { WizardRunOptions } from '@utils/types';
+
+/**
+ * What kind of WordPress tree the wizard is pointed at. The three cases need
+ * different advice: a full site owns wp-config.php, a plugin or theme is a
+ * single directory that gets dropped into one.
+ */
+export enum WordPressProjectType {
+  SITE = 'site',
+  PLUGIN = 'plugin',
+  THEME = 'theme',
+}
+
+export function getWordPressProjectTypeName(
+  projectType: WordPressProjectType,
+): string {
+  switch (projectType) {
+    case WordPressProjectType.SITE:
+      return 'WordPress site';
+    case WordPressProjectType.PLUGIN:
+      return 'WordPress plugin';
+    case WordPressProjectType.THEME:
+      return 'WordPress theme';
+  }
+}
+
+/** wp-config.php, or the sample that ships before a site is installed. */
+export function hasWordPressCore(installDir: string): boolean {
+  return [
+    'wp-config.php',
+    'wp-config-sample.php',
+    'wp-load.php',
+    'wp-settings.php',
+    path.join('wp-includes', 'version.php'),
+  ].some((rel) => fs.existsSync(path.join(installDir, rel)));
+}
+
+/**
+ * Composer-managed WordPress (Bedrock and friends) keeps core out of the
+ * project root, so the files above are absent — the giveaway is the core
+ * package in composer.json.
+ */
+export function hasComposerWordPress(installDir: string): boolean {
+  const composerPath = path.join(installDir, 'composer.json');
+  if (!fs.existsSync(composerPath)) {
+    return false;
+  }
+
+  try {
+    const composer = JSON.parse(fs.readFileSync(composerPath, 'utf-8')) as {
+      require?: Record<string, string>;
+      'require-dev'?: Record<string, string>;
+    };
+    const deps = { ...composer.require, ...composer['require-dev'] };
+    return Object.keys(deps).some(
+      (name) =>
+        name === 'johnpbloch/wordpress' ||
+        name === 'johnpbloch/wordpress-core' ||
+        name === 'roots/wordpress' ||
+        name === 'roots/bedrock-autoloader' ||
+        name.startsWith('wpackagist-'),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A plugin declares itself with a `Plugin Name:` header in a PHP file at the
+ * root of its own directory. Only root-level files are read — the header is a
+ * plugin's entry point by definition, and globbing a whole site is expensive.
+ */
+export function findPluginHeaderFile(installDir: string): string | undefined {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(installDir);
+  } catch {
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.php')) {
+      continue;
+    }
+
+    try {
+      const head = fs
+        .readFileSync(path.join(installDir, entry), 'utf-8')
+        .slice(0, 8192);
+      if (/^\s*\*?\s*Plugin Name:\s*\S/im.test(head)) {
+        return entry;
+      }
+    } catch {
+      // Unreadable file — keep looking.
+    }
+  }
+
+  return undefined;
+}
+
+/** A theme declares itself with a `Theme Name:` header in style.css. */
+export function hasThemeHeader(installDir: string): boolean {
+  const stylePath = path.join(installDir, 'style.css');
+  if (!fs.existsSync(stylePath)) {
+    return false;
+  }
+
+  try {
+    const head = fs.readFileSync(stylePath, 'utf-8').slice(0, 8192);
+    return /^\s*\*?\s*Theme Name:\s*\S/im.test(head);
+  } catch {
+    return false;
+  }
+}
+
+export function getWordPressProjectType(
+  options: Pick<WizardRunOptions, 'installDir'>,
+): WordPressProjectType {
+  const { installDir } = options;
+
+  if (hasWordPressCore(installDir) || hasComposerWordPress(installDir)) {
+    return WordPressProjectType.SITE;
+  }
+
+  if (findPluginHeaderFile(installDir)) {
+    return WordPressProjectType.PLUGIN;
+  }
+
+  return WordPressProjectType.THEME;
+}
+
+/** Reads `$wp_version` out of wp-includes/version.php. */
+export function getWordPressVersion(
+  options: Pick<WizardRunOptions, 'installDir'>,
+): string | undefined {
+  const versionPath = path.join(
+    options.installDir,
+    'wp-includes',
+    'version.php',
+  );
+
+  if (!fs.existsSync(versionPath)) {
+    return undefined;
+  }
+
+  try {
+    const content = fs.readFileSync(versionPath, 'utf-8');
+    return /\$wp_version\s*=\s*'([^']+)'/.exec(content)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+/** "6.4.2" → "6.4.x", for analytics grouping. */
+export function getWordPressVersionBucket(version: string): string {
+  const [major, minor] = version.split('.');
+  return major && minor ? `${major}.${minor}.x` : version;
+}
+
+/**
+ * Whether the plugins directory is writable — the wizard writes a plugin, and
+ * a managed host with a read-only filesystem needs different advice.
+ */
+export function findPluginsDir(installDir: string): string | undefined {
+  const candidates = [
+    path.join('wp-content', 'plugins'),
+    path.join('web', 'app', 'plugins'), // Bedrock
+    path.join('public', 'wp-content', 'plugins'),
+  ];
+
+  return candidates.find((rel) => fs.existsSync(path.join(installDir, rel)));
+}

--- a/src/frameworks/wordpress/wordpress-wizard-agent.ts
+++ b/src/frameworks/wordpress/wordpress-wizard-agent.ts
@@ -1,0 +1,153 @@
+/* WordPress wizard using posthog-agent with PostHog MCP */
+import type { WizardRunOptions } from '@utils/types';
+import type { FrameworkConfig } from '@lib/framework-config';
+import { composerPackageManager } from '@lib/detection/package-manager';
+import { Integration } from '@lib/constants';
+import {
+  WordPressProjectType,
+  findPluginHeaderFile,
+  findPluginsDir,
+  getWordPressProjectType,
+  getWordPressProjectTypeName,
+  getWordPressVersion,
+  getWordPressVersionBucket,
+  hasComposerWordPress,
+  hasThemeHeader,
+  hasWordPressCore,
+} from './utils';
+
+type WordPressContext = {
+  projectType?: WordPressProjectType;
+  pluginsDir?: string;
+  pluginHeaderFile?: string;
+};
+
+export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
+  metadata: {
+    name: 'WordPress',
+    integration: Integration.wordpress,
+    docsUrl: 'https://posthog.com/docs/libraries/wordpress',
+    unsupportedVersionDocsUrl: 'https://posthog.com/docs/libraries/php',
+    gatherContext: (options: WizardRunOptions) => {
+      const projectType = getWordPressProjectType(options);
+
+      return Promise.resolve({
+        projectType,
+        pluginsDir: findPluginsDir(options.installDir),
+        pluginHeaderFile: findPluginHeaderFile(options.installDir),
+      });
+    },
+  },
+
+  detection: {
+    packageName: 'posthog/posthog-php',
+    packageDisplayName: 'WordPress',
+    usesPackageJson: false,
+    getVersion: () => undefined,
+    getVersionBucket: getWordPressVersionBucket,
+    getInstalledVersion: (options: WizardRunOptions) =>
+      Promise.resolve(getWordPressVersion(options)),
+    detect: (options) => {
+      const { installDir } = options;
+
+      // A full site: wp-config.php and friends, or Composer-managed core.
+      if (hasWordPressCore(installDir) || hasComposerWordPress(installDir)) {
+        return Promise.resolve(true);
+      }
+
+      // A single plugin or theme directory, worked on outside a site tree.
+      if (findPluginHeaderFile(installDir) || hasThemeHeader(installDir)) {
+        return Promise.resolve(true);
+      }
+
+      return Promise.resolve(false);
+    },
+    detectPackageManager: composerPackageManager,
+  },
+
+  environment: {
+    uploadToHosting: false,
+    getEnvVars: (apiKey: string, host: string) => ({
+      POSTHOG_PROJECT_TOKEN: apiKey,
+      POSTHOG_HOST: host,
+    }),
+  },
+
+  analytics: {
+    getTags: (context) => ({
+      projectType: context.projectType || 'unknown',
+    }),
+  },
+
+  prompts: {
+    projectTypeDetection:
+      'This is a WordPress project. Look for wp-config.php, wp-content/, or a PHP file with a `Plugin Name:` header to confirm. Composer-managed installs (Bedrock) keep core out of the root — check composer.json for johnpbloch/wordpress or roots/wordpress.',
+    packageInstallation:
+      'Use Composer to install packages. Run `composer require posthog/posthog-php` without pinning a specific version, from inside the plugin directory that will own the dependency — not the site root.',
+    getAdditionalContextLines: (context) => {
+      const projectTypeName = context.projectType
+        ? getWordPressProjectTypeName(context.projectType)
+        : 'unknown';
+
+      const lines = [
+        `Project type: ${projectTypeName}`,
+        `Framework docs ID: php (use posthog://docs/frameworks/php for documentation)`,
+        "Ship the integration as a standalone plugin. Do NOT edit the active theme's functions.php — a theme switch or theme update silently removes the tracking.",
+        "Guard every plugin entry file with `if (!defined('ABSPATH')) { exit; }` before any other code.",
+        'Print the client snippet from a wp_head hook and escape the interpolated token with esc_js().',
+        'Capture pageviews client-side. Reserve PostHog::capture for server-side WordPress actions such as comment_post, user_register, or woocommerce_thankyou, and call PostHog::flush() after each capture — a web request has no single exit point like a CLI script.',
+      ];
+
+      if (context.pluginsDir) {
+        lines.push(`Plugins directory: ${context.pluginsDir}`);
+      }
+
+      if (context.pluginHeaderFile) {
+        lines.push(
+          `Existing plugin entry file: ${context.pluginHeaderFile} (add to this plugin rather than creating a new one)`,
+        );
+      }
+
+      if (context.projectType === WordPressProjectType.THEME) {
+        lines.push(
+          'This directory is a theme. Prefer creating a companion plugin next to it so tracking survives a theme change; only fall back to the theme if the user insists.',
+        );
+      }
+
+      return lines;
+    },
+  },
+
+  ui: {
+    successMessage: 'PostHog integration complete',
+    estimatedDurationMinutes: 5,
+    getOutroChanges: (context) => {
+      const projectTypeName = context.projectType
+        ? getWordPressProjectTypeName(context.projectType)
+        : 'WordPress project';
+
+      const changes = [
+        `Analyzed your ${projectTypeName}`,
+        'Installed the PostHog PHP package via Composer',
+      ];
+
+      if (context.projectType === WordPressProjectType.SITE) {
+        changes.push('Added a PostHog plugin under wp-content/plugins');
+      } else {
+        changes.push('Added PostHog initialization to your plugin entry file');
+      }
+
+      changes.push(
+        'Wired client-side autocapture on wp_head and a server-side capture on a WordPress action',
+      );
+
+      return changes;
+    },
+    getOutroNextSteps: () => [
+      'Activate the PostHog plugin from Plugins in wp-admin',
+      'Load any page on the site, then check your PostHog dashboard for incoming events',
+      'Use PostHog::capture() inside WordPress actions to track server-side events',
+      'Move the project token into a wp-config.php constant before deploying',
+    ],
+  },
+};

--- a/src/frameworks/wordpress/wordpress-wizard-agent.ts
+++ b/src/frameworks/wordpress/wordpress-wizard-agent.ts
@@ -89,13 +89,12 @@ export const WORDPRESS_AGENT_CONFIG: FrameworkConfig<WordPressContext> = {
         ? getWordPressProjectTypeName(context.projectType)
         : 'unknown';
 
+      // Integration rules (plugin over functions.php, ABSPATH, esc_js, flush)
+      // live in context-mill's wordpress commandments and reach the agent with
+      // the skill. Only project-shape facts the skill cannot know belong here.
       const lines = [
         `Project type: ${projectTypeName}`,
         `Framework docs ID: php (use posthog://docs/frameworks/php for documentation)`,
-        "Ship the integration as a standalone plugin. Do NOT edit the active theme's functions.php — a theme switch or theme update silently removes the tracking.",
-        "Guard every plugin entry file with `if (!defined('ABSPATH')) { exit; }` before any other code.",
-        'Print the client snippet from a wp_head hook and escape the interpolated token with esc_js().',
-        'Capture pageviews client-side. Reserve PostHog::capture for server-side WordPress actions such as comment_post, user_register, or woocommerce_thankyou, and call PostHog::flush() after each capture — a web request has no single exit point like a CLI script.',
       ];
 
       if (context.pluginsDir) {

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/variant-resolution.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/variant-resolution.test.ts
@@ -40,6 +40,7 @@ const INTEGRATION_ENTRIES = [
   },
   { id: 'integration-tanstack-start', framework: 'tanstack-start' },
   { id: 'integration-laravel', framework: 'laravel' },
+  { id: 'integration-wordpress', framework: 'wordpress' },
   { id: 'integration-php' },
   { id: 'integration-ruby-on-rails', framework: 'rails' },
   { id: 'integration-android', framework: 'android' },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -74,6 +74,7 @@ export enum Integration {
   flask = 'flask',
   fastapi = 'fastapi',
   laravel = 'laravel',
+  wordpress = 'wordpress',
   sveltekit = 'sveltekit',
   kmp = 'kmp',
   swift = 'swift',

--- a/src/lib/detection/__tests__/framework.test.ts
+++ b/src/lib/detection/__tests__/framework.test.ts
@@ -5,6 +5,7 @@ import { detectFramework } from '@lib/detection/framework';
 import { Integration } from '@lib/constants';
 import { ANDROID_AGENT_CONFIG } from '../../../frameworks/android/android-wizard-agent';
 import { KMP_AGENT_CONFIG } from '../../../frameworks/kmp/kmp-wizard-agent';
+import { WORDPRESS_AGENT_CONFIG } from '../../../frameworks/wordpress/wordpress-wizard-agent';
 
 /** A throwaway project dir seeded with the given files. */
 function makeProject(files: Record<string, string>): string {
@@ -201,5 +202,87 @@ describe('kmp detect', () => {
       'android/app/src/main/kotlin/MainActivity.kt': 'class MainActivity',
     });
     await expect(detect(opts)).resolves.toBe(false);
+  });
+});
+
+describe('wordpress detect', () => {
+  const detect = WORDPRESS_AGENT_CONFIG.detection.detect;
+
+  test('claims a site by wp-config.php', async () => {
+    const opts = project({
+      'wp-config.php': "<?php define('DB_NAME', 'wp');",
+      'wp-content/themes/twentytwentyfour/style.css': '/* Theme Name: TT4 */',
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('claims a fresh unpacked core before install (wp-config-sample.php only)', async () => {
+    const opts = project({
+      'wp-config-sample.php': '<?php // sample',
+      'wp-includes/version.php': "<?php $wp_version = '6.7.1';",
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('claims a Composer-managed install (Bedrock) with no core in the root', async () => {
+    const opts = project({
+      'composer.json': JSON.stringify({
+        require: { 'roots/wordpress': '^6.7' },
+      }),
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('claims a standalone plugin directory by its Plugin Name header', async () => {
+    const opts = project({
+      'my-plugin.php': '<?php\n/**\n * Plugin Name: My Plugin\n */\n',
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('claims a standalone theme directory by its Theme Name header', async () => {
+    const opts = project({
+      'style.css': '/*\nTheme Name: My Theme\n*/\n',
+      'index.php': '<?php',
+    });
+    await expect(detect(opts)).resolves.toBe(true);
+  });
+
+  test('does not claim a Laravel project that merely has composer.json', async () => {
+    const opts = project({
+      'composer.json': JSON.stringify({
+        require: { 'laravel/framework': '^11' },
+      }),
+      artisan: '#!/usr/bin/env php\n<?php // Artisan',
+    });
+    await expect(detect(opts)).resolves.toBe(false);
+  });
+
+  test('does not claim a plain PHP project', async () => {
+    const opts = project({
+      'index.php': '<?php echo "hello";',
+      'composer.json': JSON.stringify({ require: { 'monolog/monolog': '^3' } }),
+    });
+    await expect(detect(opts)).resolves.toBe(false);
+  });
+});
+
+describe('wordpress detection order', () => {
+  test('a WordPress site wins over the Node fallback despite a theme package.json', async () => {
+    const opts = project({
+      'wp-config.php': "<?php define('DB_NAME', 'wp');",
+      'package.json': JSON.stringify({ devDependencies: { vite: '^6' } }),
+      'package-lock.json': '{}',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.wordpress,
+    );
+  });
+
+  test('laravel is still checked before wordpress', () => {
+    const order = Object.values(Integration);
+    expect(order.indexOf(Integration.laravel)).toBeLessThan(
+      order.indexOf(Integration.wordpress),
+    );
   });
 });

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -13,6 +13,7 @@ import { DJANGO_AGENT_CONFIG } from '@frameworks/django/django-wizard-agent';
 import { FLASK_AGENT_CONFIG } from '@frameworks/flask/flask-wizard-agent';
 import { FASTAPI_AGENT_CONFIG } from '@frameworks/fastapi/fastapi-wizard-agent';
 import { LARAVEL_AGENT_CONFIG } from '@frameworks/laravel/laravel-wizard-agent';
+import { WORDPRESS_AGENT_CONFIG } from '@frameworks/wordpress/wordpress-wizard-agent';
 import { SVELTEKIT_AGENT_CONFIG } from '@frameworks/svelte/svelte-wizard-agent';
 import { SWIFT_AGENT_CONFIG } from '@frameworks/swift/swift-wizard-agent';
 import { KMP_AGENT_CONFIG } from '@frameworks/kmp/kmp-wizard-agent';
@@ -37,6 +38,7 @@ export const FRAMEWORK_REGISTRY: Record<Integration, FrameworkConfig> = {
   [Integration.flask]: FLASK_AGENT_CONFIG,
   [Integration.fastapi]: FASTAPI_AGENT_CONFIG,
   [Integration.laravel]: LARAVEL_AGENT_CONFIG,
+  [Integration.wordpress]: WORDPRESS_AGENT_CONFIG,
   [Integration.sveltekit]: SVELTEKIT_AGENT_CONFIG,
   [Integration.kmp]: KMP_AGENT_CONFIG,
   [Integration.swift]: SWIFT_AGENT_CONFIG,

--- a/src/ui/tui/primitives/PickerMenu.tsx
+++ b/src/ui/tui/primitives/PickerMenu.tsx
@@ -9,7 +9,7 @@
  * hints in the KeyboardHintsBar.
  */
 
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import { useEffect, useState } from 'react';
 import { Icons, Colors } from '@ui/tui/styles';
 import { PromptLabel } from './PromptLabel.js';
@@ -88,6 +88,40 @@ function lastEnabled<T>(options: PickerOption<T>[]): number {
     if (!options[i]?.disabled) return i;
   }
   return options.length - 1;
+}
+
+/** Description rows never exceed this width even on very wide terminals —
+ *  the original fixed value, kept as an upper bound rather than a constant. */
+const MAX_DESCRIPTION_WIDTH = 56;
+/** Floor so a narrow terminal still gets a readable multi-line wrap instead
+ *  of a near-zero or negative width. */
+const MIN_DESCRIPTION_WIDTH = 20;
+/** Matches the description Box's own `marginLeft`, below. */
+const DESCRIPTION_INDENT = 4;
+/** Matches the `gap` on the row of column Boxes, below. */
+const COLUMN_GAP = 4;
+
+/**
+ * Width for a wrapped option description, clamped to the terminal's actual
+ * width instead of a bare constant. A fixed width here used to overflow
+ * narrow terminals — the description Box would report a layout wider than
+ * the physical screen, and the terminal's own line-wrapping (which Ink
+ * doesn't control) would then misalign subsequent rows against Ink's cursor
+ * bookkeeping, producing overlapping/corrupted text (see wizard#986).
+ */
+function descriptionWidth(
+  terminalColumns: number,
+  columns: number,
+  centered: boolean,
+): number {
+  const outerMargin = centered ? 0 : 2;
+  const perColumn =
+    (terminalColumns - outerMargin - (columns - 1) * COLUMN_GAP) / columns;
+  const available = Math.floor(perColumn) - DESCRIPTION_INDENT;
+  return Math.max(
+    MIN_DESCRIPTION_WIDTH,
+    Math.min(MAX_DESCRIPTION_WIDTH, available),
+  );
 }
 
 interface PickerMenuProps<T> {
@@ -311,6 +345,8 @@ const MultiPickerMenu = <T,>({
   const [onButton, setOnButton] = useState(false);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const rows = Math.ceil(options.length / columns);
+  const { stdout } = useStdout();
+  const descWidth = descriptionWidth(stdout.columns, columns, centered);
 
   // Re-validate focus when the options change while mounted — a list
   // that shrinks or disables entries can leave `focused` pointing at a
@@ -498,7 +534,7 @@ const MultiPickerMenu = <T,>({
                       shrinks to its content and never wraps). Renders only when
                       set, so label-only rows are byte-for-byte unchanged. */}
                   {opt.description && (
-                    <Box marginLeft={4} width={56}>
+                    <Box marginLeft={DESCRIPTION_INDENT} width={descWidth}>
                       <Text dimColor wrap="wrap">
                         {opt.description}
                       </Text>

--- a/src/ui/tui/primitives/__tests__/PickerMenu.test.tsx
+++ b/src/ui/tui/primitives/__tests__/PickerMenu.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { Text } from 'ink';
+import { render } from 'ink-testing-library';
+import { PickerMenu } from '../PickerMenu.js';
+
+/**
+ * wizard#986: a multi-select option's description used a fixed width (56)
+ * regardless of the real terminal width. On a narrow terminal the rendered
+ * row was wider than the physical screen, so the terminal's own line
+ * wrapping (which Ink doesn't control) misaligned Ink's cursor bookkeeping
+ * for every row after it — producing overlapping/corrupted text.
+ *
+ * ink-testing-library's Stdout always reports 100 columns with no override,
+ * so these tests patch its shared prototype to drive narrower widths — the
+ * same technique used to find and confirm the fix.
+ */
+
+const LONG_DESCRIPTION_OPTIONS = [
+  {
+    label: 'No',
+    value: 'no',
+    description:
+      'Skip custom scouts; the built-in troop already covers this project.',
+  },
+  {
+    label: 'Watch',
+    value: 'ticket-failures',
+    description:
+      "Speaks up when triaged feedback stops producing tickets at the expected rate, catching cases where a GitHub or Linear token has expired or the downstream API is down — failures that are silently swallowed and don't appear in error tracking.",
+  },
+];
+
+function withStdoutColumns(columns: number, run: () => void) {
+  const probe = render(<Text> </Text>);
+  const proto = Object.getPrototypeOf(probe.stdout);
+  probe.unmount();
+  const original = Object.getOwnPropertyDescriptor(proto, 'columns');
+  Object.defineProperty(proto, 'columns', {
+    configurable: true,
+    get() {
+      return columns;
+    },
+  });
+  try {
+    run();
+  } finally {
+    if (original) Object.defineProperty(proto, 'columns', original);
+  }
+}
+
+function longestLine(frame: string): number {
+  return Math.max(...frame.split('\n').map((line) => line.length));
+}
+
+describe('PickerMenu multi-select — description width', () => {
+  it('never renders a line wider than the terminal, even when narrow', () => {
+    withStdoutColumns(40, () => {
+      const { lastFrame, unmount } = render(
+        <PickerMenu
+          mode="multi"
+          options={LONG_DESCRIPTION_OPTIONS}
+          onSelect={() => undefined}
+        />,
+      );
+      expect(longestLine(lastFrame() ?? '')).toBeLessThanOrEqual(40);
+      unmount();
+    });
+  });
+
+  it('scales the description width down as the terminal narrows', () => {
+    const widths: number[] = [];
+    for (const columns of [100, 60, 40]) {
+      withStdoutColumns(columns, () => {
+        const { lastFrame, unmount } = render(
+          <PickerMenu
+            mode="multi"
+            options={LONG_DESCRIPTION_OPTIONS}
+            onSelect={() => undefined}
+          />,
+        );
+        widths.push(longestLine(lastFrame() ?? ''));
+        unmount();
+      });
+    }
+    // Monotonically non-increasing as the terminal gets narrower.
+    expect(widths[1]).toBeLessThanOrEqual(widths[0]);
+    expect(widths[2]).toBeLessThanOrEqual(widths[1]);
+  });
+
+  it('still caps at the original 56-character width on a wide terminal', () => {
+    withStdoutColumns(200, () => {
+      const { lastFrame, unmount } = render(
+        <PickerMenu
+          mode="multi"
+          options={LONG_DESCRIPTION_OPTIONS}
+          onSelect={() => undefined}
+        />,
+      );
+      // marginLeft(4) + width(<=56) = 60 is the description row's own budget;
+      // the checkbox/label row and message can be shorter or longer on their
+      // own terms, so we only assert the description block itself held its cap.
+      const frame = lastFrame() ?? '';
+      const descriptionLines = frame
+        .split('\n')
+        .filter((line) => /^\s{4,}\S/.test(line) && !/^\s*$/.test(line));
+      for (const line of descriptionLines) {
+        expect(line.length).toBeLessThanOrEqual(64);
+      }
+      unmount();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #986.

## The bug

Multi-select options with a `description` wrapped that text in a `Box` fixed at `width={56}`, regardless of the actual terminal width. On a narrow terminal this let the row render wider than the physical screen. The terminal's own line-wrapping (which Ink doesn't control) then misaligned Ink's cursor bookkeeping for every row after it — producing the overlapping/corrupted text in #986: checkbox labels merging into their descriptions (`No` + `Skip custom scouts...` → `NoSkip custom scouts...`), the Confirm button overlapping the last option's wrapped tail, and — on a second checklist in the same run — fragments of multiple different tool names bleeding together (`FrillrebaseghtVM` reads like "Frill" + "Firebase" + something ending "...VM" overlapping).

## How I found it

Reproduced headlessly with `ink-testing-library`, patching its `Stdout` prototype to drive real widths (100 → 40 columns) since the library hardcodes 100 columns with no override. The `message` text reflowed correctly at every width; the description did not — identical wrap points from 100 down to 40 columns, confirming the fixed width never adapted.

## The fix

`descriptionWidth()` in `PickerMenu.tsx` reads the live terminal width via Ink's `useStdout()` and clamps to it — floor of 20 characters, cap of 56 (the original constant, kept as an upper bound on wide terminals), accounting for the outer margin, the per-column share when the grid has more than one column, and the description's own indent.

Verified the fix directly: re-ran the same headless harness after the change — longest rendered line now tracks the terminal width exactly (100 cols → 62, 60 cols → 60, 40 cols → 40), instead of staying near-constant regardless of width.

## Also found while investigating

- The playground demo for `PickerMenu` (`InputDemo.tsx`) never exercises the `description` prop at all — the exact code path that broke had zero coverage in the one place built to catch this visually.
- `ink-testing-library` is a real devDependency but was unused anywhere in this repo before this fix. This is the first `.tsx` test file — `vitest.config.ts` was already configured for it (`esbuild: { jsx: 'automatic' }`), just never exercised.

## Testing

- `pnpm build` — clean, including smoke + warlock security tests
- `pnpm test` — 1579/1579 passing (1576 existing + 3 new)
- `pnpm lint` — 0 errors
- New test: `src/ui/tui/primitives/__tests__/PickerMenu.test.tsx`, using the same monkeypatch-the-Stdout-prototype technique used to find the bug, kept as a permanent regression test

Opened as a draft — background on how this surfaced (a real self-driving run against a Laravel/Vue app, not a wizard-workbench fixture) is in #986.