### PR TITLE
Constrain PickerMenu description width to the terminal's real width

### DIFF
--- a/src/ui/tui/primitives/PickerMenu.tsx
+++ b/src/ui/tui/primitives/PickerMenu.tsx
@@ -9,7 +9,7 @@
  * hints in the KeyboardHintsBar.
  */
 
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import { useEffect, useState } from 'react';
 import { Icons, Colors } from '@ui/tui/styles';
 import { PromptLabel } from './PromptLabel.js';
@@ -88,6 +88,40 @@ function lastEnabled<T>(options: PickerOption<T>[]): number {
     if (!options[i]?.disabled) return i;
   }
   return options.length - 1;
+}
+
+/** Description rows never exceed this width even on very wide terminals —
+ *  the original fixed value, kept as an upper bound rather than a constant. */
+const MAX_DESCRIPTION_WIDTH = 56;
+/** Floor so a narrow terminal still gets a readable multi-line wrap instead
+ *  of a near-zero or negative width. */
+const MIN_DESCRIPTION_WIDTH = 20;
+/** Matches the description Box's own `marginLeft`, below. */
+const DESCRIPTION_INDENT = 4;
+/** Matches the `gap` on the row of column Boxes, below. */
+const COLUMN_GAP = 4;
+
+/**
+ * Width for a wrapped option description, clamped to the terminal's actual
+ * width instead of a bare constant. A fixed width here used to overflow
+ * narrow terminals — the description Box would report a layout wider than
+ * the physical screen, and the terminal's own line-wrapping (which Ink
+ * doesn't control) would then misalign subsequent rows against Ink's cursor
+ * bookkeeping, producing overlapping/corrupted text (see wizard#986).
+ */
+function descriptionWidth(
+  terminalColumns: number,
+  columns: number,
+  centered: boolean,
+): number {
+  const outerMargin = centered ? 0 : 2;
+  const perColumn =
+    (terminalColumns - outerMargin - (columns - 1) * COLUMN_GAP) / columns;
+  const available = Math.floor(perColumn) - DESCRIPTION_INDENT;
+  return Math.max(
+    MIN_DESCRIPTION_WIDTH,
+    Math.min(MAX_DESCRIPTION_WIDTH, available),
+  );
 }
 
 interface PickerMenuProps<T> {
@@ -311,6 +345,8 @@ const MultiPickerMenu = <T,>({
   const [onButton, setOnButton] = useState(false);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const rows = Math.ceil(options.length / columns);
+  const { stdout } = useStdout();
+  const descWidth = descriptionWidth(stdout.columns, columns, centered);
 
   // Re-validate focus when the options change while mounted — a list
   // that shrinks or disables entries can leave `focused` pointing at a
@@ -498,7 +534,7 @@ const MultiPickerMenu = <T,>({
                       shrinks to its content and never wraps). Renders only when
                       set, so label-only rows are byte-for-byte unchanged. */}
                   {opt.description && (
-                    <Box marginLeft={4} width={56}>
+                    <Box marginLeft={DESCRIPTION_INDENT} width={descWidth}>
                       <Text dimColor wrap="wrap">
                         {opt.description}
                       </Text>

--- a/src/ui/tui/primitives/__tests__/PickerMenu.test.tsx
+++ b/src/ui/tui/primitives/__tests__/PickerMenu.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { Text } from 'ink';
+import { render } from 'ink-testing-library';
+import { PickerMenu } from '../PickerMenu.js';
+
+/**
+ * wizard#986: a multi-select option's description used a fixed width (56)
+ * regardless of the real terminal width. On a narrow terminal the rendered
+ * row was wider than the physical screen, so the terminal's own line
+ * wrapping (which Ink doesn't control) misaligned Ink's cursor bookkeeping
+ * for every row after it — producing overlapping/corrupted text.
+ *
+ * ink-testing-library's Stdout always reports 100 columns with no override,
+ * so these tests patch its shared prototype to drive narrower widths — the
+ * same technique used to find and confirm the fix.
+ */
+
+const LONG_DESCRIPTION_OPTIONS = [
+  {
+    label: 'No',
+    value: 'no',
+    description:
+      'Skip custom scouts; the built-in troop already covers this project.',
+  },
+  {
+    label: 'Watch',
+    value: 'ticket-failures',
+    description:
+      "Speaks up when triaged feedback stops producing tickets at the expected rate, catching cases where a GitHub or Linear token has expired or the downstream API is down — failures that are silently swallowed and don't appear in error tracking.",
+  },
+];
+
+function withStdoutColumns(columns: number, run: () => void) {
+  const probe = render(<Text> </Text>);
+  const proto = Object.getPrototypeOf(probe.stdout);
+  probe.unmount();
+  const original = Object.getOwnPropertyDescriptor(proto, 'columns');
+  Object.defineProperty(proto, 'columns', {
+    configurable: true,
+    get() {
+      return columns;
+    },
+  });
+  try {
+    run();
+  } finally {
+    if (original) Object.defineProperty(proto, 'columns', original);
+  }
+}
+
+function longestLine(frame: string): number {
+  return Math.max(...frame.split('\n').map((line) => line.length));
+}
+
+describe('PickerMenu multi-select — description width', () => {
+  it('never renders a line wider than the terminal, even when narrow', () => {
+    withStdoutColumns(40, () => {
+      const { lastFrame, unmount } = render(
+        <PickerMenu
+          mode="multi"
+          options={LONG_DESCRIPTION_OPTIONS}
+          onSelect={() => undefined}
+        />,
+      );
+      expect(longestLine(lastFrame() ?? '')).toBeLessThanOrEqual(40);
+      unmount();
+    });
+  });
+
+  it('scales the description width down as the terminal narrows', () => {
+    const widths: number[] = [];
+    for (const columns of [100, 60, 40]) {
+      withStdoutColumns(columns, () => {
+        const { lastFrame, unmount } = render(
+          <PickerMenu
+            mode="multi"
+            options={LONG_DESCRIPTION_OPTIONS}
+            onSelect={() => undefined}
+          />,
+        );
+        widths.push(longestLine(lastFrame() ?? ''));
+        unmount();
+      });
+    }
+    // Monotonically non-increasing as the terminal gets narrower.
+    expect(widths[1]).toBeLessThanOrEqual(widths[0]);
+    expect(widths[2]).toBeLessThanOrEqual(widths[1]);
+  });
+
+  it('still caps at the original 56-character width on a wide terminal', () => {
+    withStdoutColumns(200, () => {
+      const { lastFrame, unmount } = render(
+        <PickerMenu
+          mode="multi"
+          options={LONG_DESCRIPTION_OPTIONS}
+          onSelect={() => undefined}
+        />,
+      );
+      // marginLeft(4) + width(<=56) = 60 is the description row's own budget;
+      // the checkbox/label row and message can be shorter or longer on their
+      // own terms, so we only assert the description block itself held its cap.
+      const frame = lastFrame() ?? '';
+      const descriptionLines = frame
+        .split('\n')
+        .filter((line) => /^\s{4,}\S/.test(line) && !/^\s*$/.test(line));
+      for (const line of descriptionLines) {
+        expect(line.length).toBeLessThanOrEqual(64);
+      }
+      unmount();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #986.

(Reopened from #987, which was accidentally branched from `wordpress-framework-support` instead of `main` and dragged in unrelated files. This branch is based on current `main` and contains only the fix below.)

## The bug

Multi-select options with a `description` wrapped that text in a `Box` fixed at `width={56}`, regardless of the actual terminal width. On a narrow terminal this let the row render wider than the physical screen. The terminal's own line-wrapping (which Ink doesn't control) then misaligned Ink's cursor bookkeeping for every row after it — producing the overlapping/corrupted text in #986: checkbox labels merging into their descriptions (`No` + `Skip custom scouts...` → `NoSkip custom scouts...`), the Confirm button overlapping the last option's wrapped tail, and — on a second checklist in the same run — fragments of multiple different tool names bleeding together (`FrillrebaseghtVM` reads like "Frill" + "Firebase" + something ending "...VM" overlapping).

## How I found it

Reproduced headlessly with `ink-testing-library`, patching its `Stdout` prototype to drive real widths (100 → 40 columns) since the library hardcodes 100 columns with no override. The `message` text reflowed correctly at every width; the description did not — identical wrap points from 100 down to 40 columns, confirming the fixed width never adapted.

## The fix

`descriptionWidth()` in `PickerMenu.tsx` reads the live terminal width via Ink's `useStdout()` and clamps to it — floor of 20 characters, cap of 56 (the original constant, kept as an upper bound on wide terminals), accounting for the outer margin, the per-column share when the grid has more than one column, and the description's own indent.

Verified the fix directly: re-ran the same headless harness after the change — longest rendered line now tracks the terminal width exactly (100 cols → 62, 60 cols → 60, 40 cols → 40), instead of staying near-constant regardless of width.

## Also found while investigating

- The playground demo for `PickerMenu` (`InputDemo.tsx`) never exercises the `description` prop at all — the exact code path that broke had zero coverage in the one place built to catch this visually.
- `ink-testing-library` is a real devDependency but was unused anywhere in this repo before this fix. This is the first `.tsx` test file — `vitest.config.ts` was already configured for it (`esbuild: { jsx: 'automatic' }`), just never exercised.

## Testing

- `pnpm build` — clean, including smoke + warlock security tests
- `pnpm test` — 1544/1544 passing against current `main` (1541 existing + 3 new)
- `pnpm lint` — 0 errors
- New test: `src/ui/tui/primitives/__tests__/PickerMenu.test.tsx`, using the same monkeypatch-the-Stdout-prototype technique used to find the bug, kept as a permanent regression test

Opened as a draft — background on how this surfaced (a real self-driving run against a Laravel/Vue app, not a wizard-workbench fixture) is in #986.