### PR TITLE
feat(telemetry): tag analytics with the task run id and package version

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -119,6 +119,8 @@ describe('CLI argument parsing', () => {
     'POSTHOG_WIZARD_CI',
     'POSTHOG_WIZARD_API_KEY',
     'POSTHOG_WIZARD_INSTALL_DIR',
+    'POSTHOG_TASK_RUN_ID',
+    'POSTHOG_TASK_ID',
   ];
   const clearWizardEnv = () => {
     for (const key of WIZARD_ENV_KEYS) delete process.env[key];
@@ -475,6 +477,25 @@ describe('CLI argument parsing', () => {
 
       const args = getLastBuildSessionArgs();
       expect(args.apiKey).toBe('phx_env_key');
+    });
+
+    test('accepts the task-run identity the sandbox exports', async () => {
+      // These two are read straight from the environment, never as CLI options,
+      // and their names must stay outside the POSTHOG_WIZARD_ prefix for that to
+      // hold: `.env('POSTHOG_WIZARD')` turns every prefixed variable into an
+      // option name and `.strictOptions()` fails the run on one it doesn't know,
+      // so renaming them under the prefix would exit every cloud run before the
+      // wizard does any work.
+      process.env.POSTHOG_WIZARD_CI = 'true';
+      process.env.POSTHOG_WIZARD_REGION = 'us';
+      process.env.POSTHOG_WIZARD_API_KEY = 'phx_env_key';
+      process.env.POSTHOG_WIZARD_INSTALL_DIR = '/tmp/test';
+      process.env.POSTHOG_TASK_RUN_ID = 'task-run-uuid';
+      process.env.POSTHOG_TASK_ID = 'task-uuid';
+
+      await runCLI([]);
+
+      expect(process.exit).not.toHaveBeenCalledWith(1);
     });
 
     test('CLI args override CI environment variables', async () => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -58,6 +58,14 @@ type RuntimeEnvKey =
   | 'POSTHOG_WIZARD_BENCHMARK_FILE'
   | 'POSTHOG_WIZARD_LOG_DIR'
   | 'POSTHOG_WIZARD_DEBUG'
+  // Identity of the PostHog task run whose sandbox launched this wizard. Set by
+  // the sandbox for every run it starts, agent or wizard. Deliberately NOT
+  // POSTHOG_WIZARD_-prefixed, for the same reason as the two keys above:
+  // yargs .env('POSTHOG_WIZARD') would claim them as CLI options and
+  // .strictOptions() would reject the run unless the wizard also declared them,
+  // which would tie every sandbox deploy to an npm release of this package.
+  | 'POSTHOG_TASK_RUN_ID'
+  | 'POSTHOG_TASK_ID'
   // Local/CI escape hatch to disable Warlock scanning without the PostHog flag.
   | 'POSTHOG_WIZARD_WARLOCK_DISABLED'
   | 'DEBUG'
@@ -81,3 +89,13 @@ type RuntimeEnvKey =
 export function runtimeEnv(key: RuntimeEnvKey): string | undefined {
   return process.env[key];
 }
+
+/**
+ * The PostHog task run that launched this wizard, when one did. A cloud run's
+ * sandbox exports both ids into the wizard's environment; every local run
+ * leaves them undefined. Resolved once at launch, like RUN_SURFACE above.
+ */
+export const TASK_RUN_ID: string | undefined =
+  runtimeEnv('POSTHOG_TASK_RUN_ID') || undefined;
+export const TASK_ID: string | undefined =
+  runtimeEnv('POSTHOG_TASK_ID') || undefined;

--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -2,6 +2,7 @@ import { Analytics, groupsFromUser } from '@utils/analytics';
 import { PostHog } from 'posthog-node';
 import { v4 as uuidv4 } from 'uuid';
 import { ANALYTICS_TEAM_TAG, WIZARD_FLAG_KEYS } from '@lib/constants';
+import { VERSION } from '@lib/version';
 import type { ApiUser } from '@lib/api';
 
 vi.mock('posthog-node');
@@ -16,6 +17,8 @@ vi.mock('uuid');
 const envState = vi.hoisted(() => ({
   isProductionBuild: false,
   runSurface: 'local' as 'cloud' | 'local',
+  taskRunId: undefined as string | undefined,
+  taskId: undefined as string | undefined,
 }));
 vi.mock('@env', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@env')>()),
@@ -24,6 +27,12 @@ vi.mock('@env', async (importOriginal) => ({
   },
   get RUN_SURFACE() {
     return envState.runSurface;
+  },
+  get TASK_RUN_ID() {
+    return envState.taskRunId;
+  },
+  get TASK_ID() {
+    return envState.taskId;
   },
 }));
 
@@ -37,6 +46,8 @@ describe('Analytics', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     envState.isProductionBuild = false;
+    envState.taskRunId = undefined;
+    envState.taskId = undefined;
     // Each run mints several distinct uuids; mock them to different values
     // so the tests reflect reality (run_id !== $session_id) rather than
     // collapsing them. Call order: anonymousId, runId (both in the
@@ -78,6 +89,7 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
           ...properties,
         },
       );
@@ -99,6 +111,7 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
           testTag: 'testValue',
           ...properties,
         },
@@ -121,6 +134,7 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
           $session_id: 'session-uuid',
         },
       );
@@ -140,6 +154,7 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
         },
       );
     });
@@ -149,7 +164,8 @@ describe('Analytics', () => {
       const properties = { integration: 'nextjs', step: 'installation' };
 
       analytics.setTag('environment', 'test');
-      analytics.setTag('version', '1.0.0');
+      // Not `version`: that key is now one of the constructor's own tags.
+      analytics.setTag('framework_version', '1.0.0');
       analytics.captureException(error, properties);
 
       expect(mockPostHogInstance.captureException).toHaveBeenCalledWith(
@@ -161,8 +177,9 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
           environment: 'test',
-          version: '1.0.0',
+          framework_version: '1.0.0',
           integration: 'nextjs',
           step: 'installation',
         },
@@ -185,6 +202,7 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
           integration: 'react',
         },
       );
@@ -204,6 +222,7 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
         },
       );
     });
@@ -366,6 +385,36 @@ describe('Analytics', () => {
     });
   });
 
+  describe('task run tags', () => {
+    it('omits both ids on a run the sandbox did not launch', () => {
+      analytics.capture('wizard: test');
+
+      const properties = (mockPostHogInstance.capture as Mock).mock.calls.at(
+        -1,
+      )?.[0].properties;
+      expect(properties).not.toHaveProperty('task_run_id');
+      expect(properties).not.toHaveProperty('task_id');
+    });
+
+    it('tags every event with the launching task run', () => {
+      envState.taskRunId = 'task-run-uuid';
+      envState.taskId = 'task-uuid';
+      const cloud = new Analytics();
+
+      cloud.capture('wizard: test');
+      cloud.captureException(new Error('e'));
+
+      // Both paths merge the same tag bag, so the join back to the task run has
+      // to hold for exceptions too, not just explicit captures.
+      expect(
+        (mockPostHogInstance.capture as Mock).mock.calls.at(-1)?.[0].properties,
+      ).toMatchObject({ task_run_id: 'task-run-uuid', task_id: 'task-uuid' });
+      expect(
+        (mockPostHogInstance.captureException as Mock).mock.calls.at(-1)?.[2],
+      ).toMatchObject({ task_run_id: 'task-run-uuid', task_id: 'task-uuid' });
+    });
+  });
+
   describe('identifyUser', () => {
     const user = {
       distinct_id: 'user-123',
@@ -472,6 +521,7 @@ describe('Analytics', () => {
         build: 'dev',
         run_id: 'run-uuid',
         run_surface: 'local',
+        version: VERSION,
         command: 'slack',
         $exception_list: [{ type: 'Error' }],
       });
@@ -654,6 +704,7 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
           integration: 'nextjs',
           localMcp: true,
           debug: false,
@@ -680,6 +731,7 @@ describe('Analytics', () => {
           build: 'dev',
           run_id: 'run-uuid',
           run_surface: 'local',
+          version: VERSION,
           $session_id: 'session-uuid',
           integration: 'svelte',
         },

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -8,7 +8,7 @@ import {
 import type { WizardSession } from '@lib/wizard-session';
 import type { ApiUser } from '@lib/api';
 import { v4 as uuidv4 } from 'uuid';
-import { IS_PRODUCTION_BUILD, RUN_SURFACE } from '@env';
+import { IS_PRODUCTION_BUILD, RUN_SURFACE, TASK_ID, TASK_RUN_ID } from '@env';
 import { VERSION } from '@lib/version';
 import { debug, logToFile } from './debug';
 import { applyCiFlagOverrides } from './ci-flag-overrides';
@@ -130,6 +130,18 @@ export class Analytics {
     this.tags.build = IS_PRODUCTION_BUILD ? 'prod' : 'dev';
 
     this.tags.run_surface = RUN_SURFACE;
+
+    // The build this run came from. Already sent as a flag-evaluation person
+    // property; tagging it makes every event attributable to a release, so a
+    // regression can be bounded to the versions that carry it.
+    this.tags.version = VERSION;
+
+    // Cloud runs only: the task run that owns the sandbox. Without these the
+    // wizard's events and the run that launched it are two unrelated streams,
+    // since run_id above is minted per process and never leaves the wizard.
+    // Left unset for local runs so the properties stay absent rather than null.
+    if (TASK_RUN_ID) this.tags.task_run_id = TASK_RUN_ID;
+    if (TASK_ID) this.tags.task_id = TASK_ID;
 
     this.anonymousId = uuidv4();
 


### PR DESCRIPTION
## Why

A cloud run launches the published wizard inside a task-run sandbox, and the wizard's own events carry
no reference to that run: `run_id` is a uuid minted per process in the Analytics constructor and never
leaves the wizard, so its events and the run that started them are two unrelated streams. The sandbox
already exports `POSTHOG_TASK_RUN_ID` and `POSTHOG_TASK_ID` into the environment the wizard inherits,
which is enough to tag the join key directly. `VERSION` is likewise already sent as a flag-evaluation
person property but is absent from events, so no event is attributable to the release that produced
it.

## What

- read `POSTHOG_TASK_RUN_ID` / `POSTHOG_TASK_ID` through the `runtimeEnv` allowlist and expose them as
  `TASK_RUN_ID` / `TASK_ID`, resolved once at launch like `RUN_SURFACE`
- tag every analytics event with `version`, and with `task_run_id` / `task_id` when the launching
  sandbox supplied them, in the same constructor tag bag that carries `run_surface`
- tests: task-run tags present on captures and exceptions for a sandbox-launched run and absent
  otherwise, `version` folded into the existing tag-bag assertions, and a CLI test asserting the two
  variables parse instead of exiting

## Notes for reviewers

- Both variables already exist on every sandbox, so this ships independently of any PostHog-side
  change: an older sandbox and a newer wizard, or the reverse, both behave.
- Their names deliberately carry no `POSTHOG_WIZARD_` prefix. `.env('POSTHOG_WIZARD')` binds every
  prefixed variable to a CLI option name and `.strictOptions()` fails the run on an undeclared one,
  so reading them under that prefix would mean this package had to declare a matching option before
  the sandbox could export anything, coupling a backend deploy to an npm release. The CLI test pins
  the names for that reason.
- The tag bag is merged by `capture`, `wizardCapture`, `captureException`, and the `$exception`
  rewrite in `before_send`, so all four paths pick this up with no per-call-site change.
- `TASK_RUN_ID` / `TASK_ID` normalize an empty string to `undefined`, and the tags are only set when
  truthy, so a local run sends the properties as absent rather than null.
- The existing "merge tags with provided properties" test used `version` as its arbitrary tag name;
  renamed to `framework_version` now that `version` is one of the constructor's own tags.
- `version` is asserted as the imported `VERSION` rather than a literal, so release bumps do not
  touch these tests.
- Test plan: `vitest run src/utils/__tests__/analytics.test.ts src/__tests__/cli.test.ts` (64 passed,
  against node_modules borrowed from a local clone since the worktree has none). The full suite was
  not run.

## Validating after merge

- Every event this package sends gains `properties.version`. Once the release rolls out, the share of
  wizard events in project 2 with `version` unset should fall to zero; a stuck non-zero share means
  an older published build is still the one users get.
- For cloud runs, `setup wizard finished` (with `run_surface: 'cloud'`) should carry
  `properties.task_run_id` and `properties.task_id` on effectively 100% of events. Local runs must
  carry neither, so `run_surface: 'local'` with a `task_run_id` set is a defect in the env read, not
  a gap.
- The join this exists for: `task_run_id` on the wizard's events equals `properties.run_id` on the
  backend's `task_run_started` / `task_run_completed` / `task_run_failed`. A cloud-surface
  `setup wizard finished` with no matching backend run, or a backend run with no wizard event, is the
  gap the tags are meant to close and should trend to zero.
- Regression: `run_surface: 'cloud'` events arriving without `task_run_id` means the sandbox is not
  exporting `POSTHOG_TASK_RUN_ID` / `POSTHOG_TASK_ID` into the wizard's environment. The tags are
  read once at launch, so this is all-or-nothing per run rather than intermittent within one.
- Nothing about how the wizard runs changes, so no `setup wizard finished` `status` distribution
  should move. A shift there would point at the release, not at this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Fixes PostHog/posthog#74316
