### PR TITLE
test(switchboard): drop fixtures for the deleted pi flags

### DIFF
--- a/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
@@ -97,19 +97,6 @@ describe('the truth table — posthog-integration × wizard-orchestrator', () =>
         trace: { harness: 'flag', model: 'flag', sequence: 'flag' },
       },
       {
-        name: "'true' + retired pi flags → identical, nothing reads them",
-        ctx: {
-          program: 'posthog-integration',
-          flags: {
-            [ORCH]: 'true',
-            'wizard-use-pi-harness': 'true',
-            'wizard-pi-model': 'gpt-5-6-terra',
-            'wizard-pi-effort': 'high',
-          },
-        },
-        binding: ORCHESTRATOR_PI_DEFAULT,
-      },
-      {
         // Harness axis code-gated on cloud; sequence scoping is the flag's own run_surface targeting (#961).
         name: "'true' on the cloud surface → orchestrator sequence, harness route disabled",
         surface: 'cloud',

--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -277,7 +277,7 @@ describe('Analytics', () => {
     it('lists only enabled wizard flags in $active_feature_flags', async () => {
       mockFlags({
         'wizard-orchestrator': true,
-        'wizard-use-pi-harness': false,
+        'wizard-self-driving-use-pi-harness': false,
         'wizard-orchestrator-override': 'sol-review',
         'unrelated-flag': 'variant-x',
       });


### PR DESCRIPTION
Removes the truth-table and analytics fixtures for `wizard-pi-model`, `wizard-pi-effort`, and `wizard-use-pi-harness`, now deleted in PostHog.

The truth-table case asserted the three keys were inert, but `WIZARD_FLAG_KEYS` is a closed set and `getAllFlagsForWizard` only populates keys from it, so those keys can never reach `ctx.flags` — the case tested an input that cannot occur. Separately, the analytics case used `wizard-use-pi-harness` as its "wizard flag but disabled" exclusion; with the key out of the set that had degenerated into a second `unrelated-flag`, so it moves to `wizard-self-driving-use-pi-harness`, which is still in the set.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*