### PR TITLE
Keep a lockfile-less site with a root index.html off the Node SDK

### DIFF
--- a/src/frameworks/javascript-web/javascript-web-wizard-agent.ts
+++ b/src/frameworks/javascript-web/javascript-web-wizard-agent.ts
@@ -8,9 +8,11 @@ import { hasDeclaredDependency } from '@utils/package-json';
 import { tryGetPackageJson } from '@utils/setup-utils';
 import {
   FRAMEWORK_PACKAGES,
+  SERVER_PACKAGES,
   detectJsPackageManager,
   detectBundler,
   hasIndexHtml,
+  hasRootIndexHtml,
   type JavaScriptContext,
 } from './utils';
 import { detectNodePackageManagers } from '@lib/detection/package-manager';
@@ -38,6 +40,10 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
     detectPackageManager: detectNodePackageManagers,
     detect: async (options) => {
       const packageJson = await tryGetPackageJson(options);
+
+      // A site with no package.json at all is deliberately left unclaimed: the
+      // snippet is the whole integration and there is nothing for the wizard to
+      // do. PostHog/posthog.com#18390 routes those users to it from the docs.
       if (!packageJson) {
         return false;
       }
@@ -70,6 +76,20 @@ export const JAVASCRIPT_WEB_AGENT_CONFIG: FrameworkConfig<JavaScriptContext> = {
       // - a lockfile, and
       // - at least one frontend signal (index.html or bundler)
       if (hasLockfile && (hasIndexHtmlFlag || hasBundler)) {
+        return true;
+      }
+
+      // No lockfile. `javascriptNode` matches any package.json, so falling
+      // through here hands a browser-only project the server SDK. Claim it
+      // instead, but only on evidence strong enough to stand without the
+      // lockfile: an index.html in the ROOT (the site's entry point, not a
+      // `docs/` page or a generated report), and no server framework in
+      // `dependencies`. A site under `public/` or `dist/` is left alone —
+      // that shape is indistinguishable from a server's asset directory.
+      const declaresServer = SERVER_PACKAGES.some(
+        (pkg) => packageJson?.dependencies?.[pkg] !== undefined,
+      );
+      if (hasRootIndexHtml(options) && !declaresServer) {
         return true;
       }
 

--- a/src/frameworks/javascript-web/utils.ts
+++ b/src/frameworks/javascript-web/utils.ts
@@ -33,6 +33,34 @@ export const FRAMEWORK_PACKAGES = [
 ] as const;
 
 /**
+ * Packages that mean the project serves requests rather than shipping a browser
+ * bundle. Checked against `dependencies` only — a static site may well keep a
+ * server in `devDependencies` to preview itself locally, and that shouldn't
+ * read as a backend.
+ */
+export const SERVER_PACKAGES = [
+  'express',
+  'fastify',
+  'koa',
+  '@nestjs/core',
+  '@hapi/hapi',
+  'hapi',
+  'restify',
+  'h3',
+] as const;
+
+/**
+ * An index.html in the project root — the entry point of a site, as opposed to
+ * a `docs/` page or a generated report deeper in the tree. Used only where a
+ * match has to stand on its own without a lockfile to corroborate it.
+ */
+export function hasRootIndexHtml(
+  options: Pick<WizardRunOptions, 'installDir'>,
+): boolean {
+  return fs.existsSync(path.join(options.installDir, 'index.html'));
+}
+
+/**
  * Detect the JS package manager for the project by checking lockfiles.
  * Reuses the existing package manager detection infrastructure.
  */

--- a/src/lib/detection/__tests__/framework.test.ts
+++ b/src/lib/detection/__tests__/framework.test.ts
@@ -115,6 +115,107 @@ describe('detectFramework (end-to-end over real project dirs)', () => {
     );
   });
 
+  test('a browser project with no committed lockfile is not handed to javascript_node', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({
+        name: 'portfolio',
+        scripts: { build: 'tailwindcss -o dist/style.css' },
+      }),
+      'index.html': '<!doctype html><html></html>',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.javascript_web,
+    );
+  });
+
+  test('an Express server with a root index.html stays on javascript_node', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({ dependencies: { express: '^4' } }),
+      'index.html': '<!doctype html><html></html>',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.javascriptNode,
+    );
+  });
+
+  test('a Node library with a docs/index.html stays on javascript_node', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({ name: 'lib' }),
+      'src/index.js': 'module.exports = {}',
+      'docs/index.html': '<!doctype html><html></html>',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.javascriptNode,
+    );
+  });
+
+  test('a server framework we do not list is still safe if index.html is not at the root', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({ dependencies: { hono: '^4' } }),
+      'public/index.html': '<!doctype html><html></html>',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.javascriptNode,
+    );
+  });
+
+  test('a server kept in devDependencies to preview a site is not read as a backend', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({
+        name: 'portfolio',
+        devDependencies: { express: '^4' },
+      }),
+      'index.html': '<!doctype html><html></html>',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.javascript_web,
+    );
+  });
+
+  // Known limit: indistinguishable from a server's asset directory without a
+  // lockfile, so it is left to javascript_node rather than guessed at.
+  test('a site whose index.html lives under public/ is not claimed without a lockfile', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({ name: 'site' }),
+      'public/index.html': '<!doctype html><html></html>',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.javascriptNode,
+    );
+  });
+
+  test('a lockfile project keeps matching on a nested index.html (unchanged)', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({ name: 'site' }),
+      'package-lock.json': '{}',
+      'public/index.html': '<!doctype html><html></html>',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.javascript_web,
+    );
+  });
+
+  test('a Node project with no frontend signal stays on javascript_node', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({ dependencies: { lodash: '^4' } }),
+      'index.js': 'module.exports = {}',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.javascriptNode,
+    );
+  });
+
+  // A site with no package.json is left unclaimed on purpose — the snippet is
+  // the whole integration. PostHog/posthog.com#18390 routes those users to it.
+  test('a hand-written static site is deliberately claimed by nobody', async () => {
+    const opts = project({
+      'index.html': '<!doctype html><html><head></head><body>hi</body></html>',
+      'about.html': '<!doctype html><html></html>',
+      'css/style.css': 'body { color: black }',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBeUndefined();
+  });
+
   test('a Kotlin Multiplatform project resolves to kmp', async () => {
     const opts = project({
       'settings.gradle.kts': 'include(":shared")',


### PR DESCRIPTION
Found while looking at #870. It isn't the discoverability problem that issue reports — PostHog/posthog.com#18390 covers that — it's a separate defect in the same corner of detection.

## Problem

`javascript_web` requires a committed lockfile. `javascript_node` matches any `package.json`. So a browser-only project whose lockfile isn't committed falls past the web integration and gets picked up by the Node one.

Reproducing against `detectFramework` on `main`:

| Project | Detected |
|---|---|
| `index.html` + `package.json` + lockfile | `javascript_web` |
| `index.html` + `package.json`, no lockfile | **`javascript_node`** |

In the second case the run installs `posthog-node` and instruments a server that doesn't exist. Nothing errors, so there's no prompt telling the user to correct it.

## What changed

One new branch in `javascript_web`'s `detect()`, reached only after the existing `hasLockfile && (indexHtml || bundler)` check has already declined. **Nothing that matches today stops matching** — this can only add matches.

With no lockfile, claim the project when both hold:

1. **`index.html` is in the project root.**
2. **No server framework in `dependencies`** (`express`, `fastify`, `koa`, `@nestjs/core`, hapi, `restify`, `h3`).

`dependencies` and not `devDependencies`, because a static site may well keep a server around to preview itself locally, and that shouldn't read as a backend.

## Why root-only

Reusing the existing `hasIndexHtml` helper here is wrong. It globs `**/index.html` six levels deep, which is fine when a lockfile is corroborating it and much too loose when it's deciding alone:

| Project, no lockfile | `**/index.html` | root-only |
|---|---|---|
| Node lib with `docs/index.html` | `javascript_web` ✗ | `javascript_node` ✓ |
| `hono` server + `public/index.html` | `javascript_web` ✗ | `javascript_node` ✓ |
| Portfolio with root `index.html` | `javascript_web` ✓ | `javascript_web` ✓ |

Root-only carries most of the weight, which is the point: the fix doesn't depend on the server list being complete. `hono` isn't on that list and is handled correctly anyway, because its `index.html` is under `public/`. The list is a second guard for a server with a root `index.html`, so an omission from it is a small miss rather than a misroute.

## What it doesn't cover

**A site whose `index.html` lives under `public/` or `dist/` is still routed to `javascript_node`.** Without a lockfile there's nothing separating that shape from a server's asset directory, and the wrong guess there is the same wrong guess this PR is fixing. So it's left alone deliberately rather than covered by a heuristic I can't defend. Pinned as a test so the limit is visible rather than surprising.

Also unchanged: a site with **no `package.json` at all** stays unclaimed. Routing those users to the JS snippet from the docs, as PostHog/posthog.com#18390 does, is a better answer than the wizard adopting static sites. Also pinned, with a pointer to that PR.

## Tests

Nine in `framework.test.ts`, seven of them negatives: the `docs/` and `public/` cases above, express in `dependencies` against `devDependencies`, a Node project with no frontend signal, and the existing lockfile path unchanged.

```
pnpm build   ✅
pnpm test    ✅ 1565 passing
pnpm lint    ✅ no new errors
```

Refs #870, PostHog/posthog.com#18390
