### PR TITLE
feat(detection): add alternatePackageNames so React Router v6 is detected

### DIFF
--- a/src/frameworks/react-router/react-router-wizard-agent.ts
+++ b/src/frameworks/react-router/react-router-wizard-agent.ts
@@ -4,9 +4,8 @@ import type { FrameworkConfig } from '@lib/framework-config';
 import { detectNodePackageManagers } from '@lib/detection/package-manager';
 import { Integration } from '@lib/constants';
 import {
-  getDeclaredVersion,
+  findDeclaredPackage,
   getInstalledPackageVersion,
-  hasDeclaredDependency,
   type PackageJson,
 } from '@utils/package-json';
 import { tryGetPackageJson } from '@utils/setup-utils';
@@ -21,6 +20,22 @@ import {
 type ReactRouterContext = {
   routerMode?: ReactRouterMode;
 };
+
+const REACT_ROUTER_PACKAGE = 'react-router';
+
+/**
+ * v6 ships the router as `react-router-dom`; v7 consolidated onto
+ * `react-router`. Both names have to count, or v6 projects — which declare
+ * only `react-router-dom` — never match and fall through to the generic
+ * JavaScript fallbacks.
+ */
+const REACT_ROUTER_ALTERNATE_PACKAGES = ['react-router-dom'];
+
+/** Lookup order matches `getReactRouterMode` in ./utils. */
+const REACT_ROUTER_PACKAGES = [
+  ...REACT_ROUTER_ALTERNATE_PACKAGES,
+  REACT_ROUTER_PACKAGE,
+];
 
 export const REACT_ROUTER_AGENT_CONFIG: FrameworkConfig<ReactRouterContext> = {
   metadata: {
@@ -41,20 +56,24 @@ export const REACT_ROUTER_AGENT_CONFIG: FrameworkConfig<ReactRouterContext> = {
   },
 
   detection: {
-    packageName: 'react-router',
+    packageName: REACT_ROUTER_PACKAGE,
+    alternatePackageNames: REACT_ROUTER_ALTERNATE_PACKAGES,
     packageDisplayName: 'React Router',
     getVersion: (packageJson: unknown) =>
-      getDeclaredVersion('react-router', packageJson as PackageJson),
+      findDeclaredPackage(REACT_ROUTER_PACKAGES, packageJson as PackageJson)
+        ?.version,
     getVersionBucket: getReactRouterVersionBucket,
     minimumVersion: '6.0.0',
     getInstalledVersion: (options: WizardRunOptions) =>
       Promise.resolve(
-        getInstalledPackageVersion('react-router', options.installDir),
+        REACT_ROUTER_PACKAGES.map((name) =>
+          getInstalledPackageVersion(name, options.installDir),
+        ).find((version) => version !== undefined),
       ),
     detect: async (options) => {
       const packageJson = await tryGetPackageJson(options);
       return packageJson
-        ? hasDeclaredDependency('react-router', packageJson)
+        ? findDeclaredPackage(REACT_ROUTER_PACKAGES, packageJson) !== undefined
         : false;
     },
     detectPackageManager: detectNodePackageManagers,

--- a/src/lib/detection/__tests__/framework.test.ts
+++ b/src/lib/detection/__tests__/framework.test.ts
@@ -79,6 +79,37 @@ describe('detectFramework (end-to-end over real project dirs)', () => {
     );
   });
 
+  test('a React Router v6 app resolves to react-router, not a JS fallback', async () => {
+    // v6 declares only `react-router-dom`; v7 consolidated onto `react-router`.
+    // Matching just the v7 name sent every v6 project to javascript_web.
+    const opts = project({
+      'package.json': JSON.stringify({
+        dependencies: {
+          react: '^18',
+          'react-dom': '^18',
+          'react-router-dom': '^6.30.2',
+        },
+      }),
+      'package-lock.json': '{}',
+      'index.html': '<html></html>',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.reactRouter,
+    );
+  });
+
+  test('a React Router v7 app resolves to react-router', async () => {
+    const opts = project({
+      'package.json': JSON.stringify({
+        dependencies: { react: '^19', 'react-router': '7.10.1' },
+      }),
+      'package-lock.json': '{}',
+    });
+    await expect(detectFramework(opts.installDir)).resolves.toBe(
+      Integration.reactRouter,
+    );
+  });
+
   test('a Vite React app resolves to javascript_web, not javascript_node', async () => {
     const opts = project({
       'package.json': JSON.stringify({

--- a/src/lib/framework-config.ts
+++ b/src/lib/framework-config.ts
@@ -92,6 +92,14 @@ export interface FrameworkDetection {
   /** Package name to check in package.json (e.g., "next", "react") */
   packageName: string;
 
+  /**
+   * Other package names that count as this framework being installed, for
+   * frameworks that changed package name across major versions (React Router
+   * v6 ships as `react-router-dom`, v7 consolidated onto `react-router`).
+   * Checked alongside `packageName`.
+   */
+  alternatePackageNames?: string[];
+
   /** Human-readable name for error messages (e.g., "Next.js") */
   packageDisplayName: string;
 

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -154,8 +154,12 @@ export const posthogIntegrationConfig: ProgramConfig = {
         installDir: session.installDir,
       });
       if (packageJson) {
-        const { hasDeclaredDependency } = await import('@utils/package-json');
-        if (!hasDeclaredDependency(config.detection.packageName, packageJson)) {
+        const { findDeclaredPackage } = await import('@utils/package-json');
+        const accepted = [
+          config.detection.packageName,
+          ...(config.detection.alternatePackageNames ?? []),
+        ];
+        if (!findDeclaredPackage(accepted, packageJson)) {
           getUI().log.warn(
             `${config.detection.packageDisplayName} does not seem to be installed. Continuing anyway — the agent will handle it.`,
           );


### PR DESCRIPTION
## Why

React Router v6 ships the router as `react-router-dom`; v7 consolidated onto `react-router`. The detection gate only checked the v7 name:

```ts
return packageJson ? hasDeclaredDependency('react-router', packageJson) : false;
```

`hasDeclaredDependency` is an exact key lookup, so a v6 project — which declares only `react-router-dom` — never matched, and first-match detection carried it through to the `javascript_web` fallback.

The rest of the config already assumes v6 is supported: `minimumVersion` is `'6.0.0'`, and `getReactRouterMode` in `./utils` checks both package names and has an explicit `V6` branch. Neither is reachable, because detection fails first. context-mill's dedicated `react-react-router-6` skill variant is unreachable for the same reason, so a v6 project gets the generic `javascript_web` rules — whose pageview guidance is written for "SPAs without a framework router".

## What this adds

An optional `alternatePackageNames` on `FrameworkDetection`, rather than special-casing React Router in the runner — following the guidance in `.claude/skills/wizard-development`: *"the interface is missing a field — extend the interface, don't add special-case logic to the runner."*

React Router declares `['react-router-dom']` there, and both names are now used in `detect`, `getVersion`, `getInstalledVersion`, and the is-it-installed warning in `posthog-integration`.

## Test plan

- [x] Two new cases in `src/lib/detection/__tests__/framework.test.ts`: a v6 project (`react-router-dom` only) and a v7 project both resolve to `Integration.reactRouter`.
- [x] `pnpm build && vitest run` — 1558 tests pass across 113 files.
- [x] `tsc --noEmit` — 27 pre-existing errors before and after, none in the touched files.
- [x] Ran every framework's `detect()` predicate over each app in `context-mill/example-apps`: `react-react-router-6` resolved to `javascript_web` before and `react-router` after. `react-react-router-7-data`, `-declarative` and `-framework` are unchanged, and no other app's result moved.
