### PR TITLE
fix(switchboard): stop tracing a binding model to the flag

### DIFF
--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -156,7 +156,7 @@ describe('switchboard decision trace', () => {
       trace: { harness: 'binding', model: 'binding', sequence: 'binding' },
     },
     {
-      name: 'the one flag → orchestrator on pi, every axis traced to the flag',
+      name: 'the one flag → orchestrator on pi; model stays traced to the binding',
       ctx: {
         program: 'posthog-integration',
         flags: { [WIZARD_ORCHESTRATOR_FLAG_KEY]: 'true' },
@@ -167,7 +167,7 @@ describe('switchboard decision trace', () => {
         model: DEFAULT_AGENT_MODEL,
         thinkingLevel: undefined,
       },
-      trace: { harness: 'flag', model: 'flag', sequence: 'flag' },
+      trace: { harness: 'flag', model: 'binding', sequence: 'flag' },
     },
   ]);
 });
@@ -215,7 +215,7 @@ describe('switchboard composed clamp', () => {
         flags: { [WIZARD_ORCHESTRATOR_FLAG_KEY]: 'true' },
       },
       binding: { ...DEFAULT_RESOLVED, harness: Harness.pi },
-      trace: { harness: 'flag', model: 'flag', sequence: 'composed' },
+      trace: { harness: 'flag', model: 'binding', sequence: 'composed' },
     },
   ]);
 });

--- a/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
@@ -94,7 +94,7 @@ describe('the truth table — posthog-integration × wizard-orchestrator', () =>
         name: "'true' → orchestrator on pi; model stays the binding default (frontmatter decides per task)",
         ctx: { program: 'posthog-integration', flags: { [ORCH]: 'true' } },
         binding: ORCHESTRATOR_PI_DEFAULT,
-        trace: { harness: 'flag', model: 'flag', sequence: 'flag' },
+        trace: { harness: 'flag', model: 'binding', sequence: 'flag' },
       },
       {
         // Harness axis code-gated on cloud; sequence scoping is the flag's own run_surface targeting (#961).

--- a/src/lib/agent/runner/switchboard/harness.ts
+++ b/src/lib/agent/runner/switchboard/harness.ts
@@ -39,7 +39,12 @@ const flagRunnerOverride: Middleware<HarnessPick> = (ctx, next) => {
   const pick = next();
   const route = resolveFlagRoute(ctx.program, ctx.flags, ctx.flagPayloads);
   if (!route) return pick;
-  if (ctx.trace) Object.assign(ctx.trace, { harness: 'flag', model: 'flag' });
+  if (ctx.trace) {
+    ctx.trace.harness = 'flag';
+    // A harness-only route leaves the model at the binding default; claiming
+    // 'flag' here made the decision log misattribute it.
+    if (route.model) ctx.trace.model = 'flag';
+  }
   return {
     harness: route.harness ?? Harness.pi,
     model: route.model ?? pick.model,


### PR DESCRIPTION
Stamp `model: 'flag'` in the decision trace only when the flag route actually carries a model.

The orchestrator gate is a harness-only route — the model falls through to the binding default (`claude-sonnet-4-6`) and per-task models come from prompt frontmatter — but the trace claimed `model=claude-sonnet-4-6 (flag)`, which reads as the flag having picked sonnet for an orchestrator run. Tests asserting the old label are updated to `(binding)`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*