### PR TITLE
fix(switchboard): trace the model to the binding when a flag route is harness-only

### DIFF
--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -156,7 +156,7 @@ describe('switchboard decision trace', () => {
       trace: { harness: 'binding', model: 'binding', sequence: 'binding' },
     },
     {
-      name: 'the one flag → orchestrator on pi, every axis traced to the flag',
+      name: 'the one flag → orchestrator on pi; the model stays traced to the binding it fell back to',
       ctx: {
         program: 'posthog-integration',
         flags: { [WIZARD_ORCHESTRATOR_FLAG_KEY]: 'true' },
@@ -167,7 +167,7 @@ describe('switchboard decision trace', () => {
         model: DEFAULT_AGENT_MODEL,
         thinkingLevel: undefined,
       },
-      trace: { harness: 'flag', model: 'flag', sequence: 'flag' },
+      trace: { harness: 'flag', model: 'binding', sequence: 'flag' },
     },
   ]);
 });
@@ -215,7 +215,7 @@ describe('switchboard composed clamp', () => {
         flags: { [WIZARD_ORCHESTRATOR_FLAG_KEY]: 'true' },
       },
       binding: { ...DEFAULT_RESOLVED, harness: Harness.pi },
-      trace: { harness: 'flag', model: 'flag', sequence: 'composed' },
+      trace: { harness: 'flag', model: 'binding', sequence: 'composed' },
     },
   ]);
 });

--- a/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
@@ -94,7 +94,7 @@ describe('the truth table — posthog-integration × wizard-orchestrator', () =>
         name: "'true' → orchestrator on pi; model stays the binding default (frontmatter decides per task)",
         ctx: { program: 'posthog-integration', flags: { [ORCH]: 'true' } },
         binding: ORCHESTRATOR_PI_DEFAULT,
-        trace: { harness: 'flag', model: 'flag', sequence: 'flag' },
+        trace: { harness: 'flag', model: 'binding', sequence: 'flag' },
       },
       {
         // Harness axis code-gated on cloud; sequence scoping is the flag's own run_surface targeting (#961).

--- a/src/lib/agent/runner/switchboard/harness.ts
+++ b/src/lib/agent/runner/switchboard/harness.ts
@@ -39,7 +39,12 @@ const flagRunnerOverride: Middleware<HarnessPick> = (ctx, next) => {
   const pick = next();
   const route = resolveFlagRoute(ctx.program, ctx.flags, ctx.flagPayloads);
   if (!route) return pick;
-  if (ctx.trace) Object.assign(ctx.trace, { harness: 'flag', model: 'flag' });
+  if (ctx.trace) {
+    ctx.trace.harness = 'flag';
+    // Harness-only routes keep the binding's model — trace it truthfully so
+    // analytics never attributes the fallback model to the flag.
+    if (route.model) ctx.trace.model = 'flag';
+  }
   return {
     harness: route.harness ?? Harness.pi,
     model: route.model ?? pick.model,


### PR DESCRIPTION
Stamp `model_source='flag'` only when the flag route actually carries a model.

Harness-only routes (the orchestrator gate) fall back to the binding default model; the trace previously attributed that fallback to the flag, so `switchboard resolved` analytics showed `pi | claude-sonnet-4-6, model_source=flag` for healthy runs — a false alarm during the 2.53.0 release watch. Orchestrator runs now report `model_source='binding'`, making the fallback visible.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*