### PR TITLE
feat(bash-fence): allow xcodegen generate

### DIFF
--- a/src/lib/__tests__/wizard-can-use-tool.test.ts
+++ b/src/lib/__tests__/wizard-can-use-tool.test.ts
@@ -137,6 +137,9 @@ describe('bash fence — allows real toolchain commands (from skills + field log
     ).toBe('allow');
     expect(allow('pod install')).toBe('allow');
     expect(allow('carthage bootstrap')).toBe('allow');
+    expect(allow('xcodegen generate')).toBe('allow');
+    expect(allow('xcodegen generate --spec project.yml')).toBe('allow');
+    expect(allow('xcodegen dump')).toBe('deny');
   });
 
   it('android/jvm ecosystem', () => {

--- a/src/lib/agent/bash-fence.ts
+++ b/src/lib/agent/bash-fence.ts
@@ -88,6 +88,9 @@ const SIMPLE_MANAGERS: Record<string, readonly string[]> = {
   swift: ['package', 'build'],
   pod: ['install', 'update', 'search'],
   carthage: ['bootstrap', 'update'],
+  // Materializes the Xcode project from project.yml so xcodebuild can verify —
+  // build-equivalent risk (runs on the project's own spec).
+  xcodegen: ['generate'],
 };
 
 // Gradle tasks are verb-anchored camelCase: assembleDebug yes, publishToMavenCentral no.
@@ -107,7 +110,7 @@ const ALLOWED_TOOLS_SUMMARY =
   'any <venv>/bin/pip|python plus <venv>/bin/<lint tool>, ' +
   'composer (install|require|update|remove|show), bundle (install|add|remove|update|show|exec <lint tool>), ' +
   'gem (install|uninstall|list|search), swift (package|build), pod (install|update|search), carthage (bootstrap|update), ' +
-  'xcodebuild (build/clean/archive actions), gradle/gradlew (build|clean|dependencies|assemble*/compile*/bundle*/lint* tasks), ' +
+  'xcodegen (generate), xcodebuild (build/clean/archive actions), gradle/gradlew (build|clean|dependencies|assemble*/compile*/bundle*/lint* tasks), ' +
   'mvn (install|compile|package|verify|dependency:tree).';
 
 function deny(analyticsReason: string, message: string): BashFenceDecision {


### PR DESCRIPTION
Allow `xcodegen generate` through the pi-harness bash fence.

A Swift run (`73f355a7`) was denied `xcodegen generate` at the verification step — the agent needed it to materialize the Xcode project from `project.yml` before `xcodebuild`. Same risk class as the installs/builds already allowed (executes the project's own spec); only the `generate` subcommand is admitted.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*