### PR TITLE
feat(auth): give the browser login 30 minutes instead of 5

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -285,10 +285,10 @@ export const AGENTIC_DETECTION_TIMEOUT_MS = 60_000;
 /**
  * Timeout for the OAuth authorization flow (ms).
  *
- * Mirrors the server-side authorization-code expiry
- * (`AUTHORIZATION_CODE_EXPIRE_SECONDS`, 5 minutes). Once the code expires the
- * callback is dead and the token exchange can no longer succeed, so we stop
- * waiting at the same moment and prompt the user to re-run rather than letting
- * them complete a login that would fail.
+ * How long the user has to complete the browser login. The authorization
+ * code is minted at approval and exchanged immediately on callback, so the
+ * server-side code expiry (`AUTHORIZATION_CODE_EXPIRE_SECONDS`, 5 minutes)
+ * bounds only the approval→exchange gap — manual-paste users have 5 minutes
+ * from approval to submit the code — not how long this window may stay open.
  */
-export const OAUTH_TIMEOUT_MS = 300_000;
+export const OAUTH_TIMEOUT_MS = 1_800_000;


### PR DESCRIPTION
Raise `OAUTH_TIMEOUT_MS` from 5 to 30 minutes.

The old value mirrored the server's `AUTHORIZATION_CODE_EXPIRE_SECONDS`, but that expiry only bounds the approval→exchange gap (the code is minted at approval and exchanged immediately on callback), not how long the login window may stay open — so users who stepped away mid-login timed out for no server-side reason. All timeout copy (TUI overlay, CI log line) derives minutes from the constant.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*