### PR TITLE
fix(wizard): Whack a mole part 5: report per-task instead of the unused binding model on orchestrator runs

### DIFF
--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -152,9 +152,7 @@ function captureSwitchboardDecision(
   binding: ProgramBinding,
 ): void {
   const trace = ctx.trace ?? {};
-  // Orchestrator tasks pick their models from prompt frontmatter — when
-  // nothing pinned a run-level model, the binding fallback is not what runs,
-  // so report the truth instead of a model no task will use.
+  // Unpinned orchestrator runs pick per-task models from frontmatter, so the binding fallback is not what runs.
   const perTaskModel =
     binding.sequence === Sequence.orchestrator && trace.model === 'binding';
   const model = perTaskModel ? 'per-task' : binding.model;

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -152,6 +152,13 @@ function captureSwitchboardDecision(
   binding: ProgramBinding,
 ): void {
   const trace = ctx.trace ?? {};
+  // Orchestrator tasks pick their models from prompt frontmatter — when
+  // nothing pinned a run-level model, the binding fallback is not what runs,
+  // so report the truth instead of a model no task will use.
+  const perTaskModel =
+    binding.sequence === Sequence.orchestrator && trace.model === 'binding';
+  const model = perTaskModel ? 'per-task' : binding.model;
+  const modelSource = perTaskModel ? 'frontmatter' : trace.model;
   analytics.wizardCapture('switchboard resolved', {
     program: ctx.program,
     flag_self_driving_use_pi_harness:
@@ -164,10 +171,10 @@ function captureSwitchboardDecision(
     cli_sequence: ctx.cliSequence,
     cli_model: ctx.cliModel,
     harness_source: trace.harness,
-    model_source: trace.model,
+    model_source: modelSource,
     sequence_source: trace.sequence,
     harness: binding.harness,
-    model: binding.model,
+    model,
     thinking_level: binding.thinkingLevel,
     sequence: binding.sequence,
   });
@@ -178,7 +185,7 @@ function captureSwitchboardDecision(
         ctx.cliModel ?? '-'
       })` +
       ` → harness=${binding.harness} (${trace.harness ?? '?'})` +
-      ` model=${binding.model} (${trace.model ?? '?'})` +
+      ` model=${model} (${modelSource ?? '?'})` +
       ` sequence=${binding.sequence} (${trace.sequence ?? '?'})`,
   );
 }

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -152,11 +152,11 @@ function captureSwitchboardDecision(
   binding: ProgramBinding,
 ): void {
   const trace = ctx.trace ?? {};
-  // Unpinned orchestrator runs pick per-task models from frontmatter, so the binding fallback is not what runs.
+  // Unpinned orchestrator runs choose a model per task from the context-mill agent prompts; the orchestrator logs that map once the prompts load.
   const perTaskModel =
     binding.sequence === Sequence.orchestrator && trace.model === 'binding';
-  const model = perTaskModel ? 'per-task' : binding.model;
-  const modelSource = perTaskModel ? 'frontmatter' : trace.model;
+  const model = perTaskModel ? 'chosen-per-task' : binding.model;
+  const modelSource = perTaskModel ? 'agent-prompts' : trace.model;
   analytics.wizardCapture('switchboard resolved', {
     program: ctx.program,
     flag_self_driving_use_pi_harness:

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -214,6 +214,22 @@ export async function runOrchestrator(
     );
   }
 
+  // The end decision the switchboard event defers to: the model each task will actually run on.
+  const taskModels = Object.fromEntries(
+    ['seed', ...registry.types].map((type) => {
+      const prompt = type === 'seed' ? seedPrompt : registry.get(type);
+      const pick = resolveHarness(switchboardCtx, type);
+      const specModel = prompt && promptModelFor(prompt, pick.harness).model;
+      return [type, isValidModel(specModel) ? specModel : pick.model];
+    }),
+  );
+  logToFile(
+    `[orchestrator] task models: ${Object.entries(taskModels)
+      .map(([t, m]) => `${t}=${m}`)
+      .join(' ')}`,
+  );
+  analytics.wizardCapture('orchestrator task models', taskModels);
+
   // Responsiveness is the headline metric of the dark launch: time to first
   // visible progress, and no single step dominating wall-clock. Track it from
   // queue transitions, with the resolved model so cheap work is attributable


### PR DESCRIPTION
Report the real model decision on orchestrator runs instead of the unused binding fallback.

```
Before: [switchboard] decision: … model=claude-sonnet-4-6 (binding)         ← a model no task runs
After:  [switchboard] decision: … model=chosen-per-task (agent-prompts)
        [orchestrator] task models: seed=openai/gpt-5.6-terra install=openai/gpt-5.6-luna init=openai/gpt-5.6-luna identify=openai/gpt-5.6-terra error-tracking=openai/gpt-5.6-luna capture=openai/gpt-5.6-terra dashboard=openai/gpt-5.6-luna review=openai/gpt-5.6-terra report=openai/gpt-5.6-luna
```

The second line is the end decision — every task type's resolved model, logged once the context-mill agent prompts load (their `model_pi`/`model_sdk` fields decide, with CLI/flag overrides and the switchboard fallback applied), and captured as an `orchestrator task models` event. Runs with a genuinely pinned run-level model are unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*