### PR TITLE
fix(source-maps): handle unsupported-platform abort without an error

### DIFF
--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -160,14 +160,20 @@ export async function runLinearProgram(
       integration: config.integrationLabel,
       reason,
       matched: matched?.message ?? null,
+      expected: matched?.expected ?? false,
     });
     await wizardAbort({
       outroData,
-      error: new WizardError(`Agent aborted: ${reason}`, {
-        integration: config.integrationLabel,
-        error_type: AgentErrorType.ABORT,
-        reason,
-      }),
+      // An `expected` case is a known dead end the outro already explains to
+      // the user — capturing it would file an error-tracking issue for a
+      // working code path. Everything else stays an exception.
+      error: matched?.expected
+        ? undefined
+        : new WizardError(`Agent aborted: ${reason}`, {
+            integration: config.integrationLabel,
+            error_type: AgentErrorType.ABORT,
+            reason,
+          }),
     });
   }
 

--- a/src/lib/agent/runner/shared/types.ts
+++ b/src/lib/agent/runner/shared/types.ts
@@ -23,6 +23,14 @@ export interface AbortCase {
   message: string;
   body: string;
   docsUrl?: string;
+  /**
+   * This abort is an expected outcome, not a failure — the wizard reached a
+   * dead end it already knows how to explain (unsupported stack, no build
+   * command). The runner still renders the error outro and still fires the
+   * `agent aborted` product event, but files no exception, so error tracking
+   * stays a list of real bugs.
+   */
+  expected?: boolean;
 }
 
 /**

--- a/src/lib/programs/__tests__/source-maps-prompt.test.ts
+++ b/src/lib/programs/__tests__/source-maps-prompt.test.ts
@@ -1,4 +1,8 @@
-import { buildSourceMapsUploadPrompt } from '@lib/programs/error-tracking-upload-source-maps/prompt';
+import {
+  buildSourceMapsUploadPrompt,
+  SOURCE_MAPS_DETECTION_FAILED_PROMPT,
+} from '@lib/programs/error-tracking-upload-source-maps/prompt';
+import { SOURCE_MAPS_ABORT_CASES } from '@lib/programs/error-tracking-upload-source-maps/detect';
 
 const baseParams = {
   displayName: 'Node.js',
@@ -9,6 +13,24 @@ const baseParams = {
   settingsUrl: 'https://us.posthog.com/settings/user-api-keys',
   uiHost: 'https://us.posthog.com',
 };
+
+describe('unsupported-platform abort', () => {
+  const reason = 'unsupported-platform';
+
+  it('is the reason the detection-failed prompt tells the agent to emit', () => {
+    expect(SOURCE_MAPS_DETECTION_FAILED_PROMPT).toContain(`[ABORT] ${reason}`);
+  });
+
+  it('renders a friendly outro instead of the raw token, and files no error', () => {
+    // No match means the runner falls back to showing `reason` verbatim and
+    // captures a WizardError for it.
+    const matched = SOURCE_MAPS_ABORT_CASES.find((c) => c.match.test(reason));
+
+    expect(matched).toBeDefined();
+    expect(matched?.body).not.toContain(reason);
+    expect(matched?.expected).toBe(true);
+  });
+});
 
 describe('buildSourceMapsUploadPrompt env file paths', () => {
   it('scopes env tools to the selected monorepo project', () => {

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -144,6 +144,22 @@ export const SOURCE_MAPS_ABORT_CASES: AbortCase[] = [
     docsUrl:
       'https://posthog.com/docs/error-tracking/upload-source-maps/react-native',
   },
+  {
+    // Emitted by SOURCE_MAPS_DETECTION_FAILED_PROMPT when the picker never
+    // resolved a project to a supported skill variant. Without this case the
+    // user is shown the bare `unsupported-platform` token, and the wizard
+    // files an error-tracking issue for a dead end it already understands.
+    match: /^unsupported-platform$/i,
+    message: "Source-map upload isn't supported for this project yet",
+    body:
+      'The wizard could not match this project to a stack it knows how to ' +
+      'wire source-map upload into. It supports Next.js, Nuxt, Angular, ' +
+      'React, Vite, Webpack, Rollup, Node.js and plain web projects, plus ' +
+      'Expo React Native, Flutter, iOS and Android. You can still upload ' +
+      'source maps manually with the PostHog CLI — see the docs below.',
+    docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
+    expected: true,
+  },
 ];
 
 // ── File / dependency probes ─────────────────────────────────────────


### PR DESCRIPTION
Renders a real message instead of the raw `unsupported-platform` token, and stops filing an error-tracking issue for it.

<img width="1808" height="376" alt="CleanShot 2026-07-29 at 12 20 30@2x" src="https://github.com/user-attachments/assets/4c676e63-bfd3-4ed4-95f1-eec936a6d49b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)