### PR TITLE
fix(self-driving): Say that it opens PRs on its own

### DIFF
--- a/src/lib/programs/self-driving/ARCHITECTURE.md
+++ b/src/lib/programs/self-driving/ARCHITECTURE.md
@@ -91,7 +91,10 @@ and its `(skill: …)` reference never disagree on the number.
   shows in use. Support's source stays idle until a channel is connected (a
   follow-up).
 - **5 — Offer issue trackers** — one multi-select (GitHub Issues / Linear /
-  Zendesk / pganalyze). Auto-connect what the run can: GitHub Issues (pick a
+  Zendesk / pganalyze). **The consent moment for autonomous PRs** — see §10;
+  every option carries a `description` naming what gets read and that a
+  fixable finding opens a draft PR unprompted at $15. Auto-connect what the
+  run can: GitHub Issues (pick a
   repo — a single connected repo is used by default with no repo research;
   research which repo matches only when several are connected) and Linear
   (one-click OAuth link → single silent `integrations-list` check → create,
@@ -858,6 +861,57 @@ repo), so it's a context-mill skill change, not platform work:
 - Refund operational process (no consent, no cap).
 - **MCP codegen + OAuth ceiling** are the only steps not in this repo's diff
   (build + manual prod edit; see 9.7).
+
+---
+
+## 10. Disclosure: autonomous PRs are the thing being consented to
+
+> [!IMPORTANT] Added after support ticket **#65283**, where a user picked Linear
+> from the step-5 multi-select reading it as "which tools do you use?", and woke
+> up to 14 unrequested PRs and a $345 bill against issues they had filed as
+> their own future work.
+
+**The behavior (posthog, unchanged — this is a disclosure fix, not a
+behavior change).** `maybe_autostart_implementation_task`
+(`products/signals/backend/auto_start.py`) opens a draft PR for any report
+judged `IMMEDIATELY_ACTIONABLE`, with **no human approval step**
+(`interaction_origin="signal_report"` makes the task auto-push and open the
+draft PR). It is **on by default**: `SignalTeamConfig.autostart_enabled` is
+nullable and only an explicit `False` disables it, and
+`default_autostart_priority` defaults to **P4 = all priorities**. When no
+suggested reviewer resolves to a GitHub-linked member, it runs under
+`_resolve_autostart_fallback_user` — "the earliest active member who enabled a
+`SignalSourceConfig`", i.e. **whoever ran this wizard**. That function's own
+docstring states the assumption this program has to earn:
+
+> _"Enabling a signal source is the team's opt-in to the signals product, of
+> which autonomous PRs are a part."_
+
+The user-facing control is the **PR generation** switch + **Threshold**
+segmented control in the Inbox
+(`posthog/frontend/src/scenes/inbox/components/config/SelfDrivingSection.tsx`).
+
+**The rule this program follows.** Enabling a source _is_ the consent, so the
+consent has to be informed at the moment it's given — and onboarding has to
+stay fast, which means **one dimmed line per option, never an extra
+question**. Concretely:
+
+| Surface                                                | Carries                                                                     |
+| ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Intro "More info" (`SelfDrivingIntroScreen.tsx`)       | Bullet: opens a draft PR by itself, flat $15                                |
+| Learn deck (`content/index.tsx`, scene 8)              | "opens a draft PR on its own — it doesn't wait to be asked" + the switch    |
+| Run tips (`content/tips.ts`)                           | `autonomy` tip + `pricing` tip                                              |
+| **Step-5 ask** (context-mill `5-connected-tools.md`)   | Prompt states the consequence; **per-option `description`** on every tool    |
+| Step-4 natives (context-mill `4-sources.md`)           | "what it reads / what Self-driving does with it" pair, carried into step 7   |
+| Report (context-mill `7-report.md`)                    | Mandatory **"Autonomous PRs and cost"** section + where to switch it off     |
+| Outro (`index.ts` `buildOutroData`)                    | `body` states unprompted PRs at every priority; next-step names the switch   |
+
+**Two traps.** (1) `description` renders **only in the multi-select path**
+(`PickerMenu.MultiPickerMenu`) — a `single` ask silently drops it, so
+consequence text for a single-select must go in the prompt string. (2) Copy
+that frames a PR as user-pulled ("kick off a PR when you like the fix") is
+worse than silence — it actively contradicts the default. Both the outro and
+the learn deck used to read that way; keep them describing a push, not a pull.
 
 ---
 

--- a/src/lib/programs/self-driving/content/index.tsx
+++ b/src/lib/programs/self-driving/content/index.tsx
@@ -170,13 +170,25 @@ export const getContentBlocks = (store?: WizardStore): ContentBlock[] => {
     { content: 'Reports land in your Self-driving inbox.', pause: 4000 },
 
     {
-      content: 'Investigate with the agent, tag teammates, or kick off a PR.',
+      content: 'Investigate with the agent, or tag teammates to loop them in.',
+      pause: 5000,
+    },
+
+    {
+      content:
+        "And when a report has a clear fix, Self-driving opens a draft PR on its own — it doesn't wait to be asked.",
       pause: 6000,
     },
 
     {
       content:
-        'That PR is the only thing you pay for: a flat $15 per report that ships a PR. Watching is free.',
+        'That PR is the only thing you pay for: a flat $15 each. Scouts, signals, and reports are free.',
+      pause: 6000,
+    },
+
+    {
+      content:
+        'You stay in control: PR generation is a switch in your inbox, with a priority threshold next to it.',
       pause: 6000,
     },
 

--- a/src/lib/programs/self-driving/content/tips.ts
+++ b/src/lib/programs/self-driving/content/tips.ts
@@ -36,10 +36,16 @@ export const SELF_DRIVING_TIPS: Tip[] = [
       'After a fix ships, PostHog measures the result. If the pattern persists, a new signal reopens the work.',
   },
   {
+    id: 'autonomy',
+    title: 'It acts on its own',
+    description:
+      'When a report has a clear fix, PostHog opens a draft PR without asking. Turn it off any time with PR generation in your inbox.',
+  },
+  {
     id: 'pricing',
     title: 'What it costs',
     description:
-      'Watching is free. You pay a flat $15 only when a report ships a PR.',
+      'Scouts, signals, and reports are free. A PR costs a flat $15 — the only thing you pay for.',
   },
   {
     id: 'work-anywhere',

--- a/src/lib/programs/self-driving/index.ts
+++ b/src/lib/programs/self-driving/index.ts
@@ -82,13 +82,16 @@ const run: ProgramRun = {
         items: [
           'Investigate reports with the agent',
           'Tag teammates to loop them in',
-          'Kick off a PR when you like the proposed fix ($15 flat)',
+          'Turn PR generation off, or raise its priority threshold',
           'Or work from Slack (tag @PostHog) and MCP',
         ],
       },
       body:
-        'Pricing: scouts, signals, and reports are free. You pay a flat ' +
-        '$15 only when a report ships a PR.',
+        'Heads up: when a report has a clear fix, Self-driving opens a draft ' +
+        'PR on its own — no approval step, at every priority. That PR is the ' +
+        'only thing you pay for, a flat $15 each; scouts, signals, and ' +
+        'reports are free. Change it any time with PR generation in your ' +
+        'inbox.',
       reportFile: REPORT_FILE,
     };
   },

--- a/src/lib/programs/self-driving/prompt.ts
+++ b/src/lib/programs/self-driving/prompt.ts
@@ -123,6 +123,13 @@ STEP 4 — Enable signal sources. (skill: "Enable sources")
    confirmed they use.
 
 STEP 5 — Offer issue-tracker integrations. (skill: "Connected tools")
+   This is the most consequential ask in the run: connecting a tracker
+   means Self-driving reads every open issue in it and opens draft PRs
+   for the ones it judges fixable — by itself, with no approval step,
+   at a flat $15 per PR. Use the skill's question text verbatim,
+   including the per-option descriptions; never reduce an option to a
+   bare tool name. A user must not be able to pick a tracker here
+   thinking they only answered "which tools do you use?".
    One batched multi-select wizard_ask for the external tools the skill
    lists. The run auto-connects the ones it can (GitHub Issues, and
    Linear via a one-click OAuth link), verifying each with a single
@@ -161,5 +168,8 @@ STEP 6b — Design custom scouts for this product. (skill: "Custom scouts")
 STEP 7 — Write the report and hand off. (skill: "Report")
    Write the report per the skill, including follow-ups for anything
    deferred. Tell the user findings will start appearing in their inbox
-   at ${inboxUrl} within about 30 minutes.`;
+   at ${inboxUrl} within about 30 minutes. The report must also carry
+   the skill's autonomous-PR section — that PRs open without approval at
+   every priority, that they cost a flat $15 each while everything else
+   is free, and where to turn that off. Never drop or soften it.`;
 }

--- a/src/ui/tui/screens/SelfDrivingIntroScreen.tsx
+++ b/src/ui/tui/screens/SelfDrivingIntroScreen.tsx
@@ -67,6 +67,10 @@ export const SelfDrivingIntroScreen = ({
         <Text>{'•'} Groups signals into prioritized reports in your inbox</Text>
         <Text>{'•'} Researches findings in your code via GitHub</Text>
         <Text>
+          {'•'} Opens a draft PR by itself when a report has a clear fix – a
+          flat $15 each, and the only thing you pay for
+        </Text>
+        <Text>
           {'•'} Measures shipped fixes, and reopens the loop if the pattern
           persists
         </Text>
@@ -78,7 +82,7 @@ export const SelfDrivingIntroScreen = ({
       <Box flexDirection="column" marginTop={1}>
         <Text>
           PostHog watches how people really use your product, finds issues, and
-          proposes fixes.
+          opens PRs to fix them.
         </Text>
       </Box>
       <Box flexDirection="column" marginTop={1} alignItems="center">


### PR DESCRIPTION
## Problem

Support ticket #65283. A user picked Linear from the step-5 multi-select — which asked *"Which of these do you use?"* with bare labels — and woke up to 14 unrequested PRs and a $345 bill, against issues they'd filed as their own future work.

Autostart is on by default at every priority (`autostart_enabled` is nullable, only explicit `False` disables it; `default_autostart_priority` = P4), and when no reviewer resolves it runs as *whoever enabled the sources* — i.e. whoever ran the wizard. The backend's own docstring says "enabling a signal source is the team's opt-in to the signals product, of which autonomous PRs are a part." We never earned that opt-in.

Worse than the silence: the outro said *"Kick off a PR when you like the proposed fix"* and the learn deck *"tag teammates, or kick off a PR"* — both frame the PR as a pull, contradicting the default.

## Changes

Disclosure only, no behavior change. One dimmed line per option, no new questions — onboarding stays fast.

- Learn deck, tips, outro: PRs are a push, not a pull, and you can switch them off
- Intro More-info: a PR bullet on the screen shown *before* the run starts
- `prompt.ts`: step 5's wording is verbatim, never reduce an option to a bare tool name
- `ARCHITECTURE.md` §10: the disclosure contract + the two traps (option `description` renders in the multi path only; pull-framing is worse than silence)

Paired with PostHog/context-mill#TBD, which does the load-bearing half — the per-option descriptions on the step-5 ask and the mandatory report section. That ships independently of the npm release, and can go first safely (the `description` field already exists in shipped wizards).

## Test plan

`pnpm build && pnpm test && pnpm fix` — 1540 pass, lint clean. Copy-only otherwise.

## LLM context

Written with Claude Code. Ticket traced through `products/signals/backend/auto_start.py` (`maybe_autostart_implementation_task`, `_resolve_autostart_fallback_user`) and `SignalTeamConfig` defaults to confirm the behavior before touching copy.