### PR TITLE
feat(source-maps): automate Go debug-symbol upload

### DIFF
--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -616,6 +616,24 @@ describe('goSdkVerifier', () => {
     expect(goSdkVerifier(tmpDir)('.')).toBe(false);
   });
 
+  it('finds the SDK inside a require block', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'go.mod'),
+      'module example.com/svc\n\ngo 1.22\n\nrequire (\n\tgithub.com/gin-gonic/gin v1.10.0\n\tgithub.com/posthog/posthog-go v1.22.0\n)\n',
+    );
+    expect(goSdkVerifier(tmpDir)('.')).toBe(true);
+  });
+
+  it('ignores non-require mentions of the module path', () => {
+    // A replace/exclude directive (or the SDK's own module declaration) is
+    // not a dependency — only `require` counts.
+    fs.writeFileSync(
+      path.join(tmpDir, 'go.mod'),
+      'module example.com/svc\n\ngo 1.22\n\nreplace github.com/posthog/posthog-go => ../fork\n\nexclude github.com/posthog/posthog-go v1.21.0\n',
+    );
+    expect(goSdkVerifier(tmpDir)('.')).toBe(false);
+  });
+
   it('returns false when go.mod is missing', () => {
     expect(goSdkVerifier(tmpDir)('.')).toBe(false);
   });

--- a/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
+++ b/src/lib/programs/__tests__/source-maps-detect-agentic.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   coerceReport,
+  goSdkVerifier,
   rustSdkVerifier,
   SOURCE_MAPS_TARGETS,
 } from '@lib/programs/error-tracking-upload-source-maps/detect-agentic';
@@ -535,7 +536,29 @@ describe('coerceReport', () => {
     );
   });
 
-  it('recognises Go but blocks it as not yet supported', () => {
+  it('retains a Go project with PostHog as instrumentable', () => {
+    const report = coerceReport({
+      repoType: 'single',
+      projects: [
+        {
+          path: '.',
+          framework: 'Go (Gin)',
+          targetId: 'go',
+          hasPostHog: true,
+        },
+      ],
+    });
+
+    expect(report.projects[0]).toEqual({
+      path: '.',
+      framework: 'Go (Gin)',
+      variant: 'go',
+      hasPostHog: true,
+      instrumentable: true,
+    });
+  });
+
+  it('points a Go project without the SDK at a manual module install', () => {
     const report = coerceReport({
       repoType: 'single',
       projects: [
@@ -543,18 +566,58 @@ describe('coerceReport', () => {
           path: '.',
           framework: 'Go',
           targetId: 'go',
-          hasPostHog: true,
+          hasPostHog: false,
         },
       ],
     });
 
     expect(report.projects[0]).toEqual(
       expect.objectContaining({
-        variant: null,
+        variant: 'go',
         instrumentable: false,
-        reason: expect.stringMatching(/isn't supported/i),
+        reason: expect.stringMatching(/add the posthog-go module/i),
       }),
     );
+  });
+});
+
+describe('goSdkVerifier', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wizard-go-detect-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('confirms the SDK from the module go.mod, root or nested', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'go.mod'),
+      'module example.com/svc\n\ngo 1.22\n\nrequire github.com/posthog/posthog-go v1.22.0\n',
+    );
+    fs.mkdirSync(path.join(tmpDir, 'services', 'api'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'services', 'api', 'go.mod'),
+      'module example.com/api\n\ngo 1.22\n',
+    );
+
+    const verify = goSdkVerifier(tmpDir);
+    expect(verify('.')).toBe(true);
+    expect(verify('services/api')).toBe(false);
+  });
+
+  it('ignores a commented-out requirement', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'go.mod'),
+      'module example.com/svc\n\ngo 1.22\n\n// require github.com/posthog/posthog-go v1.22.0\n',
+    );
+    expect(goSdkVerifier(tmpDir)('.')).toBe(false);
+  });
+
+  it('returns false when go.mod is missing', () => {
+    expect(goSdkVerifier(tmpDir)('.')).toBe(false);
   });
 });
 

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -9,7 +9,7 @@
 
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { IGNORED_DIRS } from '@utils/bounded-fs';
+import { IGNORED_DIRS, readProjectFile } from '@utils/bounded-fs';
 import {
   detectProjectsWithAgent,
   coerceAgenticReport,
@@ -95,16 +95,14 @@ export const SOURCE_MAPS_TARGETS: DetectTarget[] = [...AUTOMATABLE_VARIANTS]
 
 /** Comment-stripped substring check for the Rust SDK in one manifest. */
 function manifestMentionsSdk(manifestPath: string): boolean {
-  try {
-    return readFileSync(manifestPath, 'utf-8')
-      .split('\n')
-      .some((line) => {
-        const code = line.split('#', 1)[0];
-        return code.includes(RUST_SDK_CRATE);
-      });
-  } catch {
-    return false;
-  }
+  const content = readProjectFile(manifestPath);
+  return (
+    content != null &&
+    content.split('\n').some((line) => {
+      const code = line.split('#', 1)[0];
+      return code.includes(RUST_SDK_CRATE);
+    })
+  );
 }
 
 /**
@@ -159,11 +157,39 @@ export function rustSdkVerifier(
 }
 
 /**
+ * True when go.mod actively `require`s the SDK — single-line requires and
+ * `require ( … )` blocks only, so a `module` declaration, `replace`, or
+ * `exclude` mention of the path never counts.
+ */
+function goModRequiresSdk(content: string): boolean {
+  let inBlock: 'require' | 'other' | null = null;
+  for (const raw of content.split('\n')) {
+    const code = raw.split('//', 1)[0].trim();
+    if (code === '') continue;
+    if (inBlock != null) {
+      if (code === ')') {
+        inBlock = null;
+      } else if (inBlock === 'require' && code.includes(GO_SDK_MODULE)) {
+        return true;
+      }
+      continue;
+    }
+    if (code.endsWith('(')) {
+      inBlock = code.startsWith('require') ? 'require' : 'other';
+      continue;
+    }
+    if (code.startsWith('require ') && code.includes(GO_SDK_MODULE)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Checks a project's go.mod for the Go SDK — the same authoritative override
- * as `rustSdkVerifier`, for the same reason. Comment-stripped (`//`)
- * substring matching; no multi-module walk — unlike Cargo workspaces, a Go
- * module's requirements always live in the selected module's own go.mod.
- * Exported for testing.
+ * as `rustSdkVerifier`, for the same reason. Only `require` directives count;
+ * no multi-module walk — unlike Cargo workspaces, a Go module's requirements
+ * always live in the selected module's own go.mod. Exported for testing.
  */
 export function goSdkVerifier(
   installDir: string,
@@ -171,16 +197,8 @@ export function goSdkVerifier(
   return (projectPath) => {
     const dir =
       projectPath === '.' ? installDir : join(installDir, projectPath);
-    try {
-      return readFileSync(join(dir, 'go.mod'), 'utf-8')
-        .split('\n')
-        .some((line) => {
-          const code = line.split('//', 1)[0];
-          return code.includes(GO_SDK_MODULE);
-        });
-    } catch {
-      return false;
-    }
+    const content = readProjectFile(join(dir, 'go.mod'));
+    return content != null && goModRequiresSdk(content);
   };
 }
 

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -21,8 +21,9 @@ import type { WizardSession } from '@lib/wizard-session';
 import {
   VARIANT_DISPLAY_NAME,
   AUTOMATABLE_VARIANTS,
-  MANUAL_SDK_VARIANTS,
+  MANUAL_SDK_INSTALL,
   RUST_SDK_CRATE,
+  GO_SDK_MODULE,
   type SkillVariant,
 } from './detect.js';
 
@@ -48,14 +49,6 @@ export type DetectionReport = {
   repoType: 'monorepo' | 'single';
   projects: DetectedProject[];
 };
-
-/**
- * Variants the detector recognises so the picker can name and block them,
- * without a shipped skill behind them yet. They rank LOW — a go.mod signal
- * must not shadow a real JS/native target in the same directory, it only
- * needs to beat the generic web fallback.
- */
-const DETECTION_ONLY_VARIANTS: readonly SkillVariant[] = ['go'];
 
 /**
  * Variant precedence for the agentic picker (most specific first). The detector
@@ -95,15 +88,8 @@ const precedenceRank = (v: SkillVariant): number => {
   return i === -1 ? Number.MAX_SAFE_INTEGER : i;
 };
 
-/**
- * Source-map detection targets, ordered by VARIANT_PRECEDENCE. Detection-only
- * variants stay in the target list so the detector can identify and block
- * them instead of falling through to a JS target or the web fallback.
- */
-export const SOURCE_MAPS_TARGETS: DetectTarget[] = [
-  ...DETECTION_ONLY_VARIANTS,
-  ...AUTOMATABLE_VARIANTS,
-]
+/** Source-map detection targets, ordered by VARIANT_PRECEDENCE. */
+export const SOURCE_MAPS_TARGETS: DetectTarget[] = [...AUTOMATABLE_VARIANTS]
   .sort((a, b) => precedenceRank(a) - precedenceRank(b))
   .map((v) => ({ id: v, name: VARIANT_DISPLAY_NAME[v] }));
 
@@ -172,6 +158,32 @@ export function rustSdkVerifier(
   };
 }
 
+/**
+ * Checks a project's go.mod for the Go SDK — the same authoritative override
+ * as `rustSdkVerifier`, for the same reason. Comment-stripped (`//`)
+ * substring matching; no multi-module walk — unlike Cargo workspaces, a Go
+ * module's requirements always live in the selected module's own go.mod.
+ * Exported for testing.
+ */
+export function goSdkVerifier(
+  installDir: string,
+): (projectPath: string) => boolean {
+  return (projectPath) => {
+    const dir =
+      projectPath === '.' ? installDir : join(installDir, projectPath);
+    try {
+      return readFileSync(join(dir, 'go.mod'), 'utf-8')
+        .split('\n')
+        .some((line) => {
+          const code = line.split('//', 1)[0];
+          return code.includes(GO_SDK_MODULE);
+        });
+    } catch {
+      return false;
+    }
+  };
+}
+
 function isAutomatableVariant(value: string | null): value is SkillVariant {
   return value !== null && AUTOMATABLE_VARIANTS.includes(value as SkillVariant);
 }
@@ -203,6 +215,8 @@ export type ProjectProbes = {
    * present, because any unrelated PostHog dependency can satisfy it.
    */
   verifyRustSdk?: (path: string) => boolean;
+  /** Go: does the project's go.mod require posthog-go? Same semantics as `verifyRustSdk`. */
+  verifyGoSdk?: (path: string) => boolean;
 };
 
 const NO_PROBES: ProjectProbes = {
@@ -251,12 +265,16 @@ function classifyProject(
   p: AgenticDetectionReport['projects'][number],
   probes: ProjectProbes,
 ): DetectedProject {
-  // For rust the deterministic Cargo.toml read overrides the agent's single
-  // hasPostHog boolean, which any unrelated PostHog dependency can satisfy.
-  const hasPostHog =
-    p.targetId === 'rust' && probes.verifyRustSdk
-      ? probes.verifyRustSdk(p.path)
-      : p.hasPostHog;
+  // For the native-binary variants the deterministic manifest read overrides
+  // the agent's single hasPostHog boolean, which any unrelated PostHog
+  // dependency can satisfy.
+  const sdkVerifier =
+    p.targetId === 'rust'
+      ? probes.verifyRustSdk
+      : p.targetId === 'go'
+      ? probes.verifyGoSdk
+      : undefined;
+  const hasPostHog = sdkVerifier ? sdkVerifier(p.path) : p.hasPostHog;
   const base = {
     path: p.path,
     framework: p.framework,
@@ -302,11 +320,10 @@ function classifyProject(
   }
 
   if (!hasPostHog) {
-    // The wizard's default flow can't install the Rust SDK, so don't point
-    // users at it for that stack.
-    const install = MANUAL_SDK_VARIANTS.includes(p.targetId)
-      ? 'add the posthog-rs crate first'
-      : 'run `npx @posthog/wizard` first';
+    // The wizard's default flow can't install the Go/Rust SDKs, so don't
+    // point users at it for those stacks.
+    const install =
+      MANUAL_SDK_INSTALL[p.targetId] ?? 'run `npx @posthog/wizard` first';
     return {
       ...base,
       variant: p.targetId,
@@ -363,5 +380,6 @@ export async function detectSourceMapsProjects(
     hasBuildTarget: (path) => projectHasBuildTarget(session.installDir, path),
     isExpoProject: (path) => projectHasExpo(session.installDir, path),
     verifyRustSdk: rustSdkVerifier(session.installDir),
+    verifyGoSdk: goSdkVerifier(session.installDir),
   });
 }

--- a/src/lib/programs/error-tracking-upload-source-maps/detect.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect.ts
@@ -60,11 +60,9 @@ const DISPLAY_NAME: Record<SkillVariant, string> = {
 };
 
 /**
- * Variants the wizard can wire up source-map upload for automatically. Go is
- * recognised but not yet automatable, so the agentic picker treats it as
- * non-instrumentable. Rust uploads native debug symbols
- * (`posthog-cli symbol-sets upload`) instead of source maps, but the wiring
- * is the same shape.
+ * Variants the wizard can wire up source-map upload for automatically. Go and
+ * Rust upload native debug symbols (`posthog-cli symbol-sets upload`) instead
+ * of source maps, but the wiring is the same shape.
  *
  * Invariant: every variant listed here must have a published
  * `error-tracking-upload-source-maps-<variant>` skill in context-mill —
@@ -76,6 +74,7 @@ export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
   'ios',
   'react-native',
   'flutter',
+  'go',
   'rust',
   'web',
   'nextjs',
@@ -97,17 +96,28 @@ export const AUTOMATABLE_VARIANTS: readonly SkillVariant[] = [
  * or local dependency to fall back to when the post-build step invokes the CLI.
  */
 export const VARIANTS_REQUIRING_POSTHOG_CLI: ReadonlySet<SkillVariant> =
-  new Set(['ios', 'android', 'react-native', 'flutter', 'rust']);
+  new Set(['ios', 'android', 'react-native', 'flutter', 'go', 'rust']);
 
 /**
  * Automatable variants whose SDK the wizard's default flow cannot install —
- * remediation for a missing SDK is a manual install (posthog-rs), not
- * `npx @posthog/wizard`. Drives the missing-SDK copy in the picker.
+ * remediation for a missing SDK is a manual install (posthog-go /
+ * posthog-rs), not `npx @posthog/wizard`. Drives the missing-SDK copy in the
+ * picker and the classifier.
  */
-export const MANUAL_SDK_VARIANTS: readonly SkillVariant[] = ['rust'];
+export const MANUAL_SDK_INSTALL: Partial<Record<SkillVariant, string>> = {
+  go: 'add the posthog-go module first',
+  rust: 'add the posthog-rs crate first',
+};
+
+export const MANUAL_SDK_VARIANTS: readonly SkillVariant[] = Object.keys(
+  MANUAL_SDK_INSTALL,
+) as SkillVariant[];
 
 /** Dependency string that identifies the Rust SDK in Cargo.toml. */
 export const RUST_SDK_CRATE = 'posthog-rs';
+
+/** Module path that identifies the Go SDK in go.mod. */
+export const GO_SDK_MODULE = 'github.com/posthog/posthog-go';
 
 const POSTHOG_SDKS = new Set([
   'posthog-js',
@@ -147,8 +157,8 @@ export const SOURCE_MAPS_ABORT_CASES: AbortCase[] = [
       'The agent could not find a PostHog SDK in your project. ' +
       'Source map upload requires the SDK to already be installed so it can ' +
       'report errors. Run `npx @posthog/wizard` first to install the SDK ' +
-      '(for Rust, add the posthog-rs crate by hand first — the wizard ' +
-      'cannot install it for that stack yet).',
+      '(for Go and Rust, add posthog-go / posthog-rs by hand first — the ' +
+      'wizard cannot install the SDK for those stacks yet).',
     docsUrl: 'https://posthog.com/docs/error-tracking',
   },
   {

--- a/src/ui/tui/screens/SourceMapsDetectScreen.tsx
+++ b/src/ui/tui/screens/SourceMapsDetectScreen.tsx
@@ -215,8 +215,8 @@ export const SourceMapsDetectScreen = ({
  */
 const BlockedSummary = ({ blocked }: { blocked: DetectedProject[] }) => {
   const unsupported = blocked.filter((p) => p.variant == null).length;
-  // The wizard can't install the Rust SDK, so its missing-SDK remediation is
-  // a manual install, not `npx @posthog/wizard`.
+  // The wizard can't install the Go/Rust SDKs, so their missing-SDK
+  // remediation is a manual install, not `npx @posthog/wizard`.
   const manualSdk = blocked.filter(
     (p) => p.variant != null && MANUAL_SDK_VARIANTS.includes(p.variant),
   ).length;
@@ -238,8 +238,8 @@ const BlockedSummary = ({ blocked }: { blocked: DetectedProject[] }) => {
       )}
       {manualSdk > 0 && (
         <Text dimColor>
-          (… {manualSdk} supported but missing the PostHog SDK — add the
-          posthog-rs crate to the project first, then re-run)
+          (… {manualSdk} supported but missing the PostHog SDK — add it to the
+          project first (posthog-go / posthog-rs), then re-run)
         </Text>
       )}
     </Box>


### PR DESCRIPTION
Was stacked on #938 (rust) — that merged, so this now targets main directly.

Related PRs:
- context-mill: https://github.com/PostHog/context-mill/pull/299
- wizard-workbench: https://github.com/PostHog/wizard-workbench/pull/3297
- docs (already live): https://posthog.com/docs/error-tracking/upload-source-maps/go

Flips `go` from recognized-but-blocked to automatable, completing the native symbol-set pair:

- `go` joins `AUTOMATABLE_VARIANTS` and `VARIANTS_REQUIRING_POSTHOG_CLI`; `DETECTION_ONLY_VARIANTS` is gone (it existed only for go).
- `goSdkVerifier` probe: bounded `readProjectFile` read of the project's go.mod, matching **`require` directives only** (single-line and block form) — a `module` declaration, `replace`, or `exclude` mention never counts. The rust manifest read moved to the same bounded helper for consistency.
- Missing-SDK remediation is now a per-variant map (`MANUAL_SDK_INSTALL`): go points at posthog-go, rust at posthog-rs; picker copy generalized.

Everything server-side shipped: posthog-go v1.22.0 (grouped inline frames + `$debug_images`, PostHog/posthog-go#260), the cymbal frame-order cutoff, CLI 0.9.1 (macOS Go binaries), and the live docs page.

> [!WARNING]
> **Merge gate:** the `error-tracking-upload-source-maps-go` skill ships with the context-mill PR above — release that before this, or every Go run fails at STEP 2 with `ERROR_RESOURCE_MISSING`.

Review notes (codex, 2 rounds): took bounded reads + require-only matching. Rejected wizard-side SDK **version** gating (a v1.21 project would upload unusable symbols) — that check belongs in the skill, whose agent can actually fix it (`go get @latest`); the skill's gotcha now instructs exactly that.

Tests: 44 focused (target precedence, go retained/missing-SDK classification, verifier: require block, commented, replace/exclude, missing); full build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
