### PR TITLE
fix(self-driving): reconcile promoted tools with the real ask, restore the leak test

### DIFF
--- a/src/lib/programs/__tests__/self-driving-detect.test.ts
+++ b/src/lib/programs/__tests__/self-driving-detect.test.ts
@@ -11,7 +11,10 @@ import {
   POSTHOG_MANIFESTS,
   SELF_DRIVING_DETECTED_TOOLS_KEY,
   SELF_DRIVING_TOOL_KINDS,
+  getSelfDrivingDetectedTools,
 } from '@lib/programs/self-driving/detect';
+import { getDetectedWarehouseSources } from '@lib/programs/warehouse-source/detect';
+import { WizardStore } from '@ui/tui/store';
 import { SOURCE_DETECTORS } from '@lib/warehouse-sources/registry';
 import type { DetectedSource } from '@lib/warehouse-sources/types';
 import { toIntegrationReport } from '@lib/programs/self-driving/detect-agentic';
@@ -112,6 +115,48 @@ describe('SELF_DRIVING_TOOL_KINDS', () => {
     expect([...SELF_DRIVING_TOOL_KINDS].filter((k) => !known.has(k))).toEqual(
       [],
     );
+  });
+});
+
+describe('the detect step does not leak into the composed integration run', () => {
+  // Driven through the REAL store, the way run-wizard does it
+  // (`await store.runReadyHooks()`), because the leak lived in the plumbing
+  // rather than in `detectConnectedTools`: writing the warehouse program's key
+  // here put the scan into the integration agent's prompt, since the
+  // integrate-run phase inherits a copy of this frameworkContext and
+  // `posthog-integration` reads that key to build its prompt. Asserting on the
+  // setter's argument alone would not have caught it.
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { '@sentry/node': '^7.0.0', pg: '^8.0.0' },
+      }),
+    );
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('stashes under its own key and leaves the warehouse key untouched', async () => {
+    const store = new WizardStore('self-driving');
+    store.session = buildSession({ installDir: tmpDir });
+    await store.runReadyHooks();
+
+    // Self-driving sees its tools...
+    expect(
+      getSelfDrivingDetectedTools(store.session).map((s) => s.kind),
+    ).toContain('Sentry');
+    // ...and the integration program, reading its own key off the session it
+    // inherits, sees nothing — so its prompt is byte-identical to a run without
+    // self-driving in front of it.
+    expect(getDetectedWarehouseSources(store.session)).toEqual([]);
+    const inherited = {
+      ...store.session,
+      frameworkContext: { ...store.session.frameworkContext },
+    };
+    expect(getDetectedWarehouseSources(inherited)).toEqual([]);
   });
 });
 

--- a/src/lib/programs/self-driving/detect.ts
+++ b/src/lib/programs/self-driving/detect.ts
@@ -331,17 +331,24 @@ export function detectSelfDrivingPrerequisites(
  * `DATABASE_URL`), Stripe and OpenAI — the wall of irrelevant options this is
  * supposed to remove.
  *
- * Exactly the kinds enumerated as inbox tools in #1022, which were sourced from
- * the context-mill `self-driving` skill's connected-tools list. Deliberately no
- * guesses beyond it: this list only decides what gets PROMOTED, so leaving a
- * kind out costs a nudge (the skill still offers the tool), while putting a kind
- * in that the inbox can't connect sends the agent after a source it can't
- * create. When the skill's catalog grows, reconcile here.
+ * The intersection of two lists, computed rather than guessed: the tools the
+ * connected-tools ask actually offers (the `options` array in context-mill's
+ * `self-driving/references/5-connected-tools.md`) and the kinds this repo can
+ * detect (`SOURCE_DETECTORS`). Promoting anything outside that intersection is
+ * wasted at best and misleading at worst — a tool the ask never lists can't be
+ * picked, so pointing the agent at it sends it after a source it can't create.
  *
- * A shadow list of the registry, so it drifts in one direction the guard test
- * can't catch: a new inbox-connectable kind added to `SOURCE_DETECTORS` has to
- * be added here too or it never gets promoted. If that bites, the fix is a
- * field on `SourceDetector` rather than a third copy of this list.
+ * The ask's remaining options are deliberately absent because no detector
+ * matches them (Freshservice, Dixa, pganalyze, SonarQube, Semgrep, Rapid7
+ * InsightVM, Featurebase, Frill, Aha, UserVoice, AskNicely, Retently,
+ * Appfigures, AppFollow, Judge.me). They stay offered by the skill; they just
+ * never get promoted, which is the safe direction.
+ *
+ * A shadow list of both sources, and the guard test only covers one of them —
+ * it catches a kind that leaves `SOURCE_DETECTORS`, but nothing here can see the
+ * skill's catalog change in another repo. So when step 5's option list grows,
+ * reconcile against it. If that becomes a habit, the fix is a field on
+ * `SourceDetector` rather than a third copy of this list.
  */
 export const SELF_DRIVING_TOOL_KINDS: ReadonlySet<string> = new Set([
   // Issue trackers / code hosts
@@ -350,16 +357,27 @@ export const SELF_DRIVING_TOOL_KINDS: ReadonlySet<string> = new Set([
   'Gitea',
   'Linear',
   'Jira',
-  // Error trackers
+  'Shortcut',
+  // Error tracking
   'Sentry',
   'Rollbar',
   'Bugsnag',
+  'Honeybadger',
+  'Raygun',
   // Support desks
   'Zendesk',
   'Freshdesk',
   'Front',
   'Gorgias',
-  'Intercom',
+  'Kustomer',
+  'Plain',
+  // Security scanners
+  'Snyk',
+  // Product feedback
+  'Canny',
+  'Productboard',
+  // Search analytics
+  'GoogleSearchConsole',
 ]);
 
 /**


### PR DESCRIPTION
## Problem

Two things found by actually running the flow and reading the skill the ask comes from, rather than inferring.

**1. The promoted-tools list was wrong in both directions.** I wrote it by hand from #1022's description instead of computing it. Against the real catalogue — the `options` array in context-mill's `self-driving/references/5-connected-tools.md` — it was missing nine tools that are both offered and detectable, and it included one the ask never offers.

**2. The regression test guarding #1028's fix isn't on this branch.** #1028 was merged at its first commit; the test commit pushed shortly after was orphaned. So the frameworkContext fix is live with nothing holding it in place.

## Why

The list decides what gets promoted to the top of the connected-tools ask. Missing entries silently never surface, so a repo using Shortcut or Snyk gets no benefit from the scan at all. The wrong entry is worse than useless: promoting a tool the ask doesn't list points the agent at a source it can't create.

And a fix with no test is one refactor away from regressing — this one is invisible when it breaks, because the symptom is a paragraph quietly appearing in a *different* program's prompt.

## Changes

- Recomputed the promoted set as the intersection of what step 5 offers and what `SOURCE_DETECTORS` can detect. Adds Shortcut, Honeybadger, Raygun, Kustomer, Plain, Canny, Productboard, Snyk, GoogleSearchConsole; drops Intercom. The comment now records which half came from where, and that the guard test only covers the detector half — the skill's catalogue lives in another repo and nothing here can see it change.
- Restored the leak regression test verbatim.

## Test plan

`pnpm build && pnpm test && pnpm fix` — 1671 tests pass, 0 lint errors. The guard test confirms all 21 kinds exist in the source registry. Re-verified the restored leak test fails when the shared-key write is reintroduced, so it is actually load-bearing.

## Notes for review

- **The ask is still unprioritised in practice.** `5-connected-tools.md` contains no reference to the detected block — the ordering is hardcoded in the skill, so the wizard-side change stays inert until the companion context-mill PR lands. Worth confirming that's tracked; "safe to land in either order" doesn't hold.
- The skill already has the hook for it: step 5 says to order the tools *"seeding with any step-2 hints so a tool you saw evidence of comes first among them"*. Pointing that at the wizard's deterministic block instead of step-2's light scan looks like a small change.
- Fifteen of the ask's options have no detector (Freshservice, Dixa, pganalyze, SonarQube, Semgrep, Rapid7 InsightVM, Featurebase, Frill, Aha, UserVoice, AskNicely, Retently, Appfigures, AppFollow, Judge.me). They stay offered, just never promoted — the safe direction, but if any deserve detectors that's a registry addition.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*