### PR TITLE
feat(feature-flags): add framework-aware wizard program

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ npx @posthog/wizard self-driving
 
 If PostHog isn't already installed, the wizard runs the default integration first (composed run) before starting the self-driving setup.
 
+### Feature flags
+
+Add one real PostHog feature flag to an existing application. The wizard detects
+the project's framework, installs the matching context-mill skill, creates or
+reuses a flag, implements one safe use case, and verifies the result:
+
+```bash
+npx @posthog/wizard feature-flags
+```
+
+This program requires an existing PostHog SDK integration. If the integration
+is missing, run the default wizard first and then rerun this command.
+
 ### Audit
 
 Audit an existing PostHog integration for correctness and best practices. The

--- a/bin.ts
+++ b/bin.ts
@@ -50,6 +50,7 @@ import { basicIntegrationCommand } from './src/commands/basic-integration';
 import { mcpCommand } from './src/commands/mcp';
 import { mcpAnalyticsCommand } from './src/commands/mcp-analytics';
 import { aiObservabilityCommand } from './src/commands/ai-observability';
+import { featureFlagsCommand } from './src/commands/feature-flags';
 import { auditCommand } from './src/commands/audit';
 import { doctorCommand } from './src/commands/doctor';
 import { migrateCommand } from './src/commands/migrate';
@@ -81,6 +82,7 @@ Wizard.use(basicIntegrationCommand)
   .use(mcpCommand)
   .use(mcpAnalyticsCommand)
   .use(aiObservabilityCommand)
+  .use(featureFlagsCommand)
   .use(cliCommand)
   .use(auditCommand)
   .use(doctorCommand)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -23,6 +23,16 @@ node --input-type=module -e "import '$DIST_BIN'" 2>&1 | head -5 | grep -q 'PostH
   exit 1
 }
 
+# The feature-flags program is still registered manually in bin.ts. Exercise
+# the compiled command so registry tests cannot pass while the public CLI is
+# accidentally left unmounted.
+feature_flags_help=$(node "$DIST_BIN" feature-flags --help 2>&1)
+if ! echo "$feature_flags_help" | grep -q 'Add a PostHog feature flag to an existing app'; then
+  echo 'Smoke test failed: feature-flags command is not mounted' >&2
+  echo "$feature_flags_help" | head -5 >&2
+  exit 1
+fi
+
 # ── 2. CI flag overrides physically absent from production builds ───────────
 # The override path (src/utils/ci-flag-overrides.ts) is dead code in published
 # builds and tsdown strips it; its env var name appearing in dist/*.js means

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -25,6 +25,7 @@ import { revenueCommand } from '../commands/revenue';
 import { warehouseCommand } from '../commands/warehouse';
 import { uploadSourcemapsCommand } from '../commands/upload-sourcemaps';
 import { selfDrivingCommand } from '../commands/self-driving';
+import { featureFlagsCommand } from '../commands/feature-flags';
 import {
   dispatchFamily,
   pickerChildrenToShow,
@@ -88,6 +89,11 @@ describe('top-level command shapes', () => {
   test('warehouse is a flat skill command', () => {
     expect(warehouseCommand.name).toBe('warehouse');
     expect(warehouseCommand.children).toBeUndefined();
+  });
+
+  test('feature-flags is a flat wizard-native command', () => {
+    expect(featureFlagsCommand.name).toBe('feature-flags');
+    expect(featureFlagsCommand.children).toBeUndefined();
   });
 
   test('audit exposes the shared skill options on the parent', () => {
@@ -191,6 +197,18 @@ describe('flat skill commands', () => {
       Record<string, unknown>,
     ];
     expect(config.skillId).toBe('data-warehouse-source-setup');
+    expect(opts.installDir).toBe('/tmp/some-app');
+  });
+
+  test('feature-flags dispatches without a fixed skillId', () => {
+    expect(featureFlagsCommand.handler).toBeDefined();
+    featureFlagsCommand.handler?.(makeArgv({ installDir: '/tmp/some-app' }));
+    const [config, opts] = mockRunWizard.mock.calls[0] as [
+      { id?: string; skillId?: string },
+      Record<string, unknown>,
+    ];
+    expect(config.id).toBe('feature-flags');
+    expect(config.skillId).toBeUndefined();
     expect(opts.installDir).toBe('/tmp/some-app');
   });
 });

--- a/src/commands/feature-flags.ts
+++ b/src/commands/feature-flags.ts
@@ -1,0 +1,7 @@
+import { featureFlagsConfig } from '@lib/programs/feature-flags/index';
+
+import type { Command } from './command';
+import { nativeCommandFactory } from './factories/native-command-factory';
+
+export const featureFlagsCommand: Command =
+  nativeCommandFactory(featureFlagsConfig);

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -140,6 +140,7 @@ export const PROGRAM_BINDINGS: Partial<Record<ProgramId, ProgramBinding>> = {
     harness: Harness.anthropic,
     model: SONNET_5_MODEL,
   },
+  'feature-flags': DEFAULT_BINDING,
   slack: DEFAULT_BINDING,
 };
 

--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -13,7 +13,8 @@
  * Current additions: `McpTutorial` layers read-only on every product
  * surface (feature flags, experiments, surveys, replays, errors, web
  * analytics, LLM analytics, cohorts, persons) plus read/write on
- * annotations; `AgentSkill` adds feature-flag read/write; the default
+ * annotations; `AgentSkill` and `FeatureFlags` add feature-flag
+ * read/write; the default
  * `PostHogIntegration` run and the standalone `slack` flow add
  * `integration:read` for the Connect-Slack step. Persistence writes (dashboard:write,
  * insight:write, notebook:write, query:read) come for free from the
@@ -219,6 +220,7 @@ const PROGRAM_SCOPE_ADDITIONS: Partial<Record<ProgramId, readonly string[]>> = {
   // ever changes, this line will fail to type-check.
   'mcp-tutorial': MCP_TUTORIAL_SCOPE_ADDITIONS,
   'agent-skill': AGENT_SKILL_SCOPE_ADDITIONS,
+  'feature-flags': AGENT_SKILL_SCOPE_ADDITIONS,
   'self-driving': SELF_DRIVING_SCOPE_ADDITIONS,
   'warehouse-source': WAREHOUSE_SOURCE_SCOPE_ADDITIONS,
   'posthog-integration': CONNECT_SLACK_SCOPE_ADDITIONS,

--- a/src/lib/programs/__tests__/feature-flags-deck.test.ts
+++ b/src/lib/programs/__tests__/feature-flags-deck.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Layout guard for the narrowest LearnCard split view. At 80 terminal columns,
+ * the feature-flags deck receives a 37-character pane.
+ */
+
+import type { ReactElement, ReactNode } from 'react';
+import { getContentBlocks } from '@lib/programs/feature-flags/content/index';
+
+const PANE_WIDTH_80COL = 37;
+
+function textOf(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join('');
+  const element = node as ReactElement<{ children?: ReactNode }>;
+  return textOf(element.props?.children);
+}
+
+describe('feature-flags learn deck', () => {
+  it('keeps fixed-layout lines within the 80-column pane', () => {
+    const wideLines: string[] = [];
+
+    for (const block of getContentBlocks()) {
+      if (
+        typeof block !== 'object' ||
+        !('type' in block) ||
+        block.type !== 'lines'
+      ) {
+        continue;
+      }
+
+      for (const line of block.lines) {
+        const text = textOf(line);
+        if ([...text].length > PANE_WIDTH_80COL) wideLines.push(text);
+      }
+    }
+
+    expect(wideLines).toEqual([]);
+  });
+});

--- a/src/lib/programs/__tests__/feature-flags-prompt.test.ts
+++ b/src/lib/programs/__tests__/feature-flags-prompt.test.ts
@@ -1,77 +1,69 @@
 import { featureFlagsConfig } from '@lib/programs/feature-flags';
 
+function getRun() {
+  const run = featureFlagsConfig.run;
+  expect(run).toBeDefined();
+  expect(typeof run).not.toBe('function');
+
+  if (!run || typeof run === 'function') {
+    throw new Error('Expected a static feature flags run configuration');
+  }
+
+  return run;
+}
+
 describe('feature flags program', () => {
-  it('discovers and installs the framework-specific feature flag skill', () => {
-    const run = featureFlagsConfig.run;
-    expect(run).toBeDefined();
-    expect(typeof run).not.toBe('function');
+  it('installs the skill before planning, then gates writes on confirmation', () => {
+    const prompt = getRun().customPrompt?.({} as never) ?? '';
 
-    const prompt =
-      run && typeof run !== 'function' ? run.customPrompt?.({} as never) : '';
+    const installSkill = prompt.indexOf('Call `install_skill`');
+    const createTasks = prompt.indexOf('`TaskCreate` calls');
+    const confirmProposal = prompt.indexOf(
+      'The proposal is an interactive decision gate',
+    );
 
+    expect(installSkill).toBeGreaterThan(-1);
+    expect(createTasks).toBeGreaterThan(installSkill);
+    expect(confirmProposal).toBeGreaterThan(createTasks);
     expect(prompt).toContain('category: "feature-flags"');
-    expect(prompt).toContain('feature-flags-nextjs');
-    expect(prompt).toContain('install_skill');
+    expect(prompt).toContain('one call per workflow stage');
+    expect(prompt).toMatch(
+      /Do not call `TaskUpdate`, run\s+another tool, or start workflow work until every initial task exists/,
+    );
+    expect(prompt).toMatch(
+      /Before any PostHog write or\s+application source edit, call `wizard_ask`/,
+    );
+    expect(prompt).toContain(
+      '[ABORT] Feature flag proposal confirmation is required.',
+    );
     expect(prompt).toContain(
       '[ABORT] A matching PostHog feature flag skill could not be installed.',
     );
   });
 
-  it('declares the PostHog integration prerequisite', () => {
-    expect(featureFlagsConfig.requires).toEqual(['posthog-integration']);
-  });
+  it('keeps SDK and environment inspection inside the installed workflow', () => {
+    const prompt = getRun().customPrompt?.({} as never) ?? '';
 
-  it('uses the existing SDK instead of installing or upgrading it', () => {
-    const run = featureFlagsConfig.run;
-    expect(run).toBeDefined();
-    expect(typeof run).not.toBe('function');
-
-    const prompt =
-      run && typeof run !== 'function' ? run.customPrompt?.({} as never) : '';
-
-    expect(prompt).toMatch(/Verify existing\s+PostHog SDK integration/);
     expect(prompt).toContain(
       'do not install, reinstall, or upgrade a PostHog SDK package',
     );
-    expect(prompt).toContain(
-      '[ABORT] A working PostHog SDK integration is required.',
+    expect(prompt).toMatch(
+      /Never\s+open, read, or search value-bearing `\.env\*` files/,
     );
-  });
-
-  it('leaves the feature flag workflow in the installed skill', () => {
-    const run = featureFlagsConfig.run;
-    expect(run).toBeDefined();
-    expect(typeof run).not.toBe('function');
-
-    const prompt =
-      run && typeof run !== 'function' ? run.customPrompt?.({} as never) : '';
-
+    expect(prompt).toContain('use `check_env_keys`');
     expect(prompt).toContain(
       'The installed skill owns the feature-flag workflow',
     );
-    expect(prompt).toContain('posthog-feature-flags-report.md');
-    expect(prompt).toContain('"Try your flag"');
-    expect(prompt).toContain('the control');
-    expect(prompt).toContain('the flagged behavior');
-    expect(prompt).not.toContain('Do not capture user-entered text');
-    expect(prompt).not.toContain('follow-up read confirms it');
   });
 
   it('ends with a project-specific flag verification handoff', () => {
-    const run = featureFlagsConfig.run;
-    expect(run).toBeDefined();
-    expect(typeof run).not.toBe('function');
-
-    const outro =
-      run && typeof run !== 'function'
-        ? run.buildOutroData?.(
-            {} as never,
-            {
-              projectId: 532532,
-              host: { appHost: 'https://us.posthog.com/' },
-            } as never,
-          )
-        : undefined;
+    const outro = getRun().buildOutroData?.(
+      {} as never,
+      {
+        projectId: 532532,
+        host: { appHost: 'https://us.posthog.com/' },
+      } as never,
+    );
 
     expect(outro).toMatchObject({
       message: 'Your feature flag is ready to test',
@@ -98,69 +90,21 @@ describe('feature flags program', () => {
     );
   });
 
-  it('maps the skill abort signals to actionable outros', () => {
-    const run = featureFlagsConfig.run;
-    expect(run).toBeDefined();
-    expect(typeof run).not.toBe('function');
+  it('maps every Wizard and Context Mill abort contract', () => {
+    const abortCases = getRun().abortCases ?? [];
+    const emittedSignals = [
+      'A working PostHog SDK integration is required.',
+      'A matching PostHog feature flag skill could not be installed.',
+      'Feature flag proposal confirmation is required.',
+      'PostHog feature flag access is required.',
+      'The selected feature flag skill does not match this application.',
+    ];
 
-    const abortCases =
-      run && typeof run !== 'function' ? run.abortCases ?? [] : [];
-
-    expect(abortCases).toHaveLength(4);
-    const missingSdk = abortCases.find((abortCase) =>
-      abortCase.match.test(
-        'A working PostHog SDK integration is required. Run the default PostHog Wizard.',
-      ),
-    );
-    expect(missingSdk).toMatchObject({
-      message: 'PostHog SDK setup required',
-      body: 'Run the standard PostHog Wizard first, then run `wizard feature-flags` again.',
-      docsUrl: 'https://posthog.com/docs/getting-started/install',
-    });
-    expect(missingSdk?.body).not.toContain('report');
-    const missingSkill = abortCases.find((abortCase) =>
-      abortCase.match.test(
-        'A matching PostHog feature flag skill could not be installed.',
-      ),
-    );
-    expect(missingSkill).toMatchObject({
-      message: 'Feature flag skill unavailable',
-      body: 'The Wizard could not find or install a feature flag skill that matches this app. Check your connection and try again.',
-      docsUrl: 'https://posthog.com/docs/feature-flags',
-    });
-    expect(
-      abortCases.some((abortCase) =>
-        abortCase.match.test('PostHog feature flag access is required.'),
-      ),
-    ).toBe(true);
-    expect(
-      abortCases.some((abortCase) =>
-        abortCase.match.test(
-          'The selected feature flag skill does not match this application.',
-        ),
-      ),
-    ).toBe(true);
-  });
-
-  it('ships feature flag teaching content instead of the generic skill deck', () => {
-    const blocks = featureFlagsConfig.getContentBlocks?.() ?? [];
-    const copy = blocks
-      .flatMap((block) => {
-        if (
-          typeof block === 'object' &&
-          block !== null &&
-          'content' in block &&
-          typeof block.content === 'string'
-        ) {
-          return [block.content];
-        }
-        return [];
-      })
-      .join(' ');
-
-    expect(blocks.length).toBeGreaterThan(10);
-    expect(copy).toContain('control experience');
-    expect(copy).toContain('security boundary');
-    expect(copy).toContain('exercising both experiences');
+    for (const signal of emittedSignals) {
+      expect(
+        abortCases.some((abortCase) => abortCase.match.test(signal)),
+        `Missing abort case for: ${signal}`,
+      ).toBe(true);
+    }
   });
 });

--- a/src/lib/programs/__tests__/feature-flags-prompt.test.ts
+++ b/src/lib/programs/__tests__/feature-flags-prompt.test.ts
@@ -1,0 +1,105 @@
+import { featureFlagsConfig } from '@lib/programs/feature-flags';
+
+describe('feature flags program', () => {
+  it('discovers and installs the framework-specific feature flag skill', () => {
+    const run = featureFlagsConfig.run;
+    expect(run).toBeDefined();
+    expect(typeof run).not.toBe('function');
+
+    const prompt =
+      run && typeof run !== 'function' ? run.customPrompt?.({} as never) : '';
+
+    expect(prompt).toContain('category: "feature-flags"');
+    expect(prompt).toContain('feature-flags-nextjs');
+    expect(prompt).toContain('install_skill');
+    expect(prompt).toContain(
+      '[ABORT] A matching PostHog feature flag skill could not be installed.',
+    );
+  });
+
+  it('declares the PostHog integration prerequisite', () => {
+    expect(featureFlagsConfig.requires).toEqual(['posthog-integration']);
+  });
+
+  it('leaves the feature flag workflow in the installed skill', () => {
+    const run = featureFlagsConfig.run;
+    expect(run).toBeDefined();
+    expect(typeof run).not.toBe('function');
+
+    const prompt =
+      run && typeof run !== 'function' ? run.customPrompt?.({} as never) : '';
+
+    expect(prompt).toContain(
+      'The installed skill owns the feature-flag workflow',
+    );
+    expect(prompt).toContain('posthog-feature-flags-report.md');
+    expect(prompt).not.toContain('Do not capture user-entered text');
+    expect(prompt).not.toContain('follow-up read confirms it');
+  });
+
+  it('maps the skill abort signals to actionable outros', () => {
+    const run = featureFlagsConfig.run;
+    expect(run).toBeDefined();
+    expect(typeof run).not.toBe('function');
+
+    const abortCases =
+      run && typeof run !== 'function' ? run.abortCases ?? [] : [];
+
+    expect(abortCases).toHaveLength(4);
+    const missingSdk = abortCases.find((abortCase) =>
+      abortCase.match.test(
+        'A working PostHog SDK integration is required. Run the default PostHog Wizard.',
+      ),
+    );
+    expect(missingSdk).toMatchObject({
+      message: 'PostHog SDK setup required',
+      body: 'Run the standard PostHog Wizard first, then run `wizard feature-flags` again.',
+      docsUrl: 'https://posthog.com/docs/getting-started/install',
+    });
+    expect(missingSdk?.body).not.toContain('report');
+    const missingSkill = abortCases.find((abortCase) =>
+      abortCase.match.test(
+        'A matching PostHog feature flag skill could not be installed.',
+      ),
+    );
+    expect(missingSkill).toMatchObject({
+      message: 'Feature flag skill unavailable',
+      body: 'The Wizard could not find or install a feature flag skill that matches this app. Check your connection and try again.',
+      docsUrl: 'https://posthog.com/docs/feature-flags',
+    });
+    expect(
+      abortCases.some((abortCase) =>
+        abortCase.match.test('PostHog feature flag access is required.'),
+      ),
+    ).toBe(true);
+    expect(
+      abortCases.some((abortCase) =>
+        abortCase.match.test(
+          'The selected feature flag skill does not match this application.',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('ships feature flag teaching content instead of the generic skill deck', () => {
+    const blocks = featureFlagsConfig.getContentBlocks?.() ?? [];
+    const copy = blocks
+      .flatMap((block) => {
+        if (
+          typeof block === 'object' &&
+          block !== null &&
+          'content' in block &&
+          typeof block.content === 'string'
+        ) {
+          return [block.content];
+        }
+        return [];
+      })
+      .join(' ');
+
+    expect(blocks.length).toBeGreaterThan(10);
+    expect(copy).toContain('control experience');
+    expect(copy).toContain('security boundary');
+    expect(copy).toContain('exercising both experiences');
+  });
+});

--- a/src/lib/programs/__tests__/feature-flags-prompt.test.ts
+++ b/src/lib/programs/__tests__/feature-flags-prompt.test.ts
@@ -21,6 +21,23 @@ describe('feature flags program', () => {
     expect(featureFlagsConfig.requires).toEqual(['posthog-integration']);
   });
 
+  it('uses the existing SDK instead of installing or upgrading it', () => {
+    const run = featureFlagsConfig.run;
+    expect(run).toBeDefined();
+    expect(typeof run).not.toBe('function');
+
+    const prompt =
+      run && typeof run !== 'function' ? run.customPrompt?.({} as never) : '';
+
+    expect(prompt).toMatch(/Verify existing\s+PostHog SDK integration/);
+    expect(prompt).toContain(
+      'do not install, reinstall, or upgrade a PostHog SDK package',
+    );
+    expect(prompt).toContain(
+      '[ABORT] A working PostHog SDK integration is required.',
+    );
+  });
+
   it('leaves the feature flag workflow in the installed skill', () => {
     const run = featureFlagsConfig.run;
     expect(run).toBeDefined();
@@ -33,8 +50,52 @@ describe('feature flags program', () => {
       'The installed skill owns the feature-flag workflow',
     );
     expect(prompt).toContain('posthog-feature-flags-report.md');
+    expect(prompt).toContain('"Try your flag"');
+    expect(prompt).toContain('the control');
+    expect(prompt).toContain('the flagged behavior');
     expect(prompt).not.toContain('Do not capture user-entered text');
     expect(prompt).not.toContain('follow-up read confirms it');
+  });
+
+  it('ends with a project-specific flag verification handoff', () => {
+    const run = featureFlagsConfig.run;
+    expect(run).toBeDefined();
+    expect(typeof run).not.toBe('function');
+
+    const outro =
+      run && typeof run !== 'function'
+        ? run.buildOutroData?.(
+            {} as never,
+            {
+              projectId: 532532,
+              host: { appHost: 'https://us.posthog.com/' },
+            } as never,
+          )
+        : undefined;
+
+    expect(outro).toMatchObject({
+      message: 'Your feature flag is ready to test',
+      primaryLink: {
+        label: 'Open Feature Flags',
+        url: 'https://us.posthog.com/project/532532/feature_flags',
+      },
+      nextSteps: {
+        heading: 'Try your flag:',
+        items: [
+          'Exercise the control experience',
+          'Enable the flag for your test person and exercise the flagged experience',
+          'Confirm the live evaluation in PostHog, then restore the safe rollout',
+        ],
+      },
+      reportFile: 'posthog-feature-flags-report.md',
+      docsUrl: 'https://posthog.com/docs/feature-flags',
+    });
+    expect(outro?.handoffPrompt).toContain(
+      'complete any blocked or not-run checks',
+    );
+    expect(outro?.handoffPrompt).toContain(
+      'get my approval before changing the flag rollout',
+    );
   });
 
   it('maps the skill abort signals to actionable outros', () => {

--- a/src/lib/programs/feature-flags/content/index.tsx
+++ b/src/lib/programs/feature-flags/content/index.tsx
@@ -1,0 +1,127 @@
+/**
+ * Feature-flags learn deck. It explains the safety model while the agent picks
+ * and runs the framework-specific Context Mill skill.
+ */
+
+import { Text } from 'ink';
+import { Colors } from '@ui/tui/styles';
+import { TextRevealMode } from '@ui/tui/primitives/TextBlock';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
+
+const FLAG_PATHS: ContentBlock = {
+  type: 'lines',
+  interval: 500,
+  pause: 6000,
+  lines: [
+    <Text>
+      <Text color={Colors.muted}>flag false</Text>
+      <Text dimColor>{'       -> control experience'}</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>flag true</Text>
+      <Text dimColor>{'        -> flagged experience'}</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.muted}>flag unavailable</Text>
+      <Text dimColor>{' -> control experience'}</Text>
+    </Text>,
+  ],
+};
+
+const VERIFICATION: ContentBlock = {
+  type: 'lines',
+  interval: 500,
+  pause: 7000,
+  lines: [
+    <Text>
+      <Text color={Colors.accent}>{'  1  '}</Text>
+      <Text>Run the control path</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>{'  2  '}</Text>
+      <Text>Run the flagged path</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>{'  3  '}</Text>
+      <Text>Confirm the live evaluation</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>{'  4  '}</Text>
+      <Text>Restore the safe rollout</Text>
+    </Text>,
+  ],
+};
+
+export const getContentBlocks = (): ContentBlock[] => [
+  {
+    content: 'Welcome.',
+    pause: 3000,
+    mode: TextRevealMode.Typewriter,
+    animationInterval: 160,
+  },
+  {
+    content:
+      "I'm choosing the feature flag skill that best matches this application.",
+    pause: 5000,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  {
+    content: 'Feature flags separate deployment from release.',
+    pause: 4500,
+  },
+  {
+    content:
+      'The code can ship while the existing experience remains the default.',
+    pause: 5000,
+  },
+  FLAG_PATHS,
+
+  { type: 'clear', pause: 1500 },
+
+  {
+    content: 'A safe flag has a boring fallback.',
+    pause: 4000,
+  },
+  {
+    content:
+      'False, unavailable, and still loading should all preserve the control experience.',
+    pause: 6000,
+  },
+  {
+    content:
+      'A feature flag can control product behavior, but it must never be the security boundary.',
+    pause: 6500,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  {
+    content: 'Where the flag is evaluated matters.',
+    pause: 4000,
+  },
+  {
+    content:
+      'Use server-side evaluation for the first paint, then bootstrap the value into the client to avoid flicker.',
+    pause: 6500,
+  },
+  {
+    content:
+      'Client-side evaluation fits interactions that happen after the page has loaded.',
+    pause: 5500,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  {
+    content: 'Verification means exercising both experiences.',
+    pause: 4500,
+  },
+  VERIFICATION,
+  {
+    content:
+      'Done means the code works and PostHog received a real flag evaluation.',
+    pause: 6000,
+  },
+];

--- a/src/lib/programs/feature-flags/content/index.tsx
+++ b/src/lib/programs/feature-flags/content/index.tsx
@@ -14,16 +14,16 @@ const FLAG_PATHS: ContentBlock = {
   pause: 6000,
   lines: [
     <Text>
-      <Text color={Colors.muted}>flag false</Text>
-      <Text dimColor>{'       -> control experience'}</Text>
+      <Text color={Colors.muted}>false</Text>
+      <Text dimColor>{'       -> control'}</Text>
     </Text>,
     <Text>
-      <Text color={Colors.accent}>flag true</Text>
-      <Text dimColor>{'        -> flagged experience'}</Text>
+      <Text color={Colors.accent}>true</Text>
+      <Text dimColor>{'        -> flagged'}</Text>
     </Text>,
     <Text>
-      <Text color={Colors.muted}>flag unavailable</Text>
-      <Text dimColor>{' -> control experience'}</Text>
+      <Text color={Colors.muted}>unavailable</Text>
+      <Text dimColor>{' -> control'}</Text>
     </Text>,
   ],
 };

--- a/src/lib/programs/feature-flags/content/index.tsx
+++ b/src/lib/programs/feature-flags/content/index.tsx
@@ -1,58 +1,26 @@
 /**
- * Feature-flags learn deck. It explains the safety model while the agent picks
- * and runs the framework-specific Context Mill skill.
+ * Feature-flags learn deck. It explains when to use the program, then teaches
+ * the release, fallback, evaluation, and verification model while the agent
+ * runs the framework-specific Context Mill skill.
  */
 
 import { Text } from 'ink';
 import { Colors } from '@ui/tui/styles';
+import type { WizardStore } from '@ui/tui/store';
 import { TextRevealMode } from '@ui/tui/primitives/TextBlock';
 import type { ContentBlock } from '@ui/tui/primitives/content-types';
+import { StatusPeekTrigger } from '@ui/tui/components/StatusPeekTrigger';
+import {
+  EVALUATION_PLACEMENT,
+  RELEASE_SWITCH,
+  ROLLOUT_METER,
+  SAFE_PATHS,
+  VERIFICATION_LOOP,
+} from './visuals.js';
 
-const FLAG_PATHS: ContentBlock = {
-  type: 'lines',
-  interval: 500,
-  pause: 6000,
-  lines: [
-    <Text>
-      <Text color={Colors.muted}>false</Text>
-      <Text dimColor>{'       -> control'}</Text>
-    </Text>,
-    <Text>
-      <Text color={Colors.accent}>true</Text>
-      <Text dimColor>{'        -> flagged'}</Text>
-    </Text>,
-    <Text>
-      <Text color={Colors.muted}>unavailable</Text>
-      <Text dimColor>{' -> control'}</Text>
-    </Text>,
-  ],
-};
+const CLEAR: ContentBlock = { type: 'clear', pause: 1500 };
 
-const VERIFICATION: ContentBlock = {
-  type: 'lines',
-  interval: 500,
-  pause: 7000,
-  lines: [
-    <Text>
-      <Text color={Colors.accent}>{'  1  '}</Text>
-      <Text>Run the control path</Text>
-    </Text>,
-    <Text>
-      <Text color={Colors.accent}>{'  2  '}</Text>
-      <Text>Run the flagged path</Text>
-    </Text>,
-    <Text>
-      <Text color={Colors.accent}>{'  3  '}</Text>
-      <Text>Confirm the live evaluation</Text>
-    </Text>,
-    <Text>
-      <Text color={Colors.accent}>{'  4  '}</Text>
-      <Text>Restore the safe rollout</Text>
-    </Text>,
-  ],
-};
-
-export const getContentBlocks = (): ContentBlock[] => [
+export const getContentBlocks = (store?: WizardStore): ContentBlock[] => [
   {
     content: 'Welcome.',
     pause: 3000,
@@ -61,67 +29,110 @@ export const getContentBlocks = (): ContentBlock[] => [
   },
   {
     content:
-      "I'm choosing the feature flag skill that best matches this application.",
+      "You have a change to ship, but you're not ready to release it to everyone.",
+    pause: 5000,
+  },
+  { content: "That's when you reach for a feature flag.", pause: 4000 },
+  {
+    content: 'The Wizard handles the wiring. You keep the rollout.',
     pause: 5000,
   },
 
-  { type: 'clear', pause: 1500 },
+  CLEAR,
 
   {
-    content: 'Feature flags separate deployment from release.',
-    pause: 4500,
-  },
-  {
-    content:
-      'The code can ship while the existing experience remains the default.',
     pause: 5000,
-  },
-  FLAG_PATHS,
-
-  { type: 'clear', pause: 1500 },
-
-  {
-    content: 'A safe flag has a boring fallback.',
-    pause: 4000,
+    persist: true,
+    content: <StatusPeekTrigger store={store} />,
   },
   {
-    content:
-      'False, unavailable, and still loading should all preserve the control experience.',
     pause: 6000,
+    content: (
+      <Text>
+        Press{' '}
+        <Text color={Colors.accent} bold>
+          S
+        </Text>{' '}
+        to expand or collapse the status.
+      </Text>
+    ),
+  },
+
+  CLEAR,
+
+  {
+    content: 'Deploying code and releasing it are different jobs.',
+    pause: 5000,
   },
   {
     content:
-      'A feature flag can control product behavior, but it must never be the security boundary.',
-    pause: 6500,
+      'Your deploy puts the code in production. The flag decides who meets it.',
+    pause: 5500,
   },
+  RELEASE_SWITCH,
 
-  { type: 'clear', pause: 1500 },
+  CLEAR,
 
   {
-    content: 'Where the flag is evaluated matters.',
+    content: 'New flags start at 0%. Nobody gets surprised.',
     pause: 4000,
   },
   {
     content:
-      'Use server-side evaluation for the first paint, then bootstrap the value into the client to avoid flicker.',
-    pause: 6500,
+      'Release to a small group, watch the result, then widen the rollout.',
+    pause: 5500,
   },
+  ROLLOUT_METER,
   {
     content:
-      'Client-side evaluation fits interactions that happen after the page has loaded.',
+      'If the release misbehaves, return the rollout to 0% instead of redeploying.',
     pause: 5500,
   },
 
-  { type: 'clear', pause: 1500 },
+  CLEAR,
 
-  {
-    content: 'Verification means exercising both experiences.',
-    pause: 4500,
-  },
-  VERIFICATION,
+  { content: 'A safe fallback should be gloriously boring.', pause: 4500 },
   {
     content:
-      'Done means the code works and PostHog received a real flag evaluation.',
+      'False, loading, or unavailable all lead back to the existing experience.',
+    pause: 5500,
+  },
+  SAFE_PATHS,
+  {
+    content:
+      'Flags choose an experience. Authentication and permissions stay in code.',
     pause: 6000,
   },
+
+  CLEAR,
+
+  {
+    content: 'Evaluate the flag where the experience begins.',
+    pause: 4000,
+  },
+  {
+    content:
+      'For the first paint, evaluate on the server and bootstrap the value to avoid flicker.',
+    pause: 6000,
+  },
+  {
+    content:
+      'For an interaction after load, client-side evaluation is a good fit.',
+    pause: 5000,
+  },
+  EVALUATION_PLACEMENT,
+
+  CLEAR,
+
+  {
+    content: 'Test both doors before inviting users in.',
+    pause: 4500,
+  },
+  VERIFICATION_LOOP,
+  {
+    content:
+      'Done means both experiences work and PostHog received a live evaluation.',
+    pause: 6000,
+  },
+  { content: 'Ship the code. Keep the release button.', pause: 8000 },
 ];

--- a/src/lib/programs/feature-flags/content/visuals.tsx
+++ b/src/lib/programs/feature-flags/content/visuals.tsx
@@ -1,0 +1,120 @@
+/**
+ * Compact feature-flag diagrams for the Learn pane. Every line fits the
+ * 37-character pane used at the narrowest split-view width.
+ */
+
+import { Text } from 'ink';
+import { Colors } from '@ui/tui/styles';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
+
+export const RELEASE_SWITCH: ContentBlock = {
+  type: 'lines',
+  interval: 350,
+  pause: 7000,
+  lines: [
+    <Text bold>{'        deployed code'}</Text>,
+    <Text color={Colors.muted}>{'              |'}</Text>,
+    <Text bold color={Colors.accent}>
+      {'        feature flag'}
+    </Text>,
+    <Text color={Colors.muted}>{'          /        \\'}</Text>,
+    <Text>
+      <Text color={Colors.muted}>{'       control'}</Text>
+      <Text color="cyan">{'     change'}</Text>
+    </Text>,
+  ],
+};
+
+export const ROLLOUT_METER: ContentBlock = {
+  type: 'lines',
+  interval: 450,
+  pause: 8000,
+  lines: [
+    <Text>
+      <Text color={Colors.accent}>0% </Text>
+      <Text color={Colors.muted}>{' [----------]'}</Text>
+      <Text dimColor>{' safe start'}</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>10%</Text>
+      <Text color="cyan">{' [#'}</Text>
+      <Text color={Colors.muted}>{'---------]'}</Text>
+      <Text dimColor>{' small group'}</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>50%</Text>
+      <Text color="cyan">{' [#####'}</Text>
+      <Text color={Colors.muted}>{'-----]'}</Text>
+      <Text dimColor>{' wider release'}</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>100%</Text>
+      <Text color="cyan">{' [##########]'}</Text>
+      <Text dimColor>{' everyone'}</Text>
+    </Text>,
+  ],
+};
+
+export const SAFE_PATHS: ContentBlock = {
+  type: 'lines',
+  interval: 400,
+  pause: 7000,
+  lines: [
+    <Text>
+      <Text color={Colors.muted}>false</Text>
+      <Text dimColor>{'       -> control'}</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.muted}>loading</Text>
+      <Text dimColor>{'     -> control'}</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.muted}>unavailable</Text>
+      <Text dimColor>{' -> control'}</Text>
+    </Text>,
+    <Text>
+      <Text color="cyan">true</Text>
+      <Text dimColor>{'        -> change'}</Text>
+    </Text>,
+  ],
+};
+
+export const EVALUATION_PLACEMENT: ContentBlock = {
+  type: 'lines',
+  interval: 500,
+  pause: 7000,
+  lines: [
+    <Text>
+      <Text color={Colors.accent}>first paint</Text>
+      <Text dimColor>{'  -> server + bootstrap'}</Text>
+    </Text>,
+    <Text>
+      <Text color="cyan">later action</Text>
+      <Text dimColor>{' -> client'}</Text>
+    </Text>,
+  ],
+};
+
+export const VERIFICATION_LOOP: ContentBlock = {
+  type: 'lines',
+  interval: 500,
+  pause: 8000,
+  lines: [
+    <Text>
+      <Text color={Colors.accent}>{'  1  '}</Text>
+      <Text>Run the control experience</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>{'  2  '}</Text>
+      <Text>Run the flagged experience</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>{'  3  '}</Text>
+      <Text>Confirm a live evaluation</Text>
+    </Text>,
+    <Text>
+      <Text color={Colors.accent}>{'  4  '}</Text>
+      <Text>Restore the safe rollout</Text>
+    </Text>,
+  ],
+};

--- a/src/lib/programs/feature-flags/index.ts
+++ b/src/lib/programs/feature-flags/index.ts
@@ -1,8 +1,11 @@
 import type { ProgramConfig } from '@lib/programs/program-step';
 import { AGENT_SKILL_STEPS } from '@lib/programs/agent-skill/index';
+import { OutroKind } from '@lib/wizard-session';
 import { getContentBlocks } from './content/index.js';
 
 const FEATURE_FLAGS_REPORT_FILE = 'posthog-feature-flags-report.md';
+const FEATURE_FLAGS_DOCS_URL = 'https://posthog.com/docs/feature-flags';
+const SUCCESS_MESSAGE = 'Your feature flag is ready to test';
 
 /**
  * No fixed `skillId`: context-mill publishes one feature-flag skill per
@@ -22,6 +25,16 @@ export const featureFlagsConfig: ProgramConfig = {
     customPrompt:
       () => `Add one real PostHog feature flag to this existing application.
 
+Before planning any application changes, verify that the app already has a
+working PostHog SDK integration. Name this prerequisite check "Verify existing
+PostHog SDK integration." Use the existing SDK dependency and configuration;
+do not install, reinstall, or upgrade a PostHog SDK package.
+
+If the PostHog SDK integration is missing or not working, do not modify the app.
+Emit exactly:
+
+[ABORT] A working PostHog SDK integration is required.
+
 This flow has no pre-installed skill:
 
 1. Inspect the project's manifest and source tree to identify its framework and
@@ -39,12 +52,40 @@ without the knowledge source. Emit exactly:
 
 The installed skill owns the feature-flag workflow, PostHog configuration,
 application changes, verification, and secret-handling guidance. Write its
-final report to ./${FEATURE_FLAGS_REPORT_FILE}.`,
-    successMessage: `Feature flag added! View the report at ./${FEATURE_FLAGS_REPORT_FILE}`,
+final report to ./${FEATURE_FLAGS_REPORT_FILE}.
+
+End the report with a short "Try your flag" section that states the control
+behavior, the flagged behavior, and any verification still blocked or not run.
+Do not duplicate the detailed verification table.`,
+    successMessage: SUCCESS_MESSAGE,
     reportFile: FEATURE_FLAGS_REPORT_FILE,
-    docsUrl: 'https://posthog.com/docs/feature-flags',
+    docsUrl: FEATURE_FLAGS_DOCS_URL,
     spinnerMessage: 'Adding a PostHog feature flag...',
     estimatedDurationMinutes: 5,
+    buildOutroData: (_session, credentials) => {
+      const uiHost = credentials.host.appHost.replace(/\/$/, '');
+      const featureFlagsUrl = `${uiHost}/project/${credentials.projectId}/feature_flags`;
+
+      return {
+        kind: OutroKind.Success as const,
+        message: SUCCESS_MESSAGE,
+        primaryLink: {
+          label: 'Open Feature Flags',
+          url: featureFlagsUrl,
+        },
+        nextSteps: {
+          heading: 'Try your flag:',
+          items: [
+            'Exercise the control experience',
+            'Enable the flag for your test person and exercise the flagged experience',
+            'Confirm the live evaluation in PostHog, then restore the safe rollout',
+          ],
+        },
+        reportFile: FEATURE_FLAGS_REPORT_FILE,
+        docsUrl: FEATURE_FLAGS_DOCS_URL,
+        handoffPrompt: `Read \`${FEATURE_FLAGS_REPORT_FILE}\` and help me complete any blocked or not-run checks in its verification table. Start with the control and flagged experiences, and get my approval before changing the flag rollout.`,
+      };
+    },
     abortCases: [
       {
         match: /a working PostHog SDK integration is required/i,
@@ -56,7 +97,7 @@ final report to ./${FEATURE_FLAGS_REPORT_FILE}.`,
         match: /a matching PostHog feature flag skill could not be installed/i,
         message: 'Feature flag skill unavailable',
         body: 'The Wizard could not find or install a feature flag skill that matches this app. Check your connection and try again.',
-        docsUrl: 'https://posthog.com/docs/feature-flags',
+        docsUrl: FEATURE_FLAGS_DOCS_URL,
       },
       {
         match: /PostHog feature flag access is required/i,
@@ -69,7 +110,7 @@ final report to ./${FEATURE_FLAGS_REPORT_FILE}.`,
         match: /selected feature flag skill does not match this application/i,
         message: 'Feature flag skill does not match this app',
         body: 'Run the command again so the agent can select the framework-specific feature flag skill.',
-        docsUrl: 'https://posthog.com/docs/feature-flags',
+        docsUrl: FEATURE_FLAGS_DOCS_URL,
       },
     ],
   },

--- a/src/lib/programs/feature-flags/index.ts
+++ b/src/lib/programs/feature-flags/index.ts
@@ -1,4 +1,4 @@
-import type { ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramConfig, ProgramStep } from '@lib/programs/program-step';
 import { AGENT_SKILL_STEPS } from '@lib/programs/agent-skill/index';
 import { OutroKind } from '@lib/wizard-session';
 import { getContentBlocks } from './content/index.js';
@@ -7,22 +7,27 @@ const FEATURE_FLAGS_REPORT_FILE = 'posthog-feature-flags-report.md';
 const FEATURE_FLAGS_DOCS_URL = 'https://posthog.com/docs/feature-flags';
 const SUCCESS_MESSAGE = 'Your feature flag is ready to test';
 
+const FEATURE_FLAGS_STEPS: ProgramStep[] = AGENT_SKILL_STEPS.map((step) =>
+  step.id === 'intro' ? { ...step, screenId: 'feature-flags-intro' } : step,
+);
+
 /**
  * No fixed `skillId`: context-mill publishes one feature-flag skill per
  * framework, so the agent selects and installs the matching variant at runtime.
  */
 export const featureFlagsConfig: ProgramConfig = {
   command: 'feature-flags',
-  description: 'Add a PostHog feature flag to an existing app',
+  description: 'Ship an existing product change behind a PostHog feature flag',
   id: 'feature-flags',
-  steps: AGENT_SKILL_STEPS,
+  steps: FEATURE_FLAGS_STEPS,
   reportFile: FEATURE_FLAGS_REPORT_FILE,
   getContentBlocks,
   requires: ['posthog-integration'],
   run: {
     integrationLabel: 'feature-flags',
     customPrompt:
-      () => `Add one real PostHog feature flag to this existing application.
+      () => `Place one developer-approved product change behind a real PostHog
+feature flag in this existing application.
 
 This flow has no pre-installed skill:
 
@@ -75,7 +80,7 @@ Do not duplicate the detailed verification table.`,
     successMessage: SUCCESS_MESSAGE,
     reportFile: FEATURE_FLAGS_REPORT_FILE,
     docsUrl: FEATURE_FLAGS_DOCS_URL,
-    spinnerMessage: 'Adding a PostHog feature flag...',
+    spinnerMessage: 'Putting your change behind a PostHog feature flag...',
     estimatedDurationMinutes: 5,
     buildOutroData: (_session, credentials) => {
       const uiHost = credentials.host.appHost.replace(/\/$/, '');

--- a/src/lib/programs/feature-flags/index.ts
+++ b/src/lib/programs/feature-flags/index.ts
@@ -18,7 +18,6 @@ export const featureFlagsConfig: ProgramConfig = {
   steps: AGENT_SKILL_STEPS,
   reportFile: FEATURE_FLAGS_REPORT_FILE,
   getContentBlocks,
-  allowedTools: ['Agent'],
   requires: ['posthog-integration'],
   run: {
     integrationLabel: 'feature-flags',

--- a/src/lib/programs/feature-flags/index.ts
+++ b/src/lib/programs/feature-flags/index.ts
@@ -24,30 +24,46 @@ export const featureFlagsConfig: ProgramConfig = {
     customPrompt:
       () => `Add one real PostHog feature flag to this existing application.
 
-Before planning any application changes, verify that the app already has a
-working PostHog SDK integration. Name this prerequisite check "Verify existing
-PostHog SDK integration." Use the existing SDK dependency and configuration;
-do not install, reinstall, or upgrade a PostHog SDK package.
-
-If the PostHog SDK integration is missing or not working, do not modify the app.
-Emit exactly:
-
-[ABORT] A working PostHog SDK integration is required.
-
 This flow has no pre-installed skill:
 
 1. Inspect the project's manifest and source tree to identify its framework and
    language.
 2. Call \`load_skill_menu\` once with \`category: "feature-flags"\` and select
-   the most specific matching framework skill. For Next.js, select
-   \`feature-flags-nextjs\`; do not substitute the broad omnibus skill.
-3. Call \`install_skill\` with the selected skill ID, then follow its
-   \`SKILL.md\` and linked references end-to-end.
+   the most specific matching framework skill. Prefer a framework-specific
+   variant over a broad or omnibus skill.
+3. Call \`install_skill\` with the selected skill ID.
+4. Read the installed \`SKILL.md\` and its first workflow reference before
+   planning or changing the application.
 
 If no matching skill is available or \`install_skill\` fails, do not continue
 without the knowledge source. Emit exactly:
 
 [ABORT] A matching PostHog feature flag skill could not be installed.
+
+After reading the workflow, your next message must contain ONLY parallel
+\`TaskCreate\` calls: one call per workflow stage, all in the order defined by
+the skill. The tool accepts one task per call. Do not call \`TaskUpdate\`, run
+another tool, or start workflow work until every initial task exists.
+
+Follow the installed skill in order. Its first step verifies the existing
+PostHog SDK integration. Use the SDK dependency and configuration already in
+the project; do not install, reinstall, or upgrade a PostHog SDK package. Never
+open, read, or search value-bearing \`.env*\` files. Enumerate environment
+filenames without their contents, then use \`check_env_keys\` to check only
+whether the required configuration names are present.
+
+The proposal is an interactive decision gate. Inspect the current working tree
+and prefer a suitable developer-owned change. Before any PostHog write or
+application source edit, call \`wizard_ask\` with the proposal required by the
+skill and wait for the answer. Make this one batched call for the decision: let
+the developer accept the recommendation, choose another inspected candidate
+when available, or describe a different behavior in an optional text answer.
+Never choose or implement a demonstration feature without confirmation.
+
+If \`wizard_ask\` is unavailable, cancelled, or returns no confirmed behavior,
+do not call a PostHog write tool or edit application source. Emit exactly:
+
+[ABORT] Feature flag proposal confirmation is required.
 
 The installed skill owns the feature-flag workflow, PostHog configuration,
 application changes, verification, and secret-handling guidance. Write its
@@ -96,6 +112,12 @@ Do not duplicate the detailed verification table.`,
         match: /a matching PostHog feature flag skill could not be installed/i,
         message: 'Feature flag skill unavailable',
         body: 'The Wizard could not find or install a feature flag skill that matches this app. Check your connection and try again.',
+        docsUrl: FEATURE_FLAGS_DOCS_URL,
+      },
+      {
+        match: /feature flag proposal confirmation is required/i,
+        message: 'Feature flag proposal not confirmed',
+        body: 'Run the command again and confirm which product change the Wizard should place behind the flag.',
         docsUrl: FEATURE_FLAGS_DOCS_URL,
       },
       {

--- a/src/lib/programs/feature-flags/index.ts
+++ b/src/lib/programs/feature-flags/index.ts
@@ -1,0 +1,76 @@
+import type { ProgramConfig } from '@lib/programs/program-step';
+import { AGENT_SKILL_STEPS } from '@lib/programs/agent-skill/index';
+import { getContentBlocks } from './content/index.js';
+
+const FEATURE_FLAGS_REPORT_FILE = 'posthog-feature-flags-report.md';
+
+/**
+ * No fixed `skillId`: context-mill publishes one feature-flag skill per
+ * framework, so the agent selects and installs the matching variant at runtime.
+ */
+export const featureFlagsConfig: ProgramConfig = {
+  command: 'feature-flags',
+  description: 'Add a PostHog feature flag to an existing app',
+  id: 'feature-flags',
+  steps: AGENT_SKILL_STEPS,
+  reportFile: FEATURE_FLAGS_REPORT_FILE,
+  getContentBlocks,
+  allowedTools: ['Agent'],
+  requires: ['posthog-integration'],
+  run: {
+    integrationLabel: 'feature-flags',
+    customPrompt:
+      () => `Add one real PostHog feature flag to this existing application.
+
+This flow has no pre-installed skill:
+
+1. Inspect the project's manifest and source tree to identify its framework and
+   language.
+2. Call \`load_skill_menu\` once with \`category: "feature-flags"\` and select
+   the most specific matching framework skill. For Next.js, select
+   \`feature-flags-nextjs\`; do not substitute the broad omnibus skill.
+3. Call \`install_skill\` with the selected skill ID, then follow its
+   \`SKILL.md\` and linked references end-to-end.
+
+If no matching skill is available or \`install_skill\` fails, do not continue
+without the knowledge source. Emit exactly:
+
+[ABORT] A matching PostHog feature flag skill could not be installed.
+
+The installed skill owns the feature-flag workflow, PostHog configuration,
+application changes, verification, and secret-handling guidance. Write its
+final report to ./${FEATURE_FLAGS_REPORT_FILE}.`,
+    successMessage: `Feature flag added! View the report at ./${FEATURE_FLAGS_REPORT_FILE}`,
+    reportFile: FEATURE_FLAGS_REPORT_FILE,
+    docsUrl: 'https://posthog.com/docs/feature-flags',
+    spinnerMessage: 'Adding a PostHog feature flag...',
+    estimatedDurationMinutes: 5,
+    abortCases: [
+      {
+        match: /a working PostHog SDK integration is required/i,
+        message: 'PostHog SDK setup required',
+        body: 'Run the standard PostHog Wizard first, then run `wizard feature-flags` again.',
+        docsUrl: 'https://posthog.com/docs/getting-started/install',
+      },
+      {
+        match: /a matching PostHog feature flag skill could not be installed/i,
+        message: 'Feature flag skill unavailable',
+        body: 'The Wizard could not find or install a feature flag skill that matches this app. Check your connection and try again.',
+        docsUrl: 'https://posthog.com/docs/feature-flags',
+      },
+      {
+        match: /PostHog feature flag access is required/i,
+        message: 'PostHog feature flag access required',
+        body: 'Reconnect PostHog MCP with feature flag access, or create the proposed flag in PostHog and run the command again.',
+        docsUrl:
+          'https://posthog.com/docs/feature-flags/creating-feature-flags',
+      },
+      {
+        match: /selected feature flag skill does not match this application/i,
+        message: 'Feature flag skill does not match this app',
+        body: 'Run the command again so the agent can select the framework-specific feature flag skill.',
+        docsUrl: 'https://posthog.com/docs/feature-flags',
+      },
+    ],
+  },
+};

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -31,6 +31,7 @@ import {
 } from './mcp/index.js';
 import { mcpAnalyticsConfig } from './mcp-analytics/index.js';
 import { aiObservabilityConfig } from './ai-observability/index.js';
+import { featureFlagsConfig } from './feature-flags/index.js';
 import { slackConnectConfig } from './slack/index.js';
 
 // Generic skill program — runs an arbitrary context-mill skill chosen at
@@ -80,6 +81,7 @@ export const PROGRAM_REGISTRY = [
   mcpTutorialConfig,
   mcpAnalyticsConfig,
   aiObservabilityConfig,
+  featureFlagsConfig,
   slackConnectConfig,
 ] as const satisfies readonly ProgramConfig[];
 
@@ -105,6 +107,7 @@ export const Program = {
   McpTutorial: mcpTutorialConfig.id,
   McpAnalytics: mcpAnalyticsConfig.id,
   AiObservability: aiObservabilityConfig.id,
+  FeatureFlags: featureFlagsConfig.id,
   SlackConnect: slackConnectConfig.id,
 } as const;
 

--- a/src/ui/tui/__tests__/agent-skill-intro.test.ts
+++ b/src/ui/tui/__tests__/agent-skill-intro.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getAgentSkillIntroTarget } from '../screens/AgentSkillIntroScreen.js';
+
+describe('getAgentSkillIntroTarget', () => {
+  it('uses the selected skill when one is known before the run', () => {
+    expect(getAgentSkillIntroTarget('events-audit', 'audit')).toEqual({
+      label: 'events-audit',
+      noun: 'skill',
+    });
+  });
+
+  it('uses the program label when the agent selects a skill at runtime', () => {
+    expect(getAgentSkillIntroTarget(null, 'feature-flags')).toEqual({
+      label: 'feature-flags',
+      noun: 'program',
+    });
+  });
+});

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -28,6 +28,7 @@ import { SourceMapsDetectScreen } from './screens/SourceMapsDetectScreen.js';
 import { SourceMapsOutroScreen } from './screens/SourceMapsOutroScreen.js';
 import { AgentSkillIntroScreen } from './screens/AgentSkillIntroScreen.js';
 import { AiObservabilityIntroScreen } from './screens/AiObservabilityIntroScreen.js';
+import { FeatureFlagsIntroScreen } from './screens/FeatureFlagsIntroScreen.js';
 import { SelfDrivingIntroScreen } from './screens/SelfDrivingIntroScreen.js';
 import { SelfDrivingIntegrationCheckScreen } from './screens/SelfDrivingIntegrationCheckScreen.js';
 import { SelfDrivingIntegrationDetectScreen } from './screens/SelfDrivingIntegrationDetectScreen.js';
@@ -91,6 +92,7 @@ export function createScreens(
     [ScreenId.AiObservabilityIntro]: (
       <AiObservabilityIntroScreen store={store} />
     ),
+    [ScreenId.FeatureFlagsIntro]: <FeatureFlagsIntroScreen store={store} />,
     [ScreenId.SelfDrivingIntro]: <SelfDrivingIntroScreen store={store} />,
     [ScreenId.SelfDrivingIntegrationCheck]: (
       <SelfDrivingIntegrationCheckScreen store={store} />

--- a/src/ui/tui/screen-sequences.ts
+++ b/src/ui/tui/screen-sequences.ts
@@ -25,6 +25,7 @@ export enum ScreenId {
   MigrationIntro = 'migration-intro',
   AgentSkillIntro = 'agent-skill-intro',
   AiObservabilityIntro = 'ai-observability-intro',
+  FeatureFlagsIntro = 'feature-flags-intro',
   SelfDrivingIntro = 'self-driving-intro',
   SelfDrivingIntegrationCheck = 'self-driving-integration-check',
   SelfDrivingIntegrationDetect = 'self-driving-integration-detect',

--- a/src/ui/tui/screens/AgentSkillIntroScreen.tsx
+++ b/src/ui/tui/screens/AgentSkillIntroScreen.tsx
@@ -16,6 +16,15 @@ interface AgentSkillIntroScreenProps {
   store: WizardStore;
 }
 
+export function getAgentSkillIntroTarget(
+  skillId: string | null,
+  programLabel: string | null,
+): { label: string; noun: 'program' | 'skill' } {
+  return skillId
+    ? { label: skillId, noun: 'skill' }
+    : { label: programLabel ?? 'Wizard', noun: 'program' };
+}
+
 export const AgentSkillIntroScreen = ({
   store,
 }: AgentSkillIntroScreenProps) => {
@@ -27,7 +36,8 @@ export const AgentSkillIntroScreen = ({
   const [showingMoreInfo, setShowingMoreInfo] = useState(false);
 
   const { session } = store;
-  const skillId = session.skillId ?? 'unknown';
+  const skillId = session.skillId;
+  const target = getAgentSkillIntroTarget(skillId, session.programLabel);
   const { skillEntry, fetchFailed } = useSkillEntry(skillId, session.localMcp);
 
   let body: ReactNode;
@@ -41,14 +51,23 @@ export const AgentSkillIntroScreen = ({
             source: <Text color="cyan">https://github.com/PostHog/wizard</Text>
           </Text>
         </Box>
-        <SkillSourceInfo
-          skillId={skillId}
-          skillEntry={skillEntry}
-          fetchFailed={fetchFailed}
-        />
+        {skillId ? (
+          <SkillSourceInfo
+            skillId={skillId}
+            skillEntry={skillEntry}
+            fetchFailed={fetchFailed}
+          />
+        ) : (
+          <Text dimColor>
+            The program selects the matching Context Mill skill after inspecting
+            the app.
+          </Text>
+        )}
         <Box marginTop={1}>
           <Text dimColor>
-            {skillEntry?.name ?? (fetchFailed ? skillId : 'Loading...')}
+            {skillId
+              ? skillEntry?.name ?? (fetchFailed ? skillId : 'Loading...')
+              : target.label}
           </Text>
         </Box>
       </Box>
@@ -58,9 +77,9 @@ export const AgentSkillIntroScreen = ({
       <Text>
         Let's run the{' '}
         <Text italic color="cyan">
-          {skillId}
+          {target.label}
         </Text>{' '}
-        skill.
+        {target.noun}.
       </Text>
     );
   }

--- a/src/ui/tui/screens/FeatureFlagsIntroScreen.tsx
+++ b/src/ui/tui/screens/FeatureFlagsIntroScreen.tsx
@@ -74,7 +74,10 @@ export const FeatureFlagsIntroScreen = ({
         <Text dimColor>It wires both experiences. You keep the rollout.</Text>
       </Box>
       <Box marginTop={1}>
-        <Text dimColor>About five minutes. New flags start at 0%.</Text>
+        <Text dimColor>
+          Setup usually takes about five minutes. New flags start at 0% rollout,
+          so you decide when to release.
+        </Text>
       </Box>
     </Box>
   );

--- a/src/ui/tui/screens/FeatureFlagsIntroScreen.tsx
+++ b/src/ui/tui/screens/FeatureFlagsIntroScreen.tsx
@@ -1,0 +1,113 @@
+import { Box, Text } from 'ink';
+import { useState, useSyncExternalStore } from 'react';
+import type { WizardStore } from '@ui/tui/store';
+import { IntroScreenLayout } from './IntroScreenLayout.js';
+
+interface FeatureFlagsIntroScreenProps {
+  store: WizardStore;
+}
+
+export const FeatureFlagsIntroScreen = ({
+  store,
+}: FeatureFlagsIntroScreenProps) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  const [showingMoreInfo, setShowingMoreInfo] = useState(false);
+  const { session } = store;
+
+  const subtitle = (
+    <>
+      <Text dimColor>
+        We'll use AI to inspect your project and propose one product change to
+        place behind a PostHog feature flag.
+      </Text>
+      <Text dimColor>.env* file contents will not leave your machine.</Text>
+    </>
+  );
+
+  const body = showingMoreInfo ? (
+    <Box flexDirection="column" width={56} flexShrink={0}>
+      <Text>
+        The wizard is an agent that executes PostHog tasks. Its code is open
+        source: <Text color="cyan">https://github.com/PostHog/wizard</Text>.
+      </Text>
+      <Box flexDirection="column" marginTop={1}>
+        <Text>
+          The{' '}
+          <Text italic color="cyan">
+            feature-flags
+          </Text>{' '}
+          program:
+        </Text>
+      </Box>
+      <Box flexDirection="column" marginTop={1} paddingLeft={4}>
+        <Text>{'\u2022'} Uses the PostHog SDK already in your project</Text>
+        <Text>
+          {'\u2022'} Finds an existing product change and proposes a flag
+        </Text>
+        <Text>{'\u2022'} Waits for your approval before changing anything</Text>
+        <Text>
+          {'\u2022'} Creates or reuses a real flag with a safe rollout
+        </Text>
+        <Text>
+          {'\u2022'} Checks both experiences and writes a setup report
+        </Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          After inspecting the app, the program selects the matching
+          framework-specific Context Mill skill.
+        </Text>
+      </Box>
+    </Box>
+  ) : (
+    <Box flexDirection="column" alignItems="center">
+      <Text>Ship a change without releasing it to everyone.</Text>
+      <Box flexDirection="column" marginTop={1} alignItems="center">
+        <Text dimColor>
+          The Wizard finds an existing change, proposes the flag, and waits for
+          your approval.
+        </Text>
+        <Text dimColor>It wires both experiences. You keep the rollout.</Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>About five minutes. New flags start at 0%.</Text>
+      </Box>
+    </Box>
+  );
+
+  const menuOptions = showingMoreInfo
+    ? [{ label: 'Back', value: 'back' }]
+    : [
+        { label: 'Continue', value: 'continue' },
+        { label: 'More info', value: 'more-info' },
+        { label: 'Cancel', value: 'cancel' },
+      ];
+
+  return (
+    <IntroScreenLayout
+      installDir={session.installDir}
+      showSubtitle={!showingMoreInfo}
+      subtitle={subtitle}
+      body={body}
+      showDetection={!showingMoreInfo}
+      programLabel={session.programLabel}
+      skillId={session.skillId}
+      menuOptions={menuOptions}
+      onSelect={(value) => {
+        if (value === 'cancel') {
+          process.exit(0);
+        } else if (value === 'more-info') {
+          setShowingMoreInfo(true);
+        } else if (value === 'back') {
+          setShowingMoreInfo(false);
+        } else {
+          store.completeSetup();
+        }
+      }}
+    />
+  );
+};

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -93,6 +93,14 @@ describe('wizard OAuth scopes', () => {
     );
   });
 
+  it('requests feature flag management scopes for the feature flags program', () => {
+    const scopes = getOAuthScopesForProgram('feature-flags');
+
+    expect(scopes).toContain('feature_flag:read');
+    expect(scopes).toContain('feature_flag:write');
+    expect(scopes).toContain('property_definition:read');
+  });
+
   it('accepts a newly issued token with the completion scope', () => {
     expect(() =>
       assertWizardCompletionScope(


### PR DESCRIPTION
## Problem

The Wizard can run arbitrary Context Mill skills, but it does not have a dedicated Feature Flags program that owns skill selection, access, setup, verification, and the developer handoff.

Engineers should be able to add one real feature flag to an app that already has PostHog installed without choosing a generic skill or assembling the workflow themselves.

Depends on PostHog/context-mill#294. That PR must be merged and released before the published Wizard can install the updated feature flag workflow.

## Changes

- Add `wizard feature-flags` as a framework-aware program for apps with an existing PostHog SDK integration.
- Select and install the matching Feature Flags skill at runtime, starting with the Next.js variant.
- Request the PostHog feature flag scopes required to create or reuse a real flag.
- Stop with actionable guidance when the SDK, matching skill, or feature flag access is unavailable.
- Add a Feature Flags Learn deck covering safe fallbacks, evaluation location, both flag states, live evaluation, and rollout restoration.
- Add a project-specific outro with a direct Feature Flags link, verification checklist, generated report, and coding-agent handoff.
- Make the shared skill intro render programs whose skill is selected at runtime.
- Add CLI, prompt, OAuth, intro-screen, and command-mounting coverage.

## Test plan

- `npx --yes vitest run` - 120 test files and 1,687 tests passed before the final release rebase.
- `npx --yes vitest run src/lib/programs/__tests__/feature-flags-prompt.test.ts src/__tests__/programs-cli.test.ts src/utils/__tests__/oauth.test.ts src/ui/tui/__tests__/agent-skill-intro.test.ts` - 53 tests passed after rebasing onto `main`.
- `git diff --check origin/main...HEAD`
- `npx --no-install tsx bin.ts feature-flags --help`
- Ran the program against a Next.js App Router fixture and a live PostHog project to exercise skill selection, flag setup, application changes, the Learn pane, and report generation.
- The companion Context Mill workflow passes 139 tests, builds all 363 skills, and pins the abort contract consumed by this program.

## LLM context

Codex was used as a pair-programming and review partner for repository exploration, implementation support, test execution, and focused code and content reviews. The PostHog Wizard agent was tested against the Context Mill skill during the end-to-end workflow.
