### PR TITLE
fix(wizard): Whack a mole part 9: fail the task when its skill cannot install

### DIFF
--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -490,6 +490,15 @@ export async function runOrchestrator(
           logToFile(
             `[orchestrator] skill install failed type=${task.type} skill=${variantId} ${result.kind}`,
           );
+          // A task without its instructions must fail here, not run blind:
+          // run 91cf40eb's report task started after two EACCES install
+          // failures (unwritable external-volume cache) and died silently.
+          // The executor catches this, captures the exception, and fails the
+          // task through the normal outcome check.
+          throw new Error(
+            `Skill "${variantId}" for task "${task.type}" could not be installed (${result.kind}). ` +
+              'If this is a permissions error, check that the project directory is writable.',
+          );
         }
       }
       // Empty spinner messages suppress the per-task spinner line (the queue


### PR DESCRIPTION
Throw when a per-task skill install fails, instead of starting the task without its instructions.

```
Before: EACCES: permission denied, mkdir '/Volumes/.../skills/integration-v2-notebook'
        → logged to file only; report task starts skill-less 3s later → run dies silently
        (run 91cf40eb: 6/8 done, no exception, no task failed, no run finished)
After:  same failure → Error thrown → executor captures the exception, retries the task,
        fails it loudly at max attempts — run ends with a visible failed task
```

The executor's catch already existed (`executor.ts`: logs, `captureException`, outcome check requeues/fails); the install loop just never used it. Retry-then-fail also covers transient causes (the EACCES here was an external drive blipping mid-run).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*