### PR TITLE
fix(wizard): Whack a mole part 10: project-mismatch error accounts for a bogus --project-id

### DIFF
--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -603,7 +603,9 @@ async function askForWizardLogin(options: {
   );
   if (!resolution.ok) {
     const error = new Error(
-      `You authorized project ${resolution.granted}, but setup is targeting project ${resolution.requested}. Re-run and grant access to project ${resolution.requested} on the authorization screen.`,
+      `You authorized project ${resolution.granted}, but setup is targeting project ${resolution.requested} (from --project-id). ` +
+        `If ${resolution.requested} is not a project you own — a copy-pasted example value, say — re-run without --project-id, or with the id shown in your PostHog project settings. ` +
+        `If it is yours, re-run and grant access to project ${resolution.requested} on the authorization screen.`,
     );
     analytics.captureException(error, {
       step: 'wizard_login',


### PR DESCRIPTION
Rewrite the authorized-vs-target project mismatch error so a garbage `--project-id` gets useful advice.

```
Before: "You authorized project 530702, but setup is targeting project 123. Re-run and grant
         access to project 123 on the authorization screen."   ← 123 is a copy-pasted example; unfollowable
After:  "You authorized project 530702, but setup is targeting project 123 (from --project-id).
         If 123 is not a project you own — a copy-pasted example value, say — re-run without
         --project-id, or with the id shown in your PostHog project settings. If it is yours,
         re-run and grant access to project 123 on the authorization screen."
```

Run `438989d3` (07-29): user invoked with `--project-id 123`, authorized their real project, then got told to grant access to 123.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*