### PR TITLE
fix(tui): never page picker lists of 4 or fewer options

### DIFF
--- a/src/ui/tui/playground/demos/AskModalDemo.tsx
+++ b/src/ui/tui/playground/demos/AskModalDemo.tsx
@@ -32,12 +32,6 @@ enum DemoStep {
   Done = 'done',
 }
 
-/**
- * Counts we step through to exercise PickerMenu paging at the edges: a long
- * list that obviously pages, a just-past-the-cap list, and the degenerate
- * 1–2 item cases that (with tall rows) can still split into multiple pages.
- */
-
 /** Label-only options at a given count, e.g. "Option 1" ... "Option 100". */
 const countLabelOptions = (n: number) =>
   Array.from({ length: n }, (_, i) => ({
@@ -45,11 +39,7 @@ const countLabelOptions = (n: number) =>
     value: `opt-${i + 1}`,
   }));
 
-/**
- * Options at a given count, each carrying a wrapping description so the row
- * is tall (label + ~3 wrapped lines). This is the configuration that drives
- * `rowCost` high enough to trip the multi-page bug on 1–2 item lists.
- */
+/** Options at a given count, each with a wrapping description so rows are tall. */
 const countDescOptions = (n: number) =>
   Array.from({ length: n }, (_, i) => ({
     label: `Option ${i + 1}`,
@@ -58,11 +48,7 @@ const countDescOptions = (n: number) =>
       'A longer description that wraps onto multiple lines so each option row costs several terminal rows, exercising the viewport cap and the paging math at small counts.',
   }));
 
-/**
- * Repro of the self-driving-setup scout-proposal ask that paged 3 described
- * options one per page on a short terminal ("↓ 2 more [N] for next page").
- * With the MIN_COUNT_TO_PAGE fix, all three render on one page at any height.
- */
+/** Repro of the scout-proposal ask that paged 3 tall described options one per page. */
 const SCOUT_REPRO_OPTIONS = [
   {
     label: 'None — keep the built-in troop',

--- a/src/ui/tui/playground/demos/AskModalDemo.tsx
+++ b/src/ui/tui/playground/demos/AskModalDemo.tsx
@@ -16,12 +16,73 @@ import { Colors, Icons } from '@ui/tui/styles';
 import { LONG_OPTIONS } from './InputDemo.js';
 
 enum DemoStep {
+  ScoutRepro = 'scout-repro',
+  CountLabel100 = 'count-label-100',
+  CountLabel10 = 'count-label-10',
+  CountLabel2 = 'count-label-2',
+  CountLabel1 = 'count-label-1',
+  CountDesc100 = 'count-desc-100',
+  CountDesc10 = 'count-desc-10',
+  CountDesc2 = 'count-desc-2',
+  CountDesc1 = 'count-desc-1',
   MultiLong = 'multi-long',
   MultiDescriptions = 'multi-descriptions',
   Single = 'single',
   Grouped = 'grouped',
   Done = 'done',
 }
+
+/**
+ * Counts we step through to exercise PickerMenu paging at the edges: a long
+ * list that obviously pages, a just-past-the-cap list, and the degenerate
+ * 1–2 item cases that (with tall rows) can still split into multiple pages.
+ */
+
+/** Label-only options at a given count, e.g. "Option 1" ... "Option 100". */
+const countLabelOptions = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    label: `Option ${i + 1}`,
+    value: `opt-${i + 1}`,
+  }));
+
+/**
+ * Options at a given count, each carrying a wrapping description so the row
+ * is tall (label + ~3 wrapped lines). This is the configuration that drives
+ * `rowCost` high enough to trip the multi-page bug on 1–2 item lists.
+ */
+const countDescOptions = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    label: `Option ${i + 1}`,
+    value: `opt-${i + 1}`,
+    description:
+      'A longer description that wraps onto multiple lines so each option row costs several terminal rows, exercising the viewport cap and the paging math at small counts.',
+  }));
+
+/**
+ * Repro of the self-driving-setup scout-proposal ask that paged 3 described
+ * options one per page on a short terminal ("↓ 2 more [N] for next page").
+ * With the MIN_COUNT_TO_PAGE fix, all three render on one page at any height.
+ */
+const SCOUT_REPRO_OPTIONS = [
+  {
+    label: 'None — keep the built-in troop',
+    value: 'none',
+    description:
+      'Skip custom scouts; the built-in troop already covers this project well enough, and adding more scheduled checks would mostly duplicate the coverage you already get out of the box.',
+  },
+  {
+    label: 'Playground snapshot drift scout',
+    value: 'snapshot-drift',
+    description:
+      'Watches CI snapshot runs and flags visual drift in the playground demos before it reaches a release, so a rendering regression in a picker or overlay never ships to users unnoticed.',
+  },
+  {
+    label: 'Benchmark regression scout',
+    value: 'benchmark',
+    description:
+      'Tracks wizard-benchmark timings week over week and opens an issue when a run regresses past the recorded baseline, catching slow drift in agent latency before customers feel it.',
+  },
+];
 
 const DESCRIBED_OPTIONS = [
   {
@@ -92,13 +153,105 @@ const AskModal = ({
 );
 
 export const AskModalDemo = () => {
-  const [step, setStep] = useState<DemoStep>(DemoStep.MultiLong);
+  const [step, setStep] = useState<DemoStep>(DemoStep.ScoutRepro);
   const [results, setResults] = useState<string[]>([]);
 
   const advance = (result: string, next: DemoStep) => {
     setResults((prev) => [...prev, result]);
     setStep(next);
   };
+
+  const countLabelSteps: Partial<
+    Record<DemoStep, { next: DemoStep; count: number }>
+  > = {
+    [DemoStep.CountLabel100]: {
+      next: DemoStep.CountLabel10,
+      count: 100,
+    },
+    [DemoStep.CountLabel10]: { next: DemoStep.CountLabel2, count: 10 },
+    [DemoStep.CountLabel2]: { next: DemoStep.CountLabel1, count: 2 },
+    [DemoStep.CountLabel1]: { next: DemoStep.CountDesc100, count: 1 },
+  };
+
+  const countDescSteps: Partial<
+    Record<DemoStep, { next: DemoStep; count: number }>
+  > = {
+    [DemoStep.CountDesc100]: { next: DemoStep.CountDesc10, count: 100 },
+    [DemoStep.CountDesc10]: { next: DemoStep.CountDesc2, count: 10 },
+    [DemoStep.CountDesc2]: { next: DemoStep.CountDesc1, count: 2 },
+    [DemoStep.CountDesc1]: { next: DemoStep.MultiLong, count: 1 },
+  };
+
+  if (step === DemoStep.ScoutRepro) {
+    return (
+      <AskModal prompt="Scouts are scheduled checks that watch your data and flag issues for your inbox. Based on your repo I found two gaps the built-in troop doesn't cover — add one, both, or none. (Repro: 3 described options must stay on ONE page even in a short terminal.)">
+        <PickerMenu
+          key={step}
+          mode="multi"
+          optionMarginBottom={1}
+          options={SCOUT_REPRO_OPTIONS}
+          onSelect={(values) => {
+            const arr = Array.isArray(values) ? values : [values];
+            advance(
+              `Scout repro: ${arr.length} picked`,
+              DemoStep.CountLabel100,
+            );
+          }}
+        />
+      </AskModal>
+    );
+  }
+
+  const labelStep = countLabelSteps[step];
+  if (labelStep) {
+    const { count, next } = labelStep;
+    return (
+      <AskModal
+        prompt={`Multi-select — ${count} label-only option${
+          count === 1 ? '' : 's'
+        }. Watch whether ${
+          count <= 2 ? 'this tiny list still pages' : 'paging kicks in'
+        }.`}
+      >
+        <PickerMenu
+          key={step}
+          mode="multi"
+          options={countLabelOptions(count)}
+          onSelect={(values) => {
+            const arr = Array.isArray(values) ? values : [values];
+            advance(`Count label (${count}): ${arr.length} picked`, next);
+          }}
+        />
+      </AskModal>
+    );
+  }
+
+  const descStep = countDescSteps[step];
+  if (descStep) {
+    const { count, next } = descStep;
+    return (
+      <AskModal
+        prompt={`Multi-select — ${count} option${
+          count === 1 ? '' : 's'
+        } with wrapping descriptions (tall rows). ${
+          count <= 2
+            ? 'This is where a tiny list can still split into multiple pages.'
+            : ''
+        }`}
+      >
+        <PickerMenu
+          key={step}
+          mode="multi"
+          optionMarginBottom={1}
+          options={countDescOptions(count)}
+          onSelect={(values) => {
+            const arr = Array.isArray(values) ? values : [values];
+            advance(`Count desc (${count}): ${arr.length} picked`, next);
+          }}
+        />
+      </AskModal>
+    );
+  }
 
   if (step === DemoStep.MultiLong) {
     return (

--- a/src/ui/tui/primitives/PickerMenu.tsx
+++ b/src/ui/tui/primitives/PickerMenu.tsx
@@ -121,12 +121,7 @@ const CHROME_OVERHEAD = 13;
 const MAX_LIST_ROWS = 12;
 /** Extra rows a multi-select adds below its options: marginTop + Confirm button. */
 const CONFIRM_CHROME = 3;
-/**
- * Lists this short never page, whatever the row height. Tall described rows
- * can push `count * rowCost` past the budget even at 2-3 options, which
- * would split a handful of choices into pages of one — strictly worse than
- * letting the few rows run past the viewport cap.
- */
+/** Lists shorter than this never page — tall rows would split 2-3 options into pages of one. */
 const MIN_COUNT_TO_PAGE = 5;
 /** Width the multi-select wraps option descriptions to (matches the render). */
 const DESCRIPTION_WIDTH = 56;

--- a/src/ui/tui/primitives/PickerMenu.tsx
+++ b/src/ui/tui/primitives/PickerMenu.tsx
@@ -121,6 +121,13 @@ const CHROME_OVERHEAD = 13;
 const MAX_LIST_ROWS = 12;
 /** Extra rows a multi-select adds below its options: marginTop + Confirm button. */
 const CONFIRM_CHROME = 3;
+/**
+ * Lists this short never page, whatever the row height. Tall described rows
+ * can push `count * rowCost` past the budget even at 2-3 options, which
+ * would split a handful of choices into pages of one — strictly worse than
+ * letting the few rows run past the viewport cap.
+ */
+const MIN_COUNT_TO_PAGE = 5;
 /** Width the multi-select wraps option descriptions to (matches the render). */
 const DESCRIPTION_WIDTH = 56;
 
@@ -156,7 +163,8 @@ function usePickerViewport(
     5,
     Math.min(termRows - CHROME_OVERHEAD - chromeBelow, MAX_LIST_ROWS),
   );
-  const needsScroll = enabled && count * rowCost > budget;
+  const needsScroll =
+    enabled && count >= MIN_COUNT_TO_PAGE && count * rowCost > budget;
   // Reserve two rows for the "↑/↓ N more" indicators.
   const perPage = needsScroll
     ? Math.max(1, Math.floor((budget - 2) / rowCost))


### PR DESCRIPTION
Before bad:
<img width="936" height="679" alt="Screenshot 2026-07-30 at 1 32 14 PM" src="https://github.com/user-attachments/assets/12d6d488-5b35-4f6b-8735-4fdac0329b47" />

Now not as bad

https://github.com/user-attachments/assets/ba0c13f1-b529-4204-bbcb-ba5974e903e2

