### PR TITLE
feat(logs): add a `wizard logs` program

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -52,6 +52,7 @@ import { mcpAnalyticsCommand } from './src/commands/mcp-analytics';
 import { aiObservabilityCommand } from './src/commands/ai-observability';
 import { auditCommand } from './src/commands/audit';
 import { doctorCommand } from './src/commands/doctor';
+import { logsCommand } from './src/commands/logs';
 import { migrateCommand } from './src/commands/migrate';
 import { revenueCommand } from './src/commands/revenue';
 import { warehouseCommand } from './src/commands/warehouse';
@@ -84,6 +85,7 @@ Wizard.use(basicIntegrationCommand)
   .use(cliCommand)
   .use(auditCommand)
   .use(doctorCommand)
+  .use(logsCommand)
   .use(migrateCommand)
   .use(revenueCommand)
   .use(warehouseCommand)

--- a/e2e-harness/profiles.ts
+++ b/e2e-harness/profiles.ts
@@ -17,11 +17,13 @@ import {
 } from './e2e-profile.js';
 import posthogIntegrationE2e from '@lib/programs/posthog-integration/test/e2e.json';
 import aiObservabilityE2e from '@lib/programs/ai-observability/test/e2e.json';
+import logsE2e from '@lib/programs/logs/test/e2e.json';
 
 const PROFILES: Partial<Record<ProgramId, WizardE2eProfile>> = {
   [Program.PostHogIntegration]:
     posthogIntegrationE2e.profile as WizardE2eProfile,
   [Program.AiObservability]: aiObservabilityE2e.profile as WizardE2eProfile,
+  [Program.Logs]: logsE2e.profile as WizardE2eProfile,
 };
 
 const VARIATIONS: Partial<Record<ProgramId, WizardE2eVariation[]>> = {
@@ -29,6 +31,7 @@ const VARIATIONS: Partial<Record<ProgramId, WizardE2eVariation[]>> = {
     posthogIntegrationE2e.variations as WizardE2eVariation[],
   [Program.AiObservability]:
     aiObservabilityE2e.variations as WizardE2eVariation[],
+  [Program.Logs]: logsE2e.variations as WizardE2eVariation[],
 };
 
 /** The e2e profile for a program, or the happy-path default if none is set. */

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,0 +1,22 @@
+import { logsConfig } from '@lib/programs/logs/index';
+
+import type { Command } from './command';
+import { nativeCommandFactory } from './factories/native-command-factory';
+
+/**
+ * `wizard logs` — flat skill command, send this project's logs to PostHog and
+ * link them back to the people and sessions that produced them.
+ *
+ * Installs the OpenTelemetry log export alongside the project's existing
+ * logging, then does the part the docs can't: finds where the app already
+ * knows who a request belongs to and attaches `posthogDistinctId` and
+ * `sessionId` to every log record from a single place. The `logs-setup`
+ * context-mill skill has one variant per runtime; the agent picks the right
+ * one at run time by reading the project's manifest, and asks via
+ * `wizard_ask` when a repo holds both a frontend and a backend.
+ *
+ * Named for the product, per context-mill's CLI naming convention — the verb
+ * is implied by the wizard, as in `revenue-analytics` and `ai-observability`.
+ * Stays flat while "set up logs for this project" is the only action.
+ */
+export const logsCommand: Command = nativeCommandFactory(logsConfig);

--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -93,7 +93,11 @@ export async function runLinearProgram(
       });
 
   const middleware = session.benchmark
-    ? createBenchmarkPipeline(spinner, sessionToOptions(session))
+    ? createBenchmarkPipeline(
+        spinner,
+        sessionToOptions(session),
+        programConfig.id,
+      )
     : undefined;
 
   // 7. Build prompt

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -140,6 +140,7 @@ export const PROGRAM_BINDINGS: Partial<Record<ProgramId, ProgramBinding>> = {
     harness: Harness.anthropic,
     model: SONNET_5_MODEL,
   },
+  logs: DEFAULT_BINDING,
   slack: DEFAULT_BINDING,
 };
 

--- a/src/lib/middleware/__tests__/phase-detector.test.ts
+++ b/src/lib/middleware/__tests__/phase-detector.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { PhaseDetector } from '../phase-detector';
+
+/** Minimal assistant SDK message carrying a single text block. */
+function assistantText(text: string): any {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } };
+}
+
+/** Feed a stream of status texts and collect the phase transitions emitted. */
+function runPhases(detector: PhaseDetector, statusLines: string[]): string[] {
+  const transitions: string[] = [];
+  for (const line of statusLines) {
+    const phase = detector.detect(assistantText(`[STATUS] ${line}`));
+    if (phase) transitions.push(phase);
+  }
+  return transitions;
+}
+
+describe('PhaseDetector', () => {
+  it('walks the logs skill through its seven step phases in order', () => {
+    const detector = new PhaseDetector('logs');
+    const transitions = runPhases(detector, [
+      'Detecting application runtime',
+      'Finding existing logging',
+      'Resolving ingestion region',
+      'Adding OpenTelemetry packages',
+      'Mapping log emitting surfaces',
+      'Configuring client to send identity headers',
+      'Adding correlation to the logging pipeline',
+      'Running build',
+      'Writing logs setup report',
+    ]);
+
+    expect(transitions).toEqual([
+      '1-detect',
+      '2-install',
+      '3-plan',
+      '4-context',
+      '5-attach',
+      '6-verify',
+      '7-report',
+    ]);
+  });
+
+  it('advances only once per phase even with repeated status lines', () => {
+    const detector = new PhaseDetector('logs');
+    const transitions = runPhases(detector, [
+      'Detecting application runtime',
+      'Finding existing logging',
+      'Checking for PostHog SDKs',
+      'Resolving ingestion region',
+    ]);
+    expect(transitions).toEqual(['1-detect', '2-install']);
+  });
+
+  it('ignores non-assistant messages and text without [STATUS]', () => {
+    const detector = new PhaseDetector('logs');
+    expect(detector.detect({ type: 'user' })).toBeNull();
+    expect(
+      detector.detect(assistantText('Detecting application runtime')),
+    ).toBeNull();
+  });
+
+  it('still recognizes the core integration phases by default', () => {
+    const detector = new PhaseDetector('posthog-integration');
+    const transitions = runPhases(detector, [
+      'Checking project structure',
+      'Inserting PostHog capture code',
+      'Linting, building and prettying',
+      'Created setup report',
+    ]);
+    expect(transitions).toEqual([
+      '1.0-begin',
+      '1.1-edit',
+      '1.2-revise',
+      '1.3-conclude',
+    ]);
+  });
+
+  it('falls back to integration phases for an unknown program', () => {
+    const detector = new PhaseDetector('some-unmapped-program');
+    const transitions = runPhases(detector, [
+      'Checking project structure',
+      'Inserting PostHog capture code',
+    ]);
+    expect(transitions).toEqual(['1.0-begin', '1.1-edit']);
+  });
+});

--- a/src/lib/middleware/benchmark.ts
+++ b/src/lib/middleware/benchmark.ts
@@ -67,6 +67,7 @@ export interface BenchmarkData {
 export function createBenchmarkPipeline(
   spinner: SpinnerHandle,
   options: WizardRunOptions,
+  programId?: string,
   configOverride?: BenchmarkConfig,
 ): MiddlewarePipeline {
   const config = configOverride ?? loadBenchmarkConfig(options.installDir);
@@ -96,7 +97,7 @@ export function createBenchmarkPipeline(
   );
 
   return new MiddlewarePipeline(plugins, {
-    phaseDetector: new PhaseDetector(),
+    phaseDetector: new PhaseDetector(programId),
     autoDetectPhases: true,
   });
 }

--- a/src/lib/middleware/phase-detector.ts
+++ b/src/lib/middleware/phase-detector.ts
@@ -1,14 +1,26 @@
-/** Phase transitions from [STATUS] in assistant text. Keep in sync with program "Status to report" bullets. */
+/**
+ * Phase transitions from [STATUS] in assistant text.
+ *
+ * Phases are program-specific: each program emits its own `[STATUS]` phrases,
+ * so the detector is seeded with the phase map for the program being run. Keep
+ * each map in sync with that program's "Status to report" bullets (framework
+ * programs) or its skill step `[STATUS]` lines (skill programs).
+ *
+ * Programs without a map fall back to the core integration phases, which
+ * preserves the historical single-program behaviour.
+ */
 
-const PHASES_ORDER = [
-  '1.0-begin',
-  '1.1-edit',
-  '1.2-revise',
-  '1.3-conclude',
-] as const;
+interface PhaseMap {
+  /** Phase names in the order the program emits them. */
+  order: readonly string[];
+  /** The `[STATUS]` phrases that mark the start of each phase. */
+  phrasesByPhase: Record<string, string[]>;
+}
 
-const STATUS_PHRASES_BY_PHASE: Record<(typeof PHASES_ORDER)[number], string[]> =
-  {
+/** Core `posthog-integration` flow. Also the fallback for unmapped programs. */
+const INTEGRATION_PHASES: PhaseMap = {
+  order: ['1.0-begin', '1.1-edit', '1.2-revise', '1.3-conclude'],
+  phrasesByPhase: {
     '1.0-begin': [
       'Checking project structure',
       'Verifying PostHog dependencies',
@@ -21,10 +33,81 @@ const STATUS_PHRASES_BY_PHASE: Record<(typeof PHASES_ORDER)[number], string[]> =
       'Linting, building and prettying',
     ],
     '1.3-conclude': ['Configured dashboard', 'Created setup report'],
-  };
+  },
+};
+
+/**
+ * `wizard logs` → the `logs-setup` skill's 7-step chain (context-mill
+ * `context/skills/logs-setup`). One phase per step, keyed off the first
+ * `[STATUS]` line each step emits. Keep in sync with the step reference files.
+ */
+const LOGS_PHASES: PhaseMap = {
+  order: [
+    '1-detect',
+    '2-install',
+    '3-plan',
+    '4-context',
+    '5-attach',
+    '6-verify',
+    '7-report',
+  ],
+  phrasesByPhase: {
+    '1-detect': [
+      'Detecting application runtime',
+      'Finding existing logging',
+      'Checking for PostHog SDKs',
+      'Locating request identity',
+    ],
+    '2-install': [
+      'Resolving ingestion region',
+      'Adding OpenTelemetry packages',
+      'Wiring the log exporter',
+    ],
+    '3-plan': [
+      'Mapping log emitting surfaces',
+      'Tracing identity to log call sites',
+      'Choosing correlation tier',
+      'Writing correlation plan',
+    ],
+    '4-context': [
+      'Configuring client to send identity headers',
+      'Adding request identity context',
+      'Binding identity to the request',
+    ],
+    '5-attach': [
+      'Adding correlation to the logging pipeline',
+      'Checking log call sites are covered',
+    ],
+    '6-verify': [
+      'Installing dependencies',
+      'Linting files I edited',
+      'Running type check',
+      'Running build',
+      'Emitting a test log record',
+    ],
+    '7-report': ['Writing logs setup report'],
+  },
+};
+
+const PHASES_BY_PROGRAM: Record<string, PhaseMap> = {
+  'posthog-integration': INTEGRATION_PHASES,
+  logs: LOGS_PHASES,
+};
+
+const DEFAULT_PHASES = INTEGRATION_PHASES;
 
 export class PhaseDetector {
-  private currentPhase: 'setup' | (typeof PHASES_ORDER)[number] = 'setup';
+  private readonly phases: PhaseMap;
+  private currentPhase: string;
+
+  /**
+   * @param programId Program being benchmarked. Selects the phase map; unknown
+   * or omitted falls back to the core integration phases.
+   */
+  constructor(programId?: string) {
+    this.phases = (programId && PHASES_BY_PROGRAM[programId]) || DEFAULT_PHASES;
+    this.currentPhase = 'setup';
+  }
 
   detect(message: any): string | null {
     if (message.type !== 'assistant') return null;
@@ -39,7 +122,7 @@ export class PhaseDetector {
       if (block.type !== 'text' || typeof block.text !== 'string') continue;
       if (!block.text.includes('[STATUS]')) continue;
 
-      const phrases = STATUS_PHRASES_BY_PHASE[nextPhase];
+      const phrases = this.phases.phrasesByPhase[nextPhase] ?? [];
       for (const phrase of phrases) {
         if (block.text.includes(phrase)) {
           this.currentPhase = nextPhase;
@@ -51,11 +134,12 @@ export class PhaseDetector {
     return null;
   }
 
-  private getNextPhase(): (typeof PHASES_ORDER)[number] | null {
-    if (this.currentPhase === 'setup') return '1.0-begin';
-    const i = PHASES_ORDER.indexOf(this.currentPhase);
-    if (i < 0 || i >= PHASES_ORDER.length - 1) return null;
-    return PHASES_ORDER[i + 1];
+  private getNextPhase(): string | null {
+    const { order } = this.phases;
+    if (this.currentPhase === 'setup') return order[0] ?? null;
+    const i = order.indexOf(this.currentPhase);
+    if (i < 0 || i >= order.length - 1) return null;
+    return order[i + 1];
   }
 
   reset(): void {

--- a/src/lib/programs/logs/content/correlation-diagram.tsx
+++ b/src/lib/programs/logs/content/correlation-diagram.tsx
@@ -1,0 +1,58 @@
+/**
+ * CORRELATION_BLOCK — ASCII diagram of what the two log attributes buy you:
+ * a log line carries `posthogDistinctId`, which resolves it to a person, and
+ * `sessionId`, which resolves it to the replay of that person causing it.
+ *
+ * This is the whole pitch for logs living in PostHog rather than in a
+ * standalone log vendor, so the deck draws it rather than describing it.
+ *
+ * Kept under ~38 chars wide so it fits the LearnCard pane at an 80-column
+ * terminal.
+ */
+
+import { Text } from 'ink';
+import { Colors } from '@ui/tui/styles';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
+
+export const CORRELATION_BLOCK: ContentBlock = {
+  type: 'lines',
+  interval: 320,
+  pause: 9000,
+  lines: [
+    <Text>
+      {'  '}
+      <Text bold color="red">
+        a log line
+      </Text>
+    </Text>,
+    <Text dimColor>{'      "checkout failed: card declined"'}</Text>,
+    <Text>
+      <Text color="gray">{'  ↓ '}</Text>
+      <Text bold color={Colors.accent}>
+        posthogDistinctId
+      </Text>
+    </Text>,
+    <Text>
+      {'  '}
+      <Text bold color="cyan">
+        the person
+      </Text>
+      <Text dimColor> it happened to</Text>
+    </Text>,
+    <Text dimColor>{'      every log they ever caused'}</Text>,
+    <Text>
+      <Text color="gray">{'  ↓ '}</Text>
+      <Text bold color={Colors.accent}>
+        sessionId
+      </Text>
+    </Text>,
+    <Text>
+      {'  '}
+      <Text bold color="green">
+        the replay
+      </Text>
+      <Text dimColor> of them causing it</Text>
+    </Text>,
+    <Text dimColor>{'      watch the click that broke it'}</Text>,
+  ],
+};

--- a/src/lib/programs/logs/content/index.tsx
+++ b/src/lib/programs/logs/content/index.tsx
@@ -1,0 +1,213 @@
+/**
+ * Logs learn deck. Four movements:
+ *
+ *   1. Welcome and orient — what the agent is doing right now.
+ *   2. The pitch — why logs belong next to the rest of your product data,
+ *      drawn as the correlation chain rather than asserted.
+ *   3. What to expect from this run — additive, one attachment point, and an
+ *      honest report about how far correlation actually got.
+ *   4. Logging practices worth knowing, paraphrased from the public docs.
+ *
+ * Logging guidance paraphrased from PostHog public docs:
+ *   - posthog.com/docs/logs/best-practices
+ *   - posthog.com/docs/logs/link-session-replay
+ */
+
+import { Text } from 'ink';
+import type { WizardStore } from '@ui/tui/store';
+import { Colors } from '@ui/tui/styles';
+import { TextRevealMode } from '@ui/tui/primitives/TextBlock';
+import type { ContentBlock } from '@ui/tui/primitives/content-types';
+import { StatusPeekTrigger } from '@ui/tui/components/StatusPeekTrigger';
+import { CORRELATION_BLOCK } from './correlation-diagram.js';
+
+export const getContentBlocks = (store?: WizardStore): ContentBlock[] => [
+  // ── Welcome ────────────────────────────────────────────────────────────
+  {
+    content: 'Hello.',
+    pause: 3000,
+    mode: TextRevealMode.Typewriter,
+    animationInterval: 160,
+  },
+
+  { content: 'The Wizard is an agent.', pause: 4000 },
+
+  {
+    content: 'Right now it’s reading how your app logs today.',
+    pause: 5000,
+  },
+
+  {
+    content: 'PostHog covers the cost of running this agent.',
+    pause: 4000,
+  },
+
+  { type: 'clear', pause: 2000 },
+
+  {
+    pause: 5000,
+    persist: true,
+    content: <StatusPeekTrigger store={store} />,
+  },
+
+  {
+    pause: 6000,
+    persist: true,
+    content: (
+      <Text>
+        Press{' '}
+        <Text color={Colors.accent} bold>
+          S
+        </Text>{' '}
+        to expand or collapse the status.
+      </Text>
+    ),
+  },
+
+  { type: 'clear', pause: 2000 },
+
+  // ── Why logs here ──────────────────────────────────────────────────────
+  {
+    content: 'You already have somewhere to put logs.',
+    pause: 4000,
+  },
+
+  {
+    content: 'So here’s what’s different about putting them here.',
+    pause: 4500,
+  },
+
+  {
+    content:
+      'A log line on its own tells you what broke. It rarely tells you who it broke for, or what they did to break it.',
+    pause: 7000,
+  },
+
+  { content: 'Two attributes fix that.', pause: 3000 },
+
+  CORRELATION_BLOCK,
+
+  { type: 'clear', pause: 1500 },
+
+  {
+    content:
+      'That’s the whole idea. Your logs stop being a separate place you go, and start being part of the story of a user’s session.',
+    pause: 7000,
+  },
+
+  {
+    content:
+      'Attaching those two attributes is most of what the agent is doing right now.',
+    pause: 5500,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  // ── What to expect ─────────────────────────────────────────────────────
+  { content: 'Here’s what to expect.', pause: 3000 },
+
+  {
+    content:
+      'Your existing logging keeps working. Same library, same levels, same messages.',
+    pause: 6000,
+  },
+
+  {
+    content:
+      'The agent adds a second destination alongside it, then finds where your app already knows who the user is.',
+    pause: 6500,
+  },
+
+  {
+    content:
+      'That last part is why this is an agent and not a copy-paste snippet. Identity lives somewhere different in every codebase.',
+    pause: 7000,
+  },
+
+  {
+    content:
+      'It attaches identity in one place, so a codebase with two hundred log statements ends up with two hundred correlated ones.',
+    pause: 7000,
+  },
+
+  {
+    content:
+      'Some code can’t reach a user at all — background jobs, cron, startup. Those stay uncorrelated, and the report says so.',
+    pause: 7000,
+  },
+
+  {
+    content:
+      'Nothing gets committed. You review the diff and the report at the end.',
+    pause: 5500,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  // ── Practices ──────────────────────────────────────────────────────────
+  {
+    content: (
+      <Text bold color={Colors.accent}>
+        Worth knowing
+      </Text>
+    ),
+    pause: 2500,
+    persist: true,
+  },
+
+  {
+    content:
+      'Log structured fields, not sentences. Searching a field beats grepping a string.',
+    pause: 6000,
+  },
+
+  {
+    content: (
+      <Text>
+        Put the identifiers in attributes —{' '}
+        <Text bold color={Colors.accent}>
+          order_id
+        </Text>
+        ,{' '}
+        <Text bold color={Colors.accent}>
+          endpoint
+        </Text>
+        , duration. That’s what you’ll filter on at 3am.
+      </Text>
+    ),
+    pause: 7000,
+    persist: true,
+  },
+
+  {
+    content:
+      'Keep levels honest. If everything is an error, nothing is. Warnings you never act on are noise you pay to store.',
+    pause: 7000,
+  },
+
+  {
+    content:
+      'Never log secrets, tokens, or full request bodies. Logs are searchable by everyone on your team, which is the point.',
+    pause: 7000,
+  },
+
+  { type: 'clear', pause: 1500 },
+
+  // ── Close ──────────────────────────────────────────────────────────────
+  {
+    content:
+      'When this finishes, open a log line in PostHog and press View recording.',
+    pause: 5500,
+  },
+
+  {
+    content: (
+      <Text>
+        Then watch the session that produced it.{'\n'}
+        <Text dimColor>https://posthog.com/docs/logs</Text>
+      </Text>
+    ),
+    pause: 6500,
+    persist: true,
+  },
+];

--- a/src/lib/programs/logs/index.ts
+++ b/src/lib/programs/logs/index.ts
@@ -108,7 +108,7 @@ The final report is written to ./${LOGS_REPORT_FILE}.`,
     reportFile: LOGS_REPORT_FILE,
     docsUrl: 'https://posthog.com/docs/logs',
     spinnerMessage: 'Setting up PostHog Logs...',
-    estimatedDurationMinutes: 5,
+    estimatedDurationMinutes: 12,
     abortCases: LOGS_ABORT_CASES,
   },
 };

--- a/src/lib/programs/logs/index.ts
+++ b/src/lib/programs/logs/index.ts
@@ -10,6 +10,26 @@ const LOGS_STEPS: ProgramStep[] = AGENT_SKILL_STEPS.map((step) =>
 const LOGS_REPORT_FILE = 'posthog-logs-report.md';
 
 /**
+ * Project-level truth for whether session replay is on, read from
+ * `/api/projects/:id/` at auth time.
+ *
+ * The skill needs this to decide whether the `session` correlation tier is
+ * reachable at all, and repo-local evidence can't answer it — replay is
+ * routinely enabled from the snippet or from a separate frontend repo, so its
+ * absence here proves nothing. `null`/`undefined` means the opt-in wasn't in
+ * the payload, which is not the same as "off".
+ */
+function sessionReplayNote(enabled: boolean | null | undefined): string {
+  if (enabled === true) {
+    return 'Session replay is enabled on this PostHog project, so linking log records to recordings is achievable — aim for the `session` correlation tier.';
+  }
+  if (enabled === false) {
+    return 'Session replay is disabled on this PostHog project, so log records cannot link to recordings however they are wired. Aim for the `person` tier and say in the report that enabling session replay is what would unlock replay linking.';
+  }
+  return 'This run could not read whether session replay is enabled on this PostHog project. Wire correlation as normal and let the verify step establish which tier was actually reached, rather than assuming either way.';
+}
+
+/**
  * `[ABORT] <reason>` cases the `logs-setup` skill can emit. The reason string is
  * part of the skill contract — it is defined in the skill's `Abort statuses`
  * section (context-mill `context/skills/logs-setup`).
@@ -57,7 +77,9 @@ export const logsConfig: ProgramConfig = {
     // No `skillId`: linear.ts skips its pre-install step when one isn't set, so
     // the agent loads the menu and installs the variant that matches the
     // project. The prompt below tells it how.
-    customPrompt: () => `Set up PostHog Logs for this project.
+    customPrompt: (ctx) => `Set up PostHog Logs for this project.
+
+${sessionReplayNote(ctx.teamProductOptIns?.sessionReplay)}
 
 This flow has no pre-installed skill — you install the right one yourself:
 

--- a/src/lib/programs/logs/index.ts
+++ b/src/lib/programs/logs/index.ts
@@ -1,0 +1,92 @@
+import type { ProgramConfig, ProgramStep } from '@lib/programs/program-step';
+import type { AbortCase } from '@lib/agent/agent-runner';
+import { AGENT_SKILL_STEPS } from '@lib/programs/agent-skill/index';
+import { getContentBlocks } from '@lib/programs/logs/content/index';
+
+const LOGS_STEPS: ProgramStep[] = AGENT_SKILL_STEPS.map((step) =>
+  step.id === 'intro' ? { ...step, screenId: 'logs-intro' } : step,
+);
+
+const LOGS_REPORT_FILE = 'posthog-logs-report.md';
+
+/**
+ * `[ABORT] <reason>` cases the `logs-setup` skill can emit. The reason string is
+ * part of the skill contract — it is defined in the skill's `Abort statuses`
+ * section (context-mill `context/skills/logs-setup`).
+ */
+const LOGS_ABORT_CASES: AbortCase[] = [
+  {
+    // Skill emits: [ABORT] No supported runtime found
+    match: /^no supported runtime found$/i,
+    message: 'No supported runtime found',
+    body:
+      'The wizard automates PostHog Logs for Next.js and Python, and neither ' +
+      'appears in this directory. PostHog Logs supports many more runtimes ' +
+      'than the wizard automates today — JavaScript, Node, Go, Java, Ruby, ' +
+      'iOS, Android, React Native, Flutter, and a Datadog forwarder. See ' +
+      'https://posthog.com/docs/logs/installation to set one up by hand, or ' +
+      'run this from the directory that holds your Next.js or Python app.',
+  },
+];
+
+/**
+ * `wizard logs` — send this project's logs to PostHog and correlate each record
+ * to the person and session replay that produced it.
+ *
+ * Installation is the table-stakes half and the docs already cover it. The half
+ * that needs an agent is correlation: `posthogDistinctId` and `sessionId` have
+ * to be reachable from wherever a log line is emitted, and where that identity
+ * lives differs in every codebase — an auth middleware here, a request context
+ * there. The `logs-setup` skill chain does that work.
+ *
+ * No `run.skillId`: the context-mill `logs-setup` group ships one variant per
+ * runtime and the wizard does no runtime detection — the agent loads the menu,
+ * matches the project manifest, and installs the right variant itself (see
+ * `customPrompt`). Stays flat while "set up logs for this project" is the only
+ * action; a family form would be premature.
+ */
+export const logsConfig: ProgramConfig = {
+  command: 'logs',
+  description: 'Set up PostHog Logs and link them to sessions and people',
+  id: 'logs',
+  steps: LOGS_STEPS,
+  reportFile: LOGS_REPORT_FILE,
+  getContentBlocks,
+  run: {
+    integrationLabel: 'logs',
+    // No `skillId`: linear.ts skips its pre-install step when one isn't set, so
+    // the agent loads the menu and installs the variant that matches the
+    // project. The prompt below tells it how.
+    customPrompt: () => `Set up PostHog Logs for this project.
+
+This flow has no pre-installed skill — you install the right one yourself:
+
+1. Call \`load_skill_menu\` with \`category: "logs-setup"\`. The menu is the
+   source of truth: one variant per runtime.
+
+2. Read the project manifest to pick the variant. \`package.json\` with a
+   \`next\` dependency → the Next.js variant. \`pyproject.toml\`,
+   \`requirements.txt\`, or \`setup.py\` → the Python variant.
+
+   A repo containing both — a Next.js frontend and a Python backend — is
+   common. Server-emitted logs are where correlation is missing, so pick the
+   variant matching the runtime that emits them, and use \`wizard_ask\` when it
+   is genuinely ambiguous which that is.
+
+3. Call \`install_skill\` with the picked variant id. Then follow that skill's
+   \`SKILL.md\` and its numbered references end-to-end, one step at a time.
+
+Make only additive changes. Existing logging must keep working exactly as it
+does today — do not swap out a logging library, change log levels, or rewrite
+log messages. Do not touch existing PostHog init, identify calls, or event
+capture beyond the one \`tracing_headers\` option the skill asks for.
+
+The final report is written to ./${LOGS_REPORT_FILE}.`,
+    successMessage: `PostHog Logs configured! View the report at ./${LOGS_REPORT_FILE}`,
+    reportFile: LOGS_REPORT_FILE,
+    docsUrl: 'https://posthog.com/docs/logs',
+    spinnerMessage: 'Setting up PostHog Logs...',
+    estimatedDurationMinutes: 5,
+    abortCases: LOGS_ABORT_CASES,
+  },
+};

--- a/src/lib/programs/logs/test/e2e.json
+++ b/src/lib/programs/logs/test/e2e.json
@@ -1,0 +1,35 @@
+{
+  "program": "logs",
+  "summary": "Happy path: confirm intro, push past health issues, let the agent pick + install the runtime variant, wire the export and correlation, delete installed skills.",
+  "profile": {
+    "setup": "first",
+    "healthCheck": "dismiss",
+    "mcp": "skip",
+    "slack": "skip",
+    "skills": "delete",
+    "ask": "first"
+  },
+  "variations": [
+    {
+      "name": "default",
+      "summary": "linear / anthropic / default model — parity with main"
+    }
+  ],
+  "path": [
+    { "screen": "logs-intro", "auto": "confirm & continue" },
+    {
+      "screen": "health-check",
+      "auto": "dismiss outage — proceed even if the readiness probe flags an issue"
+    },
+    { "screen": "auth", "auto": "(external) — the runner injects credentials" },
+    {
+      "screen": "run",
+      "auto": "(external) — the agent loads the skill menu, picks the logs-setup-* variant matching the project's runtime, installs it, then walks the 7-step chain: detect, install the OTLP export, plan correlation, add the request identity context, attach posthogDistinctId + sessionId, verify, report. wizard_ask is answered with the first option, which covers the region prompt when no PostHog host is configured and the runtime pick in a repo holding both a frontend and a backend"
+    },
+    { "screen": "outro", "auto": "dismiss" },
+    {
+      "screen": "keep-skills",
+      "auto": "delete — leave nothing behind (terminal: the run's done-signal)"
+    }
+  ]
+}

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -31,6 +31,7 @@ import {
 } from './mcp/index.js';
 import { mcpAnalyticsConfig } from './mcp-analytics/index.js';
 import { aiObservabilityConfig } from './ai-observability/index.js';
+import { logsConfig } from './logs/index.js';
 import { slackConnectConfig } from './slack/index.js';
 
 // Generic skill program — runs an arbitrary context-mill skill chosen at
@@ -80,6 +81,7 @@ export const PROGRAM_REGISTRY = [
   mcpTutorialConfig,
   mcpAnalyticsConfig,
   aiObservabilityConfig,
+  logsConfig,
   slackConnectConfig,
 ] as const satisfies readonly ProgramConfig[];
 
@@ -105,6 +107,7 @@ export const Program = {
   McpTutorial: mcpTutorialConfig.id,
   McpAnalytics: mcpAnalyticsConfig.id,
   AiObservability: aiObservabilityConfig.id,
+  Logs: logsConfig.id,
   SlackConnect: slackConnectConfig.id,
 } as const;
 

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -28,6 +28,7 @@ import { SourceMapsDetectScreen } from './screens/SourceMapsDetectScreen.js';
 import { SourceMapsOutroScreen } from './screens/SourceMapsOutroScreen.js';
 import { AgentSkillIntroScreen } from './screens/AgentSkillIntroScreen.js';
 import { AiObservabilityIntroScreen } from './screens/AiObservabilityIntroScreen.js';
+import { LogsIntroScreen } from './screens/LogsIntroScreen.js';
 import { SelfDrivingIntroScreen } from './screens/SelfDrivingIntroScreen.js';
 import { SelfDrivingIntegrationCheckScreen } from './screens/SelfDrivingIntegrationCheckScreen.js';
 import { SelfDrivingIntegrationDetectScreen } from './screens/SelfDrivingIntegrationDetectScreen.js';
@@ -91,6 +92,7 @@ export function createScreens(
     [ScreenId.AiObservabilityIntro]: (
       <AiObservabilityIntroScreen store={store} />
     ),
+    [ScreenId.LogsIntro]: <LogsIntroScreen store={store} />,
     [ScreenId.SelfDrivingIntro]: <SelfDrivingIntroScreen store={store} />,
     [ScreenId.SelfDrivingIntegrationCheck]: (
       <SelfDrivingIntegrationCheckScreen store={store} />

--- a/src/ui/tui/screen-sequences.ts
+++ b/src/ui/tui/screen-sequences.ts
@@ -25,6 +25,7 @@ export enum ScreenId {
   MigrationIntro = 'migration-intro',
   AgentSkillIntro = 'agent-skill-intro',
   AiObservabilityIntro = 'ai-observability-intro',
+  LogsIntro = 'logs-intro',
   SelfDrivingIntro = 'self-driving-intro',
   SelfDrivingIntegrationCheck = 'self-driving-integration-check',
   SelfDrivingIntegrationDetect = 'self-driving-integration-detect',

--- a/src/ui/tui/screens/LogsIntroScreen.tsx
+++ b/src/ui/tui/screens/LogsIntroScreen.tsx
@@ -1,0 +1,88 @@
+import { Box, Text } from 'ink';
+import { useState, useSyncExternalStore } from 'react';
+import type { WizardStore } from '@ui/tui/store';
+import { IntroScreenLayout } from '@ui/tui/screens/IntroScreenLayout';
+import {
+  SkillSourceInfo,
+  useSkillEntry,
+} from '@ui/tui/screens/SkillSourceInfo';
+
+interface LogsIntroScreenProps {
+  store: WizardStore;
+}
+
+export const LogsIntroScreen = ({ store }: LogsIntroScreenProps) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  const [showingMoreInfo, setShowingMoreInfo] = useState(false);
+  const { session } = store;
+  // logs picks its skill variant at run time (logs-setup-nextjs,
+  // logs-setup-python), so there's no pre-seeded skillId here. Fall back to
+  // the default variant for the "more info" lookup.
+  const skillId = session.skillId ?? 'logs-setup-nextjs';
+  const { skillEntry, fetchFailed } = useSkillEntry(skillId, session.localMcp);
+
+  const body = showingMoreInfo ? (
+    <Box flexDirection="column" width={56}>
+      <Box marginBottom={1}>
+        <Text>
+          The wizard is an agent that executes PostHog tasks. Its code is open
+          source: <Text color="cyan">https://github.com/PostHog/wizard</Text>
+        </Text>
+      </Box>
+
+      <Text>
+        The{' '}
+        <Text color="cyan" italic>
+          logs
+        </Text>{' '}
+        program sends your logs to PostHog over OpenTelemetry, then correlates
+        them: it finds where your app already knows who a request belongs to and
+        attaches that identity to every log record, so a log line links to the
+        person who caused it and opens their session replay. Your existing
+        logging keeps working unchanged. Supports Next.js and Python.
+      </Text>
+      <Box marginTop={1}>
+        <SkillSourceInfo
+          skillId={skillId}
+          skillEntry={skillEntry}
+          fetchFailed={fetchFailed}
+        />
+      </Box>
+    </Box>
+  ) : (
+    <Box flexDirection="column" alignItems="center">
+      <Text>Let's send your logs to PostHog and link them to sessions.</Text>
+    </Box>
+  );
+
+  const menuOptions = showingMoreInfo
+    ? [{ label: 'Back', value: 'back' }]
+    : [
+        { label: 'Continue', value: 'continue' },
+        { label: 'More info', value: 'more-info' },
+        { label: 'Cancel', value: 'cancel' },
+      ];
+
+  const handleSelect = (value: string) => {
+    if (value === 'cancel') process.exit(0);
+    else if (value === 'more-info') setShowingMoreInfo(true);
+    else if (value === 'back') setShowingMoreInfo(false);
+    else store.completeSetup();
+  };
+
+  return (
+    <IntroScreenLayout
+      installDir={session.installDir}
+      body={body}
+      showDetection={!showingMoreInfo}
+      programLabel={session.programLabel}
+      skillId={session.skillId}
+      menuOptions={menuOptions}
+      onSelect={handleSelect}
+    />
+  );
+};


### PR DESCRIPTION
## Problem

There's no `logs` command. PostHog Logs is reachable only through the generic `wizard skill logs-<variant>`, and the skill behind it is docs-only — it points at installation docs and stops there.

Installation is the half the docs already cover well. The half they don't is **correlation**: attaching `posthogDistinctId` and `sessionId` to server-emitted records so a log line resolves to a person and opens their session replay. That's the reason to put logs in PostHog rather than in Better Stack or Datadog, and today it's left to the reader to implement by hand.

It's also a bad fit for a doc and a good fit for an agent. *"Where does this codebase already know who this request belongs to"* has a different answer in every project — an auth middleware here, a session callback there.

The moment this is built around: you run one command, then click a log line in PostHog and land in the session replay of the user who caused it.

## Changes

`wizard logs`, backed by the new `logs-setup` skill in context-mill (PostHog/context-mill#302).

Follows the `ai-observability` shape — a flat native command via `nativeCommandFactory`, with no `run.skillId` so the agent loads the menu and installs the variant matching the project's runtime rather than the wizard doing detection. The prompt tells it to ask via `wizard_ask` when a repo holds both a Next.js frontend and a Python backend, since server-emitted records are where correlation is missing and it isn't always obvious which runtime emits them.

Stays flat while "set up logs for this project" is the only action. Named for the product, per context-mill's CLI naming convention — the verb is implied by the wizard, as in `revenue-analytics` and `ai-observability`.

| File | |
|---|---|
| `src/lib/programs/logs/index.ts` | program config, custom prompt, abort case |
| `src/lib/programs/logs/content/index.tsx` | Learn deck |
| `src/lib/programs/logs/content/correlation-diagram.tsx` | ASCII diagram of the correlation chain |
| `src/lib/programs/logs/test/e2e.json` | e2e profile + documented path |
| `src/commands/logs.ts` | `nativeCommandFactory` |
| `src/ui/tui/screens/LogsIntroScreen.tsx` | intro screen |
| `bin.ts`, `program-registry.ts`, `screen-sequences.ts`, `screen-registry.tsx`, `switchboard/index.ts`, `e2e-harness/profiles.ts` | registration |

I worked from #922 as a checklist rather than trusting the registry docblock, which says `bin.ts` derives its wiring automatically — it doesn't.

**`PROGRAM_BINDINGS` is worth flagging.** It's optional at the type level, so omitting it compiles cleanly and silently falls back to the default model and harness. I did omit it, and `switchboard.test.ts` failed loudly and caught it. That test is doing real work. Bound explicitly to `DEFAULT_BINDING` — this is an ordinary linear agent-skill flow with no reason to deviate.

The abort case is wired to the `[ABORT] No supported runtime found` string the skill emits, and its body points at the full installation doc list, since Logs supports many more runtimes than the two the wizard automates today.

## On the Learn card

The deck draws the correlation chain rather than describing it, because that chain is the entire argument for logs living here:

```
  a log line
      "checkout failed: card declined"
  ↓ posthogDistinctId
  the person it happened to
      every log they ever caused
  ↓ sessionId
  the replay of them causing it
      watch the click that broke it
```

It also sets expectations for the run itself — existing logging keeps working, identity attaches in one place, background jobs legitimately stay uncorrelated and the report says so — and closes on a few logging practices from the public docs.

## Test plan

- `pnpm test` — 118 files, 1675 passed
- `pnpm lint` — 0 errors; no new warnings in the added files
- `pnpm typecheck` — 25 errors, identical to the count on `main` in this checkout, none in the added files
- `pnpm screens:check` — all screen checks pass
- `pnpm try --help` lists `logs`; `pnpm try logs --help` renders
- Ran the local loop against context-mill's dev server (`pnpm dev` + `--local-mcp`) and confirmed the wizard resolves and downloads `logs-setup-nextjs.zip` from `localhost:8765`

## LLM context

Written with Cursor. The companion context-mill PR carries the bulk of the thinking — the program deliberately stays thin, since the factory means nearly all the real logic belongs in the skill.

Made with [Cursor](https://cursor.com)