### PR TITLE
feat(wizard-tools): add publish_handoff tool for deterministic handoff

### DIFF
--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -216,6 +216,14 @@ export type AgentConfig = {
    */
   orchestrator?: import('@lib/agent/runner/sequence/orchestrator/queue-tools').OrchestratorToolsContext;
   /**
+   * Handoff-publish context. When present, the `publish_handoff` wizard tool
+   * is registered — one deterministic call writes the report file, mirrors it
+   * into a notebook, and sets handoff_text on the store so the task-stream
+   * push carries it. Built by the runner (which owns the store + the program's
+   * reportFile), absent in hosts without a store or a report.
+   */
+  handoff?: import('@lib/wizard-tools/handoff').HandoffToolsContext;
+  /**
    * Optional AIO capture — mirrors each assistant SDK message into the
    * authenticated project as `$ai_generation`. No-op instance when
    * `--capture-aio` is off. Constructed once per run by the harness.
@@ -598,6 +606,7 @@ export async function initializeAgent(
       askBridge: config.askBridge,
       askMaxQuestions: config.askMaxQuestions,
       orchestrator: config.orchestrator,
+      handoff: config.handoff,
       triageProvider,
     });
     mcpServers['wizard-tools'] = wizardToolsServer;

--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -43,6 +43,7 @@ export const anthropicBackend: AgentHarness = {
       askBridge,
       middleware,
       model,
+      handoff,
     } = inputs;
     const { skillsBaseUrl, credentials, wizardFlags, wizardMetadata } = boot;
     const { accessToken, host, projectApiKey } = credentials;
@@ -75,6 +76,7 @@ export const anthropicBackend: AgentHarness = {
         getPendingQuestion: () => session.pendingQuestion,
         modelOverride: model,
         capture,
+        handoff,
       },
       sessionToOptions(session),
     );
@@ -113,6 +115,7 @@ export const anthropicBackend: AgentHarness = {
       allowedTools,
       disallowedTools,
       orchestrator,
+      handoff,
       spinnerMessage,
       successMessage,
       errorMessage,
@@ -145,6 +148,7 @@ export const anthropicBackend: AgentHarness = {
         integrationLabel: programConfig.id,
         orchestrator,
         capture,
+        handoff,
       },
       options,
     );

--- a/src/lib/agent/runner/harness/pi/index.ts
+++ b/src/lib/agent/runner/harness/pi/index.ts
@@ -185,6 +185,7 @@ export const piBackend: AgentHarness = {
   async run(inputs: BackendRunInputs): Promise<AgentResult> {
     const { session, boot, prompt, spinner, config, programConfig } = inputs;
     const modelId = inputs.model;
+    const handoff = inputs.handoff;
 
     const capture = createAioCapture({
       enabled: session.captureAio,
@@ -393,6 +394,9 @@ export const piBackend: AgentHarness = {
           // Skip wizard_ask when the program disallows it (bare pi tool names
           // don't match the MCP-prefixed disallow list at the security gate).
           disallowedTools: programConfig.disallowedTools,
+          // Deterministic handoff: one call writes the report + notebook +
+          // session handoff_text. Absent in hosts without a store or a report.
+          handoff,
         }),
         // Task/todo tools (#526): render the todo list live in the TUI, parity
         // with the anthropic path.

--- a/src/lib/agent/runner/harness/pi/task.ts
+++ b/src/lib/agent/runner/harness/pi/task.ts
@@ -135,6 +135,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     allowedTools,
     disallowedTools,
     orchestrator,
+    handoff,
     spinnerMessage,
     successMessage,
     errorMessage,
@@ -291,15 +292,20 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     // Wizard env + package-manager tools are always on — their handlers are
     // fenced, and init/build tasks depend on them.
     const { createWizardPiTools } = await import('./tools');
+    const wizardToolNames = [
+      'check_env_keys',
+      'set_env_values',
+      'detect_package_manager',
+      // The report/notebook task publishes the handoff; keep it when the
+      // runner supplied a handoff context for this task.
+      ...(handoff ? ['publish_handoff'] : []),
+    ];
     const wizardTools = createWizardPiTools({
       workingDirectory: dir,
       skillsBaseUrl: boot.skillsBaseUrl,
       triageProvider: boot.triageProvider,
-    }).filter((t) =>
-      ['check_env_keys', 'set_env_values', 'detect_package_manager'].includes(
-        t.name,
-      ),
-    );
+      handoff,
+    }).filter((t) => wizardToolNames.includes(t.name));
 
     const { createPiOrchestratorTools } = await import('./orchestrator-tools');
     const queueTools = createPiOrchestratorTools(orchestrator).filter((t) =>

--- a/src/lib/agent/runner/harness/pi/tools.ts
+++ b/src/lib/agent/runner/harness/pi/tools.ts
@@ -34,6 +34,7 @@ import {
 import type { LLMProvider } from '@posthog/warlock';
 import { isFullyCancelled, type WizardAskBridge } from '@lib/wizard-ask-bridge';
 import { createSecretVault } from '@lib/secret-vault';
+import { publishHandoff } from '@lib/wizard-tools/handoff';
 import { withMode } from './index';
 import {
   detectNodePackageManagers,
@@ -62,6 +63,13 @@ export interface PiToolsContext {
   disallowedTools?: readonly string[];
   /** Scan-triage classifier, resolved once in bootstrap. Absent → scans fail closed. */
   triageProvider?: LLMProvider;
+  /**
+   * Handoff-publish context. When present, the `publish_handoff` pi tool is
+   * registered — same behavior as the MCP facade (one call writes the report
+   * file, mirrors it into a notebook, and sets handoff_text on the store).
+   * Absent in hosts without a store or a report.
+   */
+  handoff?: import('@lib/wizard-tools/handoff').HandoffToolsContext;
 }
 
 export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
@@ -71,6 +79,7 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
     askBridge,
     onAskPendingChange,
     triageProvider,
+    handoff,
   } = ctx;
   const detectPackageManager =
     ctx.detectPackageManager ?? detectNodePackageManagers;
@@ -388,6 +397,53 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
     setEnvValues,
     detectPm,
   ];
+
+  // publish_handoff — same deterministic handoff as the MCP facade: one call
+  // writes the report file, mirrors it into a notebook, and sets handoff_text.
+  // Sequential: it writes a file and mutates the store, so a batched turn
+  // must never run two publishes (or a publish + a write) at once.
+  if (handoff) {
+    const publishHandoffTool = defineTool({
+      name: 'publish_handoff',
+      label: 'Publish handoff',
+      description:
+        "Publish the run's markdown setup report as the handoff doc in one call: writes the report file, mirrors it into a shareable PostHog notebook, and pushes it to the PostHog session as handoff_text. Call this exactly once, with the full report markdown — do not write the report file yourself, do not call notebooks-create, and do not emit a [NOTEBOOK_URL] marker. Returns the notebook URL (or null if the notebook could not be created).",
+      promptSnippet:
+        'publish_handoff(content, title?) — write the setup report + notebook + session handoff in one call',
+      parameters: Type.Object({
+        content: Type.String({
+          description:
+            'The full markdown setup report — the same content that would have been written to the report file. Start with an H1 heading.',
+        }),
+        title: Type.Optional(
+          Type.String({
+            description:
+              'Optional notebook title. Defaults to "PostHog setup (wizard)".',
+          }),
+        ),
+      }),
+      async execute(_id, args) {
+        const result = await publishHandoff(args.content, args.title, {
+          reportPath: handoff.reportPath,
+          getCredentials: handoff.getCredentials,
+          hooks: handoff.hooks,
+          fetchImpl: handoff.fetchImpl,
+        });
+        if (!result.ok) return text(result.message);
+        const notebookLine =
+          result.notebookUrl != null
+            ? `\nNotebook: ${result.notebookUrl}`
+            : '\nNo notebook was created (credentials unavailable or upload failed — the report file and the PostHog session handoff_text are still set).';
+        return text(
+          `Published handoff to ./${path.basename(
+            result.reportPath,
+          )}.${notebookLine}`,
+        );
+      },
+    });
+    tools.push(withMode(publishHandoffTool, 'sequential'));
+  }
+
   // Register wizard_ask only when the program allows it. posthog-integration
   // disallows it (runs without structured user input); self-driving keeps it.
   // Sequential: the ask bridge holds a single in-flight question slot, so a

--- a/src/lib/agent/runner/harness/types.ts
+++ b/src/lib/agent/runner/harness/types.ts
@@ -23,6 +23,7 @@ import type { SpinnerHandle } from '@ui';
 import type { WizardAskBridge } from '@lib/wizard-ask-bridge';
 import type { AgentErrorType } from '@lib/agent/agent-interface';
 import type { OrchestratorToolsContext } from '@lib/agent/runner/sequence/orchestrator/queue-tools';
+import type { HandoffToolsContext } from '@lib/wizard-tools/handoff';
 import type {
   EffortLevel,
   ThinkingLevel,
@@ -62,6 +63,13 @@ export interface BackendRunInputs {
   model: string;
   /** Switchboard-resolved reasoning-effort override. Absent → the model's table default. */
   thinkingLevel?: EffortLevel;
+  /**
+   * Handoff-publish context threaded into the wizard-tools server so the
+   * `publish_handoff` tool is registered. Built by the runner from the
+   * program's reportFile + the live WizardStore; absent in hosts without a
+   * store or a report (the tool stays unregistered, surface stable).
+   */
+  handoff?: HandoffToolsContext;
 }
 
 /** What a runner reports back: an error classification, or nothing on success. */
@@ -91,6 +99,12 @@ export interface TaskRunInputs {
   disallowedTools?: readonly string[];
   /** Queue-tools context threaded into the in-process wizard-tools MCP. */
   orchestrator: OrchestratorToolsContext;
+  /**
+   * Handoff-publish context. Threaded into the wizard-tools server so the
+   * report/notebook task agent can call `publish_handoff`. Absent when the
+   * orchestrator run has no report file (the tool stays unregistered).
+   */
+  handoff?: HandoffToolsContext;
   /** Spinner copy. Empty strings suppress the per-task line (queue panel shows progress). */
   spinnerMessage: string;
   successMessage: string;

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -36,6 +36,7 @@ import {
 } from './switchboard';
 import { flushScanReport } from '../../yara-hooks';
 import { registerCleanup } from '../../../utils/wizard-abort';
+import type { HandoffToolsContext } from '../../wizard-tools/handoff';
 
 export type {
   ProgramRun,
@@ -53,7 +54,16 @@ export { shouldDisableAsk } from './shared/bootstrap';
 export async function runAgent(
   programConfig: ProgramConfig,
   session: WizardSession,
-  options: { composed?: boolean } = {},
+  options: {
+    composed?: boolean;
+    /**
+     * Handoff-publish context, built by the runner (which owns the WizardStore
+     * + the program's reportFile). Threaded into the wizard-tools server so
+     * the `publish_handoff` tool is registered. Absent in hosts without a
+     * store or a report — the tool stays unregistered, surface stable.
+     */
+    handoff?: HandoffToolsContext;
+  } = {},
 ): Promise<void> {
   if (!programConfig.run) {
     throw new Error(`Program "${programConfig.id}" has no run configuration.`);
@@ -78,7 +88,11 @@ export async function runProgram(
   session: WizardSession,
   config: ProgramRun,
   programConfig: ProgramConfig,
-  options: { composed?: boolean } = {},
+  options: {
+    composed?: boolean;
+    /** Threaded into the wizard-tools server as the `publish_handoff` context. */
+    handoff?: HandoffToolsContext;
+  } = {},
 ): Promise<void> {
   const boot = await bootstrapProgram(session, config, programConfig);
 
@@ -107,6 +121,7 @@ export async function runProgram(
       programConfig,
       boot,
       options.composed ?? false,
+      options.handoff,
     );
   } finally {
     flushScanReport(session);

--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -31,6 +31,7 @@ import type { ProgramRun, BootstrapResult } from '../shared/types';
 import { abortOnInstallFailure } from '../shared/errors';
 import { shouldDisableAsk, sessionToOptions } from '../shared/bootstrap';
 import { resolveHarness, getHarness } from '../switchboard';
+import type { HandoffToolsContext } from '../../../wizard-tools/handoff';
 
 export async function runLinearProgram(
   session: WizardSession,
@@ -38,6 +39,7 @@ export async function runLinearProgram(
   programConfig: ProgramConfig,
   boot: BootstrapResult,
   composed = false,
+  handoff?: HandoffToolsContext,
 ): Promise<void> {
   const { skillsBaseUrl, credentials, wizardFlags, project } = boot;
   const { projectApiKey, host, projectId } = credentials;
@@ -137,6 +139,7 @@ export async function runLinearProgram(
     middleware,
     model: pick.model,
     thinkingLevel: pick.thinkingLevel,
+    handoff,
   });
 
   // 9. Error handling (full set from both runners)

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -181,6 +181,7 @@ export async function runOrchestrator(
   session: WizardSession,
   programConfig: ProgramConfig,
   boot: BootstrapResult,
+  handoff?: import('../../../../wizard-tools/handoff').HandoffToolsContext,
 ): Promise<void> {
   const runId = randomUUID();
 
@@ -513,6 +514,10 @@ export async function runOrchestrator(
         allowedTools: resolved.allowedTools,
         disallowedTools: resolved.disallowedTools,
         orchestrator: orchestratorCtx(task.id),
+        // The report task publishes the handoff; other tasks simply won't
+        // call the tool. Threaded so publish_handoff registers for the one
+        // task that needs it.
+        handoff,
         spinnerMessage: '',
         successMessage: '',
         additionalFeatureQueue: [],

--- a/src/lib/agent/runner/switchboard/sequence.ts
+++ b/src/lib/agent/runner/switchboard/sequence.ts
@@ -17,6 +17,7 @@ import type { ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun, BootstrapResult } from '../shared/types';
 import { runLinearProgram } from '../sequence/linear';
 import { runOrchestrator } from '../sequence/orchestrator/orchestrator-runner';
+import type { HandoffToolsContext } from '../../../wizard-tools/handoff';
 import {
   DEFAULT_BINDING,
   PROGRAM_BINDINGS,
@@ -36,19 +37,21 @@ export interface SequenceRunner {
     boot: BootstrapResult,
     /** Composed sub-run (integration inside self-driving); linear-only. */
     composed: boolean,
+    /** Threaded into the wizard-tools server as the `publish_handoff` context. */
+    handoff?: HandoffToolsContext,
   ): Promise<void>;
 }
 
 export const SEQUENCE_OPTIONS: Partial<Record<Sequence, SequenceRunner>> = {
   [Sequence.linear]: {
     name: Sequence.linear,
-    run: (session, config, programConfig, boot, composed) =>
-      runLinearProgram(session, config, programConfig, boot, composed),
+    run: (session, config, programConfig, boot, composed, handoff) =>
+      runLinearProgram(session, config, programConfig, boot, composed, handoff),
   },
   [Sequence.orchestrator]: {
     name: Sequence.orchestrator,
-    run: (session, _config, programConfig, boot, _composed) =>
-      runOrchestrator(session, programConfig, boot),
+    run: (session, _config, programConfig, boot, _composed, handoff) =>
+      runOrchestrator(session, programConfig, boot, handoff),
   },
 };
 

--- a/src/lib/runners/run-non-interactive.ts
+++ b/src/lib/runners/run-non-interactive.ts
@@ -5,6 +5,7 @@ import { LoggingUI } from '@ui/logging-ui';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import { analytics } from '@utils/analytics';
 import { resolveNoTelemetry } from './resolve-no-telemetry';
+import { buildHandoffContext } from '@lib/wizard-tools/handoff';
 import type { WizardStore } from '@ui/tui/store';
 import type { TaskStreamPush } from '@lib/task-stream/task-stream-push';
 import { join } from 'node:path';
@@ -229,7 +230,17 @@ export function runNonInteractive(
       }
 
       const { runAgent } = await import('@lib/agent/agent-runner');
-      await runAgent(config, session);
+      // The headless store is what the task-stream push reads handoff_text
+      // from; CI has no store, so publish_handoff stays unregistered there.
+      const handoff = store
+        ? buildHandoffContext({
+            workingDirectory: session.installDir,
+            reportFile: config.reportFile,
+            store,
+            getCredentials: () => session.credentials,
+          }) ?? undefined
+        : undefined;
+      await runAgent(config, session, { handoff });
       await settleStream(RunPhase.Completed);
     } catch (error) {
       const errorMessage =

--- a/src/lib/runners/run-wizard.ts
+++ b/src/lib/runners/run-wizard.ts
@@ -10,9 +10,28 @@ import type { WizardSession } from '@lib/wizard-session';
 import type { TaskStreamPush as TaskStreamPushClass } from '@lib/task-stream/task-stream-push';
 import { resolveNoTelemetry } from './resolve-no-telemetry';
 import { runCleanups } from '@utils/wizard-abort';
+import { buildHandoffContext } from '@lib/wizard-tools/handoff';
 import { join } from 'node:path';
 
 const WIZARD_VERSION = VERSION;
+
+/**
+ * Build the handoff-publish context the wizard threads into `runAgent`:
+ * resolves the program's reportFile against the working directory and wires
+ * the live store so `publish_handoff` writes the report, sets handoff_text
+ * (→ task-stream push), and surfaces the notebook URL. Null when the program
+ * has no reportFile, so the tool stays unregistered.
+ */
+function handoffFor(store: WizardStore, config: ProgramConfig) {
+  return (
+    buildHandoffContext({
+      workingDirectory: store.session.installDir,
+      reportFile: config.reportFile,
+      store,
+      getCredentials: () => store.session.credentials,
+    }) ?? undefined
+  );
+}
 
 type Step = ProgramConfig['steps'][number];
 
@@ -50,7 +69,9 @@ async function advanceStep(
     await step.run(await prepareRunSession(step, store.session));
     store.completeRunStep(step.id);
   } else if (step.screenId === 'run') {
-    await runAgent(config, await prepareRunSession(step, store.session));
+    await runAgent(config, await prepareRunSession(step, store.session), {
+      handoff: handoffFor(store, config),
+    });
   } else if (step.isComplete) {
     await store.waitUntil(step.isComplete);
   }
@@ -202,7 +223,9 @@ export function runWizard(
           projectId,
         });
       } else {
-        await runAgent(config, activeTui.store.session);
+        await runAgent(config, activeTui.store.session, {
+          handoff: handoffFor(activeTui.store, config),
+        });
       }
 
       const isDone = (): boolean =>

--- a/src/lib/task-stream/handoff-watcher.ts
+++ b/src/lib/task-stream/handoff-watcher.ts
@@ -27,6 +27,14 @@ export function normalizeHandoffText(raw: unknown): string | null {
  *
  * `ignoreInitialFile` keeps a stale report from a previous run out of the
  * session: only a file (re)written during this run counts.
+ *
+ * TODO(remove): this passive watcher is now a fallback. The `publish_handoff`
+ * wizard tool (src/lib/wizard-tools/handoff.ts) captures the report
+ * deterministically — it writes the file, sets handoff_text on the store, and
+ * mirrors it into a notebook in one host-side call. Once every program's
+ * skill content calls that tool, the watcher (and the force-read in
+ * TaskStreamPush.shutdown) can be deleted in favor of the tool being the
+ * sole capture path.
  */
 export class HandoffWatcher {
   private handle: FileWatcherHandle | null = null;

--- a/src/lib/wizard-tools/__tests__/handoff.test.ts
+++ b/src/lib/wizard-tools/__tests__/handoff.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+// analytics writes to PostHog in tests — stub it before importing the core.
+vi.mock('@utils/analytics', () => ({
+  analytics: { wizardCapture: vi.fn() },
+}));
+// logToFile writes to a debug file — stub it to a no-op.
+vi.mock('@utils/debug', () => ({ logToFile: () => undefined }));
+
+import {
+  publishHandoff,
+  buildNotebookContent,
+  buildNotebookUrl,
+  normalizeHandoffContent,
+  resolveReportPath,
+  buildHandoffContext,
+  MAX_HANDOFF_CONTENT_CHARS,
+} from '@lib/wizard-tools/handoff';
+import type { Credentials } from '@lib/wizard-session';
+
+function tmpDir(): string {
+  return mkdtempSync(path.join(tmpdir(), 'handoff-test-'));
+}
+
+function creds(overrides: Partial<Credentials> = {}): Credentials {
+  return {
+    accessToken: 'phx_token',
+    projectApiKey: 'phc_key',
+    host: {
+      apiHost: 'https://us.i.posthog.com',
+      appHost: 'https://us.posthog.com',
+      gatewayUrl: 'https://gateway.us.posthog.com',
+      mcpUrl: 'https://mcp.us.posthog.com',
+    },
+    projectId: 42,
+    ...overrides,
+  } as Credentials;
+}
+
+function mockFetch(shortId: string, status = 200): typeof fetch {
+  return vi.fn(() =>
+    Promise.resolve(new Response(JSON.stringify({ short_id: shortId }), { status })),
+  ) as unknown as typeof fetch;
+}
+
+describe('normalizeHandoffContent', () => {
+  it('rejects non-string and blank input', () => {
+    expect(normalizeHandoffContent('')).toBeNull();
+    expect(normalizeHandoffContent('   \n  ')).toBeNull();
+    // @ts-expect-error — guards against the agent passing a non-string
+    expect(normalizeHandoffContent({})).toBeNull();
+  });
+
+  it('caps oversize content to the backend serializer limit', () => {
+    const huge = 'a'.repeat(MAX_HANDOFF_CONTENT_CHARS + 1000);
+    const normalized = normalizeHandoffContent(huge);
+    expect(normalized).not.toBeNull();
+    expect(normalized!.length).toBe(MAX_HANDOFF_CONTENT_CHARS);
+  });
+
+  it('passes through in-bounds content unchanged', () => {
+    expect(normalizeHandoffContent('# Report\n\nbody')).toBe(
+      '# Report\n\nbody',
+    );
+  });
+});
+
+describe('buildNotebookContent', () => {
+  it('wraps the report in a single ph-markdown-notebook node', () => {
+    const doc = buildNotebookContent('# Report');
+    expect(doc.type).toBe('doc');
+    expect(doc.content).toHaveLength(1);
+    expect(doc.content[0].type).toBe('ph-markdown-notebook');
+    expect(doc.content[0].attrs.markdown).toBe('# Report');
+    expect(doc.content[0].attrs.nodeId).toBe('markdown-notebook-v2');
+  });
+});
+
+describe('buildNotebookUrl', () => {
+  it('builds the shareable URL from the app host, project id, and short id', () => {
+    expect(buildNotebookUrl('https://us.posthog.com/', 42, 'AbCdEfGh')).toBe(
+      'https://us.posthog.com/project/42/notebooks/AbCdEfGh',
+    );
+  });
+});
+
+describe('resolveReportPath', () => {
+  it('resolves inside the working directory and rejects traversal', () => {
+    const dir = tmpDir();
+    try {
+      expect(resolveReportPath(dir, 'report.md')).toBe(
+        path.resolve(dir, 'report.md'),
+      );
+      expect(resolveReportPath(dir, 'sub/report.md')).toBe(
+        path.resolve(dir, 'sub/report.md'),
+      );
+      expect(() => resolveReportPath(dir, '../escape.md')).toThrow(
+        'Path traversal rejected',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('publishHandoff', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes the report file, sets store hooks, and returns the notebook URL', async () => {
+    const reportPath = path.join(dir, 'posthog-setup-report.md');
+    const setHandoffText = vi.fn();
+    const setNotebookUrl = vi.fn();
+    const fetchImpl = mockFetch('AbCdEfGh');
+
+    const result = await publishHandoff('# Setup report\n\nbody', 'My title', {
+      reportPath,
+      getCredentials: () => creds(),
+      hooks: { setHandoffText, setNotebookUrl },
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(reportPath, 'utf8')).toBe('# Setup report\n\nbody');
+    expect(setHandoffText).toHaveBeenCalledWith('# Setup report\n\nbody');
+    expect(setNotebookUrl).toHaveBeenCalledWith(
+      'https://us.posthog.com/project/42/notebooks/AbCdEfGh',
+    );
+    expect(result.notebookUrl).toBe(
+      'https://us.posthog.com/project/42/notebooks/AbCdEfGh',
+    );
+
+    // The notebook call hit the notebooks endpoint with the wrapped doc.
+    const call = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(call[0]).toBe('https://us.i.posthog.com/api/projects/42/notebooks/');
+    const body = JSON.parse(call[1].body);
+    expect(body.title).toBe('My title');
+    expect(body.content.content[0].type).toBe('ph-markdown-notebook');
+  });
+
+  it('rejects blank content without writing anything', async () => {
+    const reportPath = path.join(dir, 'posthog-setup-report.md');
+    const setHandoffText = vi.fn();
+    const result = await publishHandoff('   ', undefined, {
+      reportPath,
+      getCredentials: () => creds(),
+      hooks: { setHandoffText },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('blank');
+    expect(existsSync(reportPath)).toBe(false);
+    expect(setHandoffText).not.toHaveBeenCalled();
+  });
+
+  it('still writes the file + sets handoff_text when credentials are absent (no notebook)', async () => {
+    const reportPath = path.join(dir, 'posthog-setup-report.md');
+    const setHandoffText = vi.fn();
+    const setNotebookUrl = vi.fn();
+
+    const result = await publishHandoff('# Report', undefined, {
+      reportPath,
+      getCredentials: () => null, // pre-auth
+      hooks: { setHandoffText, setNotebookUrl },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(reportPath, 'utf8')).toBe('# Report');
+    expect(setHandoffText).toHaveBeenCalledWith('# Report');
+    expect(setNotebookUrl).not.toHaveBeenCalled();
+    expect(result.notebookUrl).toBeNull();
+  });
+
+  it('still writes the file + sets handoff_text when the notebook upload fails', async () => {
+    const reportPath = path.join(dir, 'posthog-setup-report.md');
+    const setHandoffText = vi.fn();
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response('boom', { status: 500 })),
+    ) as unknown as typeof fetch;
+
+    const result = await publishHandoff('# Report', undefined, {
+      reportPath,
+      getCredentials: () => creds(),
+      hooks: { setHandoffText },
+      fetchImpl,
+    });
+
+    // Notebook failure must not fail the publish — file + handoff_text load-bearing.
+    expect(result.ok).toBe(true);
+    expect(readFileSync(reportPath, 'utf8')).toBe('# Report');
+    expect(setHandoffText).toHaveBeenCalledWith('# Report');
+    expect(result.notebookUrl).toBeNull();
+  });
+});
+
+describe('buildHandoffContext', () => {
+  it('returns null when the program has no reportFile', () => {
+    const store = {
+      setHandoffText: vi.fn(),
+      setNotebookUrl: vi.fn(),
+    };
+    expect(
+      buildHandoffContext({
+        workingDirectory: tmpDir(),
+        reportFile: undefined,
+        store,
+        getCredentials: () => creds(),
+      }),
+    ).toBeNull();
+  });
+
+  it('resolves the report path and wires the store hooks', () => {
+    const dir = tmpDir();
+    try {
+      const store = {
+        setHandoffText: vi.fn(),
+        setNotebookUrl: vi.fn(),
+      };
+      const ctx = buildHandoffContext({
+        workingDirectory: dir,
+        reportFile: 'posthog-setup-report.md',
+        store,
+        getCredentials: () => null,
+      });
+      expect(ctx).not.toBeNull();
+      expect(ctx!.reportPath).toBe(
+        path.resolve(dir, 'posthog-setup-report.md'),
+      );
+      ctx!.hooks!.setHandoffText('x');
+      ctx!.hooks!.setNotebookUrl('y');
+      expect(store.setHandoffText).toHaveBeenCalledWith('x');
+      expect(store.setNotebookUrl).toHaveBeenCalledWith('y');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/wizard-tools/handoff.ts
+++ b/src/lib/wizard-tools/handoff.ts
@@ -1,0 +1,328 @@
+/**
+ * Handoff-publish core — the shared behavior behind the `publish_handoff`
+ * wizard tool. One call writes the run's markdown setup report to disk,
+ * mirrors it into a shareable PostHog notebook (direct HTTP, no agent IO),
+ * and sets it on the store so the task-stream push carries `handoff_text`
+ * to the PostHog app.
+ *
+ * Consolidating the three agent-IO paths the wizard used to run separately
+ * (write-file, `notebooks-create` via MCP, passive file-watching) into a
+ * single deterministic tool call. The pure helpers here are exported so the
+ * MCP facade (`./mcp`) and the pi facade (`harness/pi/...`) share one
+ * implementation — tool behavior cannot drift between harnesses.
+ *
+ * The notebook wire shape mirrors what the posthog-wizard MCP's
+ * `notebooks-create` accepts and what the context-mill notebook step used to
+ * instruct the agent to build by hand: a ProseMirror doc with one
+ * `ph-markdown-notebook` node whose `markdown` attr holds the report.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { logToFile } from '@utils/debug';
+import { analytics } from '@utils/analytics';
+import type { Credentials } from '@lib/wizard-session';
+
+// Match the backend serializer cap the task-stream handoff_watcher already
+// enforces (MAX_HANDOFF_TEXT_CHARS). An oversized doc would 400 the session
+// upsert and, because that payload is a full-state snapshot, take every later
+// session update down with it.
+export const MAX_HANDOFF_CONTENT_CHARS = 64 * 1024;
+
+/** Reject blank input; cap oversize instead of 400ing the session push. */
+export function normalizeHandoffContent(raw: string): string | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+  return raw.length > MAX_HANDOFF_CONTENT_CHARS
+    ? raw.slice(0, MAX_HANDOFF_CONTENT_CHARS)
+    : raw;
+}
+
+/** Default notebook title when the caller omits one. */
+export const DEFAULT_NOTEBOOK_TITLE = 'PostHog setup (wizard)';
+
+/**
+ * Build the ProseMirror doc body the notebooks API expects — one
+ * `ph-markdown-notebook` node carrying the report markdown. Same shape the
+ * context-mill notebook step hand-rolled; lifted here so the agent never has
+ * to JSON-escape a multi-page report again.
+ */
+export function buildNotebookContent(markdown: string): {
+  type: 'doc';
+  content: Array<{
+    type: 'ph-markdown-notebook';
+    attrs: { nodeId: string; markdown: string };
+  }>;
+} {
+  return {
+    type: 'doc',
+    content: [
+      {
+        type: 'ph-markdown-notebook',
+        attrs: { nodeId: 'markdown-notebook-v2', markdown },
+      },
+    ],
+  };
+}
+
+/**
+ * Build the shareable notebook URL from the create response's `short_id`.
+ * Same shape the context-mill notebook step instructed the agent to emit via
+ * `[NOTEBOOK_URL]`: `<appHost>/project/<projectId>/notebooks/<short_id>`.
+ */
+export function buildNotebookUrl(
+  appHost: string,
+  projectId: number,
+  shortId: string,
+): string {
+  return `${appHost.replace(
+    /\/$/,
+    '',
+  )}/project/${projectId}/notebooks/${shortId}`;
+}
+
+/** Resolve a report path against the working directory, refusing traversal. */
+export function resolveReportPath(
+  workingDirectory: string,
+  reportFile: string,
+): string {
+  const resolved = path.resolve(workingDirectory, reportFile);
+  if (
+    resolved !== workingDirectory &&
+    !resolved.startsWith(workingDirectory + path.sep)
+  ) {
+    throw new Error(
+      `Path traversal rejected: "${reportFile}" resolves outside working directory`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Atomically write the report markdown to disk. Uses the same rename dance as
+ * the ledger writer so the mtime bump is one step — a passive watcher (kept
+ * as a fallback) sees a single atomic swap rather than a half-written file.
+ */
+export function writeReportFile(reportPath: string, content: string): void {
+  const dir = path.dirname(reportPath);
+  fs.mkdirSync(dir, { recursive: true });
+  // writeJsonAtomic is rename-over-target; reuse the primitive but write raw
+  // text so the report stays valid markdown, not JSON-encoded.
+  const tmpPath = `${reportPath}.tmp`;
+  fs.writeFileSync(tmpPath, content, 'utf8');
+  fs.renameSync(tmpPath, reportPath);
+}
+
+export interface NotebookCreateResponse {
+  /** The notebook's short id, used to build the share URL. */
+  short_id?: string;
+  id?: string;
+}
+
+export interface PublishHandoffHooks {
+  /** Set the captured report on the store → task-stream push carries it. */
+  setHandoffText?: (text: string) => void;
+  /** Surface the notebook URL so the outro screen can link it. */
+  setNotebookUrl?: (url: string) => void;
+}
+
+/**
+ * Context the `publish_handoff` tool is bound to. Threaded into
+ * createWizardToolsServer the same way the orchestrator queue context is —
+ * built by the runner (which owns the WizardStore + task-stream push + the
+ * program's reportFile), absent in hosts without a store or a report.
+ */
+export interface HandoffToolsContext {
+  /** Absolute path the report file is written to (resolved against cwd). */
+  reportPath: string;
+  /** Lazy credentials resolver — null before auth, so the notebook step skips. */
+  getCredentials: () => Credentials | null;
+  /** Store hooks for handoff text + notebook URL. Optional in headless hosts. */
+  hooks?: PublishHandoffHooks;
+  /** Override for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface PublishHandoffOptions {
+  /** Absolute report file path (resolved against the working directory). */
+  reportPath: string;
+  /** Credentials for the notebook HTTP call; null pre-auth → notebook skipped. */
+  getCredentials: () => Credentials | null;
+  /** Optional store hooks. Absent in hosts without a store (CI, headless). */
+  hooks?: PublishHandoffHooks;
+  /** Override for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export type PublishHandoffResult =
+  | { ok: true; reportPath: string; notebookUrl: string | null }
+  | { ok: false; reason: 'blank'; message: string };
+
+/**
+ * Publish a handoff in one call: write the report file, mirror it into a
+ * PostHog notebook (direct HTTP with the run's credentials), and set the
+ * captured text on the store so the task-stream push carries `handoff_text`.
+ *
+ * Failure handling mirrors the task-stream destination: never throw to the
+ * caller. The file write and the store update are the load-bearing parts —
+ * the notebook upload is best-effort and a failure there returns `notebookUrl:
+ * null` rather than failing the whole call. The agent sees a short status and
+ * the notebook URL (or the reason it's absent).
+ */
+export async function publishHandoff(
+  content: string,
+  title: string | undefined,
+  opts: PublishHandoffOptions,
+): Promise<PublishHandoffResult> {
+  const normalized = normalizeHandoffContent(content);
+  if (normalized === null) {
+    return {
+      ok: false,
+      reason: 'blank',
+      message:
+        'Error: publish_handoff received empty content. Pass the full markdown setup report.',
+    };
+  }
+
+  // 1. Write the report file — the artifact the user opens after the run.
+  writeReportFile(opts.reportPath, normalized);
+  logToFile(`publish_handoff: wrote ${opts.reportPath}`);
+
+  // 2. Set the store so the task-stream push carries handoff_text. This is
+  //    the deterministic capture the passive HandoffWatcher used to provide;
+  //    the tool call is now the capture event (the watcher stays as a
+  //    fallback for programs that write the file directly).
+  opts.hooks?.setHandoffText?.(normalized);
+
+  // 3. Mirror the report into a PostHog notebook. Best-effort: a pre-auth or
+  //    transient failure must not fail the whole publish. Credentials may be
+  //    null early in the run; the notebook just isn't created yet.
+  let notebookUrl: string | null = null;
+  const creds = opts.getCredentials();
+  if (creds) {
+    try {
+      notebookUrl = await uploadNotebook(
+        normalized,
+        title ?? DEFAULT_NOTEBOOK_TITLE,
+        creds,
+        opts.fetchImpl,
+      );
+      if (notebookUrl) {
+        opts.hooks?.setNotebookUrl?.(notebookUrl);
+        logToFile(`publish_handoff: notebook ${notebookUrl}`);
+      }
+    } catch (err: any) {
+      // Don't fail the publish — the report file and the session push are the
+      // load-bearing deliverables. Surface the error to the debug log only.
+      logToFile(
+        `publish_handoff: notebook upload failed: ${err?.message ?? err}`,
+      );
+      analytics.wizardCapture('handoff notebook upload failed', {
+        error: String(err?.message ?? err).slice(0, 500),
+      });
+    }
+  } else {
+    logToFile('publish_handoff: no credentials yet, skipping notebook upload');
+  }
+
+  return { ok: true, reportPath: opts.reportPath, notebookUrl };
+}
+
+/**
+ * Create a PostHog notebook carrying the report markdown. Calls the notebooks
+ * REST endpoint directly with the run's access token (the `notebook:write`
+ * scope is already in WIZARD_PROVISIONING_SCOPES), so there's no MCP round-trip
+ * and no JSON-encoding the agent has to get right. Returns the shareable URL,
+ * or null if the response carried no `short_id`.
+ */
+export async function uploadNotebook(
+  markdown: string,
+  title: string,
+  creds: Credentials,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  const url = `${creds.host.apiHost.replace(/\/$/, '')}/api/projects/${
+    creds.projectId
+  }/notebooks/`;
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${creds.accessToken}`,
+    },
+    body: JSON.stringify({
+      title,
+      content: buildNotebookContent(markdown),
+    }),
+  });
+
+  if (!response.ok) {
+    let detail = '';
+    try {
+      detail = await response.text();
+    } catch {
+      // ignore
+    }
+    throw new Error(
+      `notebooks create failed (${response.status}): ${detail.slice(0, 500)}`,
+    );
+  }
+
+  const body = (await response.json()) as NotebookCreateResponse;
+  const shortId = body.short_id;
+  if (!shortId) return null;
+  return buildNotebookUrl(creds.host.appHost, creds.projectId, shortId);
+}
+
+// ---------------------------------------------------------------------------
+// Test-only exports
+// ---------------------------------------------------------------------------
+
+export const __test = {
+  writeReportFile,
+  buildNotebookContent,
+};
+
+// ---------------------------------------------------------------------------
+// Runner-facing factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal store surface the handoff context needs. The full `WizardStore`
+ * satisfies this; the narrower type keeps the runner factory decoupled from
+ * the TUI store's implementation and lets tests stub just these methods.
+ */
+export interface HandoffStoreSurface {
+  /** Mirrors the report into the store so the task-stream push carries it. */
+  setHandoffText(text: string): void;
+  /** Surfaces the notebook URL so the outro screen can link it. */
+  setNotebookUrl(url: string): void;
+}
+
+/**
+ * Build the handoff-publish context a runner threads into `runAgent`. Resolves
+ * the report path against the working directory once (the program's
+ * `reportFile` is repo-relative), wires the store hooks, and reads credentials
+ * lazily so a pre-auth call to the tool just skips the notebook upload.
+ *
+ * Returns `null` when the program has no reportFile — the runner then omits
+ * the context and the `publish_handoff` tool stays unregistered.
+ */
+export function buildHandoffContext(args: {
+  workingDirectory: string;
+  reportFile?: string;
+  store: HandoffStoreSurface;
+  getCredentials: () => Credentials | null;
+  fetchImpl?: typeof fetch;
+}): HandoffToolsContext | null {
+  if (!args.reportFile) return null;
+  const reportPath = resolveReportPath(args.workingDirectory, args.reportFile);
+  return {
+    reportPath,
+    getCredentials: args.getCredentials,
+    hooks: {
+      setHandoffText: (text) => args.store.setHandoffText(text),
+      setNotebookUrl: (url) => args.store.setNotebookUrl(url),
+    },
+    fetchImpl: args.fetchImpl,
+  };
+}

--- a/src/lib/wizard-tools/mcp.ts
+++ b/src/lib/wizard-tools/mcp.ts
@@ -47,6 +47,7 @@ import {
   type SkillEntry,
   AUDIT_STATUSES,
 } from './tools';
+import { publishHandoff, type HandoffToolsContext } from './handoff';
 
 const auditCheckSchema = z.object({
   id: z.string().min(1),
@@ -124,6 +125,14 @@ export interface WizardToolsOptions {
 
   /** Scan-triage classifier for install_skill's scan, resolved by the caller. */
   triageProvider: LLMProvider;
+
+  /**
+   * Handoff-publish context. Present when the runner can supply the program's
+   * report path plus store hooks (interactive / headless with a reportFile);
+   * when set, the `publish_handoff` tool is registered. Absent in hosts
+   * without a store or a report, so the tool surface stays stable.
+   */
+  handoff?: HandoffToolsContext;
 }
 
 /** Default per-run cap on wizard_ask calls when no override is provided. */
@@ -145,6 +154,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
     secretVault = createSecretVault(),
     orchestrator,
     triageProvider,
+    handoff,
   } = options;
   const sdk = await getSDKModule();
   const { tool, createSdkMcpServer } = sdk;
@@ -774,6 +784,68 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
     },
   );
 
+  // -- publish_handoff -----------------------------------------------------
+
+  // The deterministic handoff: one call writes the report file, mirrors it
+  // into a PostHog notebook (direct HTTP, no agent IO), and sets the captured
+  // text on the store so the task-stream push carries handoff_text. Registered
+  // only when the runner supplied a handoff context (a report path + store
+  // hooks); programs without a reportFile keep the tool surface stable.
+  const publishHandoffTool = handoff
+    ? tool(
+        'publish_handoff',
+        "Publish the run's markdown setup report as the handoff doc in one call: " +
+          'writes the report file, mirrors it into a shareable PostHog notebook, and ' +
+          'pushes it to the PostHog session as handoff_text. Call this exactly once, ' +
+          'with the full report markdown — do not write the report file yourself, do ' +
+          'not call notebooks-create, and do not emit a [NOTEBOOK_URL] marker. Returns ' +
+          'the notebook URL (or null if the notebook could not be created).',
+        {
+          content: z
+            .string()
+            .min(1)
+            .describe(
+              'The full markdown setup report — the same content that would have ' +
+                'been written to the report file. Start with an H1 heading.',
+            ),
+          title: z
+            .string()
+            .optional()
+            .describe(
+              'Optional notebook title. Defaults to "PostHog setup (wizard)".',
+            ),
+        },
+        async (args: { content: string; title?: string }) => {
+          const result = await publishHandoff(args.content, args.title, {
+            reportPath: handoff.reportPath,
+            getCredentials: handoff.getCredentials,
+            hooks: handoff.hooks,
+            fetchImpl: handoff.fetchImpl,
+          });
+          if (!result.ok) {
+            return {
+              content: [{ type: 'text' as const, text: result.message }],
+              isError: true,
+            };
+          }
+          const notebookLine =
+            result.notebookUrl != null
+              ? `\nNotebook: ${result.notebookUrl}`
+              : '\nNo notebook was created (credentials unavailable or upload failed — the report file and the PostHog session handoff_text are still set).';
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Published handoff to ./${path.basename(
+                  result.reportPath,
+                )}.${notebookLine}`,
+              },
+            ],
+          };
+        },
+      )
+    : null;
+
   // -- Assemble server ------------------------------------------------------
 
   const orchestratorTools = orchestrator
@@ -793,6 +865,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
       auditAddChecks,
       auditResolveChecks,
       wizardAsk,
+      ...(publishHandoffTool ? [publishHandoffTool] : []),
       ...orchestratorTools,
     ],
   });

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -648,6 +648,7 @@ export const WIZARD_TOOL_NAMES = {
   enqueueTask: `mcp__${SERVER_NAME}__enqueue_task`,
   completeTask: `mcp__${SERVER_NAME}__complete_task`,
   readHandoffs: `mcp__${SERVER_NAME}__read_handoffs`,
+  publishHandoff: `mcp__${SERVER_NAME}__publish_handoff`,
 } as const;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A run's handoff is produced across three separate agent-IO paths today: the agent `Write`s the report file, the agent calls `notebooks-create` via MCP (hand-encoding a multi-page report as ProseMirror JSON, with several failure modes the skill spends paragraphs warning about), and a passive `HandoffWatcher` reads the file back into the store so the task-stream push carries `handoff_text`. Three paths means three chances to drift, and three rounds of slow agent IO.

Stacks on #1045, which introduced the `handoff_text` upload to the PostHog session.

## Changes

- New `publish_handoff` wizard tool (`src/lib/wizard-tools/handoff.ts`) that in **one deterministic, host-side call**: atomically writes the report file, mirrors it into a shareable PostHog notebook via direct HTTP (using the run's already-provisioned `notebook:write` scope — no MCP round-trip), and sets the captured text on the store so the task-stream push carries `handoff_text` (the upload part #1045 introduced).
- The tool is registered into the wizard-tools MCP server **and** the pi facade, sharing one pure-logic core so behavior can't drift between harnesses — same pattern as the orchestrator queue tools. It's registered only when the runner supplies a handoff context (report path + store hooks); absent in hosts without a store/report, the surface stays stable.
- The `HandoffToolsContext` is built by the runners (which own the `WizardStore` + `TaskStreamPush` + the program's `reportFile`) and threaded through `runAgent` → the sequence runner → the harness inputs, mirroring how the orchestrator context is threaded.
- The passive `HandoffWatcher` from #1045 stays as a fallback with a `TODO(remove)` note; once every program's skill content calls `publish_handoff`, it (and the force-read in `TaskStreamPush.shutdown`) can be deleted.

Coordinated with PostHog/context-mill: the integration-v2 `report` step now calls `publish_handoff` with the full report markdown, and the `notebook` step becomes a no-op confirmation (the tool already created the notebook).

## Test plan

`npx vitest run src/lib/wizard-tools/__tests__/handoff.test.ts` — 12 new tests covering: blank-content rejection, oversize cap, notebook content shape, URL building, path-traversal rejection, file write + store hooks + notebook URL on success, blank rejection writes nothing, missing credentials still writes file + sets handoff_text (notebook skipped), notebook-upload failure still writes file + sets handoff_text, and the runner `buildHandoffContext` factory. Existing `task-stream`, `wizard-tools`, `agent-interface`, and orchestrator `queue-tools` suites still green (112 + 79 tests). `pnpm typecheck` introduces zero new errors vs. the #1045 base.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*