### PR TITLE
fix(mcp-analytics): correct abort copy and match the codemod's actual reason

### DIFF
--- a/src/lib/programs/__tests__/mcp-analytics.test.ts
+++ b/src/lib/programs/__tests__/mcp-analytics.test.ts
@@ -1,0 +1,50 @@
+import {
+  MCP_ANALYTICS_ABORT_CASES,
+  mcpAnalyticsConfig,
+} from '@lib/programs/mcp-analytics/index';
+
+describe('MCP_ANALYTICS_ABORT_CASES', () => {
+  // These are the exact `[ABORT] <reason>` strings the mcp-analytics skill
+  // emits (context-mill `context/skills/mcp-analytics/description.md`), with
+  // the `[ABORT] ` prefix already stripped — matching what the runner passes
+  // to `AbortCase.match` (src/lib/agent/runner/sequence/linear.ts).
+  const reasons = [
+    'no mcp server found',
+    'unsupported language for mcp analytics',
+    'could not locate the server entry point',
+  ];
+
+  it.each(reasons)('matches the "%s" abort reason exactly once', (reason) => {
+    const matched = MCP_ANALYTICS_ABORT_CASES.filter((c) =>
+      c.match.test(reason),
+    );
+    expect(matched).toHaveLength(1);
+    expect(matched[0].message).toBeTruthy();
+    expect(matched[0].body).toBeTruthy();
+  });
+
+  it('frames the unsupported-language abort as JS/TS *and* Python supported', () => {
+    // Python (`posthog.mcp`) shipped in posthog v7.21.0 — the copy must not
+    // claim JS/TS-only or call Python "on the roadmap".
+    const [langCase] = MCP_ANALYTICS_ABORT_CASES.filter((c) =>
+      c.match.test('unsupported language for mcp analytics'),
+    );
+    expect(langCase).toBeDefined();
+    const copy = `${langCase.message} ${langCase.body}`.toLowerCase();
+    expect(copy).toContain('python');
+    expect(copy).toContain('typescript');
+    expect(copy).not.toContain('roadmap');
+  });
+});
+
+describe('mcpAnalyticsConfig', () => {
+  it('wires the mcp-analytics abort cases into the run config', () => {
+    // `run` is statically a defined object for this program (createSkillProgram
+    // always sets it, and never uses the session-derived function form).
+    const run = mcpAnalyticsConfig.run;
+    if (!run || typeof run === 'function') {
+      throw new Error('expected a static run object');
+    }
+    expect(run.abortCases).toBe(MCP_ANALYTICS_ABORT_CASES);
+  });
+});

--- a/src/lib/programs/mcp-analytics/index.ts
+++ b/src/lib/programs/mcp-analytics/index.ts
@@ -8,14 +8,14 @@ const MCP_ANALYTICS_REPORT_FILE = 'posthog-mcp-analytics-report.md';
  * instrumented. Kept in sync with the stop conditions in the skill's
  * `description.md` (context-mill `context/skills/mcp-analytics`).
  */
-const MCP_ANALYTICS_ABORT_CASES: AbortCase[] = [
+export const MCP_ANALYTICS_ABORT_CASES: AbortCase[] = [
   {
-    match: /^not a javascript mcp server$/i,
-    message: 'Not a JavaScript/TypeScript MCP server',
+    match: /^unsupported language for mcp analytics$/i,
+    message: 'Unsupported language for MCP analytics',
     body:
-      'MCP analytics is currently TypeScript/JavaScript-only — the `@posthog/mcp` ' +
-      'SDK is a Node package (a Python SDK is on the roadmap). This project ' +
-      "doesn't look like a JS/TS MCP server, so there's nothing to instrument. " +
+      'MCP analytics supports TypeScript/JavaScript (`@posthog/mcp`) and Python ' +
+      '(`posthog.mcp`, shipped inside the `posthog` package). This project ' +
+      "doesn't look like either, so there's nothing to instrument. " +
       'See https://posthog.com/docs/mcp-analytics for the supported setups.',
   },
   {
@@ -25,6 +25,16 @@ const MCP_ANALYTICS_ABORT_CASES: AbortCase[] = [
       'This command instruments an existing MCP server with PostHog analytics, ' +
       'but no MCP server was found in this project. If you just want PostHog ' +
       'product analytics, run `npx @posthog/wizard` instead.',
+  },
+  {
+    match: /^could not locate the server entry point$/i,
+    message: 'Could not locate the MCP server entry point',
+    body:
+      "This project has MCP signals, but the agent couldn't find where the " +
+      "server is constructed or requests are dispatched, so there's nowhere " +
+      'safe to add instrumentation. See https://posthog.com/docs/mcp-analytics ' +
+      'for the supported server styles, or point the wizard at the package ' +
+      "that defines the server if it's in a monorepo subdirectory.",
   },
 ];
 


### PR DESCRIPTION
The `mcp-analytics` abort table had two defects that cancelled each other out into silence.

**Wrong copy.** One case told users "MCP analytics is currently TypeScript/JavaScript-only ... a Python SDK is on the roadmap". Python shipped a while ago — `posthog.mcp` in `posthog` v7.21.0, with codemod paths P1/P2 added in context-mill v1.26.0 — so this actively turned Python users away from a supported setup.

**Unreachable case.** That entry matched `not a javascript mcp server`, a reason the codemod never emits. Its real vocabulary is `no mcp server found`, `unsupported language for mcp analytics`, `could not locate the server entry point`, and a free-text catch-all. So the case never rendered, and an unsupported-language abort fell through to generic handling.

## What changed

- Repointed the regex at `unsupported language for mcp analytics` and rewrote the body to name both TypeScript/JavaScript and Python.
- Added the missing `could not locate the server entry point` case, which was also falling through to the generic message despite being a documented, actionable stop condition.
- Exported `MCP_ANALYTICS_ABORT_CASES` so it can be tested.

Verified the matching semantics rather than assuming them: `agent-interface.ts` strips the `[ABORT] ` prefix and trims, then `linear.ts` runs `RegExp.test()` against the full reason — so the existing anchored `/^...$/i` shape is correct.

## Testing

- New `src/lib/programs/__tests__/mcp-analytics.test.ts` (5 tests), mirroring the existing `SELF_DRIVING_ABORT_CASES` pattern: every documented reason matches exactly one case, and the copy names both languages.
- Full suite: 121 files, 1706 tests passing.
- `eslint`, `prettier --check` clean; `tsc --noEmit` shows only pre-existing unrelated errors (confirmed identical via stash).
- `codex review --base main`: no findings.

## Note for reviewers

Documentation for this contract now lives in the `debugging-mcp-analytics` skill in the monorepo, which spells out that the codemod's reasons and this table have to move together.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*