### PR TITLE
fix(agent): refresh the gateway token so long runs stop 401ing

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "build": "tsdown",
     "build:ci": "WIZARD_BUILD_NODE_ENV=ci pnpm build",
     "typecheck": "tsc --noEmit",
-    "postbuild": "chmod +x ./dist/bin.js && cp -r scripts/** dist && rm -f dist/*.no-jest.* && pnpm test:smoke && pnpm test:warlock",
+    "postbuild": "chmod +x ./dist/bin.js ./dist/auth-helper.js && cp -r scripts/** dist && rm -f dist/*.no-jest.* && pnpm test:smoke && pnpm test:warlock",
     "test:smoke": "bash ./scripts/smoke-test.sh",
     "test:warlock": "tsx scripts/warlock-smoke-test.ts",
     "lint": "pnpm lint:prettier && pnpm lint:eslint",

--- a/src/lib/agent/__tests__/rotating-credential.test.ts
+++ b/src/lib/agent/__tests__/rotating-credential.test.ts
@@ -4,9 +4,6 @@ import { readFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { createRotatingCredential } from '@lib/agent/rotating-credential';
 
-// The helper runs as its own process, so the only way to exercise it is to run
-// it. Two cases cover the whole contract: hand back what we have while it's
-// good, swap it when it isn't.
 describe('rotating gateway credential', () => {
   let server: Server;
   let tokenUrl: string;
@@ -64,8 +61,7 @@ describe('rotating gateway credential', () => {
       },
     ]);
 
-    // Reusing the spent refresh token would revoke the whole session, so the
-    // rotated one has to land on disk for the next invocation.
+    // Reusing a spent refresh token revokes the whole session.
     const state = JSON.parse(readFileSync(statePathFor(helperPath), 'utf8'));
     expect(state.refreshToken).toBe('refresh_rotated');
     expect(await run(helperPath)).toBe('pha_rotated');

--- a/src/lib/agent/__tests__/rotating-credential.test.ts
+++ b/src/lib/agent/__tests__/rotating-credential.test.ts
@@ -1,10 +1,16 @@
 import { execFile } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
 import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { createRotatingCredential } from '@lib/agent/rotating-credential';
+import { AUTH_STATE_ENV } from '@lib/agent/auth-constants';
+import { createAuthState } from '@lib/agent/rotating-credential';
 
-describe('rotating gateway credential', () => {
+// The built artifact, not the source: it's a separate bundle the agent SDK execs
+// standalone. `pnpm test` builds before running, so this exists.
+const helper = join(process.cwd(), 'dist/auth-helper.js');
+
+describe('gateway credential helper', () => {
   let server: Server;
   let tokenUrl: string;
   let refreshCalls: Array<Record<string, string>>;
@@ -35,16 +41,18 @@ describe('rotating gateway credential', () => {
     await new Promise((resolve) => server.close(resolve));
   });
 
-  // Async, not execFileSync: the token endpoint below lives in this process, so
+  // Async, not execFileSync: the token endpoint above lives in this process, so
   // blocking the event loop would deadlock the helper's request against it.
-  const run = async (helperPath: string): Promise<string> =>
-    (await promisify(execFile)(helperPath, { encoding: 'utf8' })).stdout;
-
-  const statePathFor = (helperPath: string): string =>
-    helperPath.replace(/helper\.mjs$/, 'state.json');
+  const run = async (statePath: string): Promise<string> =>
+    (
+      await promisify(execFile)(helper, {
+        encoding: 'utf8',
+        env: { ...process.env, [AUTH_STATE_ENV]: statePath },
+      })
+    ).stdout;
 
   it('rotates a token that is about to expire, and persists the new refresh token', async () => {
-    const helperPath = createRotatingCredential({
+    const statePath = createAuthState({
       accessToken: 'pha_original',
       refreshToken: 'refresh_original',
       expiresAt: Date.now() + 60_000, // inside the refresh skew
@@ -52,7 +60,7 @@ describe('rotating gateway credential', () => {
       clientId: 'client-abc',
     });
 
-    expect(await run(helperPath)).toBe('pha_rotated');
+    expect(await run(statePath)).toBe('pha_rotated');
     expect(refreshCalls).toEqual([
       {
         grant_type: 'refresh_token',
@@ -62,14 +70,15 @@ describe('rotating gateway credential', () => {
     ]);
 
     // Reusing a spent refresh token revokes the whole session.
-    const state = JSON.parse(readFileSync(statePathFor(helperPath), 'utf8'));
-    expect(state.refreshToken).toBe('refresh_rotated');
-    expect(await run(helperPath)).toBe('pha_rotated');
+    expect(JSON.parse(readFileSync(statePath, 'utf8')).refreshToken).toBe(
+      'refresh_rotated',
+    );
+    expect(await run(statePath)).toBe('pha_rotated');
     expect(refreshCalls).toHaveLength(1);
   });
 
   it('leaves a healthy token alone', async () => {
-    const helperPath = createRotatingCredential({
+    const statePath = createAuthState({
       accessToken: 'pha_healthy',
       refreshToken: 'refresh_original',
       expiresAt: Date.now() + 60 * 60_000,
@@ -77,7 +86,7 @@ describe('rotating gateway credential', () => {
       clientId: 'client-abc',
     });
 
-    expect(await run(helperPath)).toBe('pha_healthy');
+    expect(await run(statePath)).toBe('pha_healthy');
     expect(refreshCalls).toHaveLength(0);
   });
 });

--- a/src/lib/agent/__tests__/rotating-credential.test.ts
+++ b/src/lib/agent/__tests__/rotating-credential.test.ts
@@ -1,0 +1,87 @@
+import { execFile } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { createRotatingCredential } from '@lib/agent/rotating-credential';
+
+// The helper runs as its own process, so the only way to exercise it is to run
+// it. Two cases cover the whole contract: hand back what we have while it's
+// good, swap it when it isn't.
+describe('rotating gateway credential', () => {
+  let server: Server;
+  let tokenUrl: string;
+  let refreshCalls: Array<Record<string, string>>;
+
+  beforeEach(async () => {
+    refreshCalls = [];
+    server = createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk) => (body += chunk));
+      req.on('end', () => {
+        refreshCalls.push(JSON.parse(body));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            access_token: 'pha_rotated',
+            refresh_token: 'refresh_rotated',
+            expires_in: 3600,
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const { port } = server.address() as { port: number };
+    tokenUrl = `http://127.0.0.1:${port}/oauth/token`;
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  // Async, not execFileSync: the token endpoint below lives in this process, so
+  // blocking the event loop would deadlock the helper's request against it.
+  const run = async (helperPath: string): Promise<string> =>
+    (await promisify(execFile)(helperPath, { encoding: 'utf8' })).stdout;
+
+  const statePathFor = (helperPath: string): string =>
+    helperPath.replace(/helper\.mjs$/, 'state.json');
+
+  it('rotates a token that is about to expire, and persists the new refresh token', async () => {
+    const helperPath = createRotatingCredential({
+      accessToken: 'pha_original',
+      refreshToken: 'refresh_original',
+      expiresAt: Date.now() + 60_000, // inside the refresh skew
+      tokenUrl,
+      clientId: 'client-abc',
+    });
+
+    expect(await run(helperPath)).toBe('pha_rotated');
+    expect(refreshCalls).toEqual([
+      {
+        grant_type: 'refresh_token',
+        refresh_token: 'refresh_original',
+        client_id: 'client-abc',
+      },
+    ]);
+
+    // Reusing the spent refresh token would revoke the whole session, so the
+    // rotated one has to land on disk for the next invocation.
+    const state = JSON.parse(readFileSync(statePathFor(helperPath), 'utf8'));
+    expect(state.refreshToken).toBe('refresh_rotated');
+    expect(await run(helperPath)).toBe('pha_rotated');
+    expect(refreshCalls).toHaveLength(1);
+  });
+
+  it('leaves a healthy token alone', async () => {
+    const helperPath = createRotatingCredential({
+      accessToken: 'pha_healthy',
+      refreshToken: 'refresh_original',
+      expiresAt: Date.now() + 60 * 60_000,
+      tokenUrl,
+      clientId: 'client-abc',
+    });
+
+    expect(await run(helperPath)).toBe('pha_healthy');
+    expect(refreshCalls).toHaveLength(0);
+  });
+});

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -27,7 +27,8 @@ import {
 } from '@lib/wizard-session';
 import { wizardAbort, WizardError } from '@utils/wizard-abort';
 import { createCustomHeaders } from '@utils/custom-headers';
-import { HELPER_CACHE_TTL_MS } from './rotating-credential';
+import { AUTH_STATE_ENV, HELPER_CACHE_TTL_MS } from './auth-constants';
+import { AUTH_HELPER_PATH } from './rotating-credential';
 import type { HostResolution } from '@lib/host-resolution';
 import { evaluateBashCommand } from './bash-fence';
 import { createWizardToolsServer, WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
@@ -181,7 +182,7 @@ export type AgentConfig = {
   posthogMcpUrl: string;
   posthogApiKey: string;
   /** Absent (CI, on a non-expiring key) keeps `posthogApiKey` fixed for the run. */
-  apiKeyHelperPath?: string;
+  authStatePath?: string;
   host: HostResolution;
   additionalMcpServers?: Record<string, { url: string }>;
   detectPackageManager: PackageManagerDetector;
@@ -299,8 +300,8 @@ type AgentRunConfig = {
   model: string;
   /** The run's OAuth access token — the MCP config resolves it in the child. */
   posthogApiKey: string;
-  /** See {@link AgentConfig.apiKeyHelperPath}. */
-  apiKeyHelperPath?: string;
+  /** See {@link AgentConfig.authStatePath}. */
+  authStatePath?: string;
   wizardFlags?: Record<string, string>;
   wizardMetadata?: Record<string, string>;
   /** Extra tools added on top of BASE_ALLOWED_TOOLS for this run. */
@@ -621,7 +622,7 @@ export async function initializeAgent(
       allowedTools: config.allowedTools,
       disallowedTools: config.disallowedTools,
       getPendingQuestion: config.getPendingQuestion,
-      apiKeyHelperPath: config.apiKeyHelperPath,
+      authStatePath: config.authStatePath,
       suppressTaskRender: !!config.orchestrator,
       capture: config.capture,
       triageProvider,
@@ -632,7 +633,7 @@ export async function initializeAgent(
 
     logToFile(
       'Gateway token rotation:',
-      config.apiKeyHelperPath ? 'on' : 'off (no refresh token)',
+      config.authStatePath ? 'on' : 'off (no refresh token)',
     );
 
     logToFile('Agent config:', {
@@ -909,8 +910,8 @@ export async function runAgent(
               : undefined,
           },
         },
-        settings: agentConfig.apiKeyHelperPath
-          ? { apiKeyHelper: agentConfig.apiKeyHelperPath }
+        settings: agentConfig.authStatePath
+          ? { apiKeyHelper: AUTH_HELPER_PATH }
           : undefined,
         // Load skills from project's .claude/skills/ directory
         settingSources: ['project'],
@@ -984,15 +985,16 @@ export async function runAgent(
           // from the inherited copy, so re-add the wizard's own values here).
           ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
           // Leaving these set alongside the helper would pin the spawn-time value.
-          ANTHROPIC_AUTH_TOKEN: agentConfig.apiKeyHelperPath
+          ANTHROPIC_AUTH_TOKEN: agentConfig.authStatePath
             ? undefined
             : process.env.ANTHROPIC_AUTH_TOKEN,
-          CLAUDE_CODE_OAUTH_TOKEN: agentConfig.apiKeyHelperPath
+          CLAUDE_CODE_OAUTH_TOKEN: agentConfig.authStatePath
             ? undefined
             : process.env.CLAUDE_CODE_OAUTH_TOKEN,
-          CLAUDE_CODE_API_KEY_HELPER_TTL_MS: agentConfig.apiKeyHelperPath
+          CLAUDE_CODE_API_KEY_HELPER_TTL_MS: agentConfig.authStatePath
             ? String(HELPER_CACHE_TTL_MS)
             : undefined,
+          [AUTH_STATE_ENV]: agentConfig.authStatePath,
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: 'true',
           // The MCP config resolves this in the child; sending the value would
           // put it on the CLI's argv.

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -27,6 +27,7 @@ import {
 } from '@lib/wizard-session';
 import { wizardAbort, WizardError } from '@utils/wizard-abort';
 import { createCustomHeaders } from '@utils/custom-headers';
+import { HELPER_CACHE_TTL_MS } from './rotating-credential';
 import type { HostResolution } from '@lib/host-resolution';
 import { evaluateBashCommand } from './bash-fence';
 import { createWizardToolsServer, WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
@@ -179,6 +180,13 @@ export type AgentConfig = {
   workingDirectory: string;
   posthogMcpUrl: string;
   posthogApiKey: string;
+  /**
+   * Script the SDK re-runs to get a currently-valid gateway token, from
+   * `rotating-credential.ts`. Set when the OAuth grant issued a refresh token;
+   * absent (CI runs on a non-expiring personal API key) keeps `posthogApiKey`
+   * fixed for the run.
+   */
+  apiKeyHelperPath?: string;
   host: HostResolution;
   additionalMcpServers?: Record<string, { url: string }>;
   detectPackageManager: PackageManagerDetector;
@@ -296,6 +304,12 @@ type AgentRunConfig = {
   model: string;
   /** The run's OAuth access token — the MCP config resolves it in the child. */
   posthogApiKey: string;
+  /**
+   * Script the SDK re-runs to get a currently-valid gateway token. Set when the
+   * run has a refresh token; when set it replaces the fixed `ANTHROPIC_AUTH_TOKEN`
+   * in the subprocess env rather than sitting alongside it.
+   */
+  apiKeyHelperPath?: string;
   wizardFlags?: Record<string, string>;
   wizardMetadata?: Record<string, string>;
   /** Extra tools added on top of BASE_ALLOWED_TOOLS for this run. */
@@ -616,6 +630,7 @@ export async function initializeAgent(
       allowedTools: config.allowedTools,
       disallowedTools: config.disallowedTools,
       getPendingQuestion: config.getPendingQuestion,
+      apiKeyHelperPath: config.apiKeyHelperPath,
       suppressTaskRender: !!config.orchestrator,
       capture: config.capture,
       triageProvider,
@@ -623,6 +638,11 @@ export async function initializeAgent(
       // A queue context is present only on a task run; that is the sequence.
       sequence: config.orchestrator ? Sequence.orchestrator : Sequence.linear,
     };
+
+    logToFile(
+      'Gateway token rotation:',
+      config.apiKeyHelperPath ? 'on' : 'off (no refresh token)',
+    );
 
     logToFile('Agent config:', {
       workingDirectory: agentRunConfig.workingDirectory,
@@ -898,6 +918,9 @@ export async function runAgent(
               : undefined,
           },
         },
+        settings: agentConfig.apiKeyHelperPath
+          ? { apiKeyHelper: agentConfig.apiKeyHelperPath }
+          : undefined,
         // Load skills from project's .claude/skills/ directory
         settingSources: ['project'],
         // Enable all discovered skills. Omitting this is NOT "skills off" —
@@ -969,8 +992,17 @@ export async function runAgent(
           // process.env for in-process readers; the strip above removed them
           // from the inherited copy, so re-add the wizard's own values here).
           ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
-          ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
-          CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+          // With a rotating credential the helper is the single source of the
+          // token; leaving these set would pin the spawn-time value alongside it.
+          ANTHROPIC_AUTH_TOKEN: agentConfig.apiKeyHelperPath
+            ? undefined
+            : process.env.ANTHROPIC_AUTH_TOKEN,
+          CLAUDE_CODE_OAUTH_TOKEN: agentConfig.apiKeyHelperPath
+            ? undefined
+            : process.env.CLAUDE_CODE_OAUTH_TOKEN,
+          CLAUDE_CODE_API_KEY_HELPER_TTL_MS: agentConfig.apiKeyHelperPath
+            ? String(HELPER_CACHE_TTL_MS)
+            : undefined,
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: 'true',
           // The MCP config resolves this in the child; sending the value would
           // put it on the CLI's argv.

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -180,12 +180,7 @@ export type AgentConfig = {
   workingDirectory: string;
   posthogMcpUrl: string;
   posthogApiKey: string;
-  /**
-   * Script the SDK re-runs to get a currently-valid gateway token, from
-   * `rotating-credential.ts`. Set when the OAuth grant issued a refresh token;
-   * absent (CI runs on a non-expiring personal API key) keeps `posthogApiKey`
-   * fixed for the run.
-   */
+  /** Absent (CI, on a non-expiring key) keeps `posthogApiKey` fixed for the run. */
   apiKeyHelperPath?: string;
   host: HostResolution;
   additionalMcpServers?: Record<string, { url: string }>;
@@ -304,11 +299,7 @@ type AgentRunConfig = {
   model: string;
   /** The run's OAuth access token — the MCP config resolves it in the child. */
   posthogApiKey: string;
-  /**
-   * Script the SDK re-runs to get a currently-valid gateway token. Set when the
-   * run has a refresh token; when set it replaces the fixed `ANTHROPIC_AUTH_TOKEN`
-   * in the subprocess env rather than sitting alongside it.
-   */
+  /** See {@link AgentConfig.apiKeyHelperPath}. */
   apiKeyHelperPath?: string;
   wizardFlags?: Record<string, string>;
   wizardMetadata?: Record<string, string>;
@@ -992,8 +983,7 @@ export async function runAgent(
           // process.env for in-process readers; the strip above removed them
           // from the inherited copy, so re-add the wizard's own values here).
           ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
-          // With a rotating credential the helper is the single source of the
-          // token; leaving these set would pin the spawn-time value alongside it.
+          // Leaving these set alongside the helper would pin the spawn-time value.
           ANTHROPIC_AUTH_TOKEN: agentConfig.apiKeyHelperPath
             ? undefined
             : process.env.ANTHROPIC_AUTH_TOKEN,

--- a/src/lib/agent/auth-constants.ts
+++ b/src/lib/agent/auth-constants.ts
@@ -1,0 +1,16 @@
+/** Shared by the credential helper and the code that installs it. */
+
+/** Set as `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`. */
+export const HELPER_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Must stay wider than {@link HELPER_CACHE_TTL_MS}, because a result cached for
+ * the full window has to still be valid when that window ends.
+ */
+export const REFRESH_SKEW_MS = 15 * 60 * 1000;
+
+/** A lock older than this belonged to a process that died holding it. */
+export const LOCK_STALE_MS = 30 * 1000;
+
+/** Names the state file, since the SDK spawns the helper with no arguments. */
+export const AUTH_STATE_ENV = 'POSTHOG_WIZARD_AUTH_STATE';

--- a/src/lib/agent/auth-helper.ts
+++ b/src/lib/agent/auth-helper.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Prints a currently-valid gateway token, refreshing first when the one on disk
+ * is nearly out. Installed as the SDK's `settings.apiKeyHelper` so a run that
+ * outlives its one-hour token keeps working; see `rotating-credential.ts`.
+ *
+ * Its own build entry, because the SDK execs it as a standalone process.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import {
+  AUTH_STATE_ENV,
+  LOCK_STALE_MS,
+  REFRESH_SKEW_MS,
+} from './auth-constants';
+
+interface AuthState {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  tokenUrl: string;
+  clientId: string;
+}
+
+const statePath = process.env[AUTH_STATE_ENV]!;
+const lockPath = `${statePath}.lock`;
+
+const readState = (): AuthState => JSON.parse(readFileSync(statePath, 'utf8'));
+const isHealthy = (state: AuthState): boolean =>
+  state.expiresAt - Date.now() > REFRESH_SKEW_MS;
+
+// PostHog rotates refresh tokens with reuse protection on, so two concurrent
+// refreshes using the same token revoke every token in the session.
+function tryLock(): boolean {
+  try {
+    mkdirSync(lockPath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+  }
+  try {
+    if (Date.now() - statSync(lockPath).mtimeMs < LOCK_STALE_MS) return false;
+    rmSync(lockPath, { recursive: true, force: true });
+    mkdirSync(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchNewToken(state: AuthState): Promise<string> {
+  const response = await fetch(state.tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: state.refreshToken,
+      client_id: state.clientId,
+    }),
+  });
+  if (!response.ok) throw new Error(`refresh returned HTTP ${response.status}`);
+  const body = (await response.json()) as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number;
+  };
+
+  const next: AuthState = {
+    ...state,
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token ?? state.refreshToken,
+    expiresAt: Date.now() + body.expires_in * 1000,
+  };
+  // Rename so the rotated refresh token is durable before we hand out the access
+  // token it came with, and so no reader sees a half-written file.
+  writeFileSync(`${statePath}.tmp`, JSON.stringify(next), { mode: 0o600 });
+  renameSync(`${statePath}.tmp`, statePath);
+  return next.accessToken;
+}
+
+const state = readState();
+let token = state.accessToken;
+
+if (!isHealthy(state) && tryLock()) {
+  try {
+    // Whoever held the lock before us may have already refreshed.
+    const current = readState();
+    token = isHealthy(current)
+      ? current.accessToken
+      : await fetchNewToken(current);
+  } catch (err) {
+    // Falling back to the token we have yields the same 401 the agent would have
+    // hit without any of this, so a failed refresh never makes things worse.
+    process.stderr.write(
+      `[posthog-wizard] token refresh failed: ${(err as Error).message}\n`,
+    );
+  } finally {
+    rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+process.stdout.write(token);

--- a/src/lib/agent/claude-settings.ts
+++ b/src/lib/agent/claude-settings.ts
@@ -48,6 +48,10 @@ const BLOCKING_ENV_KEYS = [
   'CLAUDE_CODE_OAUTH_TOKEN',
   ...BLOCKED_AGENT_ENV_KEYS,
 ];
+// A settings *file* setting these redirects the agent's credentials, so it's a
+// conflict. The wizard sets `apiKeyHelper` itself, but via the SDK's inline
+// `settings` option (see `rotating-credential.ts`) — a different tier that these
+// on-disk scans never see, so the two don't collide.
 const BLOCKING_SETTINGS_KEYS = ['apiKeyHelper'];
 
 /** Where a settings conflict was found. */

--- a/src/lib/agent/claude-settings.ts
+++ b/src/lib/agent/claude-settings.ts
@@ -48,10 +48,8 @@ const BLOCKING_ENV_KEYS = [
   'CLAUDE_CODE_OAUTH_TOKEN',
   ...BLOCKED_AGENT_ENV_KEYS,
 ];
-// A settings *file* setting these redirects the agent's credentials, so it's a
-// conflict. The wizard sets `apiKeyHelper` itself, but via the SDK's inline
-// `settings` option (see `rotating-credential.ts`) — a different tier that these
-// on-disk scans never see, so the two don't collide.
+// The wizard sets `apiKeyHelper` itself via the SDK's inline `settings` option,
+// a separate tier these on-disk scans never see, so the two don't collide.
 const BLOCKING_SETTINGS_KEYS = ['apiKeyHelper'];
 
 /** Where a settings conflict was found. */

--- a/src/lib/agent/rotating-credential.ts
+++ b/src/lib/agent/rotating-credential.ts
@@ -1,0 +1,173 @@
+/**
+ * A gateway credential the running agent can pick up fresh.
+ *
+ * Wizard access tokens live one hour (the OAuth app isn't first-party or
+ * dynamically registered, so it gets the strict default TTL). The agent runs as
+ * one long-lived subprocess whose env is fixed at spawn, so a token injected via
+ * `ANTHROPIC_AUTH_TOKEN` can't be replaced once it goes stale — any run past the
+ * hour dies on a 401. A `wizard_ask` that nobody answers makes that easy to hit:
+ * the agent sits idle through its own token's expiry and only finds out when it
+ * resumes.
+ *
+ * So instead of a fixed token we hand the SDK `settings.apiKeyHelper`, a script
+ * it re-runs on its own cadence. The script refreshes when the token is nearly
+ * out and prints whatever is currently valid, which keeps the access-token
+ * window at an hour rather than widening it.
+ *
+ * Everything lives in a private temp dir the caller removes at exit. The refresh
+ * token is a real credential, hence 0600 and a directory only the user can enter.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { registerCleanup } from '@utils/wizard-abort';
+
+export interface RotatingCredentialInput {
+  accessToken: string;
+  refreshToken: string;
+  /** Epoch ms the access token expires. */
+  expiresAt: number;
+  tokenUrl: string;
+  clientId: string;
+}
+
+/**
+ * How long the SDK may cache one helper result, as
+ * `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`.
+ */
+export const HELPER_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Refresh once the token has less than this left. Must stay comfortably wider
+ * than {@link HELPER_CACHE_TTL_MS}: a result cached for the full window has to
+ * still be valid when the window ends, so the gap between the two is the real
+ * safety margin.
+ */
+const REFRESH_SKEW_MS = 15 * 60 * 1000;
+
+/** A lock older than this belonged to a process that died holding it. */
+const LOCK_STALE_MS = 30 * 1000;
+
+/**
+ * Runs as its own process, so it gets no bundler and no dependencies — Node
+ * built-ins and global `fetch` only. Reads its state file as a sibling rather
+ * than an argument, because a shebang can't portably pass one.
+ *
+ * The lock matters more than it looks: PostHog rotates refresh tokens and
+ * enforces reuse protection, so two concurrent refreshes with the same token
+ * revoke every token in the session.
+ */
+const helperSource = (): string => `#!${process.execPath}
+import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const statePath = fileURLToPath(new URL('./state.json', import.meta.url));
+const lockPath = statePath + '.lock';
+const REFRESH_SKEW_MS = ${REFRESH_SKEW_MS};
+const LOCK_STALE_MS = ${LOCK_STALE_MS};
+
+const readState = () => JSON.parse(readFileSync(statePath, 'utf8'));
+const isHealthy = (state) => state.expiresAt - Date.now() > REFRESH_SKEW_MS;
+
+/** Take the lock, or report that someone else holds it. Steals an orphan. */
+function tryLock() {
+  try {
+    mkdirSync(lockPath);
+    return true;
+  } catch (err) {
+    if (err.code !== 'EEXIST') throw err;
+  }
+  try {
+    if (Date.now() - statSync(lockPath).mtimeMs < LOCK_STALE_MS) return false;
+    rmSync(lockPath, { recursive: true, force: true });
+    mkdirSync(lockPath);
+    return true;
+  } catch {
+    // Lost a race to steal it, or the holder released it first. Either way
+    // someone else is on it.
+    return false;
+  }
+}
+
+async function fetchNewToken(state) {
+  const response = await fetch(state.tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: state.refreshToken,
+      client_id: state.clientId,
+    }),
+  });
+  if (!response.ok) throw new Error('refresh returned HTTP ' + response.status);
+  const body = await response.json();
+
+  const next = {
+    ...state,
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token ?? state.refreshToken,
+    expiresAt: Date.now() + body.expires_in * 1000,
+  };
+  // Rename so a reader never sees a half-written file, and so the rotated
+  // refresh token is durable before we hand out the access token it came with.
+  const tmpPath = statePath + '.tmp';
+  writeFileSync(tmpPath, JSON.stringify(next), { mode: 0o600 });
+  renameSync(tmpPath, statePath);
+  return next.accessToken;
+}
+
+const state = readState();
+let token = state.accessToken;
+
+// Only contend for the lock when a refresh is actually due — the common case is
+// a healthy token and a plain read.
+if (!isHealthy(state) && tryLock()) {
+  try {
+    // Re-read: whoever held the lock before us may have already refreshed.
+    const current = readState();
+    token = isHealthy(current) ? current.accessToken : await fetchNewToken(current);
+  } catch (err) {
+    // Fall back to what we have. If it really is expired the agent gets the same
+    // 401 it would have got without any of this, so don't make it worse.
+    process.stderr.write('[posthog-wizard] token refresh failed: ' + err.message + '\\n');
+  } finally {
+    rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+process.stdout.write(token);
+`;
+
+/** Writes the helper and its state, returning the path to run. */
+export function createRotatingCredential(
+  input: RotatingCredentialInput,
+): string {
+  // mkdtemp already creates the directory 0700.
+  const dir = mkdtempSync(path.join(tmpdir(), 'posthog-wizard-auth-'));
+  const helperPath = path.join(dir, 'helper.mjs');
+
+  writeFileSync(path.join(dir, 'state.json'), JSON.stringify(input), {
+    mode: 0o600,
+  });
+  // Executable, and pinned to the Node already running us rather than to
+  // whatever PATH the SDK resolves the helper against.
+  writeFileSync(helperPath, helperSource(), { mode: 0o700 });
+
+  registerCleanup(() => rmSync(dir, { recursive: true, force: true }));
+  return helperPath;
+}
+
+/**
+ * One per process, because every caller shares the invocation's single OAuth
+ * session. Two credentials would mean two state files holding the same refresh
+ * token, and the lock only serializes within a file — parallel orchestrator
+ * tasks would then refresh concurrently and reuse protection would revoke the
+ * whole session.
+ */
+let shared: string | undefined;
+
+export function getRotatingCredential(input: RotatingCredentialInput): string {
+  shared ??= createRotatingCredential(input);
+  return shared;
+}

--- a/src/lib/agent/rotating-credential.ts
+++ b/src/lib/agent/rotating-credential.ts
@@ -1,16 +1,17 @@
 /**
- * A gateway credential the running agent can pick up fresh.
+ * Installs the credential helper for a run.
  *
  * Wizard access tokens live one hour, and the agent subprocess has its env fixed
  * at spawn, so a token injected via `ANTHROPIC_AUTH_TOKEN` can never be replaced
- * and any run past the hour dies on a 401. Handing the SDK a re-runnable
- * `settings.apiKeyHelper` instead keeps the access-token window at an hour
- * rather than widening it.
+ * and any run past the hour dies on a 401. Pointing the SDK at a re-runnable
+ * `settings.apiKeyHelper` keeps the access-token window at an hour rather than
+ * widening it. The helper itself is `auth-helper.ts`, its own build entry.
  */
 
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { registerCleanup } from '@utils/wizard-abort';
 
 export interface RotatingCredentialInput {
@@ -22,127 +23,29 @@ export interface RotatingCredentialInput {
   clientId: string;
 }
 
-/** Set as `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`. */
-export const HELPER_CACHE_TTL_MS = 5 * 60 * 1000;
+/** Sibling of the bundle in `dist`, which is what dev and published runs both use. */
+export const AUTH_HELPER_PATH = fileURLToPath(
+  new URL('./auth-helper.js', import.meta.url),
+);
 
-/**
- * Must stay wider than {@link HELPER_CACHE_TTL_MS}, because a result cached for
- * the full window has to still be valid when that window ends.
- */
-const REFRESH_SKEW_MS = 15 * 60 * 1000;
-
-/** A lock older than this belonged to a process that died holding it. */
-const LOCK_STALE_MS = 30 * 1000;
-
-/**
- * Runs as its own process, so no bundler and no dependencies: Node built-ins and
- * global `fetch` only. It locates its state file as a sibling because a shebang
- * cannot portably pass an argument.
- */
-const helperSource = (): string => `#!${process.execPath}
-import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-
-const statePath = fileURLToPath(new URL('./state.json', import.meta.url));
-const lockPath = statePath + '.lock';
-const REFRESH_SKEW_MS = ${REFRESH_SKEW_MS};
-const LOCK_STALE_MS = ${LOCK_STALE_MS};
-
-const readState = () => JSON.parse(readFileSync(statePath, 'utf8'));
-const isHealthy = (state) => state.expiresAt - Date.now() > REFRESH_SKEW_MS;
-
-// PostHog rotates refresh tokens with reuse protection on, so two concurrent
-// refreshes using the same token revoke every token in the session.
-function tryLock() {
-  try {
-    mkdirSync(lockPath);
-    return true;
-  } catch (err) {
-    if (err.code !== 'EEXIST') throw err;
-  }
-  try {
-    if (Date.now() - statSync(lockPath).mtimeMs < LOCK_STALE_MS) return false;
-    rmSync(lockPath, { recursive: true, force: true });
-    mkdirSync(lockPath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function fetchNewToken(state) {
-  const response = await fetch(state.tokenUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      grant_type: 'refresh_token',
-      refresh_token: state.refreshToken,
-      client_id: state.clientId,
-    }),
-  });
-  if (!response.ok) throw new Error('refresh returned HTTP ' + response.status);
-  const body = await response.json();
-
-  const next = {
-    ...state,
-    accessToken: body.access_token,
-    refreshToken: body.refresh_token ?? state.refreshToken,
-    expiresAt: Date.now() + body.expires_in * 1000,
-  };
-  // Rename so the rotated refresh token is durable before we hand out the access
-  // token it came with, and so no reader sees a half-written file.
-  const tmpPath = statePath + '.tmp';
-  writeFileSync(tmpPath, JSON.stringify(next), { mode: 0o600 });
-  renameSync(tmpPath, statePath);
-  return next.accessToken;
-}
-
-const state = readState();
-let token = state.accessToken;
-
-if (!isHealthy(state) && tryLock()) {
-  try {
-    // Whoever held the lock before us may have already refreshed.
-    const current = readState();
-    token = isHealthy(current) ? current.accessToken : await fetchNewToken(current);
-  } catch (err) {
-    // Falling back to the token we have yields the same 401 the agent would have
-    // hit without any of this, so a failed refresh never makes things worse.
-    process.stderr.write('[posthog-wizard] token refresh failed: ' + err.message + '\\n');
-  } finally {
-    rmSync(lockPath, { recursive: true, force: true });
-  }
-}
-
-process.stdout.write(token);
-`;
-
-export function createRotatingCredential(
-  input: RotatingCredentialInput,
-): string {
+/** Writes the run's token state, returning the path to point the helper at. */
+export function createAuthState(input: RotatingCredentialInput): string {
   // mkdtemp creates the directory 0700, which the refresh token inside needs.
   const dir = mkdtempSync(path.join(tmpdir(), 'posthog-wizard-auth-'));
-  const helperPath = path.join(dir, 'helper.mjs');
-
-  writeFileSync(path.join(dir, 'state.json'), JSON.stringify(input), {
-    mode: 0o600,
-  });
-  // Pinned to the Node already running us, because the SDK resolves the helper
-  // against a PATH that may not have one.
-  writeFileSync(helperPath, helperSource(), { mode: 0o700 });
-
+  const statePath = path.join(dir, 'state.json');
+  writeFileSync(statePath, JSON.stringify(input), { mode: 0o600 });
   registerCleanup(() => rmSync(dir, { recursive: true, force: true }));
-  return helperPath;
+  return statePath;
 }
 
 /**
- * One per process, because the lock above only serializes within a single state
- * file. Two credentials would mean two files holding the same refresh token, so
- * parallel orchestrator tasks could refresh concurrently.
+ * One per process, because the helper's lock only serializes within a single
+ * state file. Two states would hold the same refresh token, so parallel
+ * orchestrator tasks could refresh concurrently.
  */
 let shared: string | undefined;
 
-export function getRotatingCredential(input: RotatingCredentialInput): string {
-  shared ??= createRotatingCredential(input);
+export function getAuthStatePath(input: RotatingCredentialInput): string {
+  shared ??= createAuthState(input);
   return shared;
 }

--- a/src/lib/agent/rotating-credential.ts
+++ b/src/lib/agent/rotating-credential.ts
@@ -1,21 +1,11 @@
 /**
  * A gateway credential the running agent can pick up fresh.
  *
- * Wizard access tokens live one hour (the OAuth app isn't first-party or
- * dynamically registered, so it gets the strict default TTL). The agent runs as
- * one long-lived subprocess whose env is fixed at spawn, so a token injected via
- * `ANTHROPIC_AUTH_TOKEN` can't be replaced once it goes stale — any run past the
- * hour dies on a 401. A `wizard_ask` that nobody answers makes that easy to hit:
- * the agent sits idle through its own token's expiry and only finds out when it
- * resumes.
- *
- * So instead of a fixed token we hand the SDK `settings.apiKeyHelper`, a script
- * it re-runs on its own cadence. The script refreshes when the token is nearly
- * out and prints whatever is currently valid, which keeps the access-token
- * window at an hour rather than widening it.
- *
- * Everything lives in a private temp dir the caller removes at exit. The refresh
- * token is a real credential, hence 0600 and a directory only the user can enter.
+ * Wizard access tokens live one hour, and the agent subprocess has its env fixed
+ * at spawn, so a token injected via `ANTHROPIC_AUTH_TOKEN` can never be replaced
+ * and any run past the hour dies on a 401. Handing the SDK a re-runnable
+ * `settings.apiKeyHelper` instead keeps the access-token window at an hour
+ * rather than widening it.
  */
 
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -32,17 +22,12 @@ export interface RotatingCredentialInput {
   clientId: string;
 }
 
-/**
- * How long the SDK may cache one helper result, as
- * `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`.
- */
+/** Set as `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`. */
 export const HELPER_CACHE_TTL_MS = 5 * 60 * 1000;
 
 /**
- * Refresh once the token has less than this left. Must stay comfortably wider
- * than {@link HELPER_CACHE_TTL_MS}: a result cached for the full window has to
- * still be valid when the window ends, so the gap between the two is the real
- * safety margin.
+ * Must stay wider than {@link HELPER_CACHE_TTL_MS}, because a result cached for
+ * the full window has to still be valid when that window ends.
  */
 const REFRESH_SKEW_MS = 15 * 60 * 1000;
 
@@ -50,13 +35,9 @@ const REFRESH_SKEW_MS = 15 * 60 * 1000;
 const LOCK_STALE_MS = 30 * 1000;
 
 /**
- * Runs as its own process, so it gets no bundler and no dependencies — Node
- * built-ins and global `fetch` only. Reads its state file as a sibling rather
- * than an argument, because a shebang can't portably pass one.
- *
- * The lock matters more than it looks: PostHog rotates refresh tokens and
- * enforces reuse protection, so two concurrent refreshes with the same token
- * revoke every token in the session.
+ * Runs as its own process, so no bundler and no dependencies: Node built-ins and
+ * global `fetch` only. It locates its state file as a sibling because a shebang
+ * cannot portably pass an argument.
  */
 const helperSource = (): string => `#!${process.execPath}
 import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
@@ -70,7 +51,8 @@ const LOCK_STALE_MS = ${LOCK_STALE_MS};
 const readState = () => JSON.parse(readFileSync(statePath, 'utf8'));
 const isHealthy = (state) => state.expiresAt - Date.now() > REFRESH_SKEW_MS;
 
-/** Take the lock, or report that someone else holds it. Steals an orphan. */
+// PostHog rotates refresh tokens with reuse protection on, so two concurrent
+// refreshes using the same token revoke every token in the session.
 function tryLock() {
   try {
     mkdirSync(lockPath);
@@ -84,8 +66,6 @@ function tryLock() {
     mkdirSync(lockPath);
     return true;
   } catch {
-    // Lost a race to steal it, or the holder released it first. Either way
-    // someone else is on it.
     return false;
   }
 }
@@ -109,8 +89,8 @@ async function fetchNewToken(state) {
     refreshToken: body.refresh_token ?? state.refreshToken,
     expiresAt: Date.now() + body.expires_in * 1000,
   };
-  // Rename so a reader never sees a half-written file, and so the rotated
-  // refresh token is durable before we hand out the access token it came with.
+  // Rename so the rotated refresh token is durable before we hand out the access
+  // token it came with, and so no reader sees a half-written file.
   const tmpPath = statePath + '.tmp';
   writeFileSync(tmpPath, JSON.stringify(next), { mode: 0o600 });
   renameSync(tmpPath, statePath);
@@ -120,16 +100,14 @@ async function fetchNewToken(state) {
 const state = readState();
 let token = state.accessToken;
 
-// Only contend for the lock when a refresh is actually due — the common case is
-// a healthy token and a plain read.
 if (!isHealthy(state) && tryLock()) {
   try {
-    // Re-read: whoever held the lock before us may have already refreshed.
+    // Whoever held the lock before us may have already refreshed.
     const current = readState();
     token = isHealthy(current) ? current.accessToken : await fetchNewToken(current);
   } catch (err) {
-    // Fall back to what we have. If it really is expired the agent gets the same
-    // 401 it would have got without any of this, so don't make it worse.
+    // Falling back to the token we have yields the same 401 the agent would have
+    // hit without any of this, so a failed refresh never makes things worse.
     process.stderr.write('[posthog-wizard] token refresh failed: ' + err.message + '\\n');
   } finally {
     rmSync(lockPath, { recursive: true, force: true });
@@ -139,19 +117,18 @@ if (!isHealthy(state) && tryLock()) {
 process.stdout.write(token);
 `;
 
-/** Writes the helper and its state, returning the path to run. */
 export function createRotatingCredential(
   input: RotatingCredentialInput,
 ): string {
-  // mkdtemp already creates the directory 0700.
+  // mkdtemp creates the directory 0700, which the refresh token inside needs.
   const dir = mkdtempSync(path.join(tmpdir(), 'posthog-wizard-auth-'));
   const helperPath = path.join(dir, 'helper.mjs');
 
   writeFileSync(path.join(dir, 'state.json'), JSON.stringify(input), {
     mode: 0o600,
   });
-  // Executable, and pinned to the Node already running us rather than to
-  // whatever PATH the SDK resolves the helper against.
+  // Pinned to the Node already running us, because the SDK resolves the helper
+  // against a PATH that may not have one.
   writeFileSync(helperPath, helperSource(), { mode: 0o700 });
 
   registerCleanup(() => rmSync(dir, { recursive: true, force: true }));
@@ -159,11 +136,9 @@ export function createRotatingCredential(
 }
 
 /**
- * One per process, because every caller shares the invocation's single OAuth
- * session. Two credentials would mean two state files holding the same refresh
- * token, and the lock only serializes within a file — parallel orchestrator
- * tasks would then refresh concurrently and reuse protection would revoke the
- * whole session.
+ * One per process, because the lock above only serializes within a single state
+ * file. Two credentials would mean two files holding the same refresh token, so
+ * parallel orchestrator tasks could refresh concurrently.
  */
 let shared: string | undefined;
 

--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -32,11 +32,7 @@ import type {
   TaskRunInputs,
 } from '../types';
 
-/**
- * A run can outlive its one-hour access token, and the agent subprocess can't be
- * handed a new one after spawn — so give the SDK a helper it can re-run. Only
- * possible when the grant issued a refresh token; CI keys don't expire.
- */
+/** Undefined without a refresh token, which is the CI case (keys don't expire). */
 function rotatingCredentialFor(session: WizardSession): string | undefined {
   const { refreshToken, expiresAt } = session.credentials ?? {};
   if (!refreshToken || !expiresAt) return undefined;

--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -22,7 +22,7 @@ import { createAioCapture } from '@lib/agent/aio-capture';
 import { getLogFilePath, logToFile } from '@utils/debug';
 import { detectNodePackageManagers } from '@lib/detection/package-manager';
 import { sessionToOptions } from '@lib/agent/runner/shared/bootstrap';
-import { getRotatingCredential } from '@lib/agent/rotating-credential';
+import { getAuthStatePath } from '@lib/agent/rotating-credential';
 import { getTokenEndpoint } from '@utils/oauth';
 import type { WizardSession } from '@lib/wizard-session';
 import type {
@@ -33,10 +33,10 @@ import type {
 } from '../types';
 
 /** Undefined without a refresh token, which is the CI case (keys don't expire). */
-function rotatingCredentialFor(session: WizardSession): string | undefined {
+function authStateFor(session: WizardSession): string | undefined {
   const { refreshToken, expiresAt } = session.credentials ?? {};
   if (!refreshToken || !expiresAt) return undefined;
-  return getRotatingCredential({
+  return getAuthStatePath({
     accessToken: session.credentials!.accessToken,
     refreshToken,
     expiresAt,
@@ -75,7 +75,7 @@ export const anthropicBackend: AgentHarness = {
         workingDirectory: session.installDir,
         posthogMcpUrl: host.mcpUrl,
         posthogApiKey: accessToken,
-        apiKeyHelperPath: rotatingCredentialFor(session),
+        authStatePath: authStateFor(session),
         host,
         additionalMcpServers: config.additionalMcpServers,
         detectPackageManager:
@@ -153,7 +153,7 @@ export const anthropicBackend: AgentHarness = {
         workingDirectory: session.installDir,
         posthogMcpUrl: boot.credentials.host.mcpUrl,
         posthogApiKey: boot.credentials.accessToken,
-        apiKeyHelperPath: rotatingCredentialFor(session),
+        authStatePath: authStateFor(session),
         host: boot.credentials.host,
         detectPackageManager: detectNodePackageManagers,
         skillsBaseUrl: boot.skillsBaseUrl,

--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -22,12 +22,31 @@ import { createAioCapture } from '@lib/agent/aio-capture';
 import { getLogFilePath, logToFile } from '@utils/debug';
 import { detectNodePackageManagers } from '@lib/detection/package-manager';
 import { sessionToOptions } from '@lib/agent/runner/shared/bootstrap';
+import { getRotatingCredential } from '@lib/agent/rotating-credential';
+import { getTokenEndpoint } from '@utils/oauth';
+import type { WizardSession } from '@lib/wizard-session';
 import type {
   AgentResult,
   AgentHarness,
   BackendRunInputs,
   TaskRunInputs,
 } from '../types';
+
+/**
+ * A run can outlive its one-hour access token, and the agent subprocess can't be
+ * handed a new one after spawn — so give the SDK a helper it can re-run. Only
+ * possible when the grant issued a refresh token; CI keys don't expire.
+ */
+function rotatingCredentialFor(session: WizardSession): string | undefined {
+  const { refreshToken, expiresAt } = session.credentials ?? {};
+  if (!refreshToken || !expiresAt) return undefined;
+  return getRotatingCredential({
+    accessToken: session.credentials!.accessToken,
+    refreshToken,
+    expiresAt,
+    ...getTokenEndpoint(session.baseUrl),
+  });
+}
 
 export const anthropicBackend: AgentHarness = {
   name: Harness.anthropic,
@@ -60,6 +79,7 @@ export const anthropicBackend: AgentHarness = {
         workingDirectory: session.installDir,
         posthogMcpUrl: host.mcpUrl,
         posthogApiKey: accessToken,
+        apiKeyHelperPath: rotatingCredentialFor(session),
         host,
         additionalMcpServers: config.additionalMcpServers,
         detectPackageManager:
@@ -137,6 +157,7 @@ export const anthropicBackend: AgentHarness = {
         workingDirectory: session.installDir,
         posthogMcpUrl: boot.credentials.host.mcpUrl,
         posthogApiKey: boot.credentials.accessToken,
+        apiKeyHelperPath: rotatingCredentialFor(session),
         host: boot.credentials.host,
         detectPackageManager: detectNodePackageManagers,
         skillsBaseUrl: boot.skillsBaseUrl,

--- a/src/lib/agent/runner/shared/authenticate.ts
+++ b/src/lib/agent/runner/shared/authenticate.ts
@@ -28,6 +28,8 @@ export async function authenticate(
     projectApiKey,
     host,
     accessToken,
+    refreshToken,
+    expiresAt,
     projectId,
     roleAtOrganization,
     user,
@@ -44,7 +46,14 @@ export async function authenticate(
     programId,
   });
 
-  session.credentials = { accessToken, projectApiKey, host, projectId };
+  session.credentials = {
+    accessToken,
+    refreshToken,
+    expiresAt,
+    projectApiKey,
+    host,
+    projectId,
+  };
   session.apiProject = project;
   session.roleAtOrganization = roleAtOrganization;
   session.apiUser = user;

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -23,6 +23,12 @@ export interface Credentials {
   /** Resolved at auth time and immutable thereafter — see {@link HostResolution}. */
   host: HostResolution;
   projectId: number;
+  /**
+   * Refresh token and access-token expiry, when the OAuth grant issued them.
+   * Absent for CI runs (personal API key). See {@link ProjectData}.
+   */
+  refreshToken?: string;
+  expiresAt?: number;
 }
 
 function parseProjectIdArg(value: string | undefined): number | undefined {

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -115,6 +115,21 @@ function getOAuthClientId(baseUrl?: string): string {
     : POSTHOG_PROXY_CLIENT_ID;
 }
 
+/**
+ * The token endpoint and client id for a grant. Shared by the initial code
+ * exchange and by the agent's credential helper, which runs as its own process
+ * and so needs both values handed to it rather than resolved in-module.
+ */
+export function getTokenEndpoint(baseUrl?: string): {
+  tokenUrl: string;
+  clientId: string;
+} {
+  return {
+    tokenUrl: `${getOAuthUrl(baseUrl)}/oauth/token`,
+    clientId: getOAuthClientId(baseUrl),
+  };
+}
+
 function getLocalOAuthOrigin(port: number): string {
   return `http://localhost:${port}`;
 }
@@ -334,14 +349,13 @@ async function exchangeCodeForToken(
   callbackUrl: string,
   baseUrl?: string,
 ): Promise<OAuthTokenResponse> {
-  const clientId = getOAuthClientId(baseUrl);
-  const oauthUrl = getOAuthUrl(baseUrl);
+  const { tokenUrl, clientId } = getTokenEndpoint(baseUrl);
 
-  logToFile(`[oauth] exchanging code for token at ${oauthUrl}/oauth/token`);
+  logToFile(`[oauth] exchanging code for token at ${tokenUrl}`);
   let response;
   try {
     response = await axios.post(
-      `${oauthUrl}/oauth/token`,
+      tokenUrl,
       {
         grant_type: 'authorization_code',
         code,

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -61,6 +61,14 @@ interface ProjectData {
    * inferring it from repo evidence. Null on signup flows.
    */
   project?: ApiProject | null;
+  /**
+   * Refresh token and access-token expiry from the OAuth grant, when the token
+   * endpoint issued them. Wizard access tokens live an hour, which a long run
+   * outlives, so the agent's credential helper uses these to rotate mid-run.
+   * Absent for CI runs (a personal API key, which doesn't expire).
+   */
+  refreshToken?: string;
+  expiresAt?: number;
 }
 
 export interface CliSetupConfig {
@@ -410,6 +418,8 @@ export async function getOrAskForProjectData(
   host: HostResolution;
   projectApiKey: string;
   accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
   projectId: number;
   roleAtOrganization: string | null;
   user: ApiUser | null;
@@ -475,6 +485,8 @@ export async function getOrAskForProjectData(
     host,
     projectApiKey,
     accessToken,
+    refreshToken,
+    expiresAt,
     projectId,
     roleAtOrganization,
     user,
@@ -506,6 +518,8 @@ ${cloudUrl}/settings/project#variables`);
 
   return {
     accessToken,
+    refreshToken,
+    expiresAt,
     host,
     projectApiKey: projectApiKey || DUMMY_PROJECT_API_KEY,
     projectId,
@@ -648,6 +662,8 @@ async function askForWizardLogin(options: {
 
   const data = {
     accessToken: tokenResponse.access_token,
+    refreshToken: tokenResponse.refresh_token,
+    expiresAt: Date.now() + tokenResponse.expires_in * 1000,
     projectApiKey: projectData.api_token,
     host,
     distinctId: userData.distinct_id,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['bin.ts'],
+  // auth-helper is a second entry because the agent SDK execs it standalone.
+  // Named explicitly so it lands at dist/auth-helper.js, beside the bundle that
+  // resolves it (see AUTH_HELPER_PATH).
+  entry: { bin: 'bin.ts', 'auth-helper': 'src/lib/agent/auth-helper.ts' },
   outDir: 'dist',
   format: 'esm',
   platform: 'node',


### PR DESCRIPTION
## Problem

Wizard access tokens are good for exactly one hour. The agent runs as a single long-lived subprocess, and its env is fixed at spawn time, so once that token goes stale there's no way to hand it a new one. Any run that crosses the hour mark dies on a 401 from the LLM gateway.

The easiest way to hit it is a `wizard_ask` that nobody answers. The prompt times out after 30 minutes, so the agent sits idle straight through its own token's expiry and only finds out when it resumes. Two unanswered prompts is enough to get there, and the run is dead by then.

It's also confusing when it lands. All our local diagnostics come back clean (no settings conflict, no stored Claude login), so the auth-error screen falls through to its generic branch and starts advising about key types and scopes, none of which is the actual problem. People reasonably read that as "I passed the wrong key".

## Changes

Rather than bake a token into the subprocess env, hand the SDK `settings.apiKeyHelper`: a small script it re-runs on its own cadence. The script refreshes when the token is nearly out and prints whatever is currently valid.

The thing I like about this over the obvious alternative: it keeps the access-token window at an hour instead of widening it. We could have just given the wizard's OAuth app a longer TTL server-side, but that means a longer-lived bearer token sitting on a laptop, and these tokens carry write scopes on the user's project (feature flags, dashboards, insights). Short-and-rotating is the better trade.

Details worth knowing:

- We were already being issued a refresh token at login and dropping it on the floor. Now we keep it, along with the expiry, on `Credentials`.
- The helper is its own tsdown entry (`dist/auth-helper.js`), since the SDK execs it as a standalone process. It gets its state file path from an env var on the agent subprocess, because a shebang can't portably take arguments.
- That state lives in a 0700 temp dir cleaned up at exit, and the file itself is 0600, since a refresh token is a real credential.
- It takes a lock before refreshing. PostHog rotates refresh tokens with reuse protection on, so two concurrent refreshes using the same token revoke the whole session. Same reason the credential is one-per-process: parallel orchestrator tasks would otherwise each get their own state file holding the same refresh token, and the lock only serializes within a file.
- The common path doesn't take the lock at all. It reads state, sees a healthy token, prints it. Only a due refresh contends.
- If a refresh fails it prints the token we already have. That's the same 401 we'd have got anyway, so it can't make things worse.
- CI runs on a personal API key, which doesn't expire, so they skip all of this and keep the fixed token.

## Test plan

`src/lib/agent/__tests__/rotating-credential.test.ts` runs the real helper as a subprocess against a local token endpoint, covering both branches: refresh when the token is near expiry (and persist the rotated refresh token so the spent one is never reused), pass through untouched when it's healthy. Takes about half a second.

Full suite green at 1718 tests, typecheck at parity with main.

### Known gaps, happy to follow up

- Only the anthropic harness gets rotation. The pi harness and the in-process triage provider still use the spawn-time token.
- The posthog-wizard MCP server config sends a static `Authorization` header for the whole run, so it has exactly the same expiry exposure that this PR fixes for model calls.
- The auth-error screen still shows the generic key-type advice. A dedicated "your session expired, re-run to continue" branch would save people a lot of head-scratching.
- The refresh token is written to disk. Cleanup runs on graceful exit, so a `SIGKILL`'d wizard leaves it in `/tmp`, and refresh tokens are good for 30 days versus one hour for the access token. Worth weighing against the "short-lived credential" argument above. Moving refresh into core (the parent process is alive for the whole run and could answer the helper over a socket) would keep it in memory and fix the two gaps above at the same time.

The first two both fall out naturally if we later move to a session-owned "give me a currently-valid token" accessor, which is probably the right end state. This PR deliberately doesn't go there.

## LLM context

Co-authored with Claude Code. The root cause was confirmed by reading the actual OAuth token row for a failing run (created and expires exactly 3600s apart) and matching it against the gateway's 401s, rather than inferred from the client side. Worth stating because the gateway currently logs nothing about *why* auth failed, which made this much harder to pin down than it should have been.
