### PR TITLE
feat(self-driving): wire up the Replay Vision scanners step

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,15 +273,42 @@ When creating your personal API key, ensure it has the following scopes enabled:
 
 The wizard's OAuth app on the PostHog side caps the scopes its tokens may
 carry (`OAuthApplication.scopes`). Any scope requested in this repo (see
-`src/lib/oauth/program-scopes.ts`) must be present in that list. This is
-the allow-list to keep in sync — a net-new scope (e.g.
-`product_enablement:write`, `replay_scanner:read` / `replay_scanner:write`)
-must be added to the live `OAuthApplication.scopes` on the PostHog side before
-a token can be granted it:
+`src/lib/oauth/program-scopes.ts`) must be grantable under that ceiling, or
+`/authorize` drops it and the call that needs it 403s.
+
+**The live wizard apps use the `@default` sentinel, so most net-new scopes need
+no ceiling edit.** The prod US app's `scopes` is:
 
 ```
-user:read,project:read,llm_gateway:read,dashboard:read,dashboard:write,insight:read,insight:write,query:read,notebook:read,notebook:write,health_issue:read,wizard_session:read,wizard_session:write,feature_flag:read,experiment:read,experiment_saved_metric:read,survey:read,session_recording:read,error_tracking:read,web_analytics:read,llm_analytics:read,cohort:read,person:read,annotation:read,annotation:write,activity_log:read,property_definition:read,event_definition:read,event_definition:write,action:read,warehouse_table:read,warehouse_view:read,external_data_source:read,external_data_source:write,alert:read,subscription:read,feature_flag:write,integration:read,organization:read,task:read,task:write,signal_scout:read,signal_scout:write,external_data_source:read,external_data_source:write,llm_skill:read,llm_skill:write,product_enablement:write,replay_scanner:read,replay_scanner:write
+@default,llm_gateway:read,wizard_session:read,wizard_session:write
 ```
+
+`@default` resolves (in `posthog/scopes.py`, `resolve_ceiling`) to
+`UNPRIVILEGED_SCOPES` — **every** public `obj:action` scope except three
+excluded sets: privileged (`llm_gateway:*`), internal-only objects, and
+hidden/alpha objects. It auto-tracks unprivileged scopes added to PostHog later,
+which is the whole reason it exists. The three explicit entries alongside it are
+exactly the ones `@default` excludes and that the wizard still needs
+(`llm_gateway:read` is privileged; the `wizard_session:*` pair is
+provisioning-only).
+
+So the rule for a net-new scope this repo starts requesting is:
+
+- **A normal public scope object** (`replay_scanner`, `product_enablement`,
+  `task`, `signal_scout`, `external_data_source`, `llm_skill`, …) — already
+  inside `@default`. **No ceiling edit.** Confirm with
+  `python manage.py seed_oauth_app_scopes --client-id <id> --scopes @default,… --dry-run`
+  (posthog), or evaluate the requested scope against `resolve_ceiling`.
+- **A privileged, internal, or hidden object** — `@default` deliberately
+  excludes it, so it must be added explicitly to each app's `scopes` (Django
+  admin / the `seed_oauth_app_scopes` command), per region. This is the only
+  case that needs a manual prod edit.
+
+Client IDs are per-region DB rows, not committed here — the prod US app is
+`c4Rdw8DIxgtQfA80IiSnGKlNX8QN00cFWF00QQhM`, the dev app (localhost:8010) is
+`DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ`; the prod EU app's ID lives in the EU
+deployment (referenced via `WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID`) and should be
+seeded the same `@default,…` way.
 
 If an existing Wizard authorization predates a newly required scope, reconnect
 the Wizard OAuth app. Refresh tokens retain their original grant and cannot be

--- a/README.md
+++ b/README.md
@@ -275,12 +275,12 @@ The wizard's OAuth app on the PostHog side caps the scopes its tokens may
 carry (`OAuthApplication.scopes`). Any scope requested in this repo (see
 `src/lib/oauth/program-scopes.ts`) must be present in that list. This is
 the allow-list to keep in sync — a net-new scope (e.g.
-`product_enablement:write`) must be added to the live
-`OAuthApplication.scopes` on the PostHog side before a token can be granted
-it:
+`product_enablement:write`, `replay_scanner:read` / `replay_scanner:write`)
+must be added to the live `OAuthApplication.scopes` on the PostHog side before
+a token can be granted it:
 
 ```
-user:read,project:read,llm_gateway:read,dashboard:read,dashboard:write,insight:read,insight:write,query:read,notebook:read,notebook:write,health_issue:read,wizard_session:read,wizard_session:write,feature_flag:read,experiment:read,experiment_saved_metric:read,survey:read,session_recording:read,error_tracking:read,web_analytics:read,llm_analytics:read,cohort:read,person:read,annotation:read,annotation:write,activity_log:read,property_definition:read,event_definition:read,event_definition:write,action:read,warehouse_table:read,warehouse_view:read,external_data_source:read,external_data_source:write,alert:read,subscription:read,feature_flag:write,integration:read,organization:read,task:read,task:write,signal_scout:read,signal_scout:write,external_data_source:read,external_data_source:write,llm_skill:read,llm_skill:write,product_enablement:write
+user:read,project:read,llm_gateway:read,dashboard:read,dashboard:write,insight:read,insight:write,query:read,notebook:read,notebook:write,health_issue:read,wizard_session:read,wizard_session:write,feature_flag:read,experiment:read,experiment_saved_metric:read,survey:read,session_recording:read,error_tracking:read,web_analytics:read,llm_analytics:read,cohort:read,person:read,annotation:read,annotation:write,activity_log:read,property_definition:read,event_definition:read,event_definition:write,action:read,warehouse_table:read,warehouse_view:read,external_data_source:read,external_data_source:write,alert:read,subscription:read,feature_flag:write,integration:read,organization:read,task:read,task:write,signal_scout:read,signal_scout:write,external_data_source:read,external_data_source:write,llm_skill:read,llm_skill:write,product_enablement:write,replay_scanner:read,replay_scanner:write
 ```
 
 If an existing Wizard authorization predates a newly required scope, reconnect

--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -158,6 +158,18 @@ export const AGENT_SKILL_SCOPE_ADDITIONS = [
  *     toggles without the far broader `project:write`. NOTE: net-new —
  *     must be added to the wizard OAuth app's scope ceiling on the
  *     PostHog side before it can be granted (see README / ARCHITECTURE §9).
+ *   • replay_scanner:read / replay_scanner:write — the Replay Vision
+ *     scanners step (skill step 6c) lists the team's existing scanners
+ *     and creates the `emits_signals` ones whose findings land in the
+ *     inbox (`vision-scanners-list` / `-create` / `-update`, and the
+ *     advisory `vision-scanners-estimate-create` / `vision-quota-retrieve`).
+ *     The scope OBJECT is `replay_scanner` — the `vision-scanners-*`
+ *     names are MCP tool names, not scopes. Configuring a scanner also
+ *     requires `session_recording:read` (the API pairs the two, since a
+ *     scanner's config indirectly exposes recording contents); that one
+ *     is already in this list for the step-2 usage probes. NOTE: net-new
+ *     — needs the same OAuth-ceiling edit as `product_enablement:write`
+ *     (see README / ARCHITECTURE §10).
  */
 export const SELF_DRIVING_SCOPE_ADDITIONS = [
   'task:read',
@@ -173,6 +185,8 @@ export const SELF_DRIVING_SCOPE_ADDITIONS = [
   'llm_skill:read',
   'llm_skill:write',
   'product_enablement:write',
+  'replay_scanner:read',
+  'replay_scanner:write',
 ] as const;
 
 /**

--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -155,9 +155,7 @@ export const AGENT_SKILL_SCOPE_ADDITIONS = [
  *     Session Replay / Error Tracking / Support so their sources have
  *     data to read (`products-enable`). A purpose-built scope: the
  *     server owns each enable recipe, so this can flip the product
- *     toggles without the far broader `project:write`. NOTE: net-new —
- *     must be added to the wizard OAuth app's scope ceiling on the
- *     PostHog side before it can be granted (see README / ARCHITECTURE §9).
+ *     toggles without the far broader `project:write`.
  *   • replay_scanner:read / replay_scanner:write — the Replay Vision
  *     scanners step (skill step 6c) lists the team's existing scanners
  *     and creates the `emits_signals` ones whose findings land in the
@@ -167,9 +165,14 @@ export const AGENT_SKILL_SCOPE_ADDITIONS = [
  *     names are MCP tool names, not scopes. Configuring a scanner also
  *     requires `session_recording:read` (the API pairs the two, since a
  *     scanner's config indirectly exposes recording contents); that one
- *     is already in this list for the step-2 usage probes. NOTE: net-new
- *     — needs the same OAuth-ceiling edit as `product_enablement:write`
- *     (see README / ARCHITECTURE §10).
+ *     is already in this list for the step-2 usage probes.
+ *
+ * No OAuth-ceiling edit is needed for any scope here: they are all normal
+ * public (unprivileged, non-internal, non-hidden) scope objects, and the
+ * live wizard apps' ceiling is the `@default` sentinel, which resolves to
+ * every such scope (`UNPRIVILEGED_SCOPES`) and auto-tracks new ones. Only a
+ * privileged/internal/hidden object (e.g. `llm_gateway:*`) would need a
+ * manual per-app edit. See README → "OAuth app scope ceiling".
  */
 export const SELF_DRIVING_SCOPE_ADDITIONS = [
   'task:read',

--- a/src/lib/programs/__tests__/self-driving-prompt.test.ts
+++ b/src/lib/programs/__tests__/self-driving-prompt.test.ts
@@ -43,9 +43,45 @@ describe('buildSelfDrivingPrompt', () => {
     expect(prompt.indexOf('STEP 3b — Enable products')).toBeLessThan(
       prompt.indexOf('STEP 4 — Enable signal sources'),
     );
-    // Tail mirrors the skill: custom scouts is 6b, report is 7.
+    // Tail mirrors the skill: custom scouts is 6b, scanners 6c, report is 7.
     expect(prompt).toContain('STEP 6b — Design custom scouts');
+    expect(prompt).toContain('STEP 6c — Set up Replay Vision scanners');
     expect(prompt).toContain('STEP 7 — Write the report and hand off');
+    expect(prompt.indexOf('STEP 6b — Design custom scouts')).toBeLessThan(
+      prompt.indexOf('STEP 6c — Set up Replay Vision scanners'),
+    );
+    expect(
+      prompt.indexOf('STEP 6c — Set up Replay Vision scanners'),
+    ).toBeLessThan(prompt.indexOf('STEP 7 — Write the report and hand off'));
+  });
+
+  it('lists every step as a task so the TUI task list matches the STEPs', () => {
+    const prompt = buildSelfDrivingPrompt(ctx);
+    // The task list is the contract with the TUI — a STEP with no task silently
+    // drops off the user's progress view.
+    expect(prompt).toContain('6c. Set up Replay Vision scanners');
+    expect(prompt.indexOf('6c. Set up Replay Vision scanners')).toBeLessThan(
+      prompt.indexOf('7. Write report and hand off'),
+    );
+  });
+});
+
+describe('STEP 6c — Replay Vision scanners', () => {
+  it('keeps the trust-critical bits and the never-abort contract', () => {
+    const prompt = buildSelfDrivingPrompt(ctx);
+    // Scope to STEP 6c's text and ignore incidental wrapping.
+    const step6c = prompt
+      .slice(prompt.indexOf('STEP 6c —'), prompt.indexOf('STEP 7 —'))
+      .replace(/\s+/g, ' ');
+    // emits_signals is the entire mechanism — without it the scanners run but
+    // nothing reaches the inbox, which is the whole point of the step.
+    expect(step6c).toContain('emits_signals ON');
+    // The skeletons' locked fields must not be rewritten by the agent.
+    expect(step6c).toContain('locked fields');
+    // Scanners spend Replay Vision quota, unlike anything else in the run.
+    expect(step6c).toContain('quota');
+    // Every failure here is a follow-up — this step must never end the run.
+    expect(step6c).toContain('never an abort');
   });
 });
 

--- a/src/lib/programs/__tests__/self-driving-prompt.test.ts
+++ b/src/lib/programs/__tests__/self-driving-prompt.test.ts
@@ -67,21 +67,37 @@ describe('buildSelfDrivingPrompt', () => {
 });
 
 describe('STEP 6c — Replay Vision scanners', () => {
-  it('keeps the trust-critical bits and the never-abort contract', () => {
+  // The prompt owns order + mechanics; the HOW (skeletons, the disjoint-query
+  // rule, quota) lives in the context-mill skill so it can change without a
+  // wizard release. These assertions cover the wizard's contract, not the
+  // scanner content — restating skill mechanics here is the drift to avoid.
+  const step6c = (): string => {
     const prompt = buildSelfDrivingPrompt(ctx);
-    // Scope to STEP 6c's text and ignore incidental wrapping.
-    const step6c = prompt
+    return prompt
       .slice(prompt.indexOf('STEP 6c —'), prompt.indexOf('STEP 7 —'))
       .replace(/\s+/g, ' ');
-    // emits_signals is the entire mechanism — without it the scanners run but
-    // nothing reaches the inbox, which is the whole point of the step.
-    expect(step6c).toContain('emits_signals ON');
-    // The skeletons' locked fields must not be rewritten by the agent.
-    expect(step6c).toContain('locked fields');
-    // Scanners spend Replay Vision quota, unlike anything else in the run.
-    expect(step6c).toContain('quota');
-    // Every failure here is a follow-up — this step must never end the run.
-    expect(step6c).toContain('never an abort');
+  };
+
+  it('defers the HOW to the skill', () => {
+    expect(step6c()).toContain('(skill: "Replay Vision scanners")');
+  });
+
+  it('states the never-abort posture (a wizard-owned contract)', () => {
+    expect(step6c()).toContain('never an abort');
+  });
+
+  it('names the STEP 3b (Session Replay) dependency', () => {
+    // Cross-step ordering is the wizard's to own, not the skill's.
+    expect(step6c()).toContain('STEP 3b');
+  });
+
+  it('does not restate the skill-owned scanner mechanics', () => {
+    // Guards against re-drift: these are the skill's to specify and tune.
+    const body = step6c();
+    expect(body).not.toContain('sampling_rate');
+    expect(body).not.toContain('scanner_type');
+    expect(body).not.toContain('emits_signals');
+    expect(body).not.toContain('quota');
   });
 });
 

--- a/src/lib/programs/self-driving/ARCHITECTURE.md
+++ b/src/lib/programs/self-driving/ARCHITECTURE.md
@@ -217,10 +217,17 @@ requested via a PKCE auth-code flow:
 | `external_data_source:read`, `external_data_source:write`      | Create/verify warehouse sources (STEP 5).                                                                                   |
 | `llm_skill:read`, `llm_skill:write`                            | Read the authoring guide + canonical bodies, create approved custom scouts (STEP 7).                                        |
 
-The prod `OAuthApplication.scopes` ceiling is an **exhaustive allow-list**
-(`posthog/scopes.py`, `scopes_within_ceiling`) — anything outside it is rejected
-at `/authorize`. Several of these additions are **net-new** to that ceiling and
-must be added before any real-team launch; §7 item 1 is the authoritative list.
+The prod `OAuthApplication.scopes` ceiling **uses the `@default` sentinel**
+(`posthog/scopes.py`, `resolve_ceiling`), not an exhaustive literal list. The
+live US value is `@default,llm_gateway:read,wizard_session:read,wizard_session:write`,
+where `@default` resolves to `UNPRIVILEGED_SCOPES` — every public
+(non-privileged, non-internal, non-hidden) `obj:action` scope, auto-tracking new
+ones. **Every addition above is a normal public scope object, so all are already
+inside the ceiling — no per-scope ceiling edit is needed.** Only a
+privileged/internal/hidden object would need a manual per-app edit; the wizard
+requests none. (An *exhaustive* ceiling — no `@default` — is possible and would
+reject anything unlisted, but the wizard apps aren't configured that way.) See §7
+item 1 and the README's "OAuth app scope ceiling".
 
 **Security & TUI.** YARA hooks (`src/lib/yara-hooks.ts`) scan
 Bash/Write/Edit/Read content and installed skills via the `warlock` scanner
@@ -388,24 +395,33 @@ must be running, or no scout ever dispatches.
 
 ## 7. Prod-merge checklist
 
-> [!IMPORTANT] Cross-repo launch actions. The OAuth-ceiling and flag items are
-> **manual config, not deploys** — easiest to forget. Update this list whenever
-> you add/rename a scope, flag, or backend surface.
+> [!IMPORTANT] Cross-repo launch actions. The flag items are **manual config,
+> not deploys** — easiest to forget. Update this list whenever you add/rename a
+> scope, flag, or backend surface.
 
-1. **OAuth scope ceiling (prod-admin DB action).** The prod
-   `OAuthApplication.scopes` allow-list is exhaustive (`posthog/scopes.py`), so
-   add the **ten net-new objects** self-driving needs: `task:read`,
-   `task:write`, `signal_scout:read`, `signal_scout:write`,
-   `external_data_source:read`, `external_data_source:write`, `llm_skill:read`,
-   `llm_skill:write`, `replay_scanner:read`, `replay_scanner:write`. (Its other
-   four additions — `integration:read`, `session_recording:read`, `survey:read`,
-   `error_tracking:read` — are already in the ceiling.) Note `product_enablement:write`
-   is tracked separately in 9.7 and is also still outstanding. **The scope
-   object for step 6c is `replay_scanner`** — `vision-scanners-*` are MCP tool
-   names, not scopes; getting this wrong grants nothing and the step 403s. Edit
-   the US prod client
-   `c4Rdw8DIxgtQfA80IiSnGKlNX8QN00cFWF00QQhM`, and the dev client
-   `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ` on `localhost:8010`.
+1. **OAuth scope ceiling — NO ACTION NEEDED for self-driving's scopes.** The live
+   wizard apps' `OAuthApplication.scopes` use the `@default` sentinel
+   (`posthog/scopes.py`, `resolve_ceiling`) — US prod is
+   `@default,llm_gateway:read,wizard_session:read,wizard_session:write`.
+   `@default` resolves to `UNPRIVILEGED_SCOPES`, i.e. every public
+   (non-privileged, non-internal, non-hidden) scope, and auto-tracks new ones.
+   **All of self-driving's additions — `task:*`, `signal_scout:*`,
+   `external_data_source:*`, `llm_skill:*`, `product_enablement:write`,
+   `replay_scanner:*`, and the read-only probes — are normal public objects, so
+   they are already inside the ceiling.** Verify before launch rather than
+   assuming:
+   `python manage.py seed_oauth_app_scopes --client-id <id> --scopes @default,llm_gateway:read,wizard_session:read,wizard_session:write --dry-run`
+   (posthog), or evaluate the requested set against `resolve_ceiling`.
+   A ceiling edit is required **only** if a future addition is a
+   privileged/internal/hidden object (e.g. `llm_gateway:*`), which `@default`
+   excludes by design. **One naming trap for step 6c:** the scope object is
+   `replay_scanner` — `vision-scanners-*` are MCP tool names, not scopes;
+   request the tool name and nothing is granted, so the step 403s. Client IDs
+   (for reference, not for editing): US prod
+   `c4Rdw8DIxgtQfA80IiSnGKlNX8QN00cFWF00QQhM`, dev
+   `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ` (`localhost:8010`), and the prod EU
+   app in the EU deployment (via `WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID`) — each
+   should carry the same `@default,…` value.
 2. **context-mill skill release.** Merge `self-driving-setup` to `main` with the
    `mcp-publish` label so the `latest` release contains the skill ZIP — else the
    prod wizard can't fetch it. **Sequencing for the STEP 7 `description`
@@ -596,8 +612,10 @@ must be running, or no scout ever dispatches.
 >     **before** sources are enabled, via an intent-based `products-enable` MCP
 >     tool (one narrow `product_enablement:write` scope, server-owned recipes)
 >     instead of `project:write`; Support is flag-on + a report CTA. Full
->     design, decisions, and status in **§9**. The only outstanding piece is the
->     manual OAuth-ceiling edit (9.7).
+>     design, decisions, and status in **§9**. (An earlier draft flagged a
+>     manual OAuth-ceiling edit as outstanding — that was based on a stale reading
+>     of the ceiling; `product_enablement` is inside `@default`, so there is no
+>     such step. See §7 item 1.)
 
 ---
 
@@ -664,9 +682,11 @@ self-driving state and leave the products as they are.
 
 ## 9. Proactive product enablement (replay / error tracking / support)
 
-> [!IMPORTANT] > **IMPLEMENTED** (step 3b above), with **one manual step
-> outstanding**: the `product_enablement:write` OAuth-ceiling edit on both
-> regions (9.7) — until it lands the wizard can't be granted the scope. A new
+> [!IMPORTANT] > **IMPLEMENTED** (step 3b above), **no manual prod step
+> outstanding**: `product_enablement` is a normal public scope object, so
+> `product_enablement:write` is already inside the wizard apps' `@default`
+> ceiling — no OAuth-ceiling edit (§7 item 1; an earlier draft wrongly flagged
+> one). A new
 > step turns PostHog products ON (so the signal sources have data to read)
 > **before** sources are enabled. Spans **wizard + posthog + context-mill**.
 > Code anchors: posthog `products/signals/backend/product_enablement.py` (+
@@ -856,11 +876,11 @@ repo), so it's a context-mill skill change, not platform work:
   `pnpm --filter=@posthog/mcp generate-tools`. Run in posthog CI, not by hand
   (the spec must be rebuilt from the new endpoint first; the committed
   `openapi.json` is stale until then).
-- **OAuth ceiling — MANUAL, OUTSTANDING (both regions):** add
-  `product_enablement:write` to the wizard OAuth app `OAuthApplication.scopes` —
-  US prod client `c4Rdw8DIxgtQfA80IiSnGKlNX8QN00cFWF00QQhM` + dev
-  `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ`. Until done, the consent server
-  rejects the grant. (Mechanics: §7 item 1.)
+- **OAuth ceiling — NO ACTION.** `product_enablement:write` is inside the
+  `@default` ceiling the wizard apps use, so the consent server grants it with no
+  edit. (An earlier revision of this line claimed a manual edit was outstanding;
+  that was a misreading of the ceiling — see §7 item 1 for the `@default`
+  mechanics and how to verify.)
 - **wizard — DONE.** `product_enablement:write` in
   `SELF_DRIVING_SCOPE_ADDITIONS` (`program-scopes.ts`); STEP 3b "Enable
   products" in `prompt.ts` (label mirrors the skill's `3b-enable-products.md`; +
@@ -890,18 +910,23 @@ repo), so it's a context-mill skill change, not platform work:
   off deliberately** (the flag default `False` can't distinguish "never set"
   from "off on purpose") — accepted under "enable everyone."
 - Refund operational process (no consent, no cap).
-- **MCP codegen + OAuth ceiling** are the only steps not in this repo's diff
-  (build + manual prod edit; see 9.7).
+- **MCP codegen** is the only step not in this repo's diff (posthog CI build;
+  see 9.7). No OAuth-ceiling edit is required — the scope is inside `@default`
+  (§7 item 1).
 
 ---
 
 ## 10. Replay Vision scanners (step 6c)
 
-> [!IMPORTANT] > **IMPLEMENTED** (step 6c), with **one manual step
-> outstanding**: the `replay_scanner:read` / `replay_scanner:write`
-> OAuth-ceiling edit on both regions (§7.1) — until it lands the wizard can't be
-> granted the scope and the step 403s. Spans **wizard + context-mill only**; the
-> posthog side was already done. Code anchors: posthog
+> [!IMPORTANT] > **IMPLEMENTED** (step 6c), **no manual prod step outstanding**.
+> `replay_scanner` is a normal public scope object, so `replay_scanner:read` /
+> `replay_scanner:write` are already inside the wizard apps' `@default` ceiling —
+> no OAuth-ceiling edit (see §7 item 1). Spans **wizard + context-mill only**;
+> the posthog side was already done. Sequencing that does matter: land the wizard
+> npm release (the requested scope + the STEP) **before** the context-mill
+> `mcp-publish`, or the agent reads step 6c and 403s because its token predates
+> the scope — a reconnect, not a ceiling edit, is the fix there. Code anchors:
+> posthog
 > `products/replay_vision/backend/models/replay_scanner.py`,
 > `api/scanners.py`, `temporal/activities/emit_observation_signal.py`,
 > `temporal/scanners/prompts/signals_step.jinja`; wizard `program-scopes.ts` +
@@ -1009,13 +1034,16 @@ where step 1's list already found enabled scanners.
   than assuming availability.
 - **Scope pairing** — create/update require **both** `replay_scanner:write` and
   `session_recording:read` (`ReplayScannerViewSet.dangerously_get_required_scopes`;
-  configuring a scanner indirectly exposes recording contents). The latter is
-  already in `SELF_DRIVING_SCOPE_ADDITIONS` for the step-2 usage probes, so only
-  the `replay_scanner` pair is net-new.
+  configuring a scanner indirectly exposes recording contents). Both are in
+  `SELF_DRIVING_SCOPE_ADDITIONS` (`session_recording:read` was already there for
+  the step-2 usage probes), and both are inside the `@default` ceiling — so no
+  OAuth-ceiling edit (see §7 item 1). The `replay_scanner` pair is the only part
+  net-new to the *requested* set.
 - **Never aborts.** No recordings yet (scanners are armed and start when
-  recordings begin), backend-only project (skip the URL-scoped ones), no
-  identifiable completion flow (skip scanner 3), missing tool / 404 / 403, or a
-  single failed create — all follow-ups, then step 7.
+  recordings begin), backend-only project (skip the URL-scoped Broken
+  experiences scanner, keep User frustration if there are web sessions), no
+  identifiable completion flow (fall back to top-traffic paths), missing tool /
+  404 / 403, or a single failed create — all follow-ups, then step 7.
 
 ### 10.7 Don't-trip-up notes
 

--- a/src/lib/programs/self-driving/ARCHITECTURE.md
+++ b/src/lib/programs/self-driving/ARCHITECTURE.md
@@ -58,14 +58,15 @@ install dir (checked in `detect.ts`).
 
 ---
 
-## 2. The run (9 steps)
+## 2. The run (10 steps)
 
-The agent makes its 9-item task list up front (one `TaskCreate`), drives it with
+The agent makes its 10-item task list up front (one `TaskCreate`), drives it with
 `TaskUpdate`, and asks the user only via `wizard_ask` (batched). Each prompt
 STEP names a skill reference whose matching context-mill file carries the HOW.
 **Step labels mirror the skill files exactly** — including the letter-suffix
-sub-steps `3b` (enable products) and `6b` (custom scouts) — so a prompt `STEP`
-and its `(skill: …)` reference never disagree on the number.
+sub-steps `3b` (enable products), `6b` (custom scouts), and `6c` (Replay Vision
+scanners) — so a prompt `STEP` and its `(skill: …)` reference never disagree on
+the number.
 
 **Step backbone (expected action, one line each):**
 
@@ -115,6 +116,18 @@ and its `(skill: …)` reference never disagree on the number.
   enforced run budget leaves less room, and zero is a valid outcome) (each a plain-language `label` + a dimmed `description`,
   behind a leading "None — keep the built-in troop" default option), create the
   approved subset (the only place custom scouts are made).
+- **6c — Replay Vision scanners** — the push layer: create the skill's two
+  fixed **skeletons** (Broken experiences / User frustration) with
+  `emits_signals: true`, filling only the `query` (scanner 1 targets this
+  product's key **completion** flow, read out of the repo) and a one-line
+  `{{PRODUCT_CONTEXT}}`. The two filter on deliberately different axes (URL vs
+  event) — **overlapping queries self-corroborate into promoted reports**, so
+  widening one means narrowing the other. `monitor` type, Gemini-only. Advisory
+  `vision-scanners-estimate-create` sanity-checks the query's breadth (**not** a
+  fits-in-quota test); `vision-quota-retrieve` + a confirm only when the team
+  already runs enabled scanners. Never aborts — no recordings, backend-only
+  project, no identifiable completion flow, or a deploy without the scanner API
+  are all recorded follow-ups. See §10.
 - **7 — Write report** — write `./posthog-self-driving-report.md` (everything
   changed + follow-ups); findings reach the inbox in ~30 min.
 
@@ -130,6 +143,7 @@ The table below adds the skill reference and the tool/MCP surface for each.
 | 5   | Offer issue-tracker integrations | `5-connected-tools.md` (+ `5a`, `5b`) | One batched multi-select for GitHub Issues / Linear / Zendesk / pganalyze. GitHub Issues & Linear auto-connect via `external-data-sources-create` (GitHub Issues: one connected repo → use it by default, no repo research; Linear: OAuth link + one silent `integrations-list`, never nudge); Zendesk / pganalyze are armed dormant + report follow-up (no UI redirect, no verify). Enable a (possibly dormant) responder per pick.                                                                                                                                                                                                    |
 | 6   | Configure the scout troop        | `6-scouts.md`                         | `signals-scout-config-sync` materializes the troop (~19 scouts, grows over time); `scout-metadata-get` reports the enforced run budget (100 runs/day default); enable `general` + the **3–5 specialists** for the most-used products (agent judgment over step-2 evidence), keeping the whole troop at or under **~10 enabled scouts**, never `error-tracking`/`session-replay` (covered by native sources), fall back to one universal cross-product scout if no surface qualifies, disable all the rest (`signals-scout-config-update {enabled:false}`). Never touches `emit`/`run_interval`.                                                                                                                                                                                  |
 | 6b  | Design custom scouts             | `6b-tailor-scouts.md`                 | The **only** place custom scouts are created. Gap-analyze repo surfaces vs the troop, reading the repo's for-agents context first (AGENTS.md, CLAUDE.md, ARCHITECTURE.md, `.cursor/rules`) as the map of surfaces and vocabulary; propose **at most 5** in ONE `wizard_ask` (bounded by the ~10-scout troop ceiling and the enforced run budget), each option carrying a `description` (an optional `wizard_ask` option field rendered dimmed/wrapped under the label) plus a leading "None" option that's the default highlight (so an empty submit declines); create approved ones via `llma-skill-create` (`signals-scout-<scope>`). **Canonical bodies never edited.** Declining is valid, not an abort. |
+| 6c  | Replay Vision scanners           | `6c-replay-vision-scanners.md`        | `vision-scanners-list` then `vision-scanners-create` (or `-update` on the unique-per-team `name`) for **two** locked `monitor` skeletons with `emits_signals: true` (Broken experiences, URL-scoped to the completion flow; User frustration, `$rageclick`-gated). The agent fills only `query` + `{{PRODUCT_CONTEXT}}`. **Queries must not overlap** — same-session scans self-corroborate to `WEIGHT_THRESHOLD`. `vision-scanners-estimate-create` checks the query's breadth; `vision-quota-retrieve` only when enabled scanners already exist. **No `SignalSourceConfig` row** — `emits_signals` on the scanner *is* the per-source config (`replay_vision`/`scanner_finding` is self-authorizing server-side). Never aborts. See §10.                                                                                                                                                                                          |
 | 7   | Write report & hand off          | `7-report.md`                         | Write `./posthog-self-driving-report.md`; findings appear in the inbox in ~30 min.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 **Abort contract:** the skill emits exact `[ABORT] <reason>` strings; the wizard
@@ -142,11 +156,11 @@ repos.
 ## 3. Wizard internals
 
 **Program definition** (`src/lib/programs/self-driving/`, five files):
-`index.ts` (config + lifecycle), `prompt.ts` (the 9 steps + mechanics + project
+`index.ts` (config + lifecycle), `prompt.ts` (the 10 steps + mechanics + project
 URLs), `detect.ts` (prerequisite check + abort vocabulary), `steps.ts` (TUI
 screen sequence `detect → intro → health-check → auth → run → outro`), and
 `content/tips.ts` (the program-owned `Tips`-sidebar copy that defines signal
-sources + scouts in plain language, wired via `getTips`; `RunScreen` falls back
+sources + scouts + scanners in plain language, wired via `getTips`; `RunScreen` falls back
 to `DEFAULT_TIPS` for every other program, so nothing else is affected).
 `selfDrivingConfig` is built from the `createSkillProgram` factory
 (`src/lib/programs/agent-skill/`) with overrides. Notables in `index.ts`:
@@ -222,13 +236,14 @@ the agent's `TaskCreate`/`TaskUpdate` calls synced to the TUI.
 
 Source: `context-mill/context/skills/self-driving/`. `config.yaml`
 (`template: description.md`, `tags: [signals, self-driving]`, no fetched docs),
-`description.md` (becomes `SKILL.md`; declares the 8-step chain + the
+`description.md` (becomes `SKILL.md`; declares the 10-step chain + the
 cross-cutting rules: trust the setup report, list-before-create idempotency,
 only switch sources on, ask-then-connect, **canonical scout bodies never edited
 — new scouts only in step 6b**, decline-option-first on every `wizard_ask`
 except the required step-3 GitHub gate), and the `references/` chain
 `1-check-access → 2-read-context → 3-github → 4-sources → 5-connected-tools` (+
-`5a-github`, `5b-linear`) `→ 6-scouts → 6b-tailor-scouts → 7-report` (chained by
+`5a-github`, `5b-linear`) `→ 6-scouts → 6b-tailor-scouts →
+6c-replay-vision-scanners → 7-report` (chained by
 `next_step` frontmatter; what each does is in the §2 table).
 
 The canonical `signals-scout-*` skills do **not** live here — they're in posthog
@@ -379,12 +394,16 @@ must be running, or no scout ever dispatches.
 
 1. **OAuth scope ceiling (prod-admin DB action).** The prod
    `OAuthApplication.scopes` allow-list is exhaustive (`posthog/scopes.py`), so
-   add the **eight net-new objects** self-driving needs: `task:read`,
+   add the **ten net-new objects** self-driving needs: `task:read`,
    `task:write`, `signal_scout:read`, `signal_scout:write`,
    `external_data_source:read`, `external_data_source:write`, `llm_skill:read`,
-   `llm_skill:write`. (Its other four additions — `integration:read`,
-   `session_recording:read`, `survey:read`, `error_tracking:read` — are already
-   in the ceiling.) Edit the US prod client
+   `llm_skill:write`, `replay_scanner:read`, `replay_scanner:write`. (Its other
+   four additions — `integration:read`, `session_recording:read`, `survey:read`,
+   `error_tracking:read` — are already in the ceiling.) Note `product_enablement:write`
+   is tracked separately in 9.7 and is also still outstanding. **The scope
+   object for step 6c is `replay_scanner`** — `vision-scanners-*` are MCP tool
+   names, not scopes; getting this wrong grants nothing and the step 403s. Edit
+   the US prod client
    `c4Rdw8DIxgtQfA80IiSnGKlNX8QN00cFWF00QQhM`, and the dev client
    `DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ` on `localhost:8010`.
 2. **context-mill skill release.** Merge `self-driving-setup` to `main` with the
@@ -873,6 +892,140 @@ repo), so it's a context-mill skill change, not platform work:
 - Refund operational process (no consent, no cap).
 - **MCP codegen + OAuth ceiling** are the only steps not in this repo's diff
   (build + manual prod edit; see 9.7).
+
+---
+
+## 10. Replay Vision scanners (step 6c)
+
+> [!IMPORTANT] > **IMPLEMENTED** (step 6c), with **one manual step
+> outstanding**: the `replay_scanner:read` / `replay_scanner:write`
+> OAuth-ceiling edit on both regions (§7.1) — until it lands the wizard can't be
+> granted the scope and the step 403s. Spans **wizard + context-mill only**; the
+> posthog side was already done. Code anchors: posthog
+> `products/replay_vision/backend/models/replay_scanner.py`,
+> `api/scanners.py`, `temporal/activities/emit_observation_signal.py`,
+> `temporal/scanners/prompts/signals_step.jinja`; wizard `program-scopes.ts` +
+> `prompt.ts` + `content/tips.ts`; context-mill
+> `references/6c-replay-vision-scanners.md`.
+
+### 10.1 Why it's a separate layer from scouts
+
+Replay Vision has two layers against the same inbox, and conflating them is the
+easy mistake:
+
+- **Scanner = the sensor.** Watches **one session recording**, writes an
+  observation, pushes the per-session finding. This step.
+- **Scout = the analyst.** Reads **across** accumulated observations for trends
+  and scanner health. Already in the troop as `signals-scout-replay-vision`, off
+  by default. **Step 6c does not touch it** — and because 6c runs *after* step
+  6, a project that had no scanners before this run has no observations for that
+  scout to read, so it stays an evidence-based no in step 6.
+
+### 10.2 The one switch
+
+`emits_signals` (a bool on `ReplayScanner`, default `false`) is the entire
+mechanism. There is **no new contract, enum, or migration**:
+`replay_vision`/`scanner_finding` is already a registered signal source, and it
+is **self-authorizing** — `SignalSourceConfig.is_source_enabled` returns `True`
+for that pair unconditionally, because the flag on the scanner *is* the
+per-source config. Hence step 4's explicit "don't create a `replay_vision` row".
+
+### 10.3 Where the inbox findings actually come from
+
+**This is the part that surprises people, and it shapes the skeleton design.**
+Flipping `emits_signals` appends a **fixed extra turn** to every scan
+(`signals_step.jinja`, appended in `temporal/scanners/base.py`) — identical for
+every scanner, *not* driven by the scanner's own prompt. That turn hunts for a
+genuine product defect at a deliberately high bar (point at it on screen, it
+materially hurt the user, an engineer would unambiguously agree), defaults to an
+empty list, and drops anything under `MIN_SIGNAL_CONFIDENCE = 0.4`. Findings
+emit at `SIGNAL_WEIGHT = 0.5`, so promotion into a report (`total_weight >= 1.0`)
+needs corroboration — a scanner can't flood the inbox alone.
+
+Consequence: **the `query` is the real differentiator between scanners, not the
+prompt.** The prompt is the core observation task (what a human reads in the
+Replay Vision UI, and the context the model carries into the defect turn) — it
+shapes attention, it doesn't set the signal bar. The skill says so explicitly so
+the agent spends its effort on targeting.
+
+**And it's why scanner queries must not overlap — the load-bearing constraint of
+this step.** Two scanners matching the same session each produce their own
+observation (`source_id = observation:{id}:{index}`, unique per observation, so
+no idempotency dedup) and each run the *same* defect turn over the *same*
+recording, describing the same defect in near-identical words. Grouping matches
+signals **semantically, not by source** (`temporal/grouping.py`), so both land in
+one report: `0.5 + 0.5 = 1.0 = WEIGHT_THRESHOLD` → promoted, research spawned.
+Overlapping scanners **manufacture their own corroboration**, defeating the
+half-weight design. Hence two scanners on deliberately different filter axes, and
+an explicit "widen one, narrow the other" rule in the skill.
+
+### 10.4 Skeletons, not free authoring
+
+**Two** fixed `monitor` skeletons, each locking `scanner_type`, `emits_signals`,
+and the base prompt, and leaving two blanks — `query` and a one-line
+`{{PRODUCT_CONTEXT}}`. Curated perspective, tailored targeting; the same
+locked-vs-filled split step 3b uses for product recipes.
+
+1. **Broken experiences** — scoped to the product's **key completion flow** read
+   out of the repo (not a generic "key pages" list), `sampling_rate: 0.5`.
+2. **User frustration** — `$rageclick`-gated, `sampling_rate: 1.0`.
+
+**Two, not three, and the count is derived — not a budget compromise.** 10.3's
+no-overlap constraint means a third scanner would need a *third* filter axis
+neither of these touches, and typical products don't have one. An earlier draft
+had a separate "Blocked conversion" monitor; its query is a subset of scanner
+1's, so the pair would have double-scanned the same sessions and self-promoted
+single defects into researched reports. Its actual value was never the prompt
+wording (the defect turn is fixed) but the *targeting* — insisting the agent find
+the real completion path — so that folded into scanner 1's `query` instead. The
+two survivors filter on deliberately different axes: **where** the user is (URL)
+vs **what they did** (event).
+
+**Never gate the bug scanners on `$exception`.** That reduces them to sessions
+that already threw a JS error — what error tracking catches anyway — and blinds
+them to vision's actual edge: silent breakage with no exception. Scope by
+*where* it matters plus `sampling_rate`, never by an outcome event. `$rageclick`
+in scanner 2 is the deliberate exception: there the gating event **is** the
+friction rather than a proxy for it.
+
+### 10.5 Quota — a sanity check, not a gate
+
+Enabled scanners sweep on a schedule and burn monthly Replay Vision quota, with
+no check at creation time. The edge case looks scarier than it is: ~99% of
+wizard users are **fresh** (full quota, no scanners), so "will it fit in what's
+left" essentially never bites. The real risk is one too-broad scanner torching a
+fresh month in its first sweeps, and the pre-scoped queries + `sampling_rate < 1`
+handle that. So the step **just creates them**, using
+`vision-scanners-estimate-create` as a check on the agent's *query breadth*.
+`vision-quota-retrieve` + an interactive confirm fire only in the rare case
+where step 1's list already found enabled scanners.
+
+### 10.6 Gating & failure modes
+
+- **`replay-vision` feature flag** — endpoints 404 behind
+  `ReplayVisionEnabledPermission` when off. **Not a blocker in practice:** the
+  flag's first release condition is `properties: [], rollout_percentage: 100`,
+  i.e. everyone. The skill still treats a 404 as a recorded follow-up rather
+  than assuming availability.
+- **Scope pairing** — create/update require **both** `replay_scanner:write` and
+  `session_recording:read` (`ReplayScannerViewSet.dangerously_get_required_scopes`;
+  configuring a scanner indirectly exposes recording contents). The latter is
+  already in `SELF_DRIVING_SCOPE_ADDITIONS` for the step-2 usage probes, so only
+  the `replay_scanner` pair is net-new.
+- **Never aborts.** No recordings yet (scanners are armed and start when
+  recordings begin), backend-only project (skip the URL-scoped ones), no
+  identifiable completion flow (skip scanner 3), missing tool / 404 / 403, or a
+  single failed create — all follow-ups, then step 7.
+
+### 10.7 Don't-trip-up notes
+
+- **`name` is unique per team** — a duplicate create 400s; update the existing
+  row instead.
+- **`scanner_type` is immutable after creation** — a name collision with a
+  different type means leave it alone and record it.
+- **Gemini-only** (`ScannerProvider.GOOGLE`); `gemini-3.6-flash` is the skeleton
+  default.
+- `enabled` defaults to `true` on create, so no explicit flip is needed.
 
 ---
 

--- a/src/lib/programs/self-driving/ARCHITECTURE.md
+++ b/src/lib/programs/self-driving/ARCHITECTURE.md
@@ -116,18 +116,11 @@ the number.
   enforced run budget leaves less room, and zero is a valid outcome) (each a plain-language `label` + a dimmed `description`,
   behind a leading "None — keep the built-in troop" default option), create the
   approved subset (the only place custom scouts are made).
-- **6c — Replay Vision scanners** — the push layer: create the skill's two
-  fixed **skeletons** (Broken experiences / User frustration) with
-  `emits_signals: true`, filling only the `query` (scanner 1 targets this
-  product's key **completion** flow, read out of the repo) and a one-line
-  `{{PRODUCT_CONTEXT}}`. The two filter on deliberately different axes (URL vs
-  event) — **overlapping queries self-corroborate into promoted reports**, so
-  widening one means narrowing the other. `monitor` type, Gemini-only. Advisory
-  `vision-scanners-estimate-create` sanity-checks the query's breadth (**not** a
-  fits-in-quota test); `vision-quota-retrieve` + a confirm only when the team
-  already runs enabled scanners. Never aborts — no recordings, backend-only
-  project, no identifiable completion flow, or a deploy without the scanner API
-  are all recorded follow-ups. See §10.
+- **6c — Replay Vision scanners** — the push layer: create the scanner
+  skeletons the skill defines, with `emits_signals: true`, filling only the
+  per-product blanks (`query`, `{{PRODUCT_CONTEXT}}`) from the repo. Never
+  aborts. The skill owns the skeletons and the rules that keep them cheap and
+  non-duplicative; the wizard owns the scope and this ordering. See §10.
 - **7 — Write report** — write `./posthog-self-driving-report.md` (everything
   changed + follow-ups); findings reach the inbox in ~30 min.
 
@@ -143,7 +136,7 @@ The table below adds the skill reference and the tool/MCP surface for each.
 | 5   | Offer issue-tracker integrations | `5-connected-tools.md` (+ `5a`, `5b`) | One batched multi-select for GitHub Issues / Linear / Zendesk / pganalyze. GitHub Issues & Linear auto-connect via `external-data-sources-create` (GitHub Issues: one connected repo → use it by default, no repo research; Linear: OAuth link + one silent `integrations-list`, never nudge); Zendesk / pganalyze are armed dormant + report follow-up (no UI redirect, no verify). Enable a (possibly dormant) responder per pick.                                                                                                                                                                                                    |
 | 6   | Configure the scout troop        | `6-scouts.md`                         | `signals-scout-config-sync` materializes the troop (~19 scouts, grows over time); `scout-metadata-get` reports the enforced run budget (100 runs/day default); enable `general` + the **3–5 specialists** for the most-used products (agent judgment over step-2 evidence), keeping the whole troop at or under **~10 enabled scouts**, never `error-tracking`/`session-replay` (covered by native sources), fall back to one universal cross-product scout if no surface qualifies, disable all the rest (`signals-scout-config-update {enabled:false}`). Never touches `emit`/`run_interval`.                                                                                                                                                                                  |
 | 6b  | Design custom scouts             | `6b-tailor-scouts.md`                 | The **only** place custom scouts are created. Gap-analyze repo surfaces vs the troop, reading the repo's for-agents context first (AGENTS.md, CLAUDE.md, ARCHITECTURE.md, `.cursor/rules`) as the map of surfaces and vocabulary; propose **at most 5** in ONE `wizard_ask` (bounded by the ~10-scout troop ceiling and the enforced run budget), each option carrying a `description` (an optional `wizard_ask` option field rendered dimmed/wrapped under the label) plus a leading "None" option that's the default highlight (so an empty submit declines); create approved ones via `llma-skill-create` (`signals-scout-<scope>`). **Canonical bodies never edited.** Declining is valid, not an abort. |
-| 6c  | Replay Vision scanners           | `6c-replay-vision-scanners.md`        | `vision-scanners-list` then `vision-scanners-create` (or `-update` on the unique-per-team `name`) for **two** locked `monitor` skeletons with `emits_signals: true` (Broken experiences, URL-scoped to the completion flow; User frustration, `$rageclick`-gated). The agent fills only `query` + `{{PRODUCT_CONTEXT}}`. **Queries must not overlap** — same-session scans self-corroborate to `WEIGHT_THRESHOLD`. `vision-scanners-estimate-create` checks the query's breadth; `vision-quota-retrieve` only when enabled scanners already exist. **No `SignalSourceConfig` row** — `emits_signals` on the scanner *is* the per-source config (`replay_vision`/`scanner_finding` is self-authorizing server-side). Never aborts. See §10.                                                                                                                                                                                          |
+| 6c  | Replay Vision scanners           | `6c-replay-vision-scanners.md`        | `vision-scanners-*` (list/create/update, plus the advisory estimate). Creates the skill's scanner skeletons with `emits_signals: true`; the agent fills only `query` + `{{PRODUCT_CONTEXT}}`. **No `SignalSourceConfig` row** — `emits_signals` on the scanner *is* the per-source config (`replay_vision`/`scanner_finding` is self-authorizing server-side), so step 4 skips it. Never aborts. See §10.                                                                                                                                                                                          |
 | 7   | Write report & hand off          | `7-report.md`                         | Write `./posthog-self-driving-report.md`; findings appear in the inbox in ~30 min.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 **Abort contract:** the skill emits exact `[ABORT] <reason>` strings; the wizard
@@ -216,6 +209,7 @@ requested via a PKCE auth-code flow:
 | `session_recording:read`, `survey:read`, `error_tracking:read` | Read-only usage probes (STEP 2).                                                                                            |
 | `external_data_source:read`, `external_data_source:write`      | Create/verify warehouse sources (STEP 5).                                                                                   |
 | `llm_skill:read`, `llm_skill:write`                            | Read the authoring guide + canonical bodies, create approved custom scouts (STEP 7).                                        |
+| `replay_scanner:read`, `replay_scanner:write`                  | List/create Replay Vision scanners (STEP 6c). Object is `replay_scanner` — the `vision-scanners-*` names are MCP tools, not scopes. Create/update also use `session_recording:read` (above). |
 
 The prod `OAuthApplication.scopes` ceiling **uses the `@default` sentinel**
 (`posthog/scopes.py`, `resolve_ceiling`), not an exhaustive literal list. The
@@ -918,142 +912,50 @@ repo), so it's a context-mill skill change, not platform work:
 
 ## 10. Replay Vision scanners (step 6c)
 
-> [!IMPORTANT] > **IMPLEMENTED** (step 6c), **no manual prod step outstanding**.
-> `replay_scanner` is a normal public scope object, so `replay_scanner:read` /
-> `replay_scanner:write` are already inside the wizard apps' `@default` ceiling —
-> no OAuth-ceiling edit (see §7 item 1). Spans **wizard + context-mill only**;
-> the posthog side was already done. Sequencing that does matter: land the wizard
-> npm release (the requested scope + the STEP) **before** the context-mill
-> `mcp-publish`, or the agent reads step 6c and 403s because its token predates
-> the scope — a reconnect, not a ceiling edit, is the fix there. Code anchors:
-> posthog
-> `products/replay_vision/backend/models/replay_scanner.py`,
-> `api/scanners.py`, `temporal/activities/emit_observation_signal.py`,
-> `temporal/scanners/prompts/signals_step.jinja`; wizard `program-scopes.ts` +
-> `prompt.ts` + `content/tips.ts`; context-mill
-> `references/6c-replay-vision-scanners.md`.
+The **push** layer of the inbox: scanners watch individual recordings and emit
+what they see, where sources and scouts *pull*. **The wizard owns almost none of
+it** — just the OAuth scope (§3) and the STEP that names the skill. The skeletons,
+the per-product blanks the agent fills, the rules that keep the scanners cheap and
+non-duplicative (query scoping, the disjoint-query constraint, the quota
+sanity-check) all live in the skill
+(`context-mill/.../6c-replay-vision-scanners.md`), so they can change without a
+wizard release — which is the whole reason they live there and not here. Read that
+file for the design; this section records only the facts that are about the
+**wizard flow**, not the scanner content.
 
-### 10.1 Why it's a separate layer from scouts
+- **Scope.** Object is `replay_scanner` — the `vision-scanners-*` names are MCP
+  *tools*, not scopes, so requesting a tool name grants nothing and the step
+  403s. Create/update also need `session_recording:read` (the API pairs them —
+  configuring a scanner indirectly exposes recording contents). Both are normal
+  public objects inside the wizard apps' `@default` ceiling, so **no ceiling
+  edit** (§3, §7 item 1). The one sequencing constraint: ship the wizard release
+  (scope + STEP) **before** the context-mill `mcp-publish`, or a token predating
+  the scope 403s — fixed by a reconnect, not a ceiling edit.
 
-Replay Vision has two layers against the same inbox, and conflating them is the
-easy mistake:
+- **Self-authorizing → no source row.** `emits_signals` (a bool on
+  `ReplayScanner`, default false) is the entire mechanism — no new contract,
+  enum, or migration. `SignalSourceConfig.is_source_enabled` returns `True` for
+  `replay_vision`/`scanner_finding` unconditionally, because the flag on the
+  scanner *is* the per-source config. That's why STEP 4 must **not** create a
+  `replay_vision` source row.
 
-- **Scanner = the sensor.** Watches **one session recording**, writes an
-  observation, pushes the per-session finding. This step.
-- **Scout = the analyst.** Reads **across** accumulated observations for trends
-  and scanner health. Already in the troop as `signals-scout-replay-vision`, off
-  by default. **Step 6c does not touch it** — and because 6c runs *after* step
-  6, a project that had no scanners before this run has no observations for that
-  scout to read, so it stays an evidence-based no in step 6.
+- **Separate layer from the scout.** The scanner is the *sensor* (one recording →
+  one observation → the per-session finding). `signals-scout-replay-vision` is the
+  *analyst* reading **across** accumulated observations, left off by default and
+  untouched here. Because 6c runs *after* step 6 and its scanners have produced
+  nothing yet, that scout stays an evidence-based no in step 6 — don't enable it
+  on the strength of having just created scanners.
 
-### 10.2 The one switch
+- **Never aborts.** No recordings yet (the scanners arm and start when recordings
+  begin), a backend-only project, the `replay-vision` flag off (endpoints 404
+  behind `ReplayVisionEnabledPermission` — in practice on for everyone), a missing
+  tool, or a single failed create are all recorded follow-ups, then step 7.
 
-`emits_signals` (a bool on `ReplayScanner`, default `false`) is the entire
-mechanism. There is **no new contract, enum, or migration**:
-`replay_vision`/`scanner_finding` is already a registered signal source, and it
-is **self-authorizing** — `SignalSourceConfig.is_source_enabled` returns `True`
-for that pair unconditionally, because the flag on the scanner *is* the
-per-source config. Hence step 4's explicit "don't create a `replay_vision` row".
-
-### 10.3 Where the inbox findings actually come from
-
-**This is the part that surprises people, and it shapes the skeleton design.**
-Flipping `emits_signals` appends a **fixed extra turn** to every scan
-(`signals_step.jinja`, appended in `temporal/scanners/base.py`) — identical for
-every scanner, *not* driven by the scanner's own prompt. That turn hunts for a
-genuine product defect at a deliberately high bar (point at it on screen, it
-materially hurt the user, an engineer would unambiguously agree), defaults to an
-empty list, and drops anything under `MIN_SIGNAL_CONFIDENCE = 0.4`. Findings
-emit at `SIGNAL_WEIGHT = 0.5`, so promotion into a report (`total_weight >= 1.0`)
-needs corroboration — a scanner can't flood the inbox alone.
-
-Consequence: **the `query` is the real differentiator between scanners, not the
-prompt.** The prompt is the core observation task (what a human reads in the
-Replay Vision UI, and the context the model carries into the defect turn) — it
-shapes attention, it doesn't set the signal bar. The skill says so explicitly so
-the agent spends its effort on targeting.
-
-**And it's why scanner queries must not overlap — the load-bearing constraint of
-this step.** Two scanners matching the same session each produce their own
-observation (`source_id = observation:{id}:{index}`, unique per observation, so
-no idempotency dedup) and each run the *same* defect turn over the *same*
-recording, describing the same defect in near-identical words. Grouping matches
-signals **semantically, not by source** (`temporal/grouping.py`), so both land in
-one report: `0.5 + 0.5 = 1.0 = WEIGHT_THRESHOLD` → promoted, research spawned.
-Overlapping scanners **manufacture their own corroboration**, defeating the
-half-weight design. Hence two scanners on deliberately different filter axes, and
-an explicit "widen one, narrow the other" rule in the skill.
-
-### 10.4 Skeletons, not free authoring
-
-**Two** fixed `monitor` skeletons, each locking `scanner_type`, `emits_signals`,
-and the base prompt, and leaving two blanks — `query` and a one-line
-`{{PRODUCT_CONTEXT}}`. Curated perspective, tailored targeting; the same
-locked-vs-filled split step 3b uses for product recipes.
-
-1. **Broken experiences** — scoped to the product's **key completion flow** read
-   out of the repo (not a generic "key pages" list), `sampling_rate: 0.5`.
-2. **User frustration** — `$rageclick`-gated, `sampling_rate: 1.0`.
-
-**Two, not three, and the count is derived — not a budget compromise.** 10.3's
-no-overlap constraint means a third scanner would need a *third* filter axis
-neither of these touches, and typical products don't have one. An earlier draft
-had a separate "Blocked conversion" monitor; its query is a subset of scanner
-1's, so the pair would have double-scanned the same sessions and self-promoted
-single defects into researched reports. Its actual value was never the prompt
-wording (the defect turn is fixed) but the *targeting* — insisting the agent find
-the real completion path — so that folded into scanner 1's `query` instead. The
-two survivors filter on deliberately different axes: **where** the user is (URL)
-vs **what they did** (event).
-
-**Never gate the bug scanners on `$exception`.** That reduces them to sessions
-that already threw a JS error — what error tracking catches anyway — and blinds
-them to vision's actual edge: silent breakage with no exception. Scope by
-*where* it matters plus `sampling_rate`, never by an outcome event. `$rageclick`
-in scanner 2 is the deliberate exception: there the gating event **is** the
-friction rather than a proxy for it.
-
-### 10.5 Quota — a sanity check, not a gate
-
-Enabled scanners sweep on a schedule and burn monthly Replay Vision quota, with
-no check at creation time. The edge case looks scarier than it is: ~99% of
-wizard users are **fresh** (full quota, no scanners), so "will it fit in what's
-left" essentially never bites. The real risk is one too-broad scanner torching a
-fresh month in its first sweeps, and the pre-scoped queries + `sampling_rate < 1`
-handle that. So the step **just creates them**, using
-`vision-scanners-estimate-create` as a check on the agent's *query breadth*.
-`vision-quota-retrieve` + an interactive confirm fire only in the rare case
-where step 1's list already found enabled scanners.
-
-### 10.6 Gating & failure modes
-
-- **`replay-vision` feature flag** — endpoints 404 behind
-  `ReplayVisionEnabledPermission` when off. **Not a blocker in practice:** the
-  flag's first release condition is `properties: [], rollout_percentage: 100`,
-  i.e. everyone. The skill still treats a 404 as a recorded follow-up rather
-  than assuming availability.
-- **Scope pairing** — create/update require **both** `replay_scanner:write` and
-  `session_recording:read` (`ReplayScannerViewSet.dangerously_get_required_scopes`;
-  configuring a scanner indirectly exposes recording contents). Both are in
-  `SELF_DRIVING_SCOPE_ADDITIONS` (`session_recording:read` was already there for
-  the step-2 usage probes), and both are inside the `@default` ceiling — so no
-  OAuth-ceiling edit (see §7 item 1). The `replay_scanner` pair is the only part
-  net-new to the *requested* set.
-- **Never aborts.** No recordings yet (scanners are armed and start when
-  recordings begin), backend-only project (skip the URL-scoped Broken
-  experiences scanner, keep User frustration if there are web sessions), no
-  identifiable completion flow (fall back to top-traffic paths), missing tool /
-  404 / 403, or a single failed create — all follow-ups, then step 7.
-
-### 10.7 Don't-trip-up notes
-
-- **`name` is unique per team** — a duplicate create 400s; update the existing
-  row instead.
-- **`scanner_type` is immutable after creation** — a name collision with a
-  different type means leave it alone and record it.
-- **Gemini-only** (`ScannerProvider.GOOGLE`); `gemini-3.6-flash` is the skeleton
-  default.
-- `enabled` defaults to `true` on create, so no explicit flip is needed.
+Code anchors: posthog `products/replay_vision/backend/models/replay_scanner.py`,
+`api/scanners.py`, `temporal/scanners/prompts/signals_step.jinja` (the fixed
+defect-detection turn that `emits_signals` appends — the *why* the skill cares
+more about a scanner's `query` than its prompt); wizard `program-scopes.ts` +
+`prompt.ts` + `content/tips.ts`; skill `6c-replay-vision-scanners.md`.
 
 ---
 

--- a/src/lib/programs/self-driving/content/tips.ts
+++ b/src/lib/programs/self-driving/content/tips.ts
@@ -24,6 +24,12 @@ export const SELF_DRIVING_TIPS: Tip[] = [
       'An agent on a schedule, watching your sources for anomalies and patterns. Your project gets up to 100 scout runs a day by default.',
   },
   {
+    id: 'scanner',
+    title: 'Scanner',
+    description:
+      'Where a scout reads your data, a scanner watches session recordings — an LLM spotting what broke on screen. It spends Replay Vision quota, so it stays scoped to your key flows.',
+  },
+  {
     id: 'signal-report',
     title: 'Signal → report',
     description:

--- a/src/lib/programs/self-driving/prompt.ts
+++ b/src/lib/programs/self-driving/prompt.ts
@@ -203,24 +203,11 @@ STEP 6b — Design custom scouts for this product. (skill: "Custom scouts")
    completed either way.
 
 STEP 6c — Set up Replay Vision scanners. (skill: "Replay Vision scanners")
-   Scouts pull; scanners push. A scanner is an LLM that watches individual
-   session recordings on a cadence and, with emits_signals on, pushes what
-   it finds straight into the inbox. Create the skill's scanner skeletons
-   with emits_signals ON, filling in only the two blanks each leaves you:
-   the query (which flows matter in THIS product, from the repo) and the
-   one-line product-context sentence. Never edit the locked fields — the
-   skeleton's scanner_type, emits_signals, and base prompt are the
-   trust-critical bits. Scanner names are unique per team, so update an
-   existing scanner rather than re-creating it, and scanner_type can never
-   be changed after creation. Keep the scanners' queries disjoint — two
-   scanners watching the same sessions report the same defect twice and
-   corroborate each other into the inbox, so if you widen one, narrow the
-   other. Scanners spend Replay Vision quota on a schedule, so keep the
-   skill's pre-scoped queries and sampling rates —
-   widen only with a reason. This step needs Session Replay on (STEP 3b),
-   and every failure here is a follow-up, never an abort: a project with no
-   recordings yet, an org already close to its quota, or a deploy without
-   the scanner API are all valid outcomes to record and move past.
+   Create the scanner skeletons the skill defines, filling the per-product
+   blanks it leaves you from this repo's code. Scanners need Session Replay
+   on (STEP 3b). Every failure here — no recordings yet, a backend-only
+   project, the scanner API missing — is a follow-up, never an abort; mark
+   the task completed regardless.
 
 STEP 7 — Write the report and hand off. (skill: "Report")
    Write the report per the skill, including follow-ups for anything

--- a/src/lib/programs/self-driving/prompt.ts
+++ b/src/lib/programs/self-driving/prompt.ts
@@ -58,7 +58,7 @@ export function buildSelfDrivingPrompt(
     value === true ? 'ON' : value === false ? 'OFF' : 'unknown';
   const optIns = ctx.teamProductOptIns;
 
-  return `You are setting up PostHog Self-driving for this project: you will enable the right signal sources, make sure GitHub is connected, tune the scout troop, design custom scouts for what this product uniquely needs, and hand the user a configured inbox.
+  return `You are setting up PostHog Self-driving for this project: you will enable the right signal sources, make sure GitHub is connected, tune the scout troop, design custom scouts for what this product uniquely needs, put Replay Vision scanners on its key flows, and hand the user a configured inbox.
 
 Project URLs:
 - Integrations settings: ${integrationsSettingsUrl}
@@ -93,6 +93,7 @@ tasks, in this order:
   5. Offer issue-tracker integrations
   6. Configure the scout troop
   6b. Design custom scouts
+  6c. Set up Replay Vision scanners
   7. Write report and hand off
 Drive the list with TaskUpdate — mark a task in_progress when you start
 it and completed when done. If a step turns out to be a no-op (e.g.
@@ -200,6 +201,26 @@ STEP 6b — Design custom scouts for this product. (skill: "Custom scouts")
    before creating anything; the user declining everything (or finding
    no gap at all) is a valid outcome, not an abort. Mark the task
    completed either way.
+
+STEP 6c — Set up Replay Vision scanners. (skill: "Replay Vision scanners")
+   Scouts pull; scanners push. A scanner is an LLM that watches individual
+   session recordings on a cadence and, with emits_signals on, pushes what
+   it finds straight into the inbox. Create the skill's scanner skeletons
+   with emits_signals ON, filling in only the two blanks each leaves you:
+   the query (which flows matter in THIS product, from the repo) and the
+   one-line product-context sentence. Never edit the locked fields — the
+   skeleton's scanner_type, emits_signals, and base prompt are the
+   trust-critical bits. Scanner names are unique per team, so update an
+   existing scanner rather than re-creating it, and scanner_type can never
+   be changed after creation. Keep the scanners' queries disjoint — two
+   scanners watching the same sessions report the same defect twice and
+   corroborate each other into the inbox, so if you widen one, narrow the
+   other. Scanners spend Replay Vision quota on a schedule, so keep the
+   skill's pre-scoped queries and sampling rates —
+   widen only with a reason. This step needs Session Replay on (STEP 3b),
+   and every failure here is a follow-up, never an abort: a project with no
+   recordings yet, an org already close to its quota, or a deploy without
+   the scanner API are all valid outcomes to record and move past.
 
 STEP 7 — Write the report and hand off. (skill: "Report")
    Write the report per the skill, including follow-ups for anything

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -93,6 +93,21 @@ describe('wizard OAuth scopes', () => {
     );
   });
 
+  it('grants self-driving the scanner scopes STEP 6c needs', () => {
+    const scopes = getOAuthScopesForProgram('self-driving');
+
+    // The scope OBJECT is `replay_scanner` — `vision-scanners-*` are MCP tool
+    // names, not scopes. Requesting the tool name grants nothing and STEP 6c
+    // 403s on every scanner call.
+    expect(scopes).toContain('replay_scanner:read');
+    expect(scopes).toContain('replay_scanner:write');
+    // Creating/updating a scanner requires session_recording:read alongside
+    // replay_scanner:write (the API pairs them), so losing it breaks 6c too.
+    expect(scopes).toContain('session_recording:read');
+    // Base scopes are never dropped by an addition.
+    expect(scopes).toEqual(expect.arrayContaining([...WIZARD_OAUTH_SCOPES]));
+  });
+
   it('accepts a newly issued token with the completion scope', () => {
     expect(() =>
       assertWizardCompletionScope(


### PR DESCRIPTION
Human tl;dr: Pairs with PostHog/context-mill#313. This adds the scaffolding for the new replay vision setup step in scanner. Scoping changes are key, then a little bit of text updates.

## What

The wizard glue for a new self-driving step 6c: create Replay Vision scanners with `emits_signals: true` so on-screen breakage a recording reveals reaches the inbox, alongside what sources and scouts already pull. Three small surfaces, since the HOW lives in the skill:

- **`program-scopes.ts`** — `replay_scanner:read` / `replay_scanner:write`.
- **`prompt.ts`** — STEP 6c + its task-list entry.
- **`content/tips.ts`** — a Scanner tip.

## The scope name is the thing to get right

The scope object is **`replay_scanner`**, not `vision-scanners-*`. Those are MCP *tool* names — requesting one grants nothing and the step 403s on every call. (`ReplayScannerViewSet.scope_object`.)

Create/update also require `session_recording:read` alongside `replay_scanner:write` — the API pairs them via `dangerously_get_required_scopes`, since a scanner's config indirectly exposes recording contents. That one is already granted for the step-2 usage probes, so **only the `replay_scanner` pair is net-new to the requested set.**

**No prod OAuth-ceiling edit is needed** — this corrects an earlier version of this PR (and some stale repo docs, fixed in the second commit). The live wizard apps' `OAuthApplication.scopes` use the `@default` sentinel — US prod is `@default,llm_gateway:read,wizard_session:read,wizard_session:write`. `@default` resolves to `UNPRIVILEGED_SCOPES` (every public non-privileged/non-internal/non-hidden scope) and auto-tracks new ones, so `replay_scanner:*` is already inside the ceiling. Verify with `python manage.py seed_oauth_app_scopes --client-id <id> --scopes @default,… --dry-run` on the posthog side. A ceiling edit is only ever needed for a privileged/internal/hidden object, which this isn't.

Not a blocker either: the endpoints sit behind the `replay-vision` flag and 404 when off, but its first release condition is `properties: [], rollout_percentage: 100` — everyone. The skill still treats a 404 as a recorded follow-up.

## What the prompt carries (kept deliberately thin)

Only what the wizard owns, at the same altitude as the neighbouring steps: STEP 6c is purpose + "per the skill" + the STEP 3b (Session Replay) dependency + the never-abort posture. **The scanner HOW — the skeletons, the per-product blanks, the disjoint-query rule, the quota check — lives entirely in the context-mill skill**, so it can be tuned without a wizard release. An earlier revision of this PR had leaked those specifics into `prompt.ts` and `ARCHITECTURE §10`; the third commit pulls them back out (the STEP dropped from ~15 lines to ~5, §10 went ~140 → ~48) and the docs now point at the skill for the design instead of restating it.

Why it still matters that queries stay disjoint (the design — now in the skill, and the thing worth a reviewer's eye there): `emits_signals` appends a *fixed* defect turn to every scan, identical regardless of the scanner's own prompt — so prompts don't differentiate scanners, queries do. And since grouping matches signals semantically rather than by source, two scanners over the same sessions describe one defect twice and sum `0.5 + 0.5` to exactly `WEIGHT_THRESHOLD`. Overlapping scanners **self-promote**, defeating the half-weight design that's meant to require corroboration.


## Sequencing

1. Merge this and cut the wizard npm release.
2. Then merge context-mill#313 with `mcp-publish`.

Reversed, the agent reads step 6c before the release ships the requested scope, and 403s. Note the fix there is a **reconnect** (refresh tokens keep their original grant), not a ceiling edit — nothing manual on the prod OAuth app. Everything here is inert until the skill ships, so this half is safe to land first.

## Testing

`pnpm build && pnpm test && pnpm lint` — 1722 pass, 0 lint errors. The 6c prompt tests assert the wizard's *contract* rather than restated skill content: STEP present and ordered 6b → 6c → 7, its task-list entry exists (a STEP with no task silently drops off the TUI progress view), it defers to the skill and states its never-abort posture and STEP 3b dependency, and a guard asserts it does **not** restate skill-owned mechanics (`sampling_rate` / `scanner_type` / `emits_signals` / `quota`) so the drift can't quietly return. The scope test covers `replay_scanner:*` + `session_recording:read` without weakening the base set.
