### PR TITLE
fix(oauth): degrade instead of dying when a scope predates its ceiling edit

### DIFF
--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -254,3 +254,37 @@ export function getOAuthScopesForProgram(
   }
   return merged;
 }
+
+/**
+ * Scopes requested here that may not yet exist in the wizard OAuth app's
+ * server-side ceiling (`OAuthApplication.scopes`), because widening it is a
+ * manual Django-admin edit on both prod regions that lands separately from
+ * the code that starts requesting the scope.
+ *
+ * Until that edit is made, PostHog rejects the authorize request with
+ * `invalid_scope` — and it rejects the WHOLE request, so one pending scope
+ * locks the user out of login entirely rather than degrading the one step
+ * that needs it. `performOAuthFlow` retries once without these, which turns
+ * that hard failure into a working run with a reduced grant.
+ *
+ * **Add a scope here in the same PR that starts requesting it. Remove it
+ * once the ceiling edit is confirmed live in both regions** — an entry that
+ * outlives its edit silently permits a degraded grant instead of surfacing
+ * a real misconfiguration.
+ */
+export const PENDING_CEILING_SCOPES: readonly string[] = [];
+
+/**
+ * The requested scopes minus any awaiting a ceiling edit, order preserved.
+ * Returns an equal-length copy when there is nothing to drop, so callers can
+ * compare lengths to decide whether a retry is worth attempting.
+ *
+ * `pending` is injectable for tests only — the shipped list is empty whenever
+ * every requested scope is live, which is the steady state.
+ */
+export function scopesWithoutPendingCeiling(
+  scopes: readonly string[],
+  pending: readonly string[] = PENDING_CEILING_SCOPES,
+): string[] {
+  return scopes.filter((s) => !pending.includes(s));
+}

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -9,7 +9,11 @@ import {
   WIZARD_OAUTH_SCOPES,
   WIZARD_PROVISIONING_SCOPES,
 } from '@lib/constants';
-import { getOAuthScopesForProgram } from '@lib/oauth/program-scopes';
+import {
+  getOAuthScopesForProgram,
+  PENDING_CEILING_SCOPES,
+  scopesWithoutPendingCeiling,
+} from '@lib/oauth/program-scopes';
 
 describe('extractOAuthCode', () => {
   it('extracts the code from a full callback URL', () => {
@@ -118,6 +122,43 @@ describe('wizard OAuth scopes', () => {
       'wizard_session:write',
       'event_definition:write',
     ]);
+  });
+});
+
+describe('pending-ceiling scope degradation', () => {
+  it('drops only the pending scopes, preserving order', () => {
+    expect(
+      scopesWithoutPendingCeiling(
+        ['user:read', 'replay_scanner:read', 'project:read'],
+        ['replay_scanner:read'],
+      ),
+    ).toEqual(['user:read', 'project:read']);
+  });
+
+  it('leaves the request untouched when nothing is pending', () => {
+    const requested = getOAuthScopesForProgram('self-driving');
+
+    expect(scopesWithoutPendingCeiling(requested, [])).toEqual([...requested]);
+  });
+
+  // The retry only fires when this shrinks the set, so a no-op list must not
+  // arm it — otherwise an invalid_scope for an unrelated reason would loop.
+  it('shrinks the set only when a pending scope was actually requested', () => {
+    const requested = getOAuthScopesForProgram('self-driving');
+
+    expect(
+      scopesWithoutPendingCeiling(requested, ['not:requested']).length,
+    ).toBe(requested.length);
+  });
+
+  // Degrading a base scope would hand back a token that authenticates but
+  // can't run the wizard, turning a loud failure into a confusing one.
+  it('never lists a base wizard scope as pending', () => {
+    expect(
+      PENDING_CEILING_SCOPES.filter((s) =>
+        (WIZARD_OAUTH_SCOPES as readonly string[]).includes(s),
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -12,6 +12,7 @@ import {
   POSTHOG_PROXY_CLIENT_ID,
   WIZARD_USER_AGENT,
 } from '@lib/constants';
+import { scopesWithoutPendingCeiling } from '@lib/oauth/program-scopes';
 import { getOAuthUrl, resolveBaseUrl } from './urls';
 import { abort } from './setup-utils';
 import { openTrackedLink, withUtm } from './links';
@@ -404,10 +405,13 @@ export async function performOAuthFlow(
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = generateCodeChallenge(codeVerifier);
   let shouldRetry = false;
+  // Mutable for the one-shot `invalid_scope` retry below, which re-runs the
+  // flow with the pending-ceiling scopes removed.
+  let scopes = [...config.scopes];
 
   logToFile(
     `[oauth] starting flow against ${oauthUrl}, ` +
-      `requested scopes: ${config.scopes.join(' ')}`,
+      `requested scopes: ${scopes.join(' ')}`,
   );
 
   do {
@@ -427,7 +431,7 @@ export async function performOAuthFlow(
       authUrl.searchParams.set('response_type', 'code');
       authUrl.searchParams.set('code_challenge', codeChallenge);
       authUrl.searchParams.set('code_challenge_method', 'S256');
-      authUrl.searchParams.set('scope', config.scopes.join(' '));
+      authUrl.searchParams.set('scope', scopes.join(' '));
       authUrl.searchParams.set('required_access_level', 'project');
       if (config.projectId !== undefined) {
         // Pre-select this project on the consent screen so the user just clicks Authorize.
@@ -527,6 +531,37 @@ export async function performOAuthFlow(
           );
         }
 
+        // A scope missing from the OAuth app's server-side ceiling fails the
+        // WHOLE authorize request, so one scope awaiting its manual ceiling
+        // edit locks the user out of login entirely instead of degrading the
+        // single step that needs it. Drop those and try once more: a reduced
+        // grant beats no run at all. Bounded to one attempt — the retry
+        // requests nothing pending, so this branch can't match twice.
+        const reducedScopes = scopesWithoutPendingCeiling(scopes);
+        if (
+          flowError?.code === 'invalid_scope' &&
+          reducedScopes.length < scopes.length
+        ) {
+          const dropped = scopes.filter((s) => !reducedScopes.includes(s));
+          logToFile(
+            `[oauth] invalid_scope: retrying without pending-ceiling scopes ${dropped.join(
+              ' ',
+            )}`,
+          );
+          analytics.wizardCapture('oauth pending ceiling scopes dropped', {
+            dropped_scopes: dropped.join(' '),
+            client_id: clientId,
+          });
+          getUI().log.warn(
+            `PostHog rejected ${dropped.join(
+              ', ',
+            )}, so anything needing those permissions will be skipped this run.\n\nRetrying login without them.`,
+          );
+          scopes = reducedScopes;
+          shouldRetry = true;
+          break;
+        }
+
         const accessDenied = flowError
           ? flowError.code === 'access_denied'
           : error.message.includes('access_denied');
@@ -544,7 +579,7 @@ export async function performOAuthFlow(
           getUI().log.error(
             buildOAuthFailureMessage({
               error,
-              requestedScopes: config.scopes,
+              requestedScopes: scopes,
               clientId,
               oauthUrl,
               // Same condition that selects the dev client ID: a resolvable
@@ -568,7 +603,7 @@ export async function performOAuthFlow(
           oauth_error_code: oauthErrorCode,
           oauth_error_description: flowError?.description,
           client_id: clientId,
-          requested_scopes: config.scopes.join(' '),
+          requested_scopes: scopes.join(' '),
           // Collapse OAuth callback failures of the same kind into one issue
           // instead of fragmenting by each user's install path in the stack trace.
           $exception_fingerprint: `wizard_oauth_${oauthErrorCode}`,
@@ -578,6 +613,11 @@ export async function performOAuthFlow(
         throw error;
       }
     }
+
+    // The scope-degradation retry above broke out of the port loop with the
+    // next attempt already armed — no port was exhausted, so skip the
+    // port-conflict path and re-enter the flow.
+    if (shouldRetry) continue;
 
     if (!lastProcessInfo) {
       throw new Error('No OAuth callback ports configured');


### PR DESCRIPTION
## Problem

Widening the wizard OAuth app's scope ceiling (`OAuthApplication.scopes`) is a manual Django-admin edit on both prod regions, so it lands separately from the code that starts requesting the scope. `src/lib/constants.ts` already documents the consequence:

> requesting anything outside it fails the WHOLE authorize request with `error=invalid_scope` before the consent screen renders

So during that window, one not-yet-live scope doesn't degrade the step that needs it — it locks every user of that program out of login entirely. The current copy in `oauth-errors.ts` describes this accurately and offers no way forward: *"Re-running the wizard will not help until the ceiling is updated."*

This is not hypothetical. I hit it running `wizard self-driving` off #1055, which requests the net-new `replay_scanner:read` / `replay_scanner:write`. Login to `us.posthog.com` succeeded, then the callback came back `http://localhost:8239/callback?error=invalid_scope` and the run was dead. The only way to proceed was to locally comment the two scopes out of `SELF_DRIVING_SCOPE_ADDITIONS` — which is exactly what this PR does properly, and automatically.

The failure mode is generic: it recurs for every future net-new scope, and the blast radius is the whole program rather than one step. #1055's own sequencing notes ("make the prod OAuth-ceiling edit, *then* merge") are a process workaround for a robustness gap in the client.

## Changes

- **`PENDING_CEILING_SCOPES`** in `program-scopes.ts` — declares scopes that may not be live in the ceiling yet. Ships **empty**, since everything requested today is live; it's the checklist entry that pairs with the admin edit.
- **One-shot retry in `performOAuthFlow`** — on `invalid_scope`, if the request contained pending scopes, drop them and re-enter the existing `do/while` with a reduced set. Bounded to a single extra attempt: the retry requests nothing pending, so the branch cannot match twice.
- Reuses the loop already there for port conflicts; the guard after the port loop keeps a scope retry from falling into the port-conflict path.
- The degradation is **loud** — dropped scopes are named in a `log.warn` and captured as `oauth pending ceiling scopes dropped`, so this never silently hides a real misconfiguration.

`config.scopes` becomes a local `scopes` so the retry, the failure message, and the analytics payload all report what was actually requested on the final attempt.

### The design tradeoff, stated plainly

This trades "fail loudly, fix the ceiling" for "warn loudly, finish the run with less". I think that's right when the alternative is a total lockout on a manual-edit race, and the empty default means nothing changes until someone opts a scope in. **If you'd rather the client stay strict**, the alternative worth considering is a CI check asserting every requested scope appears in the README ceiling list — happy to switch. Two notes for reviewers:

1. An entry that outlives its ceiling edit permits a degraded grant indefinitely. The doc comment says to remove it once confirmed live; a stronger version could expire entries by date.
2. The spinner prints "Authorization failed." immediately before the retry warning. Slightly awkward, but I left the existing spinner handling alone rather than restructure it.

### Suggested follow-up for #1055

That PR should add its two scopes to `PENDING_CEILING_SCOPES` in the same commit that adds them to `SELF_DRIVING_SCOPE_ADDITIONS`, then drop them once the ceiling edit is confirmed in both regions. That makes the ordering constraint in its "Sequencing" section non-fatal if the halves land out of order.

## Test plan

- `pnpm exec vitest run` — **1723 pass / 121 files**, no failures.
- Four new tests in `src/utils/__tests__/oauth.test.ts`: pending scopes are dropped with order preserved; an empty pending list is a no-op; a pending scope that wasn't requested does **not** shrink the set (so it can't arm the retry and loop); and no base `WIZARD_OAUTH_SCOPES` entry may be listed pending — degrading one of those would hand back a token that authenticates but can't run the wizard.
- `pnpm exec prettier --check` and `pnpm exec eslint` clean on all three changed files.
- `pnpm typecheck` reports **25 errors before and after** this change — all pre-existing on `main` (`ReadableStream.destroy`, `Set.slice`, etc., seemingly a Node/TS lib mismatch under Node 26). None in the changed files.

**Not verified end-to-end against production**, and I want to be upfront about it: exercising the retry needs a scope that is genuinely outside the live ceiling, and `PENDING_CEILING_SCOPES` ships empty. The scope-drop logic and the loop-arming conditions are unit-tested, and the reduced-set path is the same code that runs today for a normal first attempt, but the real `invalid_scope` → retry → consent round trip hasn't been observed. The clean way to confirm is to land #1055 with its two scopes listed pending, before the ceiling edit.

## LLM context

Investigated and authored with Cursor (Opus 5). The `invalid_scope` failure was reproduced by hand while running `wizard self-driving --local-mcp` from #1055 against `us.posthog.com`; the fix, tests, and verification above were produced in that session.

Made with [Cursor](https://cursor.com)