### PR TITLE
feat(audit): seed a Live Data sweep into the comprehensive audit

### DIFF
--- a/src/lib/programs/__tests__/audit-seed.test.ts
+++ b/src/lib/programs/__tests__/audit-seed.test.ts
@@ -1,0 +1,63 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { AUDIT_SEED_CHECKS, seedAuditLedger } from '@lib/programs/audit/seed';
+import { AUDIT_CHECKS_FILE, type AuditCheck } from '@lib/programs/audit/types';
+import { COL_AREA_WIDTH } from '@ui/tui/screens/audit/AuditChecksViewer/layout';
+
+const ids = (checks: AuditCheck[]) => checks.map((c) => c.id);
+
+describe('AUDIT_SEED_CHECKS', () => {
+  it('has no duplicate ids', () => {
+    // audit_add_checks rejects duplicates atomically, so a dupe in the seed
+    // would make the skill's very first append fail for every project.
+    expect(new Set(ids(AUDIT_SEED_CHECKS)).size).toBe(AUDIT_SEED_CHECKS.length);
+  });
+
+  it('sweeps PostHog for open findings before writing the report', () => {
+    const order = ids(AUDIT_SEED_CHECKS);
+    const sweep = order.indexOf('live-data-findings');
+
+    expect(sweep).toBeGreaterThan(-1);
+    // The sweep appends rows to the ledger, so it has to land before the
+    // report step renders the ledger — otherwise its findings miss the report.
+    expect(sweep).toBeLessThan(order.indexOf('write-report'));
+    // Appended rows join this group instead of creating a new one after the
+    // workflow rows, which is what keeps the sweep in place as it grows.
+    expect(AUDIT_SEED_CHECKS[sweep].area).toBe('Live Data');
+  });
+
+  it('fits every area in the checks viewer column', () => {
+    // Area is the one hard constraint: computeLayout pins it to a fixed
+    // COL_AREA_WIDTH that never flexes, so a longer area name is truncated at
+    // every terminal size. Labels get the flexed column and are allowed to run
+    // past COL_LABEL_MIN — several seeded ones already do, and only clip on a
+    // narrow terminal.
+    for (const check of AUDIT_SEED_CHECKS) {
+      expect(check.area.length).toBeLessThanOrEqual(COL_AREA_WIDTH);
+    }
+  });
+});
+
+describe('seedAuditLedger', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-seed-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes the seed to the ledger the skill reads', () => {
+    seedAuditLedger(tmpDir);
+
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, AUDIT_CHECKS_FILE), 'utf8'),
+    ) as AuditCheck[];
+
+    expect(ids(written)).toEqual(ids(AUDIT_SEED_CHECKS));
+  });
+});

--- a/src/lib/programs/audit/seed.ts
+++ b/src/lib/programs/audit/seed.ts
@@ -1,13 +1,21 @@
-import fs from 'fs';
 import path from 'path';
+import { writeJsonAtomic } from '@utils/atomic-ledger';
 import { logToFile } from '@utils/debug';
 import { AUDIT_CHECKS_FILE, type AuditCheck } from './types.js';
 
 /**
- * The 10 data-integrity checks the audit runs, plus one workflow row for the
- * notebook upload at the end (so the skill's `audit_resolve_checks` call for
- * `upload-notebook` succeeds — the skill writes the report to a PostHog
- * notebook as its final step).
+ * The 10 source-tree checks the audit runs, plus one row for the PostHog-side
+ * sweep and two workflow rows at the end (so the skill's
+ * `audit_resolve_checks` calls for `write-report` and `upload-notebook`
+ * succeed — the skill writes the report to disk, then mirrors it into a
+ * PostHog notebook as its final step).
+ *
+ * `posthog-side-findings` is a sweep row, not a rule: the skill reads what
+ * PostHog itself already computed for this project (error-tracking
+ * recommendations, health issues) and appends one row per open finding via
+ * `audit_add_checks`. That's why the seed can't enumerate them — the list is
+ * whatever the project's data says today, and it grows as PostHog ships new
+ * checks, with no wizard release needed.
  */
 export const AUDIT_SEED_CHECKS: AuditCheck[] = [
   {
@@ -71,6 +79,14 @@ export const AUDIT_SEED_CHECKS: AuditCheck[] = [
     status: 'pending',
   },
   {
+    id: 'live-data-findings',
+    // Area is capped at COL_AREA_WIDTH (18) in the checks viewer and never
+    // flexes, so it has to fit. Labels get the flexed column.
+    area: 'Live Data',
+    label: 'Open findings in PostHog',
+    status: 'pending',
+  },
+  {
     id: 'write-report',
     area: 'Write report',
     label: 'Create posthog-audit-report.md',
@@ -95,8 +111,6 @@ export function seedAuditLedger(
   checks: AuditCheck[] = AUDIT_SEED_CHECKS,
 ): void {
   const target = path.join(installDir, AUDIT_CHECKS_FILE);
-  const tmp = `${target}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(checks, null, 2), 'utf8');
-  fs.renameSync(tmp, target);
+  writeJsonAtomic(target, checks);
   logToFile(`seedAuditLedger: wrote ${checks.length} entries to ${target}`);
 }

--- a/src/ui/tui/screens/audit/AuditChecksViewer/sort.ts
+++ b/src/ui/tui/screens/audit/AuditChecksViewer/sort.ts
@@ -21,6 +21,10 @@ const AREA_ORDER: string[] = [
   'Session Replay — Optimize',
   'Use Case: Expansion',
   'Additional Sections',
+  // Findings read back from PostHog rather than from the source tree. Ranked
+  // after every source-tree area so the checks the user can act on in their
+  // editor come first, and ahead of the trailing workflow rows.
+  'Live Data',
 ];
 
 function areaRank(area: string): number {

--- a/src/ui/tui/screens/audit/slides/index.ts
+++ b/src/ui/tui/screens/audit/slides/index.ts
@@ -8,6 +8,7 @@ import type { AreaSlide } from './shared.js';
 import { InstallationSlide } from './installation.js';
 import { IdentificationSlide } from './identification.js';
 import { EventCaptureSlide } from './eventCapture.js';
+import { LiveDataSlide } from './liveData.js';
 import { WriteReportSlide } from './writeReport.js';
 import { UploadNotebookSlide } from './uploadNotebook.js';
 
@@ -17,6 +18,7 @@ export const AUDIT_AREA_SLIDES: AreaSlide[] = [
   InstallationSlide,
   IdentificationSlide,
   EventCaptureSlide,
+  LiveDataSlide,
   WriteReportSlide,
   UploadNotebookSlide,
 ];

--- a/src/ui/tui/screens/audit/slides/liveData.tsx
+++ b/src/ui/tui/screens/audit/slides/liveData.tsx
@@ -1,0 +1,30 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from './shared.js';
+
+const LiveDataVisual = () => (
+  <VisualBox>
+    <Text dimColor>your PostHog project</Text>
+    <Text dimColor>{'  │'}</Text>
+    <Text>
+      <Text dimColor>{'  ├ '}</Text>
+      <Text color="yellow">⚠</Text>
+      <Text dimColor> source maps not uploaded</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  └ '}</Text>
+      <Text color="cyan">•</Text>
+      <Text dimColor> error alerts not wired</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const LiveDataSlide: AreaSlide = {
+  area: 'Live Data',
+  intro: [
+    'Everything so far came from reading your code. This part comes from your data.',
+    'PostHog runs its own checks on what your project actually sends — whether stack traces resolve to your original source, whether a warehouse sync keeps failing, whether anyone is alerted when a new error appears. None of that is visible in a file.',
+    'We pull the open ones in so this report covers both halves.',
+  ],
+  visual: <LiveDataVisual />,
+  docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
+};


### PR DESCRIPTION
## The gap

`wizard audit all` only ever read the source tree — 10 hardcoded rules across Installation, Identification, and Event Capture.

Meanwhile PostHog computes its own findings per project: the error tracking `source_maps` recommendation, plus health issues across every product. The remediation string on the missing-source-maps health check is literally `npx -y @posthog/wizard@latest upload-source-maps`.

So the app told users to run the wizard, and the wizard's own audit never mentioned it.

## What this does

Seeds one row:

```
live-data-findings │ Live Data │ Open findings in PostHog
```

The audit skill resolves it by reading what PostHog already flagged and appending one row per open finding via `audit_add_checks` — so this covers source maps today and every future PostHog-side check without a wizard release. The resolution logic lives in [PostHog/context-mill#324](https://github.com/PostHog/context-mill/pull/324).

**On the area name:** it's `Live Data`, not `PostHog Findings`. Every finding in a PostHog audit is a PostHog finding, so that name carried no information. What actually distinguishes these rows is provenance — they come from the project's ingested data, not its source tree — which is also exactly the caveat a reader needs when interpreting them.

**Why seed a row at all**, when the skill could create the area itself at runtime? `PendingChecksList.groupByArea` orders groups by first-seen position in the ledger, and `applyAuditAdditions` appends to the end. Without the seed, the first appended row would create a group *after* Write report and Upload notebook, and the active-group spinner would sit on "Write report" for the whole sweep — telling the user the audit is writing the report while it's actually querying PostHog. With the seed, the group holds its place from first paint and grows in situ.

Also wires the area into the two places every other seeded area is already registered:

- `AUDIT_AREA_SLIDES` — it was the first seeded area without a slide, which would have rendered the fallback's lowercased sentence twice with no docs link
- `AREA_ORDER` in `sort.ts` — the Audit plan tab sorts by this, so the position guarantee held in one view and only held in the other by alphabetical accident

Drive-by: `seedAuditLedger` was hand-rolling the `writeFileSync` → `renameSync` that `writeJsonAtomic` already is, and that the sibling ledger writer already calls.

## Merge order

**Merge and release [context-mill#324](https://github.com/PostHog/context-mill/pull/324) first.** That PR is written to tolerate a ledger without this row, so it degrades cleanly. This PR alone would leave `live-data-findings` pending forever, which the report renders as "the audit crashed here".

## Verification

- `pnpm test` — 1723 passed; `pnpm lint` — 0 errors
- Rendered `PendingChecksList` with `ink-testing-library` at seed and mid-run: the group sits between Event Capture and Write report and goes `(0/1)` → `(3/4)` in place, with the spinner on it
- Confirmed every seeded area resolves to a slide, and the plan tab orders `Live Data` after the source-tree areas by declaration rather than by accident

🤖 Generated with [Claude Code](https://claude.com/claude-code)