### PR TITLE
feat(audit): make feature flags a wizard native doctor program

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ command names.** Old names mostly no longer exist — only some are kept as alia
 | `wizard audit events` | event capture quality + cost (**default** leaf) |
 | `wizard audit all` | comprehensive audit across every area |
 | `wizard audit autocapture` | autocapture setup + cost |
-| `wizard audit feature-flags` | feature flag usage + cost |
+| `wizard audit feature-flags` | feature flags doctor — verify delivery, audit usage + cost, fix with consent (**wizard-native**) |
 | `wizard audit identify` | `$identify` implementation |
 | `wizard audit session-replay` | session replay setup |
 | `wizard audit web-analytics` | web analytics setup (**wizard-native**, not a skill) |

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -26,6 +26,7 @@ import { warehouseCommand } from '../commands/warehouse';
 import { uploadSourcemapsCommand } from '../commands/upload-sourcemaps';
 import { selfDrivingCommand } from '../commands/self-driving';
 import {
+  buildFamilyPickerChildren,
   dispatchFamily,
   pickerChildrenToShow,
 } from '@lib/programs/dispatch-family';
@@ -33,6 +34,7 @@ import type { Command } from '../commands/command';
 import { fetchSkillMenu, type CliEntry } from '@lib/wizard-tools';
 import { auditConfig } from '@lib/programs/audit/index';
 import { webAnalyticsDoctorConfig } from '@lib/programs/web-analytics-doctor/index';
+import { featureFlagsDoctorConfig } from '@lib/programs/feature-flags-doctor/index';
 import { parseCommand } from './helpers/parse-command.no-jest';
 
 const mockFetchSkillMenu = fetchSkillMenu as MockedFunction<
@@ -142,6 +144,37 @@ describe('dispatchFamily', () => {
     expect(mockRunWizard).toHaveBeenCalledTimes(1);
     const [config] = mockRunWizard.mock.calls[0] as [{ id?: string }];
     expect(config.id).toBe(webAnalyticsDoctorConfig.id);
+  });
+
+  test('runs the wizard-native handler for `audit feature-flags`, shadowing the published skill entry', async () => {
+    // context-mill still publishes a cliEntry for `audit feature-flags`;
+    // the native handler must win without any network fetch.
+    await dispatchFamily('audit', makeArgv({ skill: 'feature-flags' }));
+    expect(mockFetchSkillMenu).not.toHaveBeenCalled();
+    expect(mockRunWizard).toHaveBeenCalledTimes(1);
+    const [config] = mockRunWizard.mock.calls[0] as [{ id?: string }];
+    expect(config.id).toBe(featureFlagsDoctorConfig.id);
+  });
+
+  test('picker de-dupes a native handler that shadows a published cliEntry', () => {
+    const children = buildFamilyPickerChildren('audit', [
+      entry({
+        skillId: 'audit-feature-flags',
+        command: 'feature-flags',
+        parentCommand: 'audit',
+      }),
+      entry({
+        skillId: 'audit-events',
+        command: 'events',
+        parentCommand: 'audit',
+      }),
+    ]);
+    const names = children.map((c) => c.name);
+    expect(names.filter((n) => n === 'feature-flags')).toHaveLength(1);
+    expect(names).toContain('events');
+    // the surviving feature-flags child is the native program, not the skill
+    const ff = children.find((c) => c.name === 'feature-flags')!;
+    expect(ff.description).toBe(featureFlagsDoctorConfig.description);
   });
 
   test('the comprehensive `audit all` runs the specialized auditConfig, not agent-skill', async () => {

--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -223,6 +223,60 @@ describe('audit ledger helpers', () => {
     });
   });
 
+  it('inserts additions inside their area group, ahead of later areas', () => {
+    const multiArea: AuditCheck[] = [
+      {
+        id: 'd-parent',
+        area: 'Delivery',
+        label: 'Flags delivered',
+        status: 'pending',
+      },
+      {
+        id: 'wf-fixes',
+        area: 'Workflow',
+        label: 'Apply fixes',
+        status: 'pending',
+      },
+      {
+        id: 'wf-report',
+        area: 'Workflow',
+        label: 'Write report',
+        status: 'pending',
+      },
+    ];
+
+    const { next, duplicates } = __test.applyAuditAdditions(multiArea, [
+      {
+        id: 'delivered-beta',
+        area: 'Delivery',
+        label: 'beta arrives as defined',
+        status: 'pending',
+      },
+      {
+        id: 'ghost-search',
+        area: 'Delivery',
+        label: 'search key missing in PostHog',
+        status: 'pending',
+      },
+      {
+        id: 'novel-row',
+        area: 'New Area',
+        label: 'novel area appends at tail',
+        status: 'pending',
+      },
+    ]);
+
+    expect(duplicates).toEqual([]);
+    expect(next.map((c) => c.id)).toEqual([
+      'd-parent',
+      'delivered-beta',
+      'ghost-search',
+      'wf-fixes',
+      'wf-report',
+      'novel-row',
+    ]);
+  });
+
   it('requires a seeded on-disk ledger before appending checks', () => {
     const target = path.join(tmpDir, __test.AUDIT_CHECKS_FILE);
 

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -128,6 +128,7 @@ export const PROGRAM_BINDINGS: Partial<Record<ProgramId, ProgramBinding>> = {
   'events-audit': DEFAULT_BINDING,
   'posthog-doctor': DEFAULT_BINDING,
   'web-analytics-doctor': DEFAULT_BINDING,
+  'feature-flags-doctor': DEFAULT_BINDING,
   migration: DEFAULT_BINDING,
   'self-driving': DEFAULT_BINDING,
   'agent-skill': DEFAULT_BINDING,

--- a/src/lib/file-watcher.ts
+++ b/src/lib/file-watcher.ts
@@ -30,6 +30,8 @@ export interface FileWatcherOptions {
   ignoreInitialFile?: boolean;
   /** Refuse to read files larger than this many bytes. */
   maxFileSizeBytes?: number;
+  /** Called (deduplicated per error) when the file can't be read as JSON. */
+  onReadError?: (message: string) => void;
 }
 
 /** Watch `path` for JSON updates and call `onUpdate(parsed)` whenever the
@@ -73,6 +75,7 @@ export function startFileWatcher(
     if (lastReadErrorSignature === errorSignature) return;
     lastReadErrorSignature = errorSignature;
     logToFile(`[file-watcher] ${message}: ${path}`);
+    options.onReadError?.(`${message}: ${path}`);
   };
 
   const read = (force = false) => {

--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -120,6 +120,21 @@ export const AGENT_SKILL_SCOPE_ADDITIONS = [
 ] as const;
 
 /**
+ * Extra scopes the feature-flags doctor needs on top of
+ * `WIZARD_OAUTH_SCOPES`. The doctor reads the flag roster
+ * (`feature-flag-get-all`) to cross-check delivery and code references,
+ * and archives/disables user-approved cleanup candidates
+ * (`feature-flag-update`) in the fix phase. Same pair the skill-backed
+ * dispatch path already gets via `AGENT_SKILL_SCOPE_ADDITIONS` — the
+ * native program must request them itself or the roster calls 403 and
+ * every roster-dependent check silently degrades to mcp_skipped.
+ */
+export const FEATURE_FLAGS_DOCTOR_SCOPE_ADDITIONS = [
+  'feature_flag:read',
+  'feature_flag:write',
+] as const;
+
+/**
  * Extra scopes the self-driving program needs on top of
  * `WIZARD_OAUTH_SCOPES`. All consumed by the PostHog MCP tools the
  * agent drives during the run:
@@ -236,6 +251,7 @@ const PROGRAM_SCOPE_ADDITIONS: Partial<Record<ProgramId, readonly string[]>> = {
   // ever changes, this line will fail to type-check.
   'mcp-tutorial': MCP_TUTORIAL_SCOPE_ADDITIONS,
   'agent-skill': AGENT_SKILL_SCOPE_ADDITIONS,
+  'feature-flags-doctor': FEATURE_FLAGS_DOCTOR_SCOPE_ADDITIONS,
   'self-driving': SELF_DRIVING_SCOPE_ADDITIONS,
   'warehouse-source': WAREHOUSE_SOURCE_SCOPE_ADDITIONS,
   'posthog-integration': CONNECT_SLACK_SCOPE_ADDITIONS,

--- a/src/lib/programs/__tests__/feature-flags-doctor-detect.test.ts
+++ b/src/lib/programs/__tests__/feature-flags-doctor-detect.test.ts
@@ -1,0 +1,148 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  detectFeatureFlagsPrerequisites,
+  featureFlagsDoctorConfig,
+  FEATURE_FLAGS_ABORT_CASES,
+} from '@lib/programs/feature-flags-doctor/index';
+import { FEATURE_FLAGS_DOCTOR_SEED_CHECKS } from '@lib/programs/feature-flags-doctor/seed';
+import { FEATURE_FLAGS_AREA_SLIDES } from '@ui/tui/screens/audit/slides/feature-flags/index';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools';
+import { buildSession } from '@lib/wizard-session';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ff-detect-'));
+}
+
+function cleanup(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writePackageJson(
+  dir: string,
+  deps: Record<string, string> = {},
+): void {
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ dependencies: deps }),
+  );
+}
+
+describe('detectFeatureFlagsPrerequisites', () => {
+  let tmpDir: string;
+  let ctx: Record<string, unknown>;
+  let setCtx: Mock;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    ctx = {};
+    setCtx = vi.fn((key: string, value: unknown) => {
+      ctx[key] = value;
+    });
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('errors when install directory is invalid', () => {
+    const session = buildSession({ installDir: '/nonexistent/path' });
+    detectFeatureFlagsPrerequisites(session, setCtx);
+
+    expect(ctx.detectError).toEqual(
+      expect.objectContaining({ kind: 'bad-directory' }),
+    );
+  });
+
+  it('errors when no package.json exists', () => {
+    const session = buildSession({ installDir: tmpDir });
+    detectFeatureFlagsPrerequisites(session, setCtx);
+
+    expect(ctx.detectError).toEqual({ kind: 'no-package-json' });
+  });
+
+  it('errors when no PostHog SDK is found', () => {
+    writePackageJson(tmpDir, { react: '18.0.0' });
+
+    const session = buildSession({ installDir: tmpDir });
+    detectFeatureFlagsPrerequisites(session, setCtx);
+
+    expect(ctx.detectError).toEqual(
+      expect.objectContaining({ kind: 'no-posthog' }),
+    );
+    expect(ctx.detectedPosthogSdks).toBeUndefined();
+  });
+
+  it('succeeds when a PostHog SDK is present', () => {
+    writePackageJson(tmpDir, { 'posthog-js': '1.0.0' });
+
+    const session = buildSession({ installDir: tmpDir });
+    detectFeatureFlagsPrerequisites(session, setCtx);
+
+    expect(ctx.detectError).toBeUndefined();
+    expect(ctx.detectedPosthogSdks).toEqual(['posthog-js']);
+  });
+});
+
+describe('FEATURE_FLAGS_ABORT_CASES', () => {
+  const reasons = [
+    'No feature flag usage',
+    'Insufficient permissions',
+    'PostHog SDK not installed',
+  ];
+
+  it.each(reasons)('matches the "%s" abort reason exactly once', (reason) => {
+    const matched = FEATURE_FLAGS_ABORT_CASES.filter((c) =>
+      c.match.test(reason),
+    );
+    expect(matched).toHaveLength(1);
+    expect(matched[0].message).toBeTruthy();
+    expect(matched[0].body).toBeTruthy();
+  });
+});
+
+describe('featureFlagsDoctorConfig', () => {
+  it('keeps wizard_ask enabled so the user can pick which fixes to apply', () => {
+    expect(featureFlagsDoctorConfig.disallowedTools ?? []).not.toContain(
+      WIZARD_TOOL_NAMES.wizardAsk,
+    );
+  });
+
+  it('wires the rebuilt audit-feature-flags skill and CLI command', () => {
+    expect(featureFlagsDoctorConfig.command).toBe('feature-flags');
+    expect(featureFlagsDoctorConfig.skillId).toBe('audit-feature-flags');
+    expect(featureFlagsDoctorConfig.id).toBe('feature-flags-doctor');
+    expect(featureFlagsDoctorConfig.parentCommand).toBe('audit');
+  });
+
+  it('routes run/intro/outro steps to the audit screens', () => {
+    const byId = Object.fromEntries(
+      featureFlagsDoctorConfig.steps.map((s) => [s.id, s.screenId]),
+    );
+    expect(byId.intro).toBe('audit-intro');
+    expect(byId.run).toBe('audit-run');
+    expect(byId.outro).toBe('audit-outro');
+  });
+
+  it('seeds a ledger with unique check ids including the workflow rows', () => {
+    const ids = FEATURE_FLAGS_DOCTOR_SEED_CHECKS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toContain('apply-fixes');
+    expect(ids).toContain('write-report');
+    expect(
+      FEATURE_FLAGS_DOCTOR_SEED_CHECKS.every((c) => c.status === 'pending'),
+    ).toBe(true);
+  });
+
+  it('has a slide for every seeded check area', () => {
+    const areas = new Set(FEATURE_FLAGS_DOCTOR_SEED_CHECKS.map((c) => c.area));
+    const slideAreas = new Set(FEATURE_FLAGS_AREA_SLIDES.map((s) => s.area));
+    for (const area of areas) {
+      expect(slideAreas).toContain(area);
+    }
+  });
+
+  it('keeps seed labels within the 40-char ledger budget', () => {
+    for (const check of FEATURE_FLAGS_DOCTOR_SEED_CHECKS) {
+      expect(check.label.length).toBeLessThanOrEqual(40);
+    }
+  });
+});

--- a/src/lib/programs/audit/seed.ts
+++ b/src/lib/programs/audit/seed.ts
@@ -110,7 +110,7 @@ export function seedAuditLedger(
   installDir: string,
   checks: AuditCheck[] = AUDIT_SEED_CHECKS,
 ): void {
-  const target = path.join(installDir, AUDIT_CHECKS_FILE);
+  const target = path.resolve(installDir, AUDIT_CHECKS_FILE);
   writeJsonAtomic(target, checks);
   logToFile(`seedAuditLedger: wrote ${checks.length} entries to ${target}`);
 }

--- a/src/lib/programs/dispatch-family.ts
+++ b/src/lib/programs/dispatch-family.ts
@@ -3,6 +3,7 @@ import type { Arguments } from 'yargs';
 import { auditConfig } from '@lib/programs/audit/index';
 import { agentSkillConfig } from '@lib/programs/program-registry';
 import { webAnalyticsDoctorConfig } from '@lib/programs/web-analytics-doctor/index';
+import { featureFlagsDoctorConfig } from '@lib/programs/feature-flags-doctor/index';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import { getSkillsBaseUrl } from '@lib/constants';
 import { fetchSkillMenu, type CliEntry } from '@lib/wizard-tools';
@@ -45,7 +46,10 @@ async function exitDispatchError(
 
 /** Wizard-native subcommands keyed by family. */
 const NATIVE_HANDLERS: Record<string, Record<string, ProgramConfig>> = {
-  audit: { 'web-analytics': webAnalyticsDoctorConfig },
+  audit: {
+    'web-analytics': webAnalyticsDoctorConfig,
+    'feature-flags': featureFlagsDoctorConfig,
+  },
 };
 
 /**
@@ -116,8 +120,10 @@ export async function dispatchFamily(
   }
 
   const available = [
-    ...Object.keys(NATIVE_HANDLERS[family] ?? {}),
-    ...familyEntries(family, entries).map((e) => e.command!),
+    ...new Set([
+      ...Object.keys(NATIVE_HANDLERS[family] ?? {}),
+      ...familyEntries(family, entries).map((e) => e.command!),
+    ]),
   ].sort();
   return exitDispatchError(
     'unknown subcommand',
@@ -145,17 +151,23 @@ export function buildFamilyPickerChildren(
       handler: (argv: Arguments) => dispatchProgram(program, argv),
     }),
   );
-  const live: Command[] = familyEntries(family, entries).map((entry) => ({
-    name: entry.command!,
-    description: entry.description,
-    handler: (argv: Arguments) => {
-      void dispatchFamily(family, {
-        ...argv,
-        skill: entry.command,
-      } as Arguments);
-    },
-    default: entry.default,
-  }));
+  // A native handler shadows a fetched entry with the same command (dispatch
+  // already prefers natives) — drop the fetched twin so the picker doesn't
+  // list the command twice while context-mill still publishes it.
+  const nativeNames = new Set(Object.keys(NATIVE_HANDLERS[family] ?? {}));
+  const live: Command[] = familyEntries(family, entries)
+    .filter((entry) => !nativeNames.has(entry.command!))
+    .map((entry) => ({
+      name: entry.command!,
+      description: entry.description,
+      handler: (argv: Arguments) => {
+        void dispatchFamily(family, {
+          ...argv,
+          skill: entry.command,
+        } as Arguments);
+      },
+      default: entry.default,
+    }));
   return [...natives, ...live];
 }
 

--- a/src/lib/programs/feature-flags-doctor/detect.ts
+++ b/src/lib/programs/feature-flags-doctor/detect.ts
@@ -1,0 +1,83 @@
+import { existsSync, statSync } from 'fs';
+import type { WizardSession } from '@lib/wizard-session';
+import type { AbortCase } from '@lib/agent/agent-runner';
+import { findPackageJsons } from '@lib/programs/shared/package-scanning';
+
+export type FeatureFlagsDetectError =
+  | {
+      kind: 'bad-directory';
+      path: string;
+      reason: 'missing' | 'not-dir' | 'unreadable';
+    }
+  | { kind: 'no-package-json' }
+  | { kind: 'no-posthog'; scannedCount: number };
+
+export const FEATURE_FLAGS_ABORT_CASES: AbortCase[] = [
+  {
+    match: /^no feature flag usage$/i,
+    message: 'No feature flag usage',
+    body:
+      'The doctor found no feature flag call sites in this project, so there ' +
+      'is nothing to check yet. Add a flag with `isFeatureEnabled` or ' +
+      '`getFeatureFlag`, then run the doctor again.',
+    docsUrl: 'https://posthog.com/docs/feature-flags/installation',
+  },
+  {
+    match: /^insufficient permissions$/i,
+    message: 'Insufficient permissions',
+    body:
+      'The doctor could not read your feature flags — the authenticated ' +
+      'token is missing flag access. Re-run the wizard to sign in again, or ' +
+      'use a key with read access to feature flags.',
+    docsUrl: 'https://posthog.com/docs/feature-flags',
+  },
+  {
+    match: /^posthog sdk not installed$/i,
+    message: 'PostHog SDK not installed',
+    body:
+      'The doctor could not find a PostHog SDK in this project. Install and ' +
+      'configure PostHog first (run `npx @posthog/wizard`), then run the ' +
+      'doctor to check your feature flags.',
+    docsUrl: 'https://posthog.com/docs/libraries/js',
+  },
+];
+
+export function detectFeatureFlagsPrerequisites(
+  session: WizardSession,
+  setFrameworkContext: (key: string, value: unknown) => void,
+): void {
+  const fail = (error: FeatureFlagsDetectError) =>
+    setFrameworkContext('detectError', error);
+
+  const installDir = session.installDir;
+
+  if (!existsSync(installDir)) {
+    fail({ kind: 'bad-directory', path: installDir, reason: 'missing' });
+    return;
+  }
+  try {
+    if (!statSync(installDir).isDirectory()) {
+      fail({ kind: 'bad-directory', path: installDir, reason: 'not-dir' });
+      return;
+    }
+  } catch {
+    fail({ kind: 'bad-directory', path: installDir, reason: 'unreadable' });
+    return;
+  }
+
+  const matches = findPackageJsons(installDir);
+
+  if (matches.length === 0) {
+    fail({ kind: 'no-package-json' });
+    return;
+  }
+
+  const sdks = [...new Set(matches.flatMap((m) => m.posthogSdks))];
+
+  if (sdks.length === 0) {
+    fail({ kind: 'no-posthog', scannedCount: matches.length });
+    return;
+  }
+
+  setFrameworkContext('detectedPosthogSdks', sdks);
+}

--- a/src/lib/programs/feature-flags-doctor/index.ts
+++ b/src/lib/programs/feature-flags-doctor/index.ts
@@ -1,0 +1,73 @@
+import type { ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramRun } from '@lib/agent/agent-runner';
+import type { WizardSession } from '@lib/wizard-session';
+import { createSkillProgram } from '../agent-skill/index.js';
+import { AUDIT_CHECKS_KEY } from '@lib/programs/audit/types';
+import { seedAuditLedger } from '@lib/programs/audit/seed';
+import { FEATURE_FLAGS_DOCTOR_PROGRAM } from './steps.js';
+import { FEATURE_FLAGS_ABORT_CASES } from './detect.js';
+import { FEATURE_FLAGS_DOCTOR_SEED_CHECKS } from './seed.js';
+
+const REPORT_FILE = 'posthog-feature-flags-report.md';
+const DOCS_URL = 'https://posthog.com/docs/feature-flags';
+
+const baseConfig = createSkillProgram({
+  skillId: 'audit-feature-flags',
+  command: 'feature-flags',
+  id: 'feature-flags-doctor',
+  description: 'Verify and fix your PostHog feature flag setup',
+  integrationLabel: 'feature-flags-doctor',
+  successMessage:
+    'Feature flags check complete! You can view the report at ./posthog-feature-flags-report.md',
+  reportFile: REPORT_FILE,
+  docsUrl: DOCS_URL,
+  spinnerMessage: 'Checking your feature flags...',
+  estimatedDurationMinutes: 5,
+  requires: ['posthog-integration'],
+  abortCases: FEATURE_FLAGS_ABORT_CASES,
+});
+
+const doctorRun = (session: WizardSession): Promise<ProgramRun> => {
+  // Seed the ledger so AuditRunScreen has rows to render before the agent
+  // emits its first check update. Sweep rows grow via audit_add_checks.
+  seedAuditLedger(session.installDir, FEATURE_FLAGS_DOCTOR_SEED_CHECKS);
+  session.frameworkContext[AUDIT_CHECKS_KEY] = FEATURE_FLAGS_DOCTOR_SEED_CHECKS;
+
+  if (!baseConfig.run || typeof baseConfig.run === 'function') {
+    throw new Error('Feature flags doctor has no static run configuration.');
+  }
+
+  return Promise.resolve({
+    ...baseConfig.run,
+    customPrompt: (ctx) =>
+      "Run the audit-feature-flags skill to check this project's PostHog " +
+      'feature flag setup. Verify read-only first (static checks, then the ' +
+      'live delivery and observability checks), then present the findings ' +
+      'with a single wizard_ask multi-select and apply only the fixes the ' +
+      'user chooses — editing project code and/or PostHog flags via the ' +
+      'MCP — before writing the report. Honor the cleanup interlock: no ' +
+      'tenant-side archive/disable options while evaluation reporting is ' +
+      'unverified.\n\n' +
+      'Project context:\n' +
+      `- PostHog Project ID: ${ctx.projectId}\n` +
+      `- PostHog public token: ${ctx.projectApiKey}\n` +
+      `- PostHog Host: ${ctx.host.apiHost}\n`,
+  });
+};
+
+export const featureFlagsDoctorConfig: ProgramConfig = {
+  ...baseConfig,
+  // Top-level reportFile so AuditRunScreen can resolve the report path
+  // synchronously without unwrapping the deferred `run` function.
+  reportFile: REPORT_FILE,
+  steps: FEATURE_FLAGS_DOCTOR_PROGRAM,
+  run: doctorRun,
+  parentCommand: 'audit',
+};
+
+export { FEATURE_FLAGS_DOCTOR_PROGRAM } from './steps.js';
+export {
+  detectFeatureFlagsPrerequisites,
+  FEATURE_FLAGS_ABORT_CASES,
+  type FeatureFlagsDetectError,
+} from './detect.js';

--- a/src/lib/programs/feature-flags-doctor/index.ts
+++ b/src/lib/programs/feature-flags-doctor/index.ts
@@ -1,6 +1,7 @@
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { WizardSession } from '@lib/wizard-session';
+import { getUI } from '@ui';
 import { createSkillProgram } from '../agent-skill/index.js';
 import { AUDIT_CHECKS_KEY } from '@lib/programs/audit/types';
 import { seedAuditLedger } from '@lib/programs/audit/seed';
@@ -22,7 +23,7 @@ const baseConfig = createSkillProgram({
   reportFile: REPORT_FILE,
   docsUrl: DOCS_URL,
   spinnerMessage: 'Checking your feature flags...',
-  estimatedDurationMinutes: 5,
+  estimatedDurationMinutes: 9,
   requires: ['posthog-integration'],
   abortCases: FEATURE_FLAGS_ABORT_CASES,
 });
@@ -31,7 +32,10 @@ const doctorRun = (session: WizardSession): Promise<ProgramRun> => {
   // Seed the ledger so AuditRunScreen has rows to render before the agent
   // emits its first check update. Sweep rows grow via audit_add_checks.
   seedAuditLedger(session.installDir, FEATURE_FLAGS_DOCTOR_SEED_CHECKS);
-  session.frameworkContext[AUDIT_CHECKS_KEY] = FEATURE_FLAGS_DOCTOR_SEED_CHECKS;
+  getUI().setFrameworkContext(
+    AUDIT_CHECKS_KEY,
+    FEATURE_FLAGS_DOCTOR_SEED_CHECKS,
+  );
 
   if (!baseConfig.run || typeof baseConfig.run === 'function') {
     throw new Error('Feature flags doctor has no static run configuration.');
@@ -39,19 +43,37 @@ const doctorRun = (session: WizardSession): Promise<ProgramRun> => {
 
   return Promise.resolve({
     ...baseConfig.run,
-    customPrompt: (ctx) =>
-      "Run the audit-feature-flags skill to check this project's PostHog " +
-      'feature flag setup. Verify read-only first (static checks, then the ' +
-      'live delivery and observability checks), then present the findings ' +
-      'with a single wizard_ask multi-select and apply only the fixes the ' +
-      'user chooses — editing project code and/or PostHog flags via the ' +
-      'MCP — before writing the report. Honor the cleanup interlock: no ' +
-      'tenant-side archive/disable options while evaluation reporting is ' +
-      'unverified.\n\n' +
-      'Project context:\n' +
-      `- PostHog Project ID: ${ctx.projectId}\n` +
-      `- PostHog public token: ${ctx.projectApiKey}\n` +
-      `- PostHog Host: ${ctx.host.apiHost}\n`,
+    askTimeoutMs: 30 * 60 * 1000,
+    customPrompt: (ctx) => {
+      const sdks = getUI().getFrameworkContext('detectedPosthogSdks');
+      const sdkLine =
+        Array.isArray(sdks) && sdks.length > 0
+          ? `- Detected PostHog SDKs (from the package.json scan): ${sdks.join(
+              ', ',
+            )}\n`
+          : '';
+      const checkIds = FEATURE_FLAGS_DOCTOR_SEED_CHECKS.map((c) => c.id).join(
+        ', ',
+      );
+      return (
+        "Run the audit-feature-flags skill to check this project's PostHog " +
+        'feature flag setup. Verify read-only first (static checks, then the ' +
+        'live delivery and observability checks), then present the findings ' +
+        'with a single wizard_ask multi-select and apply only the fixes the ' +
+        'user chooses — editing project code and/or PostHog flags via the ' +
+        'MCP — before writing the report. Honor the cleanup interlock: no ' +
+        'tenant-side archive/disable options while evaluation reporting is ' +
+        'unverified.\n\n' +
+        'Project context (authoritative — use as given, do not re-derive):\n' +
+        `- PostHog Project ID: ${ctx.projectId}\n` +
+        `- PostHog public token: ${ctx.projectApiKey} (skip .env discovery; ` +
+        'this is the token to test)\n' +
+        `- PostHog Host: ${ctx.host.apiHost}\n` +
+        sdkLine +
+        `- The audit ledger is already seeded with these check ids (do not ` +
+        `read the ledger to enumerate them): ${checkIds}\n`
+      );
+    },
   });
 };
 
@@ -61,6 +83,7 @@ export const featureFlagsDoctorConfig: ProgramConfig = {
   // synchronously without unwrapping the deferred `run` function.
   reportFile: REPORT_FILE,
   steps: FEATURE_FLAGS_DOCTOR_PROGRAM,
+  allowedTools: ['Agent'],
   run: doctorRun,
   parentCommand: 'audit',
 };

--- a/src/lib/programs/feature-flags-doctor/seed.ts
+++ b/src/lib/programs/feature-flags-doctor/seed.ts
@@ -1,0 +1,134 @@
+import type { AuditCheck } from '@lib/programs/audit/types';
+
+/**
+ * Seed rows for the feature-flags doctor ledger. Ids and areas are the
+ * contract with the `audit-feature-flags` skill (context-mill) — its
+ * `audit_resolve_checks` calls reference these ids exactly, and the
+ * AuditAreaPane slide deck is keyed by the area strings.
+ *
+ * Ordered to follow the run: static correctness → static cost → live
+ * delivery probes → observability → the consented fix phase. The area
+ * pane shows the slide for the first pending row, so seed order is the
+ * left pane's narrative order.
+ *
+ * `ff-flags-delivered`, `ff-unknown-flags`, and `ff-stale-rolled-out`
+ * are sweep rows: the skill appends one row per affected flag via
+ * `audit_add_checks` (`delivered-`/`ghost-`/`stale-` prefixes), because
+ * the seed can't enumerate a project's flags.
+ */
+export const FEATURE_FLAGS_DOCTOR_SEED_CHECKS: AuditCheck[] = [
+  {
+    id: 'ff-bootstrap-when-known-set',
+    area: 'Feature Flags',
+    label: 'Bootstrap set when initial flags known',
+    status: 'pending',
+  },
+  {
+    id: 'ff-await-readiness',
+    area: 'Feature Flags',
+    label: 'Flag evals gated on readiness',
+    status: 'pending',
+  },
+  {
+    id: 'ff-default-values',
+    area: 'Feature Flags',
+    label: 'Defaults handle the loading window',
+    status: 'pending',
+  },
+  {
+    id: 'ff-bootstrap-distinct-id-mismatch',
+    area: 'Feature Flags',
+    label: 'Bootstrapped distinct_id is stable',
+    status: 'pending',
+  },
+  {
+    id: 'ff-identified-only-pre-auth-targeting',
+    area: 'Feature Flags',
+    label: 'Pre-auth targeting has profiles',
+    status: 'pending',
+  },
+  {
+    id: 'ff-eval-before-identify',
+    area: 'Feature Flags',
+    label: 'Flag evals do not race identify()',
+    status: 'pending',
+  },
+  {
+    id: 'ff-active-but-unreferenced',
+    area: 'Feature Flags — Optimize',
+    label: 'Active flags are referenced in code',
+    status: 'pending',
+  },
+  {
+    id: 'ff-stale-rolled-out',
+    area: 'Feature Flags — Optimize',
+    label: 'No 100% flags still gated in code',
+    status: 'pending',
+  },
+  {
+    id: 'ff-local-eval-polling-interval',
+    area: 'Feature Flags — Optimize',
+    label: 'Local-eval polling interval tuned',
+    status: 'pending',
+  },
+  {
+    id: 'ff-local-eval-in-edge-handlers',
+    area: 'Feature Flags — Optimize',
+    label: 'No local eval in edge handlers',
+    status: 'pending',
+  },
+  {
+    id: 'ff-test-ci-gating',
+    area: 'Feature Flags — Optimize',
+    label: 'Test/CI runs do not fetch flags',
+    status: 'pending',
+  },
+  {
+    id: 'ff-presence',
+    area: 'Feature Flags — Delivery',
+    label: 'Flag call sites found in project',
+    status: 'pending',
+  },
+  {
+    id: 'ff-key-authenticates',
+    area: 'Feature Flags — Delivery',
+    label: 'Project key actually authenticates',
+    status: 'pending',
+  },
+  {
+    id: 'ff-flags-endpoint',
+    area: 'Feature Flags — Delivery',
+    label: "/flags works via the app's path",
+    status: 'pending',
+  },
+  {
+    id: 'ff-flags-delivered',
+    area: 'Feature Flags — Delivery',
+    label: 'Active flags arrive as defined',
+    status: 'pending',
+  },
+  {
+    id: 'ff-unknown-flags',
+    area: 'Feature Flags — Delivery',
+    label: 'Code flag keys exist in PostHog',
+    status: 'pending',
+  },
+  {
+    id: 'ff-evaluated-not-reported',
+    area: 'Feature Flags — Observability',
+    label: 'Evaluation events are reported',
+    status: 'pending',
+  },
+  {
+    id: 'apply-fixes',
+    area: 'Workflow',
+    label: 'Apply user-approved fixes',
+    status: 'pending',
+  },
+  {
+    id: 'write-report',
+    area: 'Workflow',
+    label: 'Write doctor report',
+    status: 'pending',
+  },
+];

--- a/src/lib/programs/feature-flags-doctor/steps.ts
+++ b/src/lib/programs/feature-flags-doctor/steps.ts
@@ -1,0 +1,26 @@
+import type { ProgramStep } from '@lib/programs/program-step';
+import { AGENT_SKILL_STEPS } from '@lib/programs/agent-skill/steps';
+import { detectFeatureFlagsPrerequisites } from './detect.js';
+
+/** Audit-family screens for the shared agent-skill pipeline. */
+const SCREEN_BY_STEP: Record<string, string> = {
+  intro: 'audit-intro',
+  run: 'audit-run',
+  outro: 'audit-outro',
+};
+
+const withAuditScreens = (steps: ProgramStep[]): ProgramStep[] =>
+  steps.map((step) => {
+    const override = SCREEN_BY_STEP[step.id];
+    return override ? { ...step, screenId: override } : step;
+  });
+
+export const FEATURE_FLAGS_DOCTOR_PROGRAM: ProgramStep[] = [
+  {
+    id: 'detect',
+    label: 'Detecting prerequisites',
+    onReady: (ctx) =>
+      detectFeatureFlagsPrerequisites(ctx.session, ctx.setFrameworkContext),
+  },
+  ...withAuditScreens(AGENT_SKILL_STEPS),
+];

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -19,6 +19,7 @@ import { auditConfig } from './audit/index.js';
 import { eventsAuditConfig } from './events-audit/index.js';
 import { posthogDoctorConfig } from './posthog-doctor/index.js';
 import { webAnalyticsDoctorConfig } from './web-analytics-doctor/index.js';
+import { featureFlagsDoctorConfig } from './feature-flags-doctor/index.js';
 import { migrationConfig } from './migration/index.js';
 import { errorTrackingUploadSourceMapsConfig } from './error-tracking-upload-source-maps/index.js';
 import { selfDrivingConfig } from './self-driving/index.js';
@@ -72,6 +73,7 @@ export const PROGRAM_REGISTRY = [
   eventsAuditConfig,
   posthogDoctorConfig,
   webAnalyticsDoctorConfig,
+  featureFlagsDoctorConfig,
   migrationConfig,
   selfDrivingConfig,
   agentSkillConfig,
@@ -98,6 +100,7 @@ export const Program = {
   EventsAudit: eventsAuditConfig.id,
   PosthogDoctor: posthogDoctorConfig.id,
   WebAnalyticsDoctor: webAnalyticsDoctorConfig.id,
+  FeatureFlagsDoctor: featureFlagsDoctorConfig.id,
   SelfDriving: selfDrivingConfig.id,
   AgentSkill: agentSkillConfig.id,
   McpAdd: mcpAddConfig.id,

--- a/src/lib/wizard-tools/mcp.ts
+++ b/src/lib/wizard-tools/mcp.ts
@@ -453,7 +453,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
 
   // -- audit_seed_checks ----------------------------------------------------
 
-  const auditLedgerPath = path.join(workingDirectory, AUDIT_CHECKS_FILE);
+  const auditLedgerPath = path.resolve(workingDirectory, AUDIT_CHECKS_FILE);
   const auditMutex = makeMutex();
 
   const auditSeedChecks = tool(

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -569,8 +569,10 @@ export function applyAuditUpdates(
 }
 
 /**
- * Append new checks to a seeded ledger. Duplicate ids are reported without
- * mutating the current ledger, including duplicates inside the additions.
+ * Add new checks to a seeded ledger, each after the last row sharing its
+ * `area` (novel areas append at the tail). Duplicate ids are reported
+ * without mutating the current ledger, including duplicates inside the
+ * additions.
  */
 function applyAuditAdditions(
   current: AuditCheck[],
@@ -592,7 +594,18 @@ function applyAuditAdditions(
     return { next: current, duplicates };
   }
 
-  return { next: [...current, ...additions], duplicates: [] };
+  const next = [...current];
+  for (const check of additions) {
+    let insertAt = next.length;
+    for (let i = next.length - 1; i >= 0; i--) {
+      if (next[i].area === check.area) {
+        insertAt = i + 1;
+        break;
+      }
+    }
+    next.splice(insertAt, 0, check);
+  }
+  return { next, duplicates: [] };
 }
 
 export function readLedger(targetPath: string): AuditCheck[] {

--- a/src/ui/tui/__tests__/audit-area-pane-deck.test.ts
+++ b/src/ui/tui/__tests__/audit-area-pane-deck.test.ts
@@ -1,0 +1,79 @@
+/** Deck-walk coverage for AuditAreaPane (batch resolutions must not skip cards). */
+import {
+  deckTargetIndex,
+  nextDeckIndex,
+} from '@ui/tui/screens/audit/AuditAreaPane';
+import type { AreaSlide } from '@ui/tui/screens/audit/slides/index';
+import type { AuditCheck } from '@lib/programs/audit/types';
+import { FEATURE_FLAGS_DOCTOR_SEED_CHECKS } from '@lib/programs/feature-flags-doctor/seed';
+
+const DECK: AreaSlide[] = [
+  'Feature Flags',
+  'Feature Flags — Optimize',
+  'Feature Flags — Delivery',
+  'Feature Flags — Observability',
+  'Workflow',
+].map((area) => ({ area, intro: [area], docsUrl: '' }));
+
+const withResolved = (resolvedAreas: string[]): AuditCheck[] =>
+  FEATURE_FLAGS_DOCTOR_SEED_CHECKS.map((c) =>
+    resolvedAreas.includes(c.area) ? { ...c, status: 'pass' as const } : c,
+  );
+
+describe('deckTargetIndex', () => {
+  it('targets the slide of the first pending area', () => {
+    expect(deckTargetIndex(DECK, FEATURE_FLAGS_DOCTOR_SEED_CHECKS)).toBe(0);
+    expect(deckTargetIndex(DECK, withResolved(['Feature Flags']))).toBe(1);
+  });
+
+  it('targets past the end when every check is resolved', () => {
+    const done = FEATURE_FLAGS_DOCTOR_SEED_CHECKS.map((c) => ({
+      ...c,
+      status: 'pass' as const,
+    }));
+    expect(deckTargetIndex(DECK, done)).toBe(DECK.length);
+  });
+
+  it('returns -1 for a head area with no registered slide', () => {
+    const checks: AuditCheck[] = [
+      { id: 'x', area: 'Mystery Area', label: 'x', status: 'pending' },
+    ];
+    expect(deckTargetIndex(DECK, checks)).toBe(-1);
+  });
+});
+
+describe('nextDeckIndex walk', () => {
+  it('replays the logged batch without skipping Delivery or Observability', () => {
+    const afterBatch = withResolved([
+      'Feature Flags',
+      'Feature Flags — Optimize',
+      'Feature Flags — Delivery',
+      'Feature Flags — Observability',
+    ]);
+    const target = deckTargetIndex(DECK, afterBatch);
+    expect(target).toBe(4); // head pending row is now Workflow
+
+    const visited: number[] = [];
+    let displayed = 1; // Optimize card was up when the batch landed
+    while (displayed !== nextDeckIndex(displayed, target)) {
+      displayed = nextDeckIndex(displayed, target);
+      visited.push(displayed);
+    }
+    // Delivery (2) and Observability (3) each get a full dwell on the way.
+    expect(visited).toEqual([2, 3, 4]);
+  });
+
+  it('walks one card at a time toward a finished run, then off the deck', () => {
+    expect(nextDeckIndex(3, DECK.length)).toBe(4);
+    expect(nextDeckIndex(4, DECK.length)).toBe(5); // deck played out
+  });
+
+  it('snaps backward when a sweep row re-opens an earlier area', () => {
+    expect(nextDeckIndex(3, 1)).toBe(1);
+  });
+
+  it('holds position on an unknown-area target and when caught up', () => {
+    expect(nextDeckIndex(2, -1)).toBe(2);
+    expect(nextDeckIndex(2, 2)).toBe(2);
+  });
+});

--- a/src/ui/tui/__tests__/pending-checks-list.test.ts
+++ b/src/ui/tui/__tests__/pending-checks-list.test.ts
@@ -1,0 +1,52 @@
+/** Regression coverage for the checklist squash bug (density selection). */
+import {
+  groupByArea,
+  pickDensity,
+} from '@ui/tui/screens/audit/PendingChecksList';
+import { FEATURE_FLAGS_DOCTOR_SEED_CHECKS } from '@lib/programs/feature-flags-doctor/seed';
+
+const groups = groupByArea(FEATURE_FLAGS_DOCTOR_SEED_CHECKS);
+const activeIndex = 0; // fresh seed: everything pending, first group active
+
+describe('groupByArea', () => {
+  it('groups the doctor seed into its five areas in seed order', () => {
+    expect(groups.map((g) => g.area)).toEqual([
+      'Feature Flags',
+      'Feature Flags — Optimize',
+      'Feature Flags — Delivery',
+      'Feature Flags — Observability',
+      'Workflow',
+    ]);
+    expect(groups.map((g) => g.checks.length)).toEqual([6, 5, 5, 1, 2]);
+  });
+});
+
+describe('pickDensity', () => {
+  it('expands only the active group at the heights that used to squash', () => {
+    // ghostty default ~28 rows: 19 rows + 5 headers + spacing never fit.
+    for (const rows of [24, 28, 32]) {
+      expect(pickDensity(groups, activeIndex, rows)).toBe('active');
+    }
+  });
+
+  it('renders the full list when the terminal is tall enough', () => {
+    expect(pickDensity(groups, activeIndex, 50)).toBe('full');
+  });
+
+  it('degrades to headers only in very short terminals', () => {
+    expect(pickDensity(groups, activeIndex, 18)).toBe('headers');
+  });
+
+  it('accounts for the active group size, not just the group count', () => {
+    // Delivery active (5 checks) needs one row less than correctness (6).
+    const deliveryActive = groups.findIndex(
+      (g) => g.area === 'Feature Flags — Delivery',
+    );
+    expect(pickDensity(groups, deliveryActive, 22)).toBe('active');
+    expect(pickDensity(groups, activeIndex, 22)).toBe('headers');
+  });
+
+  it('falls back to headers when no group is active and nothing fits', () => {
+    expect(pickDensity(groups, -1, 15)).toBe('headers');
+  });
+});

--- a/src/ui/tui/screens/audit/AuditAreaPane.tsx
+++ b/src/ui/tui/screens/audit/AuditAreaPane.tsx
@@ -13,7 +13,7 @@
  * Pressing `O` opens the active slide's docs URL.
  */
 
-import { Fragment } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { spawn } from 'node:child_process';
 import { Colors } from '@ui/tui/styles';
@@ -47,6 +47,30 @@ const openLink = (url: string) => {
   spawn(cmd, args, { detached: true, stdio: 'ignore' }).unref();
 };
 
+// ── Deck walk ────────────────────────────────────────────────────────
+
+/** Minimum time a card stays up before the walk may advance past it. */
+export const DECK_MIN_DWELL_MS = 12_000;
+
+/** Deck index the walk heads toward: `slides.length` = run finished,
+ * `-1` = head area has no slide (caller shows a fallback card). */
+export function deckTargetIndex(
+  slides: AreaSlide[],
+  checks: AuditCheck[],
+): number {
+  const headArea = checks.find((c) => c.status === 'pending')?.area;
+  if (headArea === undefined) return slides.length;
+  return slides.findIndex((s) => s.area === headArea);
+}
+
+/** One walk step: advance one card toward the target, snap backward. */
+export function nextDeckIndex(displayed: number, target: number): number {
+  if (target < 0) return displayed;
+  if (target < displayed) return target;
+  if (target > displayed) return displayed + 1;
+  return displayed;
+}
+
 // ── Component ────────────────────────────────────────────────────────
 
 interface AuditAreaPaneProps {
@@ -70,11 +94,34 @@ export const AuditAreaPane = ({
   dashboardUrl,
   notebookUrl,
 }: AuditAreaPaneProps) => {
-  const pendingChecks = checks.filter((c) => c.status === 'pending');
-  const activeArea = pendingChecks[0]?.area;
-  const slide = activeArea
-    ? slides.find((s) => s.area === activeArea) ?? fallbackSlide(activeArea)
-    : null;
+  const activeArea = checks.find((c) => c.status === 'pending')?.area;
+  const target = deckTargetIndex(slides, checks);
+
+  const [displayedIdx, setDisplayedIdx] = useState(0);
+  const lastAdvanceRef = useRef(Date.now());
+
+  // Snap backward immediately; walk forward one card per dwell.
+  useEffect(() => {
+    if (target >= 0 && target < displayedIdx) {
+      lastAdvanceRef.current = Date.now();
+      setDisplayedIdx(target);
+      return;
+    }
+    if (target <= displayedIdx) return;
+    const timer = setInterval(() => {
+      if (Date.now() - lastAdvanceRef.current < DECK_MIN_DWELL_MS) return;
+      lastAdvanceRef.current = Date.now();
+      setDisplayedIdx((i) => nextDeckIndex(i, target));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [target, displayedIdx]);
+
+  const slide =
+    target === -1 && activeArea !== undefined
+      ? fallbackSlide(activeArea)
+      : displayedIdx < slides.length
+      ? slides[displayedIdx]
+      : null;
 
   useInput((input) => {
     if (input.toLowerCase() === 'o' && slide?.docsUrl) {
@@ -87,7 +134,11 @@ export const AuditAreaPane = ({
       <UrlsFooter dashboardUrl={dashboardUrl} notebookUrl={notebookUrl} />
     ) : null;
 
-  // Active area — agent is still resolving checks for this slide's area.
+  // Ledger empty — PendingChecksList owns the loading state.
+  if (checks.length === 0) {
+    return null;
+  }
+
   if (slide) {
     const hasFindings = checks.some(isFinding);
     return (
@@ -98,14 +149,7 @@ export const AuditAreaPane = ({
     );
   }
 
-  // Ledger empty — the seed hook fires synchronously at intro `onReady`,
-  // so this only happens if the seed file write failed. Render nothing
-  // rather than misleading the user with a "wrapped up" message.
-  if (checks.length === 0) {
-    return null;
-  }
-
-  // Every check is resolved and the agent is composing the report.
+  // Deck played out and every check resolved — report is being written.
   return (
     <Box flexDirection="column">
       <WritingReport reportPath={reportPath} />
@@ -123,7 +167,7 @@ const ActiveSlide = ({
   slide: AreaSlide;
   hasFindings: boolean;
 }) => (
-  <Box flexDirection="column" paddingX={1}>
+  <Box flexDirection="column" paddingX={1} flexShrink={0}>
     <Text bold color={Colors.accent}>
       Verifying {slide.area.toLowerCase()}
     </Text>

--- a/src/ui/tui/screens/audit/AuditRunScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditRunScreen.tsx
@@ -12,8 +12,7 @@ import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
 import { useFileWatcher } from '@ui/tui/hooks/file-watcher';
 import { AuditChecksViewer } from './AuditChecksViewer/AuditChecksViewer.js';
 import { AuditAreaPane } from './AuditAreaPane.js';
-import { AUDIT_AREA_SLIDES } from './slides/index.js';
-import { EVENTS_AUDIT_AREA_SLIDES } from './slides/events-audit/index.js';
+import { getAreaSlides } from './slides/index.js';
 import { PendingChecksList } from './PendingChecksList.js';
 import {
   AUDIT_CHECKS_FILE,
@@ -50,10 +49,7 @@ export const AuditRunScreen = ({ store }: AuditRunScreenProps) => {
     AUDIT_REPORT_FILE;
   const reportPath = `./${reportFile}`;
   const pendingChecksList = <PendingChecksList checks={checks} />;
-  const slides =
-    store.session.skillId === 'audit-events'
-      ? EVENTS_AUDIT_AREA_SLIDES
-      : AUDIT_AREA_SLIDES;
+  const slides = getAreaSlides(store.session.skillId);
   const areaPane = (
     <AuditAreaPane
       checks={checks}

--- a/src/ui/tui/screens/audit/AuditRunScreen.tsx
+++ b/src/ui/tui/screens/audit/AuditRunScreen.tsx
@@ -1,5 +1,5 @@
 import { useSyncExternalStore } from 'react';
-import { join } from 'node:path';
+import { resolve } from 'node:path';
 import { Box } from 'ink';
 import type { WizardStore } from '@ui/tui/store';
 import {
@@ -35,8 +35,15 @@ export const AuditRunScreen = ({ store }: AuditRunScreenProps) => {
   );
 
   // Mirror the agent's audit ledger into the store.
-  useFileWatcher(join(store.session.installDir, AUDIT_CHECKS_FILE), (parsed) =>
-    store.setFrameworkContext(AUDIT_CHECKS_KEY, coerceAuditChecks(parsed)),
+  const ledgerPath = resolve(store.session.installDir, AUDIT_CHECKS_FILE);
+  useFileWatcher(
+    ledgerPath,
+    (parsed) =>
+      store.setFrameworkContext(AUDIT_CHECKS_KEY, coerceAuditChecks(parsed)),
+    {
+      onReadError: (message) =>
+        store.pushStatus(`Audit checklist file unreadable — ${message}`),
+    },
   );
 
   const statuses =
@@ -48,7 +55,9 @@ export const AuditRunScreen = ({ store }: AuditRunScreenProps) => {
     getProgramConfig(store.router.activeProgram).reportFile ??
     AUDIT_REPORT_FILE;
   const reportPath = `./${reportFile}`;
-  const pendingChecksList = <PendingChecksList checks={checks} />;
+  const pendingChecksList = (
+    <PendingChecksList checks={checks} ledgerPath={ledgerPath} />
+  );
   const slides = getAreaSlides(store.session.skillId);
   const areaPane = (
     <AuditAreaPane

--- a/src/ui/tui/screens/audit/PendingChecksList.tsx
+++ b/src/ui/tui/screens/audit/PendingChecksList.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { Spinner } from '@inkjs/ui';
 import {
@@ -7,17 +8,20 @@ import {
 import { Colors, Icons } from '@ui/tui/styles';
 import { LoadingBox } from '@ui/tui/primitives/index';
 import { useStdoutDimensions } from '@ui/tui/hooks/useStdoutDimensions';
+import { WIZARD_LOG_FILE } from '@utils/paths';
 
 interface PendingChecksListProps {
   checks: AuditCheck[];
+  /** Absolute ledger path, shown in the empty-state diagnostics. */
+  ledgerPath?: string;
 }
 
-interface Group {
+export interface Group {
   area: string;
   checks: AuditCheck[];
 }
 
-function groupByArea(checks: AuditCheck[]): Group[] {
+export function groupByArea(checks: AuditCheck[]): Group[] {
   const order: string[] = [];
   const map = new Map<string, AuditCheck[]>();
   for (const c of checks) {
@@ -52,7 +56,7 @@ const GroupHeader = ({
   const total = group.checks.length;
   const { icon, color } = groupIcon(group);
   return (
-    <Box>
+    <Box flexShrink={0}>
       {isActive ? (
         <Box marginRight={1}>
           <Spinner />
@@ -75,63 +79,138 @@ const GroupHeader = ({
 const CheckRow = ({ check }: { check: AuditCheck }) => {
   const { glyph, color } = AUDIT_SEVERITY_STYLE[check.status];
   return (
-    <Text>
-      <Text color={color}>{glyph}</Text>
-      <Text dimColor={check.status === 'pending'}> {check.label}</Text>
-    </Text>
+    <Box flexShrink={0}>
+      <Text>
+        <Text color={color}>{glyph}</Text>
+        <Text dimColor={check.status === 'pending'}> {check.label}</Text>
+      </Text>
+    </Box>
   );
 };
 
-const COLLAPSE_BELOW_ROWS = 24;
+/** Rows the surrounding chrome (tab bar, borders, status bar) consumes. */
+const CHROME_ROWS = 10;
 
-export const PendingChecksList = ({ checks }: PendingChecksListProps) => {
+const DIAGNOSTICS_AFTER_S = 10;
+const QUIT_HINT_AFTER_S = 30;
+
+/** Empty-ledger state with escalating diagnostics — never a bare spinner. */
+const SeedingState = ({ ledgerPath }: { ledgerPath?: string }) => {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Checks</Text>
+      <Text> </Text>
+      <LoadingBox message="Seeding audit checklist..." />
+      {elapsed >= DIAGNOSTICS_AFTER_S && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>
+            Still waiting for the checklist
+            {ledgerPath ? ` at ${ledgerPath}` : ''}.
+          </Text>
+          <Text dimColor>Logs: {WIZARD_LOG_FILE}</Text>
+        </Box>
+      )}
+      {elapsed >= QUIT_HINT_AFTER_S && (
+        <Box marginTop={1}>
+          <Text dimColor>
+            This is taking longer than expected — press ctrl+c to quit, then
+            re-run the command.
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+/** How much of the list fits: everything, the active group expanded with the
+ * rest as one-line headers, or headers only. */
+export type Density = 'full' | 'active' | 'headers';
+
+export function pickDensity(
+  groups: Group[],
+  activeIndex: number,
+  termRows: number,
+): Density {
+  const available = termRows - CHROME_ROWS;
+  const fullRows =
+    2 +
+    groups.reduce((rows, g) => rows + 1 + g.checks.length, 0) +
+    (groups.length - 1);
+  if (fullRows <= available) return 'full';
+  const activeRows =
+    2 +
+    groups.length +
+    (activeIndex >= 0 ? groups[activeIndex].checks.length : 0);
+  if (activeRows <= available) return 'active';
+  return 'headers';
+}
+
+export const PendingChecksList = ({
+  checks,
+  ledgerPath,
+}: PendingChecksListProps) => {
   const [, termRows] = useStdoutDimensions();
 
   if (checks.length === 0) {
-    return (
-      <Box flexDirection="column">
-        <Text bold>Checks</Text>
-        <Text> </Text>
-        <LoadingBox message="Seeding audit checklist..." />
-      </Box>
-    );
+    return <SeedingState ledgerPath={ledgerPath} />;
   }
 
   const groups = groupByArea(checks);
   const activeIndex = groups.findIndex((g) =>
     g.checks.some((c) => c.status === 'pending'),
   );
-  const collapsed = termRows < COLLAPSE_BELOW_ROWS;
+  const density = pickDensity(groups, activeIndex, termRows);
 
+  // flexShrink=0 throughout so overflow clips instead of squashing rows.
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" flexShrink={0}>
       <Text bold>Checks</Text>
       <Text> </Text>
-      {collapsed
-        ? groups.map((group, i) => (
+      {density === 'headers' &&
+        groups.map((group, i) => (
+          <GroupHeader
+            key={group.area}
+            group={group}
+            showIcon
+            isActive={i === activeIndex}
+          />
+        ))}
+      {density === 'active' &&
+        groups.map((group, i) => (
+          <Box key={group.area} flexDirection="column" flexShrink={0}>
             <GroupHeader
-              key={group.area}
               group={group}
-              showIcon
+              showIcon={i !== activeIndex}
               isActive={i === activeIndex}
             />
-          ))
-        : groups.map((group, i) => (
-            <Box
-              key={group.area}
-              flexDirection="column"
-              marginTop={i === 0 ? 0 : 1}
-            >
-              <GroupHeader
-                group={group}
-                showIcon={false}
-                isActive={i === activeIndex}
-              />
-              {group.checks.map((c) => (
-                <CheckRow key={c.id} check={c} />
-              ))}
-            </Box>
-          ))}
+            {i === activeIndex &&
+              group.checks.map((c) => <CheckRow key={c.id} check={c} />)}
+          </Box>
+        ))}
+      {density === 'full' &&
+        groups.map((group, i) => (
+          <Box
+            key={group.area}
+            flexDirection="column"
+            flexShrink={0}
+            marginTop={i === 0 ? 0 : 1}
+          >
+            <GroupHeader
+              group={group}
+              showIcon={false}
+              isActive={i === activeIndex}
+            />
+            {group.checks.map((c) => (
+              <CheckRow key={c.id} check={c} />
+            ))}
+          </Box>
+        ))}
     </Box>
   );
 };

--- a/src/ui/tui/screens/audit/slides/feature-flags/correctness.tsx
+++ b/src/ui/tui/screens/audit/slides/feature-flags/correctness.tsx
@@ -1,0 +1,33 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const CorrectnessVisual = () => (
+  <VisualBox>
+    <Text dimColor>page load</Text>
+    <Text>
+      <Text dimColor>{'  ▼ '}</Text>
+      <Text color="cyan">isFeatureEnabled('beta')</Text>
+      <Text dimColor>{'  → '}</Text>
+      <Text color="yellow">undefined</Text>
+      <Text dimColor>{'  (still loading)'}</Text>
+    </Text>
+    <Text dimColor>{'  │  …flags arrive…'}</Text>
+    <Text>
+      <Text dimColor>{'  ▼ '}</Text>
+      <Text color="cyan">isFeatureEnabled('beta')</Text>
+      <Text dimColor>{'  → '}</Text>
+      <Text color="green">true</Text>
+    </Text>
+  </VisualBox>
+);
+
+export const FlagCorrectnessSlide: AreaSlide = {
+  area: 'Feature Flags',
+  intro: [
+    'Client-side flags load asynchronously — a flag evaluated before the SDK is ready returns undefined, and undefined is not false.',
+    "We're checking every flag call site for the classic traps: evaluating during the loading window, missing default values, bootstrap mismatches, and flags evaluated before identify() resolves the real user.",
+    'Each of these fails silently — the app just renders the wrong thing with no error anywhere.',
+  ],
+  visual: <CorrectnessVisual />,
+  docsUrl: 'https://posthog.com/docs/feature-flags/best-practices',
+};

--- a/src/ui/tui/screens/audit/slides/feature-flags/delivery.tsx
+++ b/src/ui/tui/screens/audit/slides/feature-flags/delivery.tsx
@@ -1,0 +1,29 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const DeliveryVisual = () => (
+  <VisualBox>
+    <Text>
+      <Text color="cyan">POST /flags</Text>
+      <Text dimColor>{'  with your project key'}</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'  ▼ '}</Text>
+      <Text color="green">200</Text>
+      <Text dimColor>{'  { flags: {} }  ← but why?'}</Text>
+    </Text>
+    <Text dimColor>{'  key not loaded? proxy broken?'}</Text>
+    <Text dimColor>{'  nothing configured? filtered client?'}</Text>
+  </VisualBox>
+);
+
+export const FlagDeliverySlide: AreaSlide = {
+  area: 'Feature Flags — Delivery',
+  intro: [
+    'A misconfigured flag does not throw an error — the app quietly serves defaults while the dashboard says everything is active. An empty flags response looks identical across several unrelated causes.',
+    "We're evaluating your flags through the real /flags endpoint, with your project's own key, via the same path your app uses — and cross-checking what comes back against your flag definitions. Every flag key referenced in code is also checked against what actually exists in PostHog.",
+    'If something is not arriving, the report names which cause you are hitting.',
+  ],
+  visual: <DeliveryVisual />,
+  docsUrl: 'https://posthog.com/docs/feature-flags/troubleshooting',
+};

--- a/src/ui/tui/screens/audit/slides/feature-flags/index.ts
+++ b/src/ui/tui/screens/audit/slides/feature-flags/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Slide registry for the feature-flags doctor program. Each entry is keyed
+ * by `AuditCheck.area` and follows the doctor's ledger order: correctness →
+ * cost → live delivery → observability → the consented fix phase.
+ *
+ * `AuditAreaPane` looks the active area up here when the active program is
+ * the feature-flags doctor.
+ */
+
+import type { AreaSlide } from '../shared.js';
+import { FlagCorrectnessSlide } from './correctness.js';
+import { FlagOptimizeSlide } from './optimize.js';
+import { FlagDeliverySlide } from './delivery.js';
+import { FlagObservabilitySlide } from './observability.js';
+import { FlagWorkflowSlide } from './workflow.js';
+
+export const FEATURE_FLAGS_AREA_SLIDES: AreaSlide[] = [
+  FlagCorrectnessSlide,
+  FlagOptimizeSlide,
+  FlagDeliverySlide,
+  FlagObservabilitySlide,
+  FlagWorkflowSlide,
+];

--- a/src/ui/tui/screens/audit/slides/feature-flags/observability.tsx
+++ b/src/ui/tui/screens/audit/slides/feature-flags/observability.tsx
@@ -1,0 +1,28 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const ObservabilityVisual = () => (
+  <VisualBox>
+    <Text>
+      <Text color="cyan">evaluate flag</Text>
+      <Text dimColor>{'  ✓ your app got a value'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">report it</Text>
+      <Text dimColor>{'     '}</Text>
+      <Text color="yellow">$feature_flag_called?</Text>
+    </Text>
+    <Text dimColor>{'  └─ different things. experiments +'}</Text>
+    <Text dimColor>{'     staleness both live on the 2nd'}</Text>
+  </VisualBox>
+);
+
+export const FlagObservabilitySlide: AreaSlide = {
+  area: 'Feature Flags — Observability',
+  intro: [
+    'Evaluating a flag and reporting that it was evaluated are different things. SDKs report evaluations as $feature_flag_called events — experiments use them for exposure, and PostHog measures flag staleness from them.',
+    'If those events are suppressed, a heavily-used flag looks stale — and archiving it would turn off a live feature. That is why the doctor verifies reporting is flowing before it will offer any cleanup.',
+  ],
+  visual: <ObservabilityVisual />,
+  docsUrl: 'https://posthog.com/docs/experiments/exposures',
+};

--- a/src/ui/tui/screens/audit/slides/feature-flags/optimize.tsx
+++ b/src/ui/tui/screens/audit/slides/feature-flags/optimize.tsx
@@ -1,0 +1,27 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const OptimizeVisual = () => (
+  <VisualBox>
+    <Text>
+      <Text color="cyan">old-flag</Text>
+      <Text dimColor>{'  100% for months, still gated in code'}</Text>
+    </Text>
+    <Text>
+      <Text color="cyan">ghost-exp</Text>
+      <Text dimColor>{' active, zero code references'}</Text>
+    </Text>
+    <Text dimColor>{'  └─ both still evaluated (and billed)'}</Text>
+    <Text dimColor>{'     on every /flags request'}</Text>
+  </VisualBox>
+);
+
+export const FlagOptimizeSlide: AreaSlide = {
+  area: 'Feature Flags — Optimize',
+  intro: [
+    'Flags are billed by /flags requests, and active flags keep evaluating even when your code stopped referencing them — removing a flag from code does not stop the charges. Only archiving or disabling it in PostHog does.',
+    "We're looking for flag debt in both directions: flags fully rolled out but still gated in code, and active flags nothing references anymore — plus local-evaluation polling costs and test runs silently burning requests.",
+  ],
+  visual: <OptimizeVisual />,
+  docsUrl: 'https://posthog.com/docs/feature-flags/cutting-costs',
+};

--- a/src/ui/tui/screens/audit/slides/feature-flags/workflow.tsx
+++ b/src/ui/tui/screens/audit/slides/feature-flags/workflow.tsx
@@ -1,0 +1,33 @@
+import { Text } from 'ink';
+import { VisualBox, type AreaSlide } from '../shared.js';
+
+const WorkflowVisual = () => (
+  <VisualBox>
+    <Text>
+      <Text dimColor>{'[x] '}</Text>
+      <Text>fix typo'd key </Text>
+      <Text color="cyan">beta-serach</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'[x] '}</Text>
+      <Text>strip gate for </Text>
+      <Text color="cyan">new-nav</Text>
+      <Text dimColor>{'  (100%)'}</Text>
+    </Text>
+    <Text>
+      <Text dimColor>{'[ ] '}</Text>
+      <Text dimColor>archive unused flags…</Text>
+    </Text>
+    <Text dimColor>{'  └─ only what you pick, safe order'}</Text>
+  </VisualBox>
+);
+
+export const FlagWorkflowSlide: AreaSlide = {
+  area: 'Workflow',
+  intro: [
+    "The findings become a checklist — you pick which fixes to apply, and nothing you don't pick gets touched.",
+    'Fixes follow the safe cleanup order: code gates are stripped first and flags are only disabled in PostHog after you deploy — never the other way around, so a live feature is never switched off under running code.',
+  ],
+  visual: <WorkflowVisual />,
+  docsUrl: 'https://posthog.com/docs/feature-flags/cleaning-up-stale-flags',
+};

--- a/src/ui/tui/screens/audit/slides/index.ts
+++ b/src/ui/tui/screens/audit/slides/index.ts
@@ -22,3 +22,22 @@ export const AUDIT_AREA_SLIDES: AreaSlide[] = [
   WriteReportSlide,
   UploadNotebookSlide,
 ];
+
+/**
+ * Deck registry keyed by `session.skillId`. Programs on the audit-run
+ * screen get the deck matching their skill; anything unlisted falls back
+ * to the comprehensive-audit deck. To give a new audit program its own
+ * deck, add a `<skill>/index.ts` deck module and one entry here.
+ */
+import { EVENTS_AUDIT_AREA_SLIDES } from './events-audit/index.js';
+import { FEATURE_FLAGS_AREA_SLIDES } from './feature-flags/index.js';
+
+const SLIDES_BY_SKILL: Record<string, AreaSlide[]> = {
+  'audit-events': EVENTS_AUDIT_AREA_SLIDES,
+  'events-audit': EVENTS_AUDIT_AREA_SLIDES,
+  'audit-feature-flags': FEATURE_FLAGS_AREA_SLIDES,
+};
+
+export function getAreaSlides(skillId: string | null | undefined): AreaSlide[] {
+  return (skillId && SLIDES_BY_SKILL[skillId]) || AUDIT_AREA_SLIDES;
+}

--- a/src/utils/__tests__/oauth.test.ts
+++ b/src/utils/__tests__/oauth.test.ts
@@ -93,6 +93,19 @@ describe('wizard OAuth scopes', () => {
     );
   });
 
+  it('grants the feature-flags doctor the flag scopes its roster and fix phase need', () => {
+    const scopes = getOAuthScopesForProgram('feature-flags-doctor');
+
+    // Without feature_flag:read the roster call (`feature-flag-get-all`)
+    // 403s and every roster-dependent check silently degrades to
+    // mcp_skipped — the exact failure the first live run surfaced.
+    expect(scopes).toContain('feature_flag:read');
+    // The fix phase archives/disables approved cleanup candidates.
+    expect(scopes).toContain('feature_flag:write');
+    // Base scopes are never dropped by an addition.
+    expect(scopes).toEqual(expect.arrayContaining([...WIZARD_OAUTH_SCOPES]));
+  });
+
   it('grants self-driving the scanner scopes STEP 6c needs', () => {
     const scopes = getOAuthScopesForProgram('self-driving');
 


### PR DESCRIPTION
## Problem

Pairs with PostHog/context-mill#329, which should land first.

`audit feature-flags` is skill-backed today, so it gets the generic run screen: three lines of boilerplate and a spinner. The rebuilt skill runs a 19-check pipeline and asks for consent before applying fixes.

## Changes

Makes `audit feature-flags` wizard-native, the same move `audit web-analytics` made. The native handler shadows the published `cliEntry`, so the command and skill id are unchanged and there's no context-mill release coupling.

- **The program** (`feature-flags-doctor`) — detect step, audit-family screens, and a 19-row seeded ledger whose ids are the contract with the skill. Sweep rows (`ghost-*`, `stale-*`) get appended at runtime per flag.
- **Slide registry** — `AuditRunScreen` picked its deck with a hardcoded `skillId === 'audit-events'` ternary, so any third audit program silently got the comprehensive deck. Replaced with a lookup keyed by skill, plus a five-slide feature-flags deck. Side effect: `events-audit`'s flat-command form was hitting the same fallthrough and now gets its own deck too.
- **OAuth scopes** — the doctor requests `feature_flag:read`/`write`. Native programs don't inherit `agent-skill`'s additions, so without this the roster call 403s and every roster-dependent check silently degrades. Found the hard way on a live run.
- **Picker de-dupe** — a native handler shadowing a published entry listed the command twice.

<img width="1004" height="865" alt="04-ledger-findings" src="https://github.com/user-attachments/assets/fe58bc20-6c7a-48e8-8857-d4301041278f" />
<img width="1019" height="865" alt="03-consent-interlock" src="https://github.com/user-attachments/assets/f921d2a8-08e0-45a7-8bb4-5ca8866d9603" />

## Test plan

- `pnpm build && pnpm test` (1745, +15 new) and `pnpm lint` green.
- Ran end-to-end against a Next.js app with seeded flags and three planted defects. All three caught, two selected fixes applied, cleanup correctly withheld, healthy flags verified. Same app on `main`: all three silent.


## Notes / open questions

Three things I'd like a maintainer opinion on rather than deciding unilaterally:

1. **The ledger has no "fixed" state.** Approve a fix, watch it apply, and the row stays red — `AuditStatus` has no way to say "was a finding, now handled" I've added this to a list of follow ups for later, but thoughts are welcome. `web-analytics`'s findings JSON already models this (`fix.applied`), so it's parity rather than a new concept.
2. **Parent + sweep rows double-count in the outro** — "Code flag keys exist in PostHog" and "beta-serach not found in PostHog" are one problem shown twice. Resolve the parent to pass, or collapse children in the summary?
3. **Area naming** — kept the incumbent's `Feature Flags — Optimize` prefix. Bare verbs read better standalone, imo; happy to flatten.

Also spotted but left alone: `AuditChecksOutroSection` renders "1 warnings", and its counts ignore fixes applied during the run. Both pre-existing and family-wide — can drive-by if wanted.