### PR TITLE
feat(posthog-integration): detect existing PostHog, surface the other tricks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ confuse it with the top-level `wizard skill` command.
 
 ### Where the surface is defined (source of truth)
 
-- **Registration:** [`bin.ts`](bin.ts) — the `.use()` chain wires each command.
+- **Registration:** [`src/commands/index.ts`](src/commands/index.ts) —
+  `ALL_COMMANDS` is the list [`bin.ts`](bin.ts) registers. Add a new command
+  there and nothing else needs touching.
 - **Command shape:** [`src/commands/command.ts`](src/commands/command.ts) — the
   `Command` interface every command implements.
 - **Flat native commands** (e.g. `revenue-analytics`, `upload-source-maps`) are

--- a/bin.ts
+++ b/bin.ts
@@ -46,22 +46,7 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 import { Wizard } from './src/wizard';
-import { basicIntegrationCommand } from './src/commands/basic-integration';
-import { mcpCommand } from './src/commands/mcp';
-import { mcpAnalyticsCommand } from './src/commands/mcp-analytics';
-import { replayVisionCommand } from './src/commands/replay-vision';
-import { aiObservabilityCommand } from './src/commands/ai-observability';
-import { metricsCommand } from './src/commands/metrics';
-import { auditCommand } from './src/commands/audit';
-import { doctorCommand } from './src/commands/doctor';
-import { migrateCommand } from './src/commands/migrate';
-import { revenueCommand } from './src/commands/revenue';
-import { warehouseCommand } from './src/commands/warehouse';
-import { selfDrivingCommand } from './src/commands/self-driving';
-import { slackCommand } from './src/commands/slack';
-import { uploadSourcemapsCommand } from './src/commands/upload-sourcemaps';
-import { skillCommand } from './src/commands/skill';
-import { cliCommand } from './src/commands/cli';
+import { ALL_COMMANDS } from './src/commands';
 import { recoverOrphanedSettingsBackups } from './src/lib/agent/claude-settings';
 
 // Heal any .claude/settings backup a previous interrupted run left orphaned,
@@ -79,20 +64,4 @@ function resolveInstallDir(): string {
   return process.env.POSTHOG_WIZARD_INSTALL_DIR ?? process.cwd();
 }
 
-Wizard.use(basicIntegrationCommand)
-  .use(mcpCommand)
-  .use(mcpAnalyticsCommand)
-  .use(replayVisionCommand)
-  .use(aiObservabilityCommand)
-  .use(metricsCommand)
-  .use(cliCommand)
-  .use(auditCommand)
-  .use(doctorCommand)
-  .use(migrateCommand)
-  .use(revenueCommand)
-  .use(warehouseCommand)
-  .use(selfDrivingCommand)
-  .use(slackCommand)
-  .use(uploadSourcemapsCommand)
-  .use(skillCommand)
-  .init();
+Wizard.use(...ALL_COMMANDS).init();

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -35,6 +35,9 @@ import { fetchSkillMenu, type CliEntry } from '@lib/wizard-tools';
 import { auditConfig } from '@lib/programs/audit/index';
 import { webAnalyticsDoctorConfig } from '@lib/programs/web-analytics-doctor/index';
 import { parseCommand } from './helpers/parse-command.no-jest';
+import { ALL_COMMANDS } from '../commands';
+import { commandKeys } from '../commands/command';
+import { getSubcommandPrograms } from '@lib/programs/program-registry';
 
 const mockFetchSkillMenu = fetchSkillMenu as MockedFunction<
   typeof fetchSkillMenu
@@ -56,6 +59,28 @@ function entry(partial: Partial<CliEntry> & { skillId: string }): CliEntry {
 function mockMenu(cliEntries: CliEntry[]): void {
   mockFetchSkillMenu.mockResolvedValue({ categories: {}, cliEntries });
 }
+
+// A program's `command` field says what it calls itself, not whether the CLI
+// can run it. Retiring or moving a command leaves that field behind, and the
+// program keeps advertising a word nobody can type.
+describe('advertised commands', () => {
+  const registered = new Set(
+    ALL_COMMANDS.flatMap((command) => commandKeys(command.name)),
+  );
+
+  test('every advertised command is one the CLI registers', () => {
+    // A nested program is reached through its parent, so that's the word
+    // yargs knows — `audit`, not `web-analytics`.
+    const wordFor = (program: { parentCommand?: string; command: string }) =>
+      program.parentCommand ?? program.command;
+
+    const unrunnable = getSubcommandPrograms()
+      .filter((program) => !registered.has(wordFor(program)))
+      .map((program) => `${program.id} advertises "${wordFor(program)}"`);
+
+    expect(unrunnable).toEqual([]);
+  });
+});
 
 describe('top-level command shapes', () => {
   beforeEach(() => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Every command the CLI registers, in the order `--help` lists them.
+ *
+ * Kept here rather than inline in bin.ts so registration and the tests that
+ * check it read from the same list — a program can otherwise advertise a
+ * command that no longer exists, and nothing catches it.
+ */
+
+import type { Command } from './command';
+import { basicIntegrationCommand } from './basic-integration';
+import { mcpCommand } from './mcp';
+import { mcpAnalyticsCommand } from './mcp-analytics';
+import { replayVisionCommand } from './replay-vision';
+import { aiObservabilityCommand } from './ai-observability';
+import { metricsCommand } from './metrics';
+import { cliCommand } from './cli';
+import { auditCommand } from './audit';
+import { doctorCommand } from './doctor';
+import { migrateCommand } from './migrate';
+import { revenueCommand } from './revenue';
+import { warehouseCommand } from './warehouse';
+import { selfDrivingCommand } from './self-driving';
+import { slackCommand } from './slack';
+import { uploadSourcemapsCommand } from './upload-sourcemaps';
+import { skillCommand } from './skill';
+
+export const ALL_COMMANDS: readonly Command[] = [
+  basicIntegrationCommand,
+  mcpCommand,
+  mcpAnalyticsCommand,
+  replayVisionCommand,
+  aiObservabilityCommand,
+  metricsCommand,
+  cliCommand,
+  auditCommand,
+  doctorCommand,
+  migrateCommand,
+  revenueCommand,
+  warehouseCommand,
+  selfDrivingCommand,
+  slackCommand,
+  uploadSourcemapsCommand,
+  skillCommand,
+];

--- a/src/lib/programs/__tests__/posthog-integration-detect.test.ts
+++ b/src/lib/programs/__tests__/posthog-integration-detect.test.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { detectExistingPostHog } from '@lib/programs/posthog-integration/detect';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ph-detect-'));
+}
+
+function writePackageJson(
+  dir: string,
+  pkg: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  } = {},
+): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
+}
+
+describe('detectExistingPosthog', () => {
+  let tmpDir: string;
+  let setPosthogSdkDetected: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    setPosthogSdkDetected = vi.fn();
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  const run = (dir: string) =>
+    detectExistingPostHog({ setPosthogSdkDetected }, dir);
+
+  it('reports false when no package.json exists', () => {
+    run(tmpDir);
+    expect(setPosthogSdkDetected).toHaveBeenCalledWith(false);
+  });
+
+  it('reports false when dependencies have no PostHog SDK', () => {
+    writePackageJson(tmpDir, { dependencies: { react: '^19.0.0' } });
+    run(tmpDir);
+    expect(setPosthogSdkDetected).toHaveBeenCalledWith(false);
+  });
+
+  it('reports true for posthog-js in dependencies', () => {
+    writePackageJson(tmpDir, { dependencies: { 'posthog-js': '^1.0.0' } });
+    run(tmpDir);
+    expect(setPosthogSdkDetected).toHaveBeenCalledWith(true);
+  });
+
+  it('reports true for posthog-node in devDependencies', () => {
+    writePackageJson(tmpDir, { devDependencies: { 'posthog-node': '^4.0.0' } });
+    run(tmpDir);
+    expect(setPosthogSdkDetected).toHaveBeenCalledWith(true);
+  });
+
+  it('reports true for a PostHog SDK in a nested monorepo package', () => {
+    writePackageJson(tmpDir, { dependencies: {} });
+    writePackageJson(path.join(tmpDir, 'apps', 'web'), {
+      dependencies: { 'posthog-js': '^1.0.0' },
+    });
+    run(tmpDir);
+    expect(setPosthogSdkDetected).toHaveBeenCalledWith(true);
+  });
+
+  it('does not throw and reports false for an invalid install dir', () => {
+    expect(() => run('/nonexistent/path')).not.toThrow();
+    expect(setPosthogSdkDetected).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/lib/programs/__tests__/program-registry.test.ts
+++ b/src/lib/programs/__tests__/program-registry.test.ts
@@ -1,6 +1,7 @@
 import {
   PROGRAM_REGISTRY,
   agentSkillConfig,
+  getCommandPath,
   getProgramConfig,
   getSubcommandPrograms,
 } from '@lib/programs/program-registry';
@@ -34,11 +35,30 @@ describe('getSubcommandPrograms', () => {
     const subcommands = getSubcommandPrograms();
     const commands = subcommands.map((c) => c.command);
 
-    expect(commands).toContain('integrate');
     expect(commands).toContain('revenue-analytics');
     for (const config of subcommands) {
       expect(config.command).toBeTruthy();
     }
+  });
+});
+
+// What a user types to reach the program. A nested program's own `command` is
+// only half of that, so anything telling a user how to run one has to join it
+// to the parent.
+describe('getCommandPath', () => {
+  const subcommand = (id: string) =>
+    getSubcommandPrograms().find((config) => config.id === id)!;
+
+  it('reaches a nested program through its parent', () => {
+    expect(getCommandPath(subcommand('web-analytics-doctor'))).toBe(
+      'audit web-analytics',
+    );
+  });
+
+  it('leaves a top-level program alone', () => {
+    expect(getCommandPath(subcommand('revenue-analytics-setup'))).toBe(
+      'revenue-analytics',
+    );
   });
 });
 

--- a/src/lib/programs/__tests__/program-registry.test.ts
+++ b/src/lib/programs/__tests__/program-registry.test.ts
@@ -2,6 +2,7 @@ import {
   PROGRAM_REGISTRY,
   agentSkillConfig,
   getCommandPath,
+  getLaunchablePrograms,
   getProgramConfig,
   getSubcommandPrograms,
 } from '@lib/programs/program-registry';
@@ -59,6 +60,40 @@ describe('getCommandPath', () => {
     expect(getCommandPath(subcommand('revenue-analytics-setup'))).toBe(
       'revenue-analytics',
     );
+  });
+});
+
+// The programs the intro can hand off to in-session. A family parent isn't one
+// of them — typing `wizard audit` opens a picker rather than running anything,
+// so there's nothing to hand off to. Its leaves are still fair game.
+describe('getLaunchablePrograms', () => {
+  const ids = () => getLaunchablePrograms().map((config) => config.id);
+
+  it('skips a family parent', () => {
+    expect(ids()).not.toContain('audit');
+  });
+
+  it('keeps the leaves under that family', () => {
+    expect(ids()).toContain('web-analytics-doctor');
+  });
+
+  it('keeps the flat programs', () => {
+    expect(ids()).toContain('revenue-analytics-setup');
+    expect(ids()).toContain('metrics');
+  });
+
+  // Derived from who claims whom as a parent, so the next family drops out on
+  // its own instead of waiting for someone to remember this list.
+  it('drops nothing but parents', () => {
+    const parents = new Set(
+      getSubcommandPrograms().map((config) => config.parentCommand),
+    );
+    const dropped = getSubcommandPrograms()
+      .filter((config) => !ids().includes(config.id))
+      .map((config) => config.command);
+
+    expect(dropped).not.toEqual([]);
+    expect(dropped.every((command) => parents.has(command))).toBe(true);
   });
 });
 

--- a/src/lib/programs/events-audit/index.ts
+++ b/src/lib/programs/events-audit/index.ts
@@ -20,7 +20,6 @@ export { SETUP_REPORT_FILE };
 const DOCS_URL = 'https://posthog.com/docs/product-analytics/best-practices';
 
 export const eventsAuditConfig: ProgramConfig = {
-  command: 'events-audit',
   description: 'Audit PostHog event tracking in this project',
   id: 'events-audit',
   skillId: 'events-audit',

--- a/src/lib/programs/posthog-integration/detect.ts
+++ b/src/lib/programs/posthog-integration/detect.ts
@@ -132,8 +132,8 @@ function detectWarehouseSourcesForSuggestion(
 
 /**
  * Scan for existing PostHog SDKs in the project. Dependency-level signal only,
- * not a verified (or complete) install. Besteffort: scan failure reports false
- * rather than breaking the detection step.
+ * not a verified (or complete) install. Best-effort: scan failure reports
+ * false rather than breaking the detection step.
  */
 export function detectExistingPostHog(
   ctx: Pick<ProgramReadyContext, 'setPosthogSdkDetected'>,

--- a/src/lib/programs/posthog-integration/detect.ts
+++ b/src/lib/programs/posthog-integration/detect.ts
@@ -20,6 +20,7 @@ import {
 import { analytics } from '@utils/analytics';
 import { detectWarehouseSources } from '@lib/warehouse-sources/detect';
 import { DETECTED_WAREHOUSE_SOURCES_KEY } from '@lib/programs/warehouse-source/detect';
+import { findPackageJsons } from '@lib/programs/shared/package-scanning';
 
 export async function detectPostHogIntegration(
   ctx: ProgramReadyContext,
@@ -73,6 +74,7 @@ export async function detectPostHogIntegration(
   }
 
   detectWarehouseSourcesForSuggestion(ctx, installDir);
+  detectExistingPostHog(ctx, installDir);
 
   ctx.setDetectionComplete();
 }
@@ -125,5 +127,26 @@ function detectWarehouseSourcesForSuggestion(
       error instanceof Error ? error : new Error(String(error)),
       { step: 'detectWarehouseSourcesForSuggestion' },
     );
+  }
+}
+
+/**
+ * Scan for existing PostHog SDKs in the project. Dependency-level signal only,
+ * not a verified (or complete) install. Besteffort: scan failure reports false
+ * rather than breaking the detection step.
+ */
+export function detectExistingPostHog(
+  ctx: Pick<ProgramReadyContext, 'setPosthogSdkDetected'>,
+  installDir: string,
+): void {
+  try {
+    const pkgJsons = findPackageJsons(installDir);
+    ctx.setPosthogSdkDetected(pkgJsons.some((p) => p.posthogSdks.length > 0));
+  } catch (error) {
+    analytics.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { step: 'detectExistingPosthog' },
+    );
+    ctx.setPosthogSdkDetected(false);
   }
 }

--- a/src/lib/programs/posthog-integration/detect.ts
+++ b/src/lib/programs/posthog-integration/detect.ts
@@ -20,6 +20,7 @@ import {
 import { analytics } from '@utils/analytics';
 import { detectWarehouseSources } from '@lib/warehouse-sources/detect';
 import { DETECTED_WAREHOUSE_SOURCES_KEY } from '@lib/programs/warehouse-source/detect';
+import { findPackageJsons } from '@lib/programs/shared/package-scanning';
 
 export async function detectPostHogIntegration(
   ctx: ProgramReadyContext,
@@ -75,6 +76,7 @@ export async function detectPostHogIntegration(
   }
 
   detectWarehouseSourcesForSuggestion(ctx, installDir);
+  detectExistingPostHog(ctx, installDir);
 
   ctx.setDetectionComplete();
 }
@@ -127,5 +129,26 @@ function detectWarehouseSourcesForSuggestion(
       error instanceof Error ? error : new Error(String(error)),
       { step: 'detectWarehouseSourcesForSuggestion' },
     );
+  }
+}
+
+/**
+ * Scan for existing PostHog SDKs in the project. Dependency-level signal only,
+ * not a verified (or complete) install. Besteffort: scan failure reports false
+ * rather than breaking the detection step.
+ */
+export function detectExistingPostHog(
+  ctx: Pick<ProgramReadyContext, 'setPosthogSdkDetected'>,
+  installDir: string,
+): void {
+  try {
+    const pkgJsons = findPackageJsons(installDir);
+    ctx.setPosthogSdkDetected(pkgJsons.some((p) => p.posthogSdks.length > 0));
+  } catch (error) {
+    analytics.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { step: 'detectExistingPosthog' },
+    );
+    ctx.setPosthogSdkDetected(false);
   }
 }

--- a/src/lib/programs/posthog-integration/detect.ts
+++ b/src/lib/programs/posthog-integration/detect.ts
@@ -134,8 +134,8 @@ function detectWarehouseSourcesForSuggestion(
 
 /**
  * Scan for existing PostHog SDKs in the project. Dependency-level signal only,
- * not a verified (or complete) install. Besteffort: scan failure reports false
- * rather than breaking the detection step.
+ * not a verified (or complete) install. Best-effort: scan failure reports
+ * false rather than breaking the detection step.
  */
 export function detectExistingPostHog(
   ctx: Pick<ProgramReadyContext, 'setPosthogSdkDetected'>,

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -180,7 +180,6 @@ export const SETUP_REPORT_FILE = 'posthog-setup-report.md';
 export { EVENT_PLAN_FILE } from './constants.js';
 
 export const posthogIntegrationConfig: ProgramConfig = {
-  command: 'integrate',
   description: 'Set up PostHog SDK integration',
   id: 'posthog-integration',
   agentFlow: 'integration-v2',

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -142,3 +142,10 @@ export function getCommandPath(config: SubcommandProgram): string {
     ? `${config.parentCommand} ${config.command}`
     : config.command;
 }
+
+/** Programs the intro can launch, Family parents open a picker instead. */
+export function getLaunchablePrograms(): SubcommandProgram[] {
+  const all = getSubcommandPrograms();
+  const parents = new Set(all.map((config) => config.parentCommand));
+  return all.filter((config) => !parents.has(config.command));
+}

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -135,3 +135,10 @@ export function getSubcommandPrograms(): SubcommandProgram[] {
     (c): c is SubcommandProgram => c.command != null,
   );
 }
+
+/** What a user types to reach the program. Nested ones go through its parent. */
+export function getCommandPath(config: SubcommandProgram): string {
+  return config.parentCommand
+    ? `${config.parentCommand} ${config.command}`
+    : config.command;
+}

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -59,6 +59,7 @@ export interface ProgramReadyContext {
   }) => void;
   readonly addDiscoveredFeature: (feature: DiscoveredFeature) => void;
   readonly setDetectionComplete: () => void;
+  readonly setPosthogSdkDetected: (detected: boolean) => void;
 }
 
 export interface ProgramStep {

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -52,6 +52,7 @@ export interface ProgramReadyContext {
   }) => void;
   readonly addDiscoveredFeature: (feature: DiscoveredFeature) => void;
   readonly setDetectionComplete: () => void;
+  readonly setPosthogSdkDetected: (detected: boolean) => void;
 }
 
 export interface ProgramStep {

--- a/src/lib/runners/run-wizard.ts
+++ b/src/lib/runners/run-wizard.ts
@@ -2,6 +2,7 @@ import { VERSION } from '@lib/version';
 import { logToFile, getLogFilePath } from '@utils/debug';
 import { runAgent } from '@lib/agent/agent-runner';
 import { authenticate } from '@lib/agent/runner/shared/authenticate';
+import { getProgramConfig } from '@lib/programs/program-registry';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { Harness, Sequence } from '@lib/constants';
 import type { startTUI as StartTUIFn } from '@ui/tui/start-tui';
@@ -182,10 +183,16 @@ export function runWizard(
       process.on('SIGINT', onSignal);
       process.on('SIGTERM', onSignal);
 
-      await activeTui.store.runReadyHooks();
-      // Settle the pre-run screens. `integration-check` is a no-op gate for
-      // programs without it.
-      await activeTui.store.getGate('intro');
+      for (;;) {
+        await activeTui.store.runReadyHooks();
+        // Settle the pre-run screens. `integration-check` is a no-op gate for
+        // programs without it.
+        await activeTui.store.getGate('intro');
+
+        const active = activeTui.store.router.activeProgram;
+        if (active === config.id) break;
+        config = getProgramConfig(active);
+      }
       await activeTui.store.getGate('integration-check');
       await activeTui.store.getGate('health-check');
 

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -222,6 +222,9 @@ export interface WizardSession {
   /** Human-readable label for the detected framework variant (e.g., "Django with Wagtail CMS") */
   detectedFrameworkLabel: string | null;
 
+  /** A PostHog SDK appears in a project manifest (set by detect). Dependency-level signal, not a verified install */
+  posthogSdkDetected: boolean;
+
   /** True once framework detection has run (whether it found something or not) */
   detectionComplete: boolean;
 
@@ -405,6 +408,7 @@ export function buildSession(args: {
     frameworkContext: {},
     typescript: false,
     detectedFrameworkLabel: null,
+    posthogSdkDetected: false,
     detectionComplete: false,
     unsupportedVersion: null,
 

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -255,7 +255,7 @@ export interface WizardSession {
   /** Human-readable label for the detected framework variant (e.g., "Django with Wagtail CMS") */
   detectedFrameworkLabel: string | null;
 
-  /** A PostHog SDK appears in a project manifest (set by detect). Dependency-level signal, not a verified install */
+  /** Existing PostHog detected in the project (set during detect). Signal, not proof. Currently a dependency-level check */
   posthogSdkDetected: boolean;
 
   /** True once framework detection has run (whether it found something or not) */

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -255,6 +255,9 @@ export interface WizardSession {
   /** Human-readable label for the detected framework variant (e.g., "Django with Wagtail CMS") */
   detectedFrameworkLabel: string | null;
 
+  /** A PostHog SDK appears in a project manifest (set by detect). Dependency-level signal, not a verified install */
+  posthogSdkDetected: boolean;
+
   /** True once framework detection has run (whether it found something or not) */
   detectionComplete: boolean;
 
@@ -446,6 +449,7 @@ export function buildSession(args: {
     frameworkContext: {},
     typescript: false,
     detectedFrameworkLabel: null,
+    posthogSdkDetected: false,
     detectionComplete: false,
     unsupportedVersion: null,
 

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -222,7 +222,7 @@ export interface WizardSession {
   /** Human-readable label for the detected framework variant (e.g., "Django with Wagtail CMS") */
   detectedFrameworkLabel: string | null;
 
-  /** A PostHog SDK appears in a project manifest (set by detect). Dependency-level signal, not a verified install */
+  /** Existing PostHog detected in the project (set during detect). Signal, not proof. Currently a dependency-level check */
   posthogSdkDetected: boolean;
 
   /** True once framework detection has run (whether it found something or not) */

--- a/src/ui/tui/__tests__/posthog-integration-intro.test.ts
+++ b/src/ui/tui/__tests__/posthog-integration-intro.test.ts
@@ -1,17 +1,36 @@
 /**
- * Intro-screen copy decisions, extracted from PostHogIntegrationIntroScreen so
- * they can be asserted without a render — vitest aliases `ink` to no-op stubs
- * suite-wide (vitest.config.ts), so the screen itself draws nothing here.
+ * Intro-screen copy and menu decisions, extracted from
+ * PostHogIntegrationIntroScreen so they can be asserted without a render —
+ * vitest aliases `ink` to no-op stubs suite-wide (vitest.config.ts), so the
+ * screen itself draws nothing here.
  *
  * These assert the wiring, not the wording: which headline each detection state
- * resolves to. Copy edits land in one place and don't drag the test with them.
+ * resolves to, and what order the menu offers. Copy edits land in one place and
+ * don't drag the test with them — menu order is pinned on `value` (stable
+ * identifiers), and the only label asserted is the one that actually branches.
  */
 
 import {
+  CONTINUE_ANYWAY_LABEL,
+  CONTINUE_LABEL,
   DEFAULT_HEADLINE,
   DETECTED_HEADLINE,
   introHeadline,
+  introMenuOptions,
 } from '@ui/tui/posthog-integration-intro';
+
+const valuesFor = (args: {
+  view?: 'default' | 'more-info' | 'privacy' | 'commands';
+  showContinue?: boolean;
+  posthogSdkDetected?: boolean;
+}): string[] =>
+  (
+    introMenuOptions({
+      view: args.view ?? 'default',
+      showContinue: args.showContinue ?? true,
+      posthogSdkDetected: args.posthogSdkDetected ?? false,
+    }) ?? []
+  ).map((option) => option.value);
 
 describe('introHeadline', () => {
   it('leads with the detection when PostHog is already installed', () => {
@@ -26,5 +45,88 @@ describe('introHeadline', () => {
   // the two headlines ever collapse to the same string.
   it('resolves the two states to different copy', () => {
     expect(DETECTED_HEADLINE).not.toBe(DEFAULT_HEADLINE);
+  });
+});
+
+describe('introMenuOptions', () => {
+  describe('an install we already detected', () => {
+    // The ask: exploring the other commands outranks re-running an
+    // integration the project may not need.
+    it('offers the tricks before continuing', () => {
+      expect(valuesFor({ posthogSdkDetected: true })).toEqual([
+        'commands',
+        'continue',
+        'framework',
+        'more-info',
+        'cancel',
+      ]);
+    });
+
+    it('hedges the continue label', () => {
+      const options = introMenuOptions({
+        view: 'default',
+        showContinue: true,
+        posthogSdkDetected: true,
+      });
+      expect(options?.find((o) => o.value === 'continue')?.label).toBe(
+        CONTINUE_ANYWAY_LABEL,
+      );
+    });
+  });
+
+  describe('a clean project', () => {
+    it('is untouched by any of this', () => {
+      expect(valuesFor({ posthogSdkDetected: false })).toEqual([
+        'continue',
+        'framework',
+        'more-info',
+        'cancel',
+      ]);
+    });
+
+    it('continues without the hedge', () => {
+      const options = introMenuOptions({
+        view: 'default',
+        showContinue: true,
+        posthogSdkDetected: false,
+      });
+      expect(options?.find((o) => o.value === 'continue')?.label).toBe(
+        CONTINUE_LABEL,
+      );
+    });
+  });
+
+  // Same reasoning as the headline pair: with neither side a literal, both
+  // label assertions pass vacuously if the two ever collapse.
+  it('distinguishes the two continue labels', () => {
+    expect(CONTINUE_ANYWAY_LABEL).not.toBe(CONTINUE_LABEL);
+  });
+
+  describe('the sub-views', () => {
+    it('gives the tricks view a way back', () => {
+      expect(valuesFor({ view: 'commands', posthogSdkDetected: true })).toEqual(
+        ['back'],
+      );
+    });
+
+    it('gives the privacy view a way back', () => {
+      expect(valuesFor({ view: 'privacy' })).toEqual(['back']);
+    });
+
+    it('reaches privacy from more info', () => {
+      expect(valuesFor({ view: 'more-info' })).toEqual(['back', 'privacy']);
+    });
+  });
+
+  // Detecting, picking a framework, and the unsupported-version prompt all
+  // clear showContinue — the screen owns the interaction, so no menu renders.
+  it('renders no menu when there is nothing to continue to', () => {
+    expect(
+      introMenuOptions({
+        view: 'default',
+        showContinue: false,
+        posthogSdkDetected: true,
+      }),
+    ).toBeNull();
   });
 });

--- a/src/ui/tui/__tests__/posthog-integration-intro.test.ts
+++ b/src/ui/tui/__tests__/posthog-integration-intro.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Intro-screen copy decisions, extracted from PostHogIntegrationIntroScreen so
+ * they can be asserted without a render — vitest aliases `ink` to no-op stubs
+ * suite-wide (vitest.config.ts), so the screen itself draws nothing here.
+ *
+ * These assert the wiring, not the wording: which headline each detection state
+ * resolves to. Copy edits land in one place and don't drag the test with them.
+ */
+
+import {
+  DEFAULT_HEADLINE,
+  DETECTED_HEADLINE,
+  introHeadline,
+} from '@ui/tui/posthog-integration-intro';
+
+describe('introHeadline', () => {
+  it('leads with the detection when PostHog is already installed', () => {
+    expect(introHeadline(true)).toBe(DETECTED_HEADLINE);
+  });
+
+  it('keeps the default headline for a clean project', () => {
+    expect(introHeadline(false)).toBe(DEFAULT_HEADLINE);
+  });
+
+  // Without literals on either side, both assertions above pass vacuously if
+  // the two headlines ever collapse to the same string.
+  it('resolves the two states to different copy', () => {
+    expect(DETECTED_HEADLINE).not.toBe(DEFAULT_HEADLINE);
+  });
+});

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -18,6 +18,7 @@ import { buildSession } from '@lib/wizard-session';
 import { HostResolution } from '@lib/host-resolution';
 import { Integration } from '@lib/constants';
 import { analytics } from '@utils/analytics';
+import { getProgramConfig } from '@lib/programs/program-registry';
 
 vi.mock('../../../utils/analytics.js', () => ({
   analytics: {
@@ -92,6 +93,93 @@ describe('WizardStore', () => {
       const store = createStore();
       expect(store.getVersion()).toBe(0);
       expect(store.getSnapshot()).toBe(0);
+    });
+
+    // Picking one of the wizard's other commands from the intro runs it in
+    // this session instead of making the user quit and type it. Nothing has
+    // happened yet at that point — no auth, no agent, no files touched — so
+    // the switch only has to repoint the router and start the new program's
+    // journey from its own first screen.
+    describe('switchProgram', () => {
+      it('makes the chosen program the active one', () => {
+        const store = createStore();
+        store.switchProgram(Program.Metrics);
+        expect(store.router.activeProgram).toBe(Program.Metrics);
+      });
+
+      it('routes to the new program instead of finishing the old one', () => {
+        const store = createStore();
+        store.switchProgram(Program.Metrics);
+        expect(store.router.resolve(store.session)).toBe(ScreenId.MetricsIntro);
+      });
+
+      // The old intro is behind us, but every program gates its intro on the
+      // same `setupConfirmed` flag — leaving it set marks the new program's
+      // intro complete before the user has seen it.
+      it('does not carry the old confirmation into the new intro', () => {
+        const store = createStore();
+        store.completeSetup();
+        expect(store.session.setupConfirmed).toBe(true);
+
+        store.switchProgram(Program.Metrics);
+
+        expect(store.session.setupConfirmed).toBe(false);
+        expect(store.router.resolve(store.session)).toBe(ScreenId.MetricsIntro);
+      });
+
+      // bin.ts parks on these gates. They resolved for the program we left, so
+      // reusing them would run the new program past its own screens.
+      it('reopens the gates for the new program', async () => {
+        const store = createStore();
+        const before = store.getGate('intro');
+        store.completeSetup();
+        await expect(before).resolves.toBeUndefined();
+
+        store.switchProgram(Program.Metrics);
+
+        const after = store.getGate('intro');
+        expect(after).not.toBe(before);
+        await expect(
+          Promise.race([after, Promise.resolve('pending')]),
+        ).resolves.toBe('pending');
+      });
+
+      // The runner is parked on the old program's intro gate at the moment of
+      // the switch. Dropping that promise without resolving it strands the
+      // runner — no error, no new program, just a wizard that stops.
+      it('releases callers parked on the old gates', async () => {
+        const store = createStore();
+        const parked = store.getGate('intro');
+
+        store.switchProgram(Program.Metrics);
+
+        await expect(parked).resolves.toBeUndefined();
+      });
+
+      it('reports screens under the new program', () => {
+        const store = createStore();
+        store.switchProgram(Program.Metrics);
+        expect(store.analyticsProgramId).toBe(Program.Metrics);
+      });
+
+      it('follows the new program for label and skill', () => {
+        const store = createStore();
+        store.switchProgram(Program.Metrics);
+        expect(store.session.programLabel).toBe(Program.Metrics);
+        expect(store.session.skillId).toBe(
+          getProgramConfig(Program.Metrics).skillId ?? null,
+        );
+      });
+
+      // Selecting the program already running should cost the user nothing —
+      // in particular it must not throw away a confirmation they just gave.
+      it('leaves the session alone when the program is unchanged', () => {
+        const store = createStore();
+        store.completeSetup();
+        store.switchProgram(Program.PostHogIntegration);
+        expect(store.session.setupConfirmed).toBe(true);
+        expect(store.router.activeProgram).toBe(Program.PostHogIntegration);
+      });
     });
   });
 

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -215,6 +215,13 @@ describe('WizardStore', () => {
       expect(store.session.detectionComplete).toBe(true);
     });
 
+    it('setPosthogSdkDetected stores the verdict', () => {
+      const store = createStore();
+      expect(store.session.posthogSdkDetected).toBe(false);
+      store.setPosthogSdkDetected(true);
+      expect(store.session.posthogSdkDetected).toBe(true);
+    });
+
     it('setDetectedFramework sets the label', () => {
       const store = createStore();
       store.setDetectedFramework('Django');

--- a/src/ui/tui/posthog-integration-intro.ts
+++ b/src/ui/tui/posthog-integration-intro.ts
@@ -1,7 +1,50 @@
+export type IntroMenuView = 'default' | 'more-info' | 'privacy' | 'commands';
+
+export const CONTINUE_LABEL = 'Continue';
+export const CONTINUE_ANYWAY_LABEL = 'Continue anyway';
+
 export const DEFAULT_HEADLINE = "Let's do two hours of work in eight minutes.";
 export const DETECTED_HEADLINE =
   'Looks like you already have PostHog installed.';
 
 export function introHeadline(posthogSdkDetected: boolean): string {
   return posthogSdkDetected ? DETECTED_HEADLINE : DEFAULT_HEADLINE;
+}
+
+export function introMenuOptions({
+  view,
+  showContinue,
+  posthogSdkDetected,
+}: {
+  view: IntroMenuView;
+  showContinue: boolean;
+  posthogSdkDetected: boolean;
+}): { label: string; value: string }[] | null {
+  if (view === 'more-info') {
+    return [
+      { label: 'Back', value: 'back' },
+      { label: 'Privacy & data usage', value: 'privacy' },
+    ];
+  }
+
+  if (view === 'privacy' || view === 'commands') {
+    return [{ label: 'Back', value: 'back' }];
+  }
+
+  if (showContinue) {
+    return [
+      ...(posthogSdkDetected
+        ? [{ label: 'Explore wizard tricks', value: 'commands' }]
+        : []),
+      {
+        label: posthogSdkDetected ? CONTINUE_ANYWAY_LABEL : CONTINUE_LABEL,
+        value: 'continue',
+      },
+      { label: 'Change framework', value: 'framework' },
+      { label: 'More info', value: 'more-info' },
+      { label: 'Cancel', value: 'cancel' },
+    ];
+  }
+
+  return null;
 }

--- a/src/ui/tui/posthog-integration-intro.ts
+++ b/src/ui/tui/posthog-integration-intro.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_HEADLINE = "Let's do two hours of work in eight minutes.";
+export const DETECTED_HEADLINE =
+  'Looks like you already have PostHog installed.';
+
+export function introHeadline(posthogSdkDetected: boolean): string {
+  return posthogSdkDetected ? DETECTED_HEADLINE : DEFAULT_HEADLINE;
+}

--- a/src/ui/tui/router.ts
+++ b/src/ui/tui/router.ts
@@ -50,8 +50,14 @@ export class WizardRouter {
   private overlays: Overlay[] = [];
 
   constructor(programId: ProgramId = Program.PostHogIntegration) {
+    this.setProgram(programId);
+  }
+
+  /** Point the router at a different program. */
+  setProgram(programId: ProgramId): void {
     this.programId = programId;
     this.sequence = PROGRAM_SEQUENCES[programId];
+    this.overlays = [];
   }
 
   /**

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -14,8 +14,8 @@ import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { Integration } from '@lib/constants';
 import {
-  getSubcommandPrograms,
   getCommandPath,
+  getLaunchablePrograms,
 } from '@lib/programs/program-registry';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
@@ -167,24 +167,17 @@ export const PostHogIntegrationIntroScreen = ({
     );
   } else if (view === 'commands') {
     body = (
-      <Box flexDirection="column" width={64} flexShrink={0}>
-        <Text>The wizard can do more than integrate with your project:</Text>
-        <Box flexDirection="column" marginTop={1}>
-          {getSubcommandPrograms().map((program) => (
-            <Box key={getCommandPath(program)}>
-              <Box width={22} flexShrink={0}>
-                <Text color="cyan">{getCommandPath(program)}</Text>
-              </Box>
-              <Text dimColor>{program.description}</Text>
-            </Box>
-          ))}
-        </Box>
-        <Box marginTop={1}>
-          <Text dimColor>
-            Run any of these later: npx @posthog/wizard {'<command>'}
-          </Text>
-        </Box>
-      </Box>
+      <PickerMenu
+        message="The wizard can do more than integrate with your project:"
+        options={getLaunchablePrograms().map((program) => ({
+          label: `${getCommandPath(program).padEnd(21)}${program.description}`,
+          value: program.id,
+        }))}
+        onSelect={(value) => {
+          const id = Array.isArray(value) ? value[0] : value;
+          store.switchProgram(id);
+        }}
+      />
     );
   } else if (view === 'privacy') {
     body = <PrivacyPanel />;

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -15,13 +15,15 @@ import type { WizardStore } from '@ui/tui/store';
 import { Integration } from '@lib/constants';
 import { getSubcommandPrograms } from '@lib/programs/program-registry';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
-import { introHeadline } from '@ui/tui/posthog-integration-intro';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
 import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
 import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
 import { analytics } from '@utils/analytics';
-
-type View = 'default' | 'more-info' | 'privacy' | 'commands';
+import type { IntroMenuView } from '@ui/tui/posthog-integration-intro';
+import {
+  introHeadline,
+  introMenuOptions,
+} from '@ui/tui/posthog-integration-intro';
 
 /** Framework picker shown when auto-detection fails. */
 const FrameworkPicker = ({
@@ -69,7 +71,7 @@ export const PostHogIntegrationIntroScreen = ({
 
   const [pickingFramework, setPickingFramework] = useState(false);
   const [manuallySelected, setManuallySelected] = useState(false);
-  const [view, setView] = useState<View>('default');
+  const [view, setView] = useState<IntroMenuView>('default');
 
   const { session } = store;
   const config = session.frameworkConfig;
@@ -257,29 +259,11 @@ export const PostHogIntegrationIntroScreen = ({
 
   // ── Menu ───────────────────────────────────────────────────────────
 
-  let menuOptions: { label: string; value: string }[] | null = null;
-
-  if (view === 'more-info') {
-    menuOptions = [
-      { label: 'Back', value: 'back' },
-      { label: 'Privacy & data usage', value: 'privacy' },
-    ];
-  } else if (view === 'privacy' || view === 'commands') {
-    menuOptions = [{ label: 'Back', value: 'back' }];
-  } else if (showContinue) {
-    const continueLabel = session.posthogSdkDetected
-      ? 'Continue anyway'
-      : 'Continue';
-    menuOptions = [
-      { label: continueLabel, value: 'continue' },
-      { label: 'Change framework', value: 'framework' },
-      { label: 'More info', value: 'more-info' },
-      ...(session.posthogSdkDetected
-        ? [{ label: 'Other wizard tricks', value: 'commands' }]
-        : []),
-      { label: 'Cancel', value: 'cancel' },
-    ];
-  }
+  const menuOptions = introMenuOptions({
+    view,
+    showContinue,
+    posthogSdkDetected: session.posthogSdkDetected,
+  });
 
   const handleSelect = (value: string) => {
     analytics.wizardCapture('intro menu selected', { value, view });

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -13,7 +13,10 @@ import type { ReactNode } from 'react';
 import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { Integration } from '@lib/constants';
-import { getSubcommandPrograms } from '@lib/programs/program-registry';
+import {
+  getSubcommandPrograms,
+  getCommandPath,
+} from '@lib/programs/program-registry';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
 import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
@@ -168,9 +171,9 @@ export const PostHogIntegrationIntroScreen = ({
         <Text>The wizard can do more than integrate with your project:</Text>
         <Box flexDirection="column" marginTop={1}>
           {getSubcommandPrograms().map((program) => (
-            <Box key={program.command}>
+            <Box key={getCommandPath(program)}>
               <Box width={22} flexShrink={0}>
-                <Text color="cyan">{program.command}</Text>
+                <Text color="cyan">{getCommandPath(program)}</Text>
               </Box>
               <Text dimColor>{program.description}</Text>
             </Box>

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -190,6 +190,13 @@ export const PostHogIntegrationIntroScreen = ({
     });
   }
 
+  if (session.posthogSdkDetected) {
+    detectionRows.push({
+      label: 'PostHog',
+      value: 'detected in package.json',
+    });
+  }
+
   // ── Children (between rows and menu) ───────────────────────────────
 
   let bodyChildren: ReactNode = null;
@@ -242,8 +249,11 @@ export const PostHogIntegrationIntroScreen = ({
   } else if (view === 'privacy') {
     menuOptions = [{ label: 'Back', value: 'back' }];
   } else if (showContinue) {
+    const continueLabel = session.posthogSdkDetected
+      ? 'Continue anyway'
+      : 'Continue';
     menuOptions = [
-      { label: 'Continue', value: 'continue' },
+      { label: continueLabel, value: 'continue' },
       { label: 'Change framework', value: 'framework' },
       { label: 'More info', value: 'more-info' },
       { label: 'Cancel', value: 'cancel' },

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -13,13 +13,14 @@ import type { ReactNode } from 'react';
 import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { Integration } from '@lib/constants';
+import { getSubcommandPrograms } from '@lib/programs/program-registry';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
 import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
 import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
 import { analytics } from '@utils/analytics';
 
-type View = 'default' | 'more-info' | 'privacy';
+type View = 'default' | 'more-info' | 'privacy' | 'commands';
 
 /** Framework picker shown when auto-detection fails. */
 const FrameworkPicker = ({
@@ -161,6 +162,27 @@ export const PostHogIntegrationIntroScreen = ({
         </Box>
       </Box>
     );
+  } else if (view === 'commands') {
+    body = (
+      <Box flexDirection="column" width={64} flexShrink={0}>
+        <Text>The wizard can do more than integrate with your project:</Text>
+        <Box flexDirection="column" marginTop={1}>
+          {getSubcommandPrograms().map((program) => (
+            <Box key={program.command}>
+              <Box width={22} flexShrink={0}>
+                <Text color="cyan">{program.command}</Text>
+              </Box>
+              <Text dimColor>{program.description}</Text>
+            </Box>
+          ))}
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>
+            Run any of these later: npx @posthog/wizard {'<command>'}
+          </Text>
+        </Box>
+      </Box>
+    );
   } else if (view === 'privacy') {
     body = <PrivacyPanel />;
   } else if (showContinue) {
@@ -246,7 +268,7 @@ export const PostHogIntegrationIntroScreen = ({
       { label: 'Back', value: 'back' },
       { label: 'Privacy & data usage', value: 'privacy' },
     ];
-  } else if (view === 'privacy') {
+  } else if (view === 'privacy' || view === 'commands') {
     menuOptions = [{ label: 'Back', value: 'back' }];
   } else if (showContinue) {
     const continueLabel = session.posthogSdkDetected
@@ -256,6 +278,9 @@ export const PostHogIntegrationIntroScreen = ({
       { label: continueLabel, value: 'continue' },
       { label: 'Change framework', value: 'framework' },
       { label: 'More info', value: 'more-info' },
+      ...(session.posthogSdkDetected
+        ? [{ label: 'Other wizard tricks', value: 'commands' }]
+        : []),
       { label: 'Cancel', value: 'cancel' },
     ];
   }
@@ -269,6 +294,8 @@ export const PostHogIntegrationIntroScreen = ({
       setManuallySelected(true);
     } else if (value === 'more-info') {
       setView('more-info');
+    } else if (value === 'commands') {
+      setView('commands');
     } else if (value === 'privacy') {
       setView('privacy');
     } else if (value === 'back') {

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -187,6 +187,13 @@ export const PostHogIntegrationIntroScreen = ({
     });
   }
 
+  if (session.posthogSdkDetected) {
+    detectionRows.push({
+      label: 'PostHog',
+      value: 'detected in package.json',
+    });
+  }
+
   // ── Children (between rows and menu) ───────────────────────────────
 
   let bodyChildren: ReactNode = null;
@@ -239,8 +246,11 @@ export const PostHogIntegrationIntroScreen = ({
   } else if (view === 'privacy') {
     menuOptions = [{ label: 'Back', value: 'back' }];
   } else if (showContinue) {
+    const continueLabel = session.posthogSdkDetected
+      ? 'Continue anyway'
+      : 'Continue';
     menuOptions = [
-      { label: 'Continue', value: 'continue' },
+      { label: continueLabel, value: 'continue' },
       { label: 'Change framework', value: 'framework' },
       { label: 'More info', value: 'more-info' },
       { label: 'Cancel', value: 'cancel' },

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -15,6 +15,7 @@ import type { WizardStore } from '@ui/tui/store';
 import { Integration } from '@lib/constants';
 import { getSubcommandPrograms } from '@lib/programs/program-registry';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
+import { introHeadline } from '@ui/tui/posthog-integration-intro';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
 import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
 import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
@@ -184,11 +185,9 @@ export const PostHogIntegrationIntroScreen = ({
     body = <PrivacyPanel />;
   } else if (showContinue) {
     body = (
-      <>
-        <Box>
-          <Text>Let's do two hours of work in eight minutes.</Text>
-        </Box>
-      </>
+      <Box>
+        <Text>{introHeadline(session.posthogSdkDetected)}</Text>
+      </Box>
     );
   }
 

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -13,13 +13,14 @@ import type { ReactNode } from 'react';
 import { useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import { Integration } from '@lib/constants';
+import { getSubcommandPrograms } from '@lib/programs/program-registry';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { IntroScreenLayout, type DetectionRow } from './IntroScreenLayout.js';
 import { SkillSourceInfo, useSkillEntry } from './SkillSourceInfo.js';
 import { PrivacyPanel } from '@ui/tui/components/PrivacyPanel';
 import { analytics } from '@utils/analytics';
 
-type View = 'default' | 'more-info' | 'privacy';
+type View = 'default' | 'more-info' | 'privacy' | 'commands';
 
 /** Framework picker shown when auto-detection fails. */
 const FrameworkPicker = ({
@@ -158,6 +159,27 @@ export const PostHogIntegrationIntroScreen = ({
         </Box>
       </Box>
     );
+  } else if (view === 'commands') {
+    body = (
+      <Box flexDirection="column" width={64} flexShrink={0}>
+        <Text>The wizard can do more than integrate with your project:</Text>
+        <Box flexDirection="column" marginTop={1}>
+          {getSubcommandPrograms().map((program) => (
+            <Box key={program.command}>
+              <Box width={22} flexShrink={0}>
+                <Text color="cyan">{program.command}</Text>
+              </Box>
+              <Text dimColor>{program.description}</Text>
+            </Box>
+          ))}
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>
+            Run any of these later: npx @posthog/wizard {'<command>'}
+          </Text>
+        </Box>
+      </Box>
+    );
   } else if (view === 'privacy') {
     body = <PrivacyPanel />;
   } else if (showContinue) {
@@ -243,7 +265,7 @@ export const PostHogIntegrationIntroScreen = ({
       { label: 'Back', value: 'back' },
       { label: 'Privacy & data usage', value: 'privacy' },
     ];
-  } else if (view === 'privacy') {
+  } else if (view === 'privacy' || view === 'commands') {
     menuOptions = [{ label: 'Back', value: 'back' }];
   } else if (showContinue) {
     const continueLabel = session.posthogSdkDetected
@@ -253,6 +275,9 @@ export const PostHogIntegrationIntroScreen = ({
       { label: continueLabel, value: 'continue' },
       { label: 'Change framework', value: 'framework' },
       { label: 'More info', value: 'more-info' },
+      ...(session.posthogSdkDetected
+        ? [{ label: 'Other wizard tricks', value: 'commands' }]
+        : []),
       { label: 'Cancel', value: 'cancel' },
     ];
   }
@@ -266,6 +291,8 @@ export const PostHogIntegrationIntroScreen = ({
       setManuallySelected(true);
     } else if (value === 'more-info') {
       setView('more-info');
+    } else if (value === 'commands') {
+      setView('commands');
     } else if (value === 'privacy') {
       setView('privacy');
     } else if (value === 'back') {

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -875,6 +875,23 @@ export class WizardStore {
     this.emitChange();
   }
 
+  switchProgram(program: ProgramId): void {
+    if (program === this.router.activeProgram) return;
+
+    // Flush unresolved promises so the wizard can advance
+    for (const gate of this._gates.values()) gate.resolve();
+    this._gates.clear();
+
+    this.router.setProgram(program);
+    this._initFromProgram(program);
+
+    const config = getProgramConfig(program);
+    this.$session.setKey('setupConfirmed', false);
+    this.$session.setKey('programLabel', config.id);
+    this.$session.setKey('skillId', config.skillId ?? null);
+    this.emitChange();
+  }
+
   // ── Derived state ───────────────────────────────────────────────
 
   /**

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -301,6 +301,7 @@ export class WizardStore {
       setFrameworkContext: (k, v) => this.setFrameworkContext(k, v),
       setFrameworkConfig: (i, c) => this.setFrameworkConfig(i, c),
       setDetectedFramework: (l) => this.setDetectedFramework(l),
+      setPosthogSdkDetected: (d) => this.setPosthogSdkDetected(d),
       setSkillId: (id) => this.setSkillId(id),
       setUnsupportedVersion: (info) => this.setUnsupportedVersion(info),
       addDiscoveredFeature: (f) => this.addDiscoveredFeature(f),
@@ -481,6 +482,11 @@ export class WizardStore {
   setDetectedFramework(label: string): void {
     this.$session.setKey('detectedFrameworkLabel', label);
     analytics.setTag('detected_framework', label);
+    this.emitChange();
+  }
+
+  setPosthogSdkDetected(detected: boolean): void {
+    this.$session.setKey('posthogSdkDetected', detected);
     this.emitChange();
   }
 

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -298,6 +298,7 @@ export class WizardStore {
       setFrameworkContext: (k, v) => this.setFrameworkContext(k, v),
       setFrameworkConfig: (i, c) => this.setFrameworkConfig(i, c),
       setDetectedFramework: (l) => this.setDetectedFramework(l),
+      setPosthogSdkDetected: (d) => this.setPosthogSdkDetected(d),
       setSkillId: (id) => this.setSkillId(id),
       setUnsupportedVersion: (info) => this.setUnsupportedVersion(info),
       addDiscoveredFeature: (f) => this.addDiscoveredFeature(f),
@@ -478,6 +479,11 @@ export class WizardStore {
   setDetectedFramework(label: string): void {
     this.$session.setKey('detectedFrameworkLabel', label);
     analytics.setTag('detected_framework', label);
+    this.emitChange();
+  }
+
+  setPosthogSdkDetected(detected: boolean): void {
+    this.$session.setKey('posthogSdkDetected', detected);
     this.emitChange();
   }
 

--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -1,4 +1,5 @@
-import { Analytics, groupsFromUser } from '@utils/analytics';
+import { Analytics, groupsFromUser, sessionProperties } from '@utils/analytics';
+import { buildSession } from '@lib/wizard-session';
 import { PostHog } from 'posthog-node';
 import { v4 as uuidv4 } from 'uuid';
 import { ANALYTICS_TEAM_TAG, WIZARD_FLAG_KEYS } from '@lib/constants';
@@ -629,6 +630,16 @@ describe('Analytics', () => {
       const beforeSend = getBeforeSend();
 
       expect(beforeSend(null)).toBeNull();
+    });
+  });
+
+  describe('sessionProperties', () => {
+    it('includes the posthog_sdk_detected verdict', () => {
+      const session = buildSession({});
+      expect(sessionProperties(session).posthog_sdk_detected).toBe(false);
+
+      session.posthogSdkDetected = true;
+      expect(sessionProperties(session).posthog_sdk_detected).toBe(true);
     });
   });
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -46,6 +46,7 @@ export function sessionProperties(
     discovered_features: session.discoveredFeatures,
     additional_features: session.additionalFeatureQueue,
     run_phase: session.runPhase,
+    posthog_sdk_detected: session.posthogSdkDetected,
   };
 }
 


### PR DESCRIPTION
## Problem

If you run the wizard on a project that already has PostHog you need to walk through the full integration flow again. The original issue quotes a user who bailed out of fear it would overwrite their setup. I also ran into this issue and fortunately, in my testing re-runs mostly don't do anything (destructive or otherwise). No-op still takes ~8 minutes due to auth, skill installation, and running of the agent. Adjacent problem is that the additional wizard tools (or "tricks") aren't made apparent to the user, first run or subsequent runs.

Part of #616.

## Changes

**Detection**

- Detection step scans `package.json` files for PostHog SDK using the existing `findPackageJsons()` (same helper revenue-analytics detection uses, monorepo-aware) and sets `session.posthogSdkDetected`
- `posthog_sdk_detected` added to the standard session properties so existing events can be filtered by it

**Intro**

- Intro leads with `Looks like you already have PostHog installed.` when detected; clean projects keep the "two hours in eight minutes" tagline. The `PostHog ✔ detected in package.json` row sits below the framework line as supporting evidence
- "Explore wizard tricks" is the **first** option when PostHog is detected, ahead of "Continue anyway" (label borrowed from the health-check view) — exploring the other commands outranks re-running an integration the project may not need. Either way the continue path still routes into the normal (full) flow
- Headline and menu construction moved to an ink-free `src/ui/tui/posthog-integration-intro.ts` so both can be asserted in vitest, which stubs `ink` suite-wide

**The tricks list was advertising commands that don't exist**

Turns out `getSubcommandPrograms()` had no consumer before this PR, so nobody noticed it had drifted. It filters on "declares a `command` field," which isn't the same as "the CLI registers this command":

- `integrate` became the default `$0` flow but kept its field
- `events-audit` moved to `audit events` but kept its field
- `web-analytics` rendered without the `audit` parent it's actually reached through

Fixed by deleting the two dead fields and adding `getCommandPath()` to join the parent. There *was* a test covering this — it asserted the registry agreed with itself, which is exactly how the drift survived. Replaced with one that checks the registry against what `bin.ts` actually registers.

That guard needed the command list in a place both `bin.ts` and a test could read, so the 16-call `.use()` chain became `ALL_COMMANDS` in `src/commands/index.ts` and `bin.ts` collapsed to `Wizard.use(...ALL_COMMANDS).init()`. Same pattern as `PROGRAM_REGISTRY`, applied to the one list that didn't have it. `AGENTS.md` updated to match. `--help` output is byte-identical before and after.

**Picking a trick now runs it**

Selecting one switches this session to that program instead of printing a command to run later:

- `WizardRouter.setProgram()` repoints the sequence
- `WizardStore.switchProgram()` releases and rebuilds the gates, resets `setupConfirmed` so the new program's intro isn't skipped, and follows the new program for `programLabel` / `skillId`
- `runWizard` loops over the intro gate and re-resolves `config` when the active program changed while it was parked there

The switch only lands at the intro, which is what keeps it small — no auth yet, no agent, no files touched, so there's nothing to unwind. After the chosen program finishes, the wizard exits normally rather than returning here.

Regarding the weak signal: the notes on the issue call out that a dependency isn't proof of a working install (agreed :100:) which is why nothing gates or routes on this. A false positive costs a slightly more cautious button label. Init and/or env-key checks or post-auth server-side signals can tighten it further before anything ever routes on the flag.

I left the intro's tagline untouched for clean projects primarily because I couldn't come up with anything that had enough "WOW" as the "2 hours in 8 minutes" line (srsly, so good).

<img width="912" height="740" alt="image" src="https://github.com/user-attachments/assets/b9798de8-2ed5-410b-9a61-d909f625d872" />

<img width="912" height="740" alt="image" src="https://github.com/user-attachments/assets/b8166f79-e193-44eb-9b4c-393f7bb01ae9" />

<img width="912" height="740" alt="image" src="https://github.com/user-attachments/assets/7c6bb708-1b30-42ea-95b8-4de3ff98fe5c" />

## Deliberately left out

**`wizard audit` doesn't appear in the picker.** It's a family parent — typing it opens a runtime picker fed by context-mill's skill menu rather than running anything, so there's nothing to hand off to. Wiring that up means a network fetch and a second picker inside a screen that currently does neither, which felt like its own PR. `audit web-analytics` is in the list and works. The exclusion is derived from who claims whom as a parent, so the next family drops out on its own instead of waiting for someone to remember.

## Noticed, not touched

- **`eventsAuditConfig` is unreachable.** `audit events` resolves through `configForCliEntry`, which returns the generic `agentSkillConfig` with the skill id injected — only `audit all` gets a specialized config. So that program's steps, seed ledger, and report wiring can't run. Looks intentional given the comment on `configForCliEntry`, but worth confirming
- **`ProgramId` isn't actually a union.** Every config is annotated `: ProgramConfig`, which widens `id` to `string`, so the "compile-time union of every registered program id" comment doesn't hold. Nothing here depends on it, but it means program ids aren't checked
- **A switched run reports under the program it started in.** The task stream is constructed with `programId` before the intro gate. Rebuilding it mid-run risks double-attach and dropped events, which seemed worse than a slightly-off label
- **Detection is package.json-only**, so Django/Laravel/Swift/Go/Rust/Java/Elixir projects always report false. Multi-ecosystem detection already exists in `error-tracking-upload-source-maps/detect-agentic.ts` if we ever want to tighten it

## Test plan

- Contract test, written red-first, for `detectExistingPostHog`. Covers 6 cases: no `package.json`, `dependencies` without PostHog SDK, `dependencies`, `devDependencies`, nested monorepo packages, invalid installation directory (shouldn't `throw`)
- Store setter test alongside the existing session-setter tests with a `sessionProperties` test pinning the new property
- Headline and menu-order tests. Order is pinned on each option's `value` rather than its label, so copy edits don't drag the test along; the only label asserted is the continue one, which branches on the detection
- Drift guard asserting every advertised command is one `bin.ts` registers, reading the same `ALL_COMMANDS` array that registers them so the test can't fall out of sync with reality
- Program-switch tests covering what the switch leaves behind: the intro confirmation must not carry over, and the gates the runner parks on must both reopen *and* release whoever is already waiting — a dropped gate promise strands the runner with no error, which reads as the wizard simply stopping
- Every test above was written red first and committed separately from the code that turns it green
- `pnpm test && pnpm fix` clean — 2050 tests, 143 files
- Live runs via `pnpm try` against a clean project and one with PostHog already installed. Clean project renders identically to `main`. Nothing gates on the detection flag, so `--ci`/headless usage is unaffected

## LLM context

Friendly robots, specifically Claude Code, were utilized to help me better understand an unfamiliar codebase. Tests were generated (with my direction) with attribution on those commits. Code changes were guided, but handcrafted to help knock some ring rust off (mostly, as I think Claude committed one of my changes when I wasn't looking 👀 ). All verification runs were done by a human. Robots also played janitor and helped me identify typos.
