### PR TITLE
fix(detection): make agentic project classification reliable

### DIFF
--- a/src/lib/detection/__tests__/agentic.test.ts
+++ b/src/lib/detection/__tests__/agentic.test.ts
@@ -1,5 +1,6 @@
 import {
   coerceAgenticReport,
+  deriveReportJson,
   manifestGlob,
   resolveProjectDir,
 } from '@lib/detection/agentic';
@@ -107,6 +108,104 @@ describe('coerceAgenticReport', () => {
     expect(keep('apps/web')).toBe('apps/web');
     expect(keep('.')).toBe('.');
     expect(keep('ios')).toBe('ios');
+  });
+});
+
+describe('deriveReportJson', () => {
+  const verdict = (path: string, targetId: string) =>
+    `{"path":"${path}","framework":"Node.js","targetId":"${targetId}","hasPostHog":true}`;
+
+  it('merges verdict lines and a one-line assembly, later entries winning', () => {
+    // Every parseable line contributes: the pretty block parses on no line,
+    // the compact assembly's projects merge like verdicts, later wins.
+    const text = [
+      verdict('backend-1', 'node'),
+      verdict('backend-2', 'vite'),
+      '```json',
+      '{\n  "repoType": "monorepo",\n  "projects": []\n}',
+      '```',
+      '{"repoType":"monorepo","projects":[{"path":"backend-2","targetId":"rollup","hasPostHog":true}]}',
+    ].join('\n');
+
+    const parsed = deriveReportJson(text) as {
+      repoType: string;
+      projects: { path: string; targetId: string }[];
+    };
+    expect(parsed.repoType).toBe('monorepo');
+    expect(parsed.projects.map((p) => [p.path, p.targetId])).toEqual([
+      ['backend-1', 'node'],
+      ['backend-2', 'rollup'],
+    ]);
+  });
+
+  it('rebuilds the report from verdict lines when the assembly never arrived', () => {
+    // The model sometimes narrates the assembly as prose; verdict lines are
+    // the data. Shape echoes skip; repeated paths dedupe, last wins.
+    const text = [
+      'The shape is {"path":string}.',
+      verdict('backend-1', 'vite'),
+      verdict('backend-1', 'node'),
+      verdict('backend-2', 'rollup'),
+      '**Summary**: both projects classified.',
+    ].join('\n');
+
+    const parsed = deriveReportJson(text) as {
+      repoType: string;
+      projects: { path: string; targetId: string }[];
+    };
+    expect(parsed.repoType).toBe('monorepo');
+    expect(parsed.projects.map((p) => [p.path, p.targetId])).toEqual([
+      ['backend-1', 'node'],
+      ['backend-2', 'rollup'],
+    ]);
+  });
+
+  it('returns null when the text carries no usable objects', () => {
+    expect(deriveReportJson('no report here')).toBeNull();
+    expect(deriveReportJson('almost {"broken": json}')).toBeNull();
+  });
+});
+
+describe('coerceAgenticReport matchingTargets', () => {
+  const project = (
+    extra: Record<string, unknown>,
+    rerankIds?: readonly string[],
+  ) =>
+    coerceAgenticReport({ projects: [{ path: '.', ...extra }] }, TARGETS, {
+      rerankIds,
+    }).projects[0];
+
+  it('re-ranks a valid pick only among rerankIds', () => {
+    // Misordered honest enumeration: within the rerank set the priority
+    // winner replaces the pick (TARGETS ranks node above vite)...
+    expect(
+      project({ matchingTargets: ['vite', 'node'], targetId: 'vite' }, [
+        'node',
+        'vite',
+      ]).targetId,
+    ).toBe('node');
+    // ...but a winner outside the set never beats a valid pick — enumerations
+    // get padded across exclusive stacks (a Flutter app listing react-native).
+    expect(
+      project({ matchingTargets: ['nextjs', 'vite'], targetId: 'vite' }, [
+        'vite',
+      ]).targetId,
+    ).toBe('vite');
+    expect(
+      project({ matchingTargets: ['vite', 'node'], targetId: 'vite' }).targetId,
+    ).toBe('vite');
+  });
+
+  it('falls back to the highest-priority enumerated id when the pick is unusable', () => {
+    // TARGETS is the priority order; unknown ids are skipped.
+    expect(
+      project({ matchingTargets: ['rocket', 'vite', 'node'], targetId: null })
+        .targetId,
+    ).toBe('node');
+    expect(
+      project({ matchingTargets: ['vite'], targetId: 'rocket' }).targetId,
+    ).toBe('vite');
+    expect(project({ matchingTargets: ['rocket'] }).targetId).toBeNull();
   });
 });
 

--- a/src/lib/detection/agentic.ts
+++ b/src/lib/detection/agentic.ts
@@ -112,6 +112,12 @@ export type AgenticDetectOptions = {
   purpose?: string;
   /** Ask the agent to label exactly one project `recommended` (the main client app). Off by default. */
   recommend?: boolean;
+  /**
+   * Target ids whose technologies co-occur in one manifest (e.g. the JS
+   * family). Among these, the enumeration's priority winner overrides the
+   * model's pick; elsewhere a valid pick always wins — see coerceAgenticReport.
+   */
+  rerankIds?: readonly string[];
   /** Streaming activity callback for the UI. */
   onEvent?: DetectEvent;
 };
@@ -123,7 +129,8 @@ function buildPrompt(
   recommend: boolean,
 ): string {
   const targetList = targets.map((t) => `- ${t.id} → ${t.name}`).join('\n');
-  const projectShape = `{"path":string,"framework":string,"targetId":string|null,"hasPostHog":boolean${
+  // matchingTargets precedes targetId: the model enumerates before it picks.
+  const projectShape = `{"path":string,"framework":string,"matchingTargets":string[],"targetId":string|null,"hasPostHog":boolean,"evidence":string${
     recommend ? ',"recommended":boolean' : ''
   }}`;
   return [
@@ -136,10 +143,12 @@ function buildPrompt(
     'Do exactly this:',
     `1. Run Glob ONCE with this pattern to find every project manifest in the repo in a single call: "${manifestGlob()}". Discard any result whose path contains node_modules/, dist/, build/, .next/, out/, coverage/, vendor/, .venv/, site-packages/, target/, Pods/, Carthage/, or DerivedData/. Group the remaining results by directory — each directory is one project. Three exceptions to "directory = project": a project.pbxproj lives inside a "<Name>.xcodeproj/" wrapper, so the project root is the PARENT of that .xcodeproj directory; a project.yml at a directory root is an XcodeGen-generated Xcode app rooted at that directory; a gradle/libs.versions.toml is a version catalog belonging to the gradle project rooted at the PARENT of that gradle/ directory (read it alongside the build.gradle when deciding hasPostHog), never its own project.`,
     '2. Decide repoType: "monorepo" if the root package.json has a "workspaces" field OR a pnpm-workspace.yaml / turbo.json / nx.json / lerna.json was found at the root, else "single".',
-    '3. For EACH project directory, Read its manifest(s) ONCE. From the dependency lists decide:',
+    `3. For EACH project directory, ONE AT A TIME: Read its manifest(s) ONCE, decide the fields below, then IMMEDIATELY — before reading any other project — write that project's verdict as one JSON line of shape ${projectShape}. Never write a verdict from memory of an earlier Read; the manifest you just read is the only source. Decide from its dependency lists:`,
     '   - the human-readable framework name (e.g. "Next.js", "Django", "Rails"),',
-    '   - the matching target id from the list below. That list is ordered by priority — most specific first — so when a project could match more than one target (e.g. it uses several of the listed technologies), pick the one listed EARLIEST. Use null only if none matches,',
+    '   - matchingTargets: EVERY target id from the list below whose technology appears in THIS manifest, in the priority order of the list. An id belongs here only if you can point at the dependency or setting in the manifest you just read — never carry one over from another project,',
+    '   - targetId: the FIRST entry of matchingTargets (the list is ordered by priority, most specific first). null when matchingTargets is empty,',
     `   - hasPostHog: true if any dependency is a PostHog SDK. This includes: a name containing "posthog" in any ecosystem (e.g. posthog-js, posthog-node, @posthog/*, posthog for pip/gem/hex, a com.posthog:* gradle/maven coordinate, a PostHog NuGet PackageReference); an SPM package named "PostHog" or a repositoryURL of github.com/PostHog/posthog-ios (in Package.swift or a .pbxproj); or a "pod 'PostHog'" line in a Podfile. Else false.`,
+    '   - evidence: the manifest fact that decided targetId, with the file it came from (e.g. "rollup in devDependencies of backend/package.json"). When targetId is null, name the closest fact you saw. One short clause, quoted from the manifest you just read.',
     '   Do NOT read any file other than these manifests.',
     ...(recommend
       ? [
@@ -151,7 +160,7 @@ function buildPrompt(
     targetList,
     '',
     'Output requirements:',
-    '- Respond with ONLY a single JSON object. No prose, no markdown code fences.',
+    '- After the last verdict line, respond with ONLY a single JSON object assembling the verdict lines you wrote, copied VERBATIM — same path, framework, targetId and evidence per project. No prose, no markdown code fences.',
     `- Shape: {"repoType":"monorepo"|"single","projects":[${projectShape}]}`,
     '- "path" is the project directory relative to the working directory; use "." for the repo root.',
     '- "targetId" MUST be exactly one of the target ids above when it matches; if several match, use the one listed earliest; otherwise null.',
@@ -165,15 +174,38 @@ function buildPrompt(
   ].join('\n');
 }
 
-function extractJson(text: string): unknown {
-  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const candidate = fenced ? fenced[1] : text;
-  const start = candidate.indexOf('{');
-  const end = candidate.lastIndexOf('}');
-  if (start === -1 || end === -1 || end < start) {
-    throw new Error('Agent did not return a JSON object');
+/**
+ * Build the detection report from the agent's output, or null when it holds
+ * no verdicts. Exported for testing.
+ *
+ * The verdict lines are far more reliable than the model's final assembly
+ * (prose, pretty-printing, per-object fences), so every parseable line
+ * contributes: objects with a `path` merge by path (last wins), and a
+ * one-line assembly's `projects` merge the same way. `repoType` is
+ * approximated from the count — it only feeds telemetry and display.
+ */
+export function deriveReportJson(text: string): unknown | null {
+  const byPath = new Map<string, Record<string, unknown>>();
+  for (const line of text.split('\n')) {
+    const start = line.indexOf('{');
+    const end = line.lastIndexOf('}');
+    if (start === -1 || end <= start) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line.slice(start, end + 1));
+    } catch {
+      continue; // not JSON — prose, shape echoes, pretty-printed fragments
+    }
+    const obj = (parsed ?? {}) as Record<string, unknown>;
+    const candidates = Array.isArray(obj.projects) ? obj.projects : [obj];
+    for (const candidate of candidates) {
+      const p = (candidate ?? {}) as Record<string, unknown>;
+      if (typeof p.path === 'string') byPath.set(p.path, p);
+    }
   }
-  return JSON.parse(candidate.slice(start, end + 1));
+  if (byPath.size === 0) return null;
+  const projects = [...byPath.values()];
+  return { repoType: projects.length > 1 ? 'monorepo' : 'single', projects };
 }
 
 /**
@@ -203,19 +235,39 @@ export function resolveProjectDir(installDir: string, rel: unknown): string {
 export function coerceAgenticReport(
   parsed: unknown,
   validTargetIds: readonly string[],
-  options?: { recommend?: boolean },
+  options?: { recommend?: boolean; rerankIds?: readonly string[] },
 ): AgenticDetectionReport {
   const recommend = options?.recommend === true;
+  const rerankIds = options?.rerankIds ?? [];
   const obj = (parsed ?? {}) as Record<string, unknown>;
   const repoType = obj.repoType === 'monorepo' ? 'monorepo' : 'single';
   const rawProjects = Array.isArray(obj.projects) ? obj.projects : [];
   let recommendedSeen = false;
   const projects: AgenticProject[] = rawProjects.map((raw) => {
     const p = (raw ?? {}) as Record<string, unknown>;
-    const targetId =
+    // Trust the model's pick; an invalid one falls back to the enumeration's
+    // highest-priority member (validTargetIds IS the priority order). The
+    // winner overrides a valid pick only when both sit in rerankIds — stacks
+    // that co-occur in one manifest, where a misordered enumeration is the
+    // common miss. Elsewhere enumerations are padded across exclusive stacks
+    // (a Flutter app listing react-native) and must not beat a correct pick.
+    const pick =
       typeof p.targetId === 'string' && validTargetIds.includes(p.targetId)
         ? p.targetId
         : null;
+    const enumerated = Array.isArray(p.matchingTargets)
+      ? validTargetIds.find((id) =>
+          (p.matchingTargets as unknown[]).includes(id),
+        ) ?? null
+      : null;
+    const targetId =
+      pick === null
+        ? enumerated
+        : enumerated !== null &&
+          rerankIds.includes(enumerated) &&
+          rerankIds.includes(pick)
+        ? enumerated
+        : pick;
     const recommended = recommend && !recommendedSeen && p.recommended === true;
     recommendedSeen ||= recommended;
     return {
@@ -278,6 +330,7 @@ export async function detectProjectsWithAgent(
     targets,
     purpose = 'set up a PostHog integration',
     recommend = false,
+    rerankIds,
     onEvent,
   } = options;
   const { accessToken, host } = session.credentials;
@@ -356,14 +409,10 @@ export async function detectProjectsWithAgent(
     throw new Error(result.message || `Agent error: ${result.error}`);
   }
 
-  const output = resultText || collected.join('\n');
-  try {
-    return coerceAgenticReport(
-      extractJson(output),
-      targets.map((t) => t.id),
-      { recommend },
-    );
-  } catch (err) {
+  // Transcript first, final message last — its verdicts win path conflicts.
+  const output = `${collected.join('\n')}\n${resultText}`;
+  const derived = deriveReportJson(output);
+  if (derived === null) {
     // The prompt tells the agent to emit `[ABORT] detection failed` when the
     // repo has no recognizable project manifests. Surface that (and any other
     // non-JSON terminal output that carries the abort signal) as an empty
@@ -372,6 +421,11 @@ export async function detectProjectsWithAgent(
     if (output.includes(AgentSignals.ABORT)) {
       return { repoType: 'single', projects: [] };
     }
-    throw err;
+    throw new Error('Agent did not return a JSON object');
   }
+  return coerceAgenticReport(
+    derived,
+    targets.map((t) => t.id),
+    { recommend, rerankIds },
+  );
 }

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -93,6 +93,21 @@ export const SOURCE_MAPS_TARGETS: DetectTarget[] = [...AUTOMATABLE_VARIANTS]
   .sort((a, b) => precedenceRank(a) - precedenceRank(b))
   .map((v) => ({ id: v, name: VARIANT_DISPLAY_NAME[v] }));
 
+// JS variants co-occur in one package.json (react+vite, node+rollup), so the
+// enumeration's priority winner may override the agent's pick among them.
+// Mobile/native stacks are mutually exclusive and stay pick-wins.
+const JS_RERANK_VARIANTS: readonly SkillVariant[] = [
+  'nextjs',
+  'nuxt',
+  'angular',
+  'vite',
+  'webpack',
+  'rollup',
+  'react',
+  'node',
+  'web',
+];
+
 /** Comment-stripped substring check for the Rust SDK in one manifest. */
 function manifestMentionsSdk(manifestPath: string): boolean {
   const content = readProjectFile(manifestPath);
@@ -392,6 +407,7 @@ export async function detectSourceMapsProjects(
   const report = await detectProjectsWithAgent(session, {
     targets: SOURCE_MAPS_TARGETS,
     purpose: 'set up PostHog Error Tracking source-map upload',
+    rerankIds: JS_RERANK_VARIANTS,
     onEvent,
   });
   return toSourceMapsReport(report, {


### PR DESCRIPTION
I noticed agentic detection sometimes becomes unreliable. Especially when repository contains projects with very similar names (backend1 and backend2 for example).

Another thing is that sometimes when we detect node+rollup variant it classified it simply as node and dropped rollup.

Did some back and forth with my Claude. This PR makes it 100% reliable. Tested multiple times on problematic repositories and then as a sanity check I ran the detection on our workbench. All good

What changed, briefly:

- The agent now writes each project's verdict right after reading that project's manifest, together with the dependency that proves it. Before, it wrote the whole report from memory at the end - that's where the mix-ups came from.
- It also lists every matching technology first, and for JS (where node + rollup coexist in one package.json) the code picks the most specific one. So rollup can't get dropped in favor of plain node anymore.
- The report is built from those per-project lines directly, so a badly formatted final answer can't lose an otherwise correct scan.
