### PR TITLE
fix(orchestrator): register cache cleanup on wizardAbort paths

### DIFF
--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/cache-cleanup.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/cache-cleanup.test.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  clearCleanup,
+  registerCleanup,
+  runCleanups,
+} from '@utils/wizard-abort';
+import { wipeOrchestratorCache } from '@lib/agent/runner/sequence/orchestrator/cache-cleanup';
+import {
+  QueueStore,
+  QUEUE_DIR_NAME,
+} from '@lib/agent/runner/sequence/orchestrator/queue';
+
+vi.mock('@utils/analytics', () => ({
+  analytics: { captureException: vi.fn(), wizardCapture: vi.fn() },
+}));
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'orchestrator-cache-'));
+}
+
+describe('wipeOrchestratorCache', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    clearCleanup();
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    clearCleanup();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes the cache directory created by QueueStore', () => {
+    new QueueStore(dir, 'run-1');
+    const cachePath = path.join(dir, QUEUE_DIR_NAME);
+    expect(fs.existsSync(cachePath)).toBe(true);
+
+    wipeOrchestratorCache(dir);
+
+    expect(fs.existsSync(cachePath)).toBe(false);
+  });
+
+  it('is a no-op when the cache directory is already gone', () => {
+    expect(() => wipeOrchestratorCache(dir)).not.toThrow();
+  });
+
+  it('removes the cache when run via registerCleanup (abort path)', () => {
+    new QueueStore(dir, 'run-1');
+    const cachePath = path.join(dir, QUEUE_DIR_NAME);
+    expect(fs.existsSync(cachePath)).toBe(true);
+
+    registerCleanup(() => wipeOrchestratorCache(dir));
+    runCleanups();
+
+    expect(fs.existsSync(cachePath)).toBe(false);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/cache-cleanup.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/cache-cleanup.ts
@@ -1,0 +1,25 @@
+import { rmSync } from 'fs';
+import * as path from 'path';
+import { analytics } from '@utils/analytics';
+import { QUEUE_DIR_NAME } from './queue';
+
+/**
+ * Remove `<installDir>/.posthog-wizard-cache/`.
+ *
+ * Used from the orchestrator `finally` (success / throw unwind) and from
+ * `registerCleanup` (wizardAbort / SIGINT) — the same dual-path pattern as
+ * `flushScanReport` in the program runner.
+ */
+export function wipeOrchestratorCache(installDir: string): void {
+  try {
+    rmSync(path.join(installDir, QUEUE_DIR_NAME), {
+      recursive: true,
+      force: true,
+    });
+  } catch (err) {
+    analytics.captureException(
+      err instanceof Error ? err : new Error(String(err)),
+      { step: 'orchestrator_cache_cleanup' },
+    );
+  }
+}

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -36,7 +36,8 @@ import { getUI } from '@ui';
 import { analytics } from '@utils/analytics';
 import { ciExcludedTaskTypes } from '@utils/ci-flag-overrides';
 import { logToFile } from '@utils/debug';
-import { wizardAbort, WizardError } from '@utils/wizard-abort';
+import { registerCleanup, wizardAbort, WizardError } from '@utils/wizard-abort';
+import { wipeOrchestratorCache } from './cache-cleanup';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { BootstrapResult } from '../../shared/types';
 import {
@@ -292,6 +293,9 @@ export async function runOrchestrator(
       }
     },
   });
+  // Abort/SIGINT run registerCleanup (success uses the finally below) — same
+  // dual-path pattern as flushScanReport in the program runner.
+  registerCleanup(() => wipeOrchestratorCache(session.installDir));
 
   // Give task agents the framework's finished reference integration to match,
   // the same EXAMPLE.md the linear flow uses. Install it under the run dir rather
@@ -583,17 +587,9 @@ export async function runOrchestrator(
     // Success or failure, no run artifact outlives the run — wipe the whole
     // cache folder (queue, handoffs, reference example, installed task
     // instructions). The .DELETE-ME.md inside is the fallback if we don't.
-    try {
-      rmSync(path.join(session.installDir, QUEUE_DIR_NAME), {
-        recursive: true,
-        force: true,
-      });
-    } catch (err) {
-      analytics.captureException(
-        err instanceof Error ? err : new Error(String(err)),
-        { step: 'orchestrator_cache_cleanup' },
-      );
-    }
+    // Abort paths use the registerCleanup registered above instead of this
+    // finally (process.exit skips it).
+    wipeOrchestratorCache(session.installDir);
     try {
       sweepRunInstalledSkills(
         claudeSkillsDir,


### PR DESCRIPTION
## Problem

After an aborted orchestrator run (accidental Ctrl+C in the wrong terminal window, but I assume errors would produce this as well), the install dir was left with an untracked `.posthog-wizard-cache/` (plus`.DELETE-ME.md` saying it should have been removed when the wizard finished - which initiated my research into this fix).

`QueueStore` creates that folder as soon as the orchestrator starts, but the wipe only lives in the `finally` after `drainQueue`. Abort goes through `wizardAbort()` → `process.exit()` and never hits that path, and the cache dir was never registered with `registerCleanup()`. Ctrl+C / SIGTERM have the same gap (`run-wizard` already calls `runCleanups()` before exit).

## Changes

Extract `wipeOrchestratorCache` and wire it with the same dual-path pattern as `flushScanReport` in the program runner:
- `registerCleanup(() => wipeOrchestratorCache(...))` right after `new QueueStore(...)` — covers abort / SIGINT
- reuse the helper in the existing `finally` — covers normal completion 

`QueueStore` stays free of abort/analytics wiring.

## Test plan

- Unit tests in `cache-cleanup.test.ts`: wipe removes a `QueueStore`-created cache dir; wipe via `registerCleanup` / `runCleanups`; no-op when already gone
- `pnpm exec vitest run src/lib/agent/runner/sequence/orchestrator/__tests__/` (63 tests passed, including the new ones)
- `pnpm build`
- Manual: start an orchestrator run, abort or Ctrl+C, confirm `.posthog-wizard-cache/` is gone; successful run still leaves none behind