### PR TITLE
fix(wizard): report skill-install failures accurately, and report the ones we were missing

### DIFF
--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -17,6 +17,7 @@ import {
   resolveEnvPath,
 } from '@lib/wizard-tools';
 import type { AuditCheck } from '@lib/programs/audit/types';
+import * as analyticsModule from '../../utils/analytics';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'wizard-tools-'));
@@ -577,32 +578,63 @@ describe('downloadWithRetry', () => {
   });
 });
 
-describe('installSkillById', () => {
-  const entries = [
-    { id: 'integration-v2-init-django', name: 'init', downloadUrl: 'u' },
-  ];
+describe('installSkillById analytics', () => {
+  const noNetwork = () => Promise.reject(new Error('offline'));
 
-  it('uses supplied menu entries instead of refetching the menu', async () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reports a menu fetch failure, which resolves before downloadSkill can see it', async () => {
+    const capture = vi
+      .spyOn(analyticsModule.analytics, 'wizardCapture')
+      .mockImplementation(() => undefined);
     const originalFetch = global.fetch;
-    global.fetch = (() => {
-      throw new Error('menu must not be refetched');
-    }) as any;
+    global.fetch = noNetwork as any;
 
     try {
-      const result = await installSkillById(
-        'not-in-menu',
-        '/tmp',
-        'https://x',
-        {
-          triage: undefined,
-          menuEntries: entries,
-        },
-      );
-
-      expect(result).toEqual({
-        kind: 'skill-not-found',
-        skillId: 'not-in-menu',
+      const result = await installSkillById('any-skill', '/tmp', 'https://x', {
+        triage: undefined,
       });
+
+      expect(result).toEqual({ kind: 'menu-fetch-failed' });
+      expect(capture).toHaveBeenCalledWith(
+        'skill install failed',
+        expect.objectContaining({
+          skill_id: 'any-skill',
+          install_step: 'menu',
+          error: 'menu-fetch-failed',
+        }),
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  }, 20000);
+
+  it('reports a skill missing from the menu', async () => {
+    const capture = vi
+      .spyOn(analyticsModule.analytics, 'wizardCapture')
+      .mockImplementation(() => undefined);
+    const originalFetch = global.fetch;
+    global.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve({ categories: { integration: [] } }),
+      })) as any;
+
+    try {
+      const result = await installSkillById('missing', '/tmp', 'https://x', {
+        triage: undefined,
+      });
+
+      expect(result).toEqual({ kind: 'skill-not-found', skillId: 'missing' });
+      expect(capture).toHaveBeenCalledWith(
+        'skill install failed',
+        expect.objectContaining({
+          install_step: 'resolve',
+          error: 'skill-not-found',
+        }),
+      );
     } finally {
       global.fetch = originalFetch;
     }

--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -7,9 +7,11 @@ import {
   DEFAULT_ASK_MAX_QUESTIONS,
   WIZARD_TOOL_NAMES,
   __test,
+  describeInstallFailure,
   ensureGitignoreCoverage,
   evaluateAskCap,
   fetchSkillMenu,
+  installSkillById,
   mergeEnvValues,
   parseEnvKeys,
   resolveEnvPath,
@@ -572,6 +574,68 @@ describe('downloadWithRetry', () => {
         maxAttempts: 3,
       }),
     ).rejects.toThrow(/attempt 1.*attempt 2.*attempt 3/s);
+  });
+});
+
+describe('installSkillById', () => {
+  const entries = [
+    { id: 'integration-v2-init-django', name: 'init', downloadUrl: 'u' },
+  ];
+
+  it('uses supplied menu entries instead of refetching the menu', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = (() => {
+      throw new Error('menu must not be refetched');
+    }) as any;
+
+    try {
+      const result = await installSkillById(
+        'not-in-menu',
+        '/tmp',
+        'https://x',
+        {
+          triage: undefined,
+          menuEntries: entries,
+        },
+      );
+
+      expect(result).toEqual({
+        kind: 'skill-not-found',
+        skillId: 'not-in-menu',
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+});
+
+describe('describeInstallFailure', () => {
+  it('names the network as the cause of a menu fetch failure', () => {
+    const message = describeInstallFailure({ kind: 'menu-fetch-failed' });
+
+    expect(message).toMatch(/network/i);
+    // A menu fetch never touches the project directory — blaming permissions
+    // sent users to check `chmod` for what was a GitHub blip.
+    expect(message).not.toMatch(/permission|writable/i);
+  });
+
+  it('surfaces the underlying error of a failed download', () => {
+    const message = describeInstallFailure({
+      kind: 'download-failed',
+      message: 'HTTP 503 Service Unavailable',
+    });
+
+    expect(message).toContain('HTTP 503 Service Unavailable');
+    expect(message).not.toMatch(/permission|writable/i);
+  });
+
+  it('names the missing skill when the menu lacks it', () => {
+    const message = describeInstallFailure({
+      kind: 'skill-not-found',
+      skillId: 'integration-v2-init-django',
+    });
+
+    expect(message).toContain('integration-v2-init-django');
   });
 });
 

--- a/src/lib/__tests__/yara-hooks.test.ts
+++ b/src/lib/__tests__/yara-hooks.test.ts
@@ -669,6 +669,93 @@ describe('yara-hooks', () => {
         expect(output.additionalContext).toContain('YARA VIOLATION');
       });
 
+      it('reports a match enforced without triage when the gateway errors', async () => {
+        mockScan.mockResolvedValueOnce(
+          matched(
+            match('posthog_pii_in_capture_call', {
+              category: 'posthog_pii',
+              severity: 'high',
+              scan_context: 'output',
+            }),
+          ),
+        );
+        mockTriage.mockRejectedValueOnce(new TypeError('gateway unreachable'));
+
+        const hook = createPostToolUseYaraHooks(dummyProvider, noopTerminate)[0]
+          .hooks[0];
+        await hook(
+          input({ tool_name: 'Write', tool_input: { content: 'x' } }),
+          't3b',
+          { signal: dummySignal },
+        );
+
+        const call = mockAnalytics.analytics.wizardCapture.mock.calls.find(
+          (c: unknown[]) => c[0] === 'yara triage unavailable',
+        );
+        expect(call).toBeDefined();
+        expect(call?.[1]).toEqual(
+          expect.objectContaining({
+            rule: 'posthog_pii_in_capture_call',
+            severity: 'high',
+            reason: 'error',
+            error_kind: 'TypeError',
+          }),
+        );
+        // Only the error's class travels — its message can quote scanned content.
+        expect(JSON.stringify(call?.[1])).not.toContain('gateway unreachable');
+      });
+
+      it('reports a match enforced without triage when no provider exists', async () => {
+        mockScan.mockResolvedValueOnce(
+          matched(
+            match('posthog_pii_in_capture_call', {
+              category: 'posthog_pii',
+              severity: 'high',
+              scan_context: 'output',
+            }),
+          ),
+        );
+        const hook = createPostToolUseYaraHooks(undefined, noopTerminate)[0]
+          .hooks[0];
+        await hook(
+          input({ tool_name: 'Write', tool_input: { content: 'x' } }),
+          't4b',
+          { signal: dummySignal },
+        );
+
+        const call = mockAnalytics.analytics.wizardCapture.mock.calls.find(
+          (c: unknown[]) => c[0] === 'yara triage unavailable',
+        );
+        expect(call?.[1]).toEqual(
+          expect.objectContaining({ reason: 'no-provider' }),
+        );
+      });
+
+      it('stays silent when triage actually ran', async () => {
+        const m = match('posthog_pii_in_capture_call', {
+          category: 'posthog_pii',
+          severity: 'high',
+          scan_context: 'output',
+        });
+        mockScan.mockResolvedValueOnce(matched(m));
+        mockTriage.mockResolvedValueOnce([
+          { ...m, triage: { verdict: 'true_positive', reason: 'real' } },
+        ]);
+        const hook = createPostToolUseYaraHooks(dummyProvider, noopTerminate)[0]
+          .hooks[0];
+        await hook(
+          input({ tool_name: 'Write', tool_input: { content: 'x' } }),
+          't4c',
+          { signal: dummySignal },
+        );
+
+        expect(
+          mockAnalytics.analytics.wizardCapture.mock.calls.find(
+            (c: unknown[]) => c[0] === 'yara triage unavailable',
+          ),
+        ).toBeUndefined();
+      });
+
       it('skips triage on PreToolUse Bash even when a provider is supplied', async () => {
         // PreToolUse Bash always blocks on any flagged command, so triage
         // would be wasted LLM work. Verify the hook never calls triage.

--- a/src/lib/__tests__/yara-hooks.test.ts
+++ b/src/lib/__tests__/yara-hooks.test.ts
@@ -731,6 +731,75 @@ describe('yara-hooks', () => {
         );
       });
 
+      it('never carries the scanned content that tripped the rule', async () => {
+        const m = match('posthog_pii_in_capture_call', {
+          category: 'posthog_pii',
+          severity: 'high',
+          scan_context: 'output',
+        });
+        // The literal text warlock lifts out of the user's file.
+        m.matchedStrings = ["capture('login', { email: user.email })"];
+        mockScan.mockResolvedValueOnce(matched(m));
+        mockTriage.mockRejectedValueOnce(new Error('gateway down'));
+
+        const hook = createPostToolUseYaraHooks(dummyProvider, noopTerminate)[0]
+          .hooks[0];
+        await hook(
+          input({
+            tool_name: 'Write',
+            tool_input: { content: "capture('login', { email: user.email })" },
+          }),
+          't3c',
+          { signal: dummySignal },
+        );
+
+        const call = mockAnalytics.analytics.wizardCapture.mock.calls.find(
+          (c: unknown[]) => c[0] === 'yara triage unavailable',
+        );
+        const payload = JSON.stringify(call?.[1]);
+        expect(payload).not.toContain('user.email');
+        expect(payload).not.toContain('capture(');
+        expect(payload).not.toContain('matchedStrings');
+        // Rule identity only.
+        expect(Object.keys(call?.[1] as object).sort()).toEqual([
+          'category',
+          'error_kind',
+          'reason',
+          'rule',
+          'scan_context',
+          'severity',
+        ]);
+      });
+
+      it('does not report the PreToolUse Bash skip, which is by design', async () => {
+        mockScan.mockResolvedValueOnce(
+          matched(
+            match('destructive_rm_rf', {
+              category: 'destructive_operations',
+              severity: 'critical',
+              scan_context: 'command',
+            }),
+          ),
+        );
+
+        const hook = createPreToolUseYaraHooks(dummyProvider)[0].hooks[0];
+        const result = await hook(
+          input({ tool_name: 'Bash', tool_input: { command: 'rm -rf /' } }),
+          't4d',
+          { signal: dummySignal },
+        );
+
+        // The match really did fire — this isn't passing because nothing matched.
+        expect(result.decision).toBe('block');
+        // Bash blocks on any flagged command and passes no provider on purpose.
+        // Counting that as an outage would bury the real gateway failures.
+        expect(
+          mockAnalytics.analytics.wizardCapture.mock.calls.find(
+            (c: unknown[]) => c[0] === 'yara triage unavailable',
+          ),
+        ).toBeUndefined();
+      });
+
       it('stays silent when triage actually ran', async () => {
         const m = match('posthog_pii_in_capture_call', {
           category: 'posthog_pii',

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -313,7 +313,6 @@ export async function runOrchestrator(
       {
         skillsRoot: path.join(QUEUE_DIR_NAME, 'reference'),
         triage: boot.triageProvider,
-        menuEntries: menuSkillEntries,
       },
     );
     if (ref.kind === 'ok') {
@@ -500,11 +499,7 @@ export async function runOrchestrator(
           variantId,
           session.installDir,
           boot.skillsBaseUrl,
-          {
-            skillsRoot: taskSkillsRoot,
-            triage: boot.triageProvider,
-            menuEntries: menuSkillEntries,
-          },
+          { skillsRoot: taskSkillsRoot, triage: boot.triageProvider },
         );
         if (result.kind === 'ok') {
           skillPaths.push(path.join(result.path, 'SKILL.md'));

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -28,6 +28,7 @@ import {
 } from '@lib/constants';
 import { FRAMEWORK_REGISTRY } from '@lib/registry';
 import {
+  describeInstallFailure,
   installSkillById,
   fetchSkillMenu,
   type SkillEntry,
@@ -312,6 +313,7 @@ export async function runOrchestrator(
       {
         skillsRoot: path.join(QUEUE_DIR_NAME, 'reference'),
         triage: boot.triageProvider,
+        menuEntries: menuSkillEntries,
       },
     );
     if (ref.kind === 'ok') {
@@ -498,7 +500,11 @@ export async function runOrchestrator(
           variantId,
           session.installDir,
           boot.skillsBaseUrl,
-          { skillsRoot: taskSkillsRoot, triage: boot.triageProvider },
+          {
+            skillsRoot: taskSkillsRoot,
+            triage: boot.triageProvider,
+            menuEntries: menuSkillEntries,
+          },
         );
         if (result.kind === 'ok') {
           skillPaths.push(path.join(result.path, 'SKILL.md'));
@@ -513,7 +519,7 @@ export async function runOrchestrator(
           // task through the normal outcome check.
           throw new Error(
             `Skill "${variantId}" for task "${task.type}" could not be installed (${result.kind}). ` +
-              'If this is a permissions error, check that the project directory is writable.',
+              describeInstallFailure(result),
           );
         }
       }

--- a/src/lib/agent/runner/shared/errors.ts
+++ b/src/lib/agent/runner/shared/errors.ts
@@ -2,6 +2,7 @@
  * Shared error helpers for the runner pipeline.
  */
 
+import { describeInstallFailure } from '@lib/wizard-tools';
 import type { InstallSkillResult } from '@lib/wizard-tools';
 import { wizardAbort, WizardError } from '@utils/wizard-abort';
 
@@ -11,19 +12,8 @@ export async function abortOnInstallFailure(
 ): Promise<void> {
   if (result.kind === 'ok') return;
 
-  const message = (() => {
-    switch (result.kind) {
-      case 'menu-fetch-failed':
-        return 'Could not fetch the skill menu from context-mill.\nCheck your network connection and try again.';
-      case 'skill-not-found':
-        return `Could not find the "${result.skillId}" skill in the context-mill menu.\nPlease try again later.`;
-      case 'download-failed':
-        return `Failed to install skill: ${result.message}\nPlease try again.`;
-    }
-  })();
-
   await wizardAbort({
-    message,
+    message: describeInstallFailure(result),
     error: new WizardError(`Skill install failed: ${result.kind}`, {
       integration: integrationLabel,
       error_type: result.kind,

--- a/src/lib/fetch-retry.ts
+++ b/src/lib/fetch-retry.ts
@@ -6,8 +6,11 @@
  */
 
 const DEFAULT_TIMEOUT_MS = 60000; // per attempt
-const DEFAULT_MAX_ATTEMPTS = 3;
-const DEFAULT_BACKOFF_MS = 500; // doubles each retry
+// 4 attempts over ~7s of backoff. The old 3-over-1.5s gave up inside the
+// length of a typical GitHub release-download blip, so a whole run died on a
+// wobble that had cleared by the time the user retried by hand.
+const DEFAULT_MAX_ATTEMPTS = 4;
+const DEFAULT_BACKOFF_MS = 1000; // doubles each retry
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/lib/fetch-retry.ts
+++ b/src/lib/fetch-retry.ts
@@ -6,11 +6,8 @@
  */
 
 const DEFAULT_TIMEOUT_MS = 60000; // per attempt
-// 4 attempts over ~7s of backoff. The old 3-over-1.5s gave up inside the
-// length of a typical GitHub release-download blip, so a whole run died on a
-// wobble that had cleared by the time the user retried by hand.
-const DEFAULT_MAX_ATTEMPTS = 4;
-const DEFAULT_BACKOFF_MS = 1000; // doubles each retry
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_MS = 500; // doubles each retry
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -199,9 +199,7 @@ export async function downloadSkill(
   const skillDir = skillsRoot
     ? path.join(installDir, skillsRoot, skillEntry.id)
     : path.join(installDir, '.claude', 'skills', skillEntry.id);
-  // Reported as `install_step`, not `step`: a numeric `step` is already defined
-  // project-wide, and the collision types this one numeric too, so every
-  // string value reads back null and the stage is invisible in queries.
+  // Reported as `install_step`; a project-wide numeric `step` collides and nulls this one out.
   let installStep: 'download' | 'extract' = 'download';
 
   try {
@@ -270,10 +268,7 @@ export type InstallSkillResult =
   | { kind: 'skill-not-found'; skillId: string }
   | { kind: 'download-failed'; message: string };
 
-/**
- * What actually went wrong, in the user's terms. One vocabulary for every
- * caller — a network failure must never be reported as a permissions problem.
- */
+/** One vocabulary for every caller, so a network failure isn't reported as a permissions problem. */
 export function describeInstallFailure(
   result: Exclude<InstallSkillResult, { kind: 'ok' }>,
 ): string {
@@ -292,10 +287,7 @@ export function describeInstallFailure(
  * finds the skill, downloads and extracts it. Programs should use this
  * instead of composing fetchSkillMenu + downloadSkill themselves.
  *
- * Every exit reports `skill install failed`. `downloadSkill` only covers the
- * failures it can see itself, so the two that resolve before it is ever called
- * are captured here — otherwise a menu that won't load looks, in analytics,
- * exactly like a skill that was never attempted.
+ * Reports the two failures that resolve before `downloadSkill` can capture them.
  */
 export async function installSkillById(
   skillId: string,

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -185,13 +185,6 @@ export interface SkillInstallOptions {
   skillsRoot?: string;
   /** Scan-triage classifier. `undefined` = no gateway, so a flagged skill fails closed. */
   triage: LLMProvider | undefined;
-  /**
-   * Menu entries the caller already fetched. Supplying them skips the per-install
-   * menu round trip — a caller that installs N skills otherwise re-downloads
-   * `skill-menu.json` N times, and every one of those is another chance for a
-   * transient GitHub blip to fail an install that had nothing to do with the menu.
-   */
-  menuEntries?: readonly SkillEntry[];
 }
 
 /**
@@ -206,12 +199,15 @@ export async function downloadSkill(
   const skillDir = skillsRoot
     ? path.join(installDir, skillsRoot, skillEntry.id)
     : path.join(installDir, '.claude', 'skills', skillEntry.id);
-  let step: 'download' | 'extract' = 'download';
+  // Reported as `install_step`, not `step`: a numeric `step` is already defined
+  // project-wide, and the collision types this one numeric too, so every
+  // string value reads back null and the stage is invisible in queries.
+  let installStep: 'download' | 'extract' = 'download';
 
   try {
     fs.mkdirSync(skillDir, { recursive: true });
     const data = await downloadWithRetry(skillEntry.downloadUrl);
-    step = 'extract';
+    installStep = 'extract';
     const fileCount = skillEntry.bundle
       ? extractBundle(
           JSON.parse(Buffer.from(data).toString('utf8')) as SkillBundle,
@@ -230,7 +226,7 @@ export async function downloadSkill(
       logToFile(`downloadSkill: ${poisonReason}`);
       analytics.wizardCapture('skill install failed', {
         skill_id: skillEntry.id,
-        step: 'scan',
+        install_step: 'scan',
         platform: process.platform,
         error: poisonReason.slice(0, 500),
       });
@@ -251,7 +247,7 @@ export async function downloadSkill(
     // A skill-less run still reports success — keep the failure visible.
     analytics.wizardCapture('skill install failed', {
       skill_id: skillEntry.id,
-      step,
+      install_step: installStep,
       platform: process.platform,
       error: String(err.message).slice(0, 500),
     });
@@ -292,12 +288,14 @@ export function describeInstallFailure(
 }
 
 /**
- * High-level "install a skill by ID" helper. Finds the skill in the menu,
- * downloads and extracts it. Programs should use this instead of composing
- * fetchSkillMenu + downloadSkill themselves.
+ * High-level "install a skill by ID" helper. Fetches the skill menu,
+ * finds the skill, downloads and extracts it. Programs should use this
+ * instead of composing fetchSkillMenu + downloadSkill themselves.
  *
- * Pass `options.menuEntries` when the menu is already in hand — installing
- * without it costs one `skill-menu.json` fetch per skill.
+ * Every exit reports `skill install failed`. `downloadSkill` only covers the
+ * failures it can see itself, so the two that resolve before it is ever called
+ * are captured here — otherwise a menu that won't load looks, in analytics,
+ * exactly like a skill that was never attempted.
  */
 export async function installSkillById(
   skillId: string,
@@ -305,15 +303,29 @@ export async function installSkillById(
   skillsBaseUrl: string,
   options: SkillInstallOptions,
 ): Promise<InstallSkillResult> {
-  let entries = options.menuEntries;
-  if (!entries) {
-    const menu = await fetchSkillMenu(skillsBaseUrl);
-    if (!menu) return { kind: 'menu-fetch-failed' };
-    entries = Object.values(menu.categories).flat();
+  const menu = await fetchSkillMenu(skillsBaseUrl);
+  if (!menu) {
+    analytics.wizardCapture('skill install failed', {
+      skill_id: skillId,
+      install_step: 'menu',
+      platform: process.platform,
+      error: 'menu-fetch-failed',
+    });
+    return { kind: 'menu-fetch-failed' };
   }
 
-  const skill = entries.find((s) => s.id === skillId);
-  if (!skill) return { kind: 'skill-not-found', skillId };
+  const skill = Object.values(menu.categories)
+    .flat()
+    .find((s) => s.id === skillId);
+  if (!skill) {
+    analytics.wizardCapture('skill install failed', {
+      skill_id: skillId,
+      install_step: 'resolve',
+      platform: process.platform,
+      error: 'skill-not-found',
+    });
+    return { kind: 'skill-not-found', skillId };
+  }
 
   const result = await downloadSkill(skill, installDir, options);
   if (!result.success) {

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -185,6 +185,13 @@ export interface SkillInstallOptions {
   skillsRoot?: string;
   /** Scan-triage classifier. `undefined` = no gateway, so a flagged skill fails closed. */
   triage: LLMProvider | undefined;
+  /**
+   * Menu entries the caller already fetched. Supplying them skips the per-install
+   * menu round trip — a caller that installs N skills otherwise re-downloads
+   * `skill-menu.json` N times, and every one of those is another chance for a
+   * transient GitHub blip to fail an install that had nothing to do with the menu.
+   */
+  menuEntries?: readonly SkillEntry[];
 }
 
 /**
@@ -268,9 +275,29 @@ export type InstallSkillResult =
   | { kind: 'download-failed'; message: string };
 
 /**
- * High-level "install a skill by ID" helper. Fetches the skill menu,
- * finds the skill, downloads and extracts it. Programs should use this
- * instead of composing fetchSkillMenu + downloadSkill themselves.
+ * What actually went wrong, in the user's terms. One vocabulary for every
+ * caller — a network failure must never be reported as a permissions problem.
+ */
+export function describeInstallFailure(
+  result: Exclude<InstallSkillResult, { kind: 'ok' }>,
+): string {
+  switch (result.kind) {
+    case 'menu-fetch-failed':
+      return 'Could not fetch the skill menu from context-mill.\nCheck your network connection and try again.';
+    case 'skill-not-found':
+      return `Could not find the "${result.skillId}" skill in the context-mill menu.\nPlease try again later.`;
+    case 'download-failed':
+      return `Failed to install skill: ${result.message}\nPlease try again.`;
+  }
+}
+
+/**
+ * High-level "install a skill by ID" helper. Finds the skill in the menu,
+ * downloads and extracts it. Programs should use this instead of composing
+ * fetchSkillMenu + downloadSkill themselves.
+ *
+ * Pass `options.menuEntries` when the menu is already in hand — installing
+ * without it costs one `skill-menu.json` fetch per skill.
  */
 export async function installSkillById(
   skillId: string,
@@ -278,12 +305,14 @@ export async function installSkillById(
   skillsBaseUrl: string,
   options: SkillInstallOptions,
 ): Promise<InstallSkillResult> {
-  const menu = await fetchSkillMenu(skillsBaseUrl);
-  if (!menu) return { kind: 'menu-fetch-failed' };
+  let entries = options.menuEntries;
+  if (!entries) {
+    const menu = await fetchSkillMenu(skillsBaseUrl);
+    if (!menu) return { kind: 'menu-fetch-failed' };
+    entries = Object.values(menu.categories).flat();
+  }
 
-  const skill = Object.values(menu.categories)
-    .flat()
-    .find((s) => s.id === skillId);
+  const skill = entries.find((s) => s.id === skillId);
   if (!skill) return { kind: 'skill-not-found', skillId };
 
   const result = await downloadSkill(skill, installDir, options);

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -575,6 +575,7 @@ async function triageFilter(
     logToFile(
       `[YARA] triage skipped (no provider) — treating ${matches.length} match(es) as real`,
     );
+    reportTriageUnavailable(matches, ctx, 'no-provider');
     return matches;
   }
   try {
@@ -603,7 +604,46 @@ async function triageFilter(
     return kept;
   } catch (err) {
     logToFile('[YARA] triage failed — treating all matches as real:', err);
+    reportTriageUnavailable(
+      matches,
+      ctx,
+      'error',
+      err instanceof Error ? err.name : 'unknown',
+    );
     return matches;
+  }
+}
+
+/**
+ * Report that a match was enforced *without* ever being triaged — the gateway
+ * was missing, down, or timed out, so we failed closed on the rule author's
+ * recommendation alone.
+ *
+ * Failing closed is the right call, but until now it was invisible: no event
+ * was emitted, so an enforced match looked identical whether triage had
+ * confirmed it or never ran. That makes a rule's real false-positive rate
+ * unmeasurable, because `yara triage overruled` can only fire when triage
+ * worked. Auth failures against the gateway are common enough that a chunk of
+ * enforcement is very likely running blind.
+ *
+ * Deliberately omits the error's message and any scanned content — only the
+ * rule metadata and a coarse error class leave the machine.
+ */
+function reportTriageUnavailable(
+  matches: ScanMatch[],
+  ctx: ScanContext,
+  reason: 'no-provider' | 'error',
+  errorKind?: string,
+): void {
+  for (const m of matches) {
+    analytics.wizardCapture('yara triage unavailable', {
+      rule: m.rule,
+      severity: m.metadata.severity,
+      category: m.metadata.category,
+      scan_context: ctx,
+      reason,
+      ...(errorKind ? { error_kind: errorKind } : {}),
+    });
   }
 }
 
@@ -1043,9 +1083,17 @@ export async function scanInstalledSkill(
     );
     return null;
   }
-  return `Poisoned skill detected: ${verdict.match.rule} (${
-    verdict.match.metadata.severity ?? 'unknown'
-  }) in ${absoluteSkillDir}`;
+  // A match carries a `triage` field only when the triage model actually ruled
+  // on it. Without one we failed closed on the rule alone — say so, so a
+  // first-party skill deleted because the gateway was unreachable is not
+  // reported to the user (or to error tracking) as a confirmed attack.
+  const triaged = 'triage' in verdict.match;
+  return (
+    `Poisoned skill detected: ${verdict.match.rule} (${
+      verdict.match.metadata.severity ?? 'unknown'
+    }) in ${absoluteSkillDir}` +
+    (triaged ? '' : ' — triage unavailable, failing closed on the rule alone')
+  );
 }
 
 /**

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -569,13 +569,19 @@ async function triageFilter(
   matches: ScanMatch[],
   ctx: ScanContext,
   llmProvider: LLMProvider | undefined,
+  triage: TriageExpectation,
 ): Promise<ScanMatch[]> {
   if (matches.length === 0) return [];
   if (!llmProvider) {
     logToFile(
       `[YARA] triage skipped (no provider) — treating ${matches.length} match(es) as real`,
     );
-    reportTriageUnavailable(matches, ctx, 'no-provider');
+    // Only a surface that expects triage produces a signal here. PreToolUse
+    // Bash passes no provider on purpose, and counting those would swamp the
+    // gateway failures this event exists to find.
+    if (triage === 'expected') {
+      reportTriageUnavailable(matches.map(ruleIdentity), ctx, 'no-provider');
+    }
     return matches;
   }
   try {
@@ -605,13 +611,37 @@ async function triageFilter(
   } catch (err) {
     logToFile('[YARA] triage failed — treating all matches as real:', err);
     reportTriageUnavailable(
-      matches,
+      matches.map(ruleIdentity),
       ctx,
       'error',
       err instanceof Error ? err.name : 'unknown',
     );
     return matches;
   }
+}
+
+/**
+ * A match's rule identity, with the scanned content stripped off.
+ *
+ * `ScanMatch.matchedStrings` holds the text that tripped the rule, lifted
+ * verbatim out of whatever was scanned — the user's source, their Bash
+ * commands, their secrets. Telemetry projects to this first so a `ScanMatch`
+ * never reaches an analytics call at all: there is then no field to spread and
+ * nothing to leak, rather than a full match object one careless edit away from
+ * shipping the content it carries.
+ */
+interface RuleIdentity {
+  rule: string;
+  severity: ScanMatch['metadata']['severity'];
+  category: Category | undefined;
+}
+
+function ruleIdentity(match: ScanMatch): RuleIdentity {
+  return {
+    rule: match.rule,
+    severity: match.metadata.severity,
+    category: match.metadata.category,
+  };
 }
 
 /**
@@ -626,26 +656,34 @@ async function triageFilter(
  * worked. Auth failures against the gateway are common enough that a chunk of
  * enforcement is very likely running blind.
  *
- * Deliberately omits the error's message and any scanned content — only the
- * rule metadata and a coarse error class leave the machine.
+ * Takes `RuleIdentity`, never `ScanMatch`, so the scanned content is already
+ * gone by the time telemetry is in scope. The error's message is omitted too —
+ * only a coarse error class leaves the machine.
  */
 function reportTriageUnavailable(
-  matches: ScanMatch[],
+  rules: readonly RuleIdentity[],
   ctx: ScanContext,
   reason: 'no-provider' | 'error',
   errorKind?: string,
 ): void {
-  for (const m of matches) {
+  for (const r of rules) {
     analytics.wizardCapture('yara triage unavailable', {
-      rule: m.rule,
-      severity: m.metadata.severity,
-      category: m.metadata.category,
+      rule: r.rule,
+      severity: r.severity,
+      category: r.category,
       scan_context: ctx,
       reason,
       ...(errorKind ? { error_kind: errorKind } : {}),
     });
   }
 }
+
+/**
+ * Whether the caller expected triage to run. `skipped-by-design` marks the
+ * surfaces that pass no provider deliberately, so a missing verdict there is
+ * the design working, not a gateway to go and investigate.
+ */
+type TriageExpectation = 'expected' | 'skipped-by-design';
 
 /** A chunk of scanned content together with the matches found inside it. */
 interface FlaggedChunk {
@@ -723,10 +761,11 @@ async function triageFlagged(
   flagged: FlaggedChunk[],
   ctx: ScanContext,
   llmProvider: LLMProvider | undefined,
+  triage: TriageExpectation = 'expected',
 ): Promise<ScanMatch[]> {
   const triaged = await Promise.all(
     flagged.map(({ chunk, matches }) =>
-      triageFilter(chunk, matches, ctx, llmProvider),
+      triageFilter(chunk, matches, ctx, llmProvider, triage),
     ),
   );
   return dedupeByRule(triaged.flat());
@@ -741,9 +780,10 @@ export async function scanAndTriage(
   content: string,
   ctx: ScanContext,
   llmProvider: LLMProvider | undefined,
+  triage: TriageExpectation = 'expected',
 ): Promise<ScanMatch[]> {
   const flagged = await scanForContext(content, ctx);
-  return triageFlagged(flagged, ctx, llmProvider);
+  return triageFlagged(flagged, ctx, llmProvider, triage);
 }
 
 // ─── PreToolUse Hooks ────────────────────────────────────────────
@@ -778,7 +818,12 @@ export function createPreToolUseYaraHooks(
             recordScan();
             // Skip triage on PreToolUse Bash: any flagged command is blocked
             // regardless of triage verdict, so the LLM call would be wasted.
-            const matches = await scanAndTriage(command, 'command', undefined);
+            const matches = await scanAndTriage(
+              command,
+              'command',
+              undefined,
+              'skipped-by-design',
+            );
             if (matches.length === 0) return {};
 
             const match = highestSeverityMatch(matches);

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -576,9 +576,7 @@ async function triageFilter(
     logToFile(
       `[YARA] triage skipped (no provider) — treating ${matches.length} match(es) as real`,
     );
-    // Only a surface that expects triage produces a signal here. PreToolUse
-    // Bash passes no provider on purpose, and counting those would swamp the
-    // gateway failures this event exists to find.
+    // PreToolUse Bash passes no provider on purpose, so it isn't a signal.
     if (triage === 'expected') {
       reportTriageUnavailable(matches.map(ruleIdentity), ctx, 'no-provider');
     }
@@ -620,16 +618,7 @@ async function triageFilter(
   }
 }
 
-/**
- * A match's rule identity, with the scanned content stripped off.
- *
- * `ScanMatch.matchedStrings` holds the text that tripped the rule, lifted
- * verbatim out of whatever was scanned — the user's source, their Bash
- * commands, their secrets. Telemetry projects to this first so a `ScanMatch`
- * never reaches an analytics call at all: there is then no field to spread and
- * nothing to leak, rather than a full match object one careless edit away from
- * shipping the content it carries.
- */
+/** Rule identity with the scanned content stripped off, so telemetry never sees `matchedStrings`. */
 interface RuleIdentity {
   rule: string;
   severity: ScanMatch['metadata']['severity'];
@@ -644,22 +633,7 @@ function ruleIdentity(match: ScanMatch): RuleIdentity {
   };
 }
 
-/**
- * Report that a match was enforced *without* ever being triaged — the gateway
- * was missing, down, or timed out, so we failed closed on the rule author's
- * recommendation alone.
- *
- * Failing closed is the right call, but until now it was invisible: no event
- * was emitted, so an enforced match looked identical whether triage had
- * confirmed it or never ran. That makes a rule's real false-positive rate
- * unmeasurable, because `yara triage overruled` can only fire when triage
- * worked. Auth failures against the gateway are common enough that a chunk of
- * enforcement is very likely running blind.
- *
- * Takes `RuleIdentity`, never `ScanMatch`, so the scanned content is already
- * gone by the time telemetry is in scope. The error's message is omitted too —
- * only a coarse error class leaves the machine.
- */
+/** Report a match enforced without triage, so blind enforcement is measurable. */
 function reportTriageUnavailable(
   rules: readonly RuleIdentity[],
   ctx: ScanContext,
@@ -678,11 +652,7 @@ function reportTriageUnavailable(
   }
 }
 
-/**
- * Whether the caller expected triage to run. `skipped-by-design` marks the
- * surfaces that pass no provider deliberately, so a missing verdict there is
- * the design working, not a gateway to go and investigate.
- */
+/** Whether the caller expected triage to run, so a deliberate skip isn't reported as an outage. */
 type TriageExpectation = 'expected' | 'skipped-by-design';
 
 /** A chunk of scanned content together with the matches found inside it. */
@@ -1128,10 +1098,7 @@ export async function scanInstalledSkill(
     );
     return null;
   }
-  // A match carries a `triage` field only when the triage model actually ruled
-  // on it. Without one we failed closed on the rule alone — say so, so a
-  // first-party skill deleted because the gateway was unreachable is not
-  // reported to the user (or to error tracking) as a confirmed attack.
+  // Only a triaged match carries a verdict; without one we failed closed on the rule alone.
   const triaged = 'triage' in verdict.match;
   return (
     `Poisoned skill detected: ${verdict.match.rule} (${


### PR DESCRIPTION
## Problem

Over the **last 7 days**, external prod orchestrator runs: 2,658 total, 58 genuinely incomplete (2.2%), 164 stranded steps.

Skill installs are a small slice of that — 21 install failures across ~12 runs, and only **4 of the 35 partial drains** involve one at all. At those volumes nothing is diagnosable unless each failure is attributed correctly, and three of the reporting paths were not.

**1. The error blamed the wrong thing.** The orchestrator hardcoded *"If this is a permissions error, check that the project directory is writable"* onto **every** failure kind, so users hitting a network failure were sent to check `chmod`. A menu fetch never touches the project directory. The accurate per-kind wording already existed in `abortOnInstallFailure` — but only the linear path used it.

**2. Two failure kinds emitted no event at all.** `menu-fetch-failed` and `skill-not-found` both resolve inside `installSkillById` before `downloadSkill` is called, and `downloadSkill` owned the only `skill install failed` capture. So a menu that wouldn't load looked, in analytics, exactly like a skill nobody attempted.

**3. The failing stage was invisible.** The capture sends `step`, but a numeric `step` is already defined project-wide, and the collision types this one numeric too — so every `download` / `extract` / `scan` value reads back null. The values were being sent correctly all along; the property name was just unusable.

Recovering the stage via `JSONExtractString` is what makes the last week readable, and it does not look like the 30-day total:

| stage | last 7d (events / runs) | last 30d (events / runs) |
|---|---|---|
| `download` | 14 / 9 | 48 / 39 |
| `scan` | 6 / 2 | 190 / 162 |
| `extract` | 1 / 1 | 26 / 8 |

The 30-day `scan` column is one bounded incident (Jul 24–28) that is already over — zero since Aug 5. The 30-day `extract` column is a single day (Jul 30). Reading the 30-day total as a standing problem points at the scanner; reading the last week points at downloads, and at no single dominant cause: GitHub 5xx (6 events / 3 runs), local filesystem — `ENOTDIR`, `ENOSPC`, `EPERM` on `C:\Windows\System32` (5 / 5), fetch timeouts (4 / 2), scanner (6 / 2).

**4. Enforcement can run blind, invisibly.** `triageFilter` fails closed in two places: no provider, and the triage call throwing. Failing closed is correct. But both paths only wrote to the local log, so an enforced match is indistinguishable from one triage actually confirmed. `yara triage overruled` can only fire when triage *worked*, which makes any rule's true false-positive rate unmeasurable by construction — including during a spike like Jul 24–28.

## Changes

No behaviour changes to scanning or fetching. A flagged skill is still deleted, the install still fails, retries are untouched.

- Extract `describeInstallFailure` as the one place that turns an `InstallSkillResult` into user-facing text, used by both the orchestrator and the linear path — including the underlying download error, which the orchestrator previously discarded.
- Capture `skill install failed` for `menu-fetch-failed` and `skill-not-found`, so every install failure kind is countable in one place.
- Rename the captured `step` to `install_step`, escaping the numeric collision so the failing stage is queryable without reaching for `JSONExtractString`.
- Emit `yara triage unavailable` when a match is enforced without ever being triaged, carrying rule identity, scan context, `no-provider` vs `error`, and the error's class.
- `scanInstalledSkill` marks its reason string when the deciding match carries no triage verdict, so a skill deleted because the gateway was unreachable stops being reported to the user, and to error tracking, as a confirmed attack.

### Keeping scanned content out of telemetry

A `ScanMatch` carries `matchedStrings` — the text that tripped the rule, lifted verbatim from whatever was scanned: the user's source on the Write/Edit path, their Bash commands on PreToolUse, their secrets whenever a `hardcoded_secret` or `posthog_pii` rule is what matched.

The new event never contained any of it, but the first cut passed whole `ScanMatch` objects into the reporting function, which put user code one `...m` away from shipping — in a file that has already had to hand-guard the same mistake twice for the free-text triage reason. Telemetry now takes a `RuleIdentity` (rule, severity, category) produced by `ruleIdentity()`, so the content is gone before analytics is in scope and there is no field left to spread.

Tracing those call sites also turned up a signal bug: PreToolUse Bash passes no provider **on purpose**, since a flagged command is blocked whatever triage would say. The untriaged report fired there too, so every blocked Bash command would have counted as a triage outage and buried the real gateway failures. Callers now state whether triage was expected, and only `expected` reports.

## Test plan

- `pnpm build && pnpm test` — 1758 tests pass.
- `wizard-tools.test.ts`: `menu-fetch-failed` and `skill-not-found` each emit a capture carrying the right `install_step`; `describeInstallFailure` never mentions permissions or writability for a menu fetch, and surfaces the underlying error for a failed download.
- `yara-hooks.test.ts`: the payload has exactly the six rule-identity keys and contains none of the matched content even when warlock returns a match carrying it; a blocked Bash command emits nothing while still returning `block`; the event fires with `reason: 'error'` plus the error class when the gateway throws, with `reason: 'no-provider'` where triage was expected, and stays silent when triage actually ran.

## Follow-ups, deliberately not here

- `downloadWithRetry` calls `fetchWithRetry`, then reads `resp.arrayBuffer()` **outside** the retry loop, still bound to the 60s abort signal. A body read that stalls or drops mid-transfer is therefore never retried — which matches the `The operation was aborted due to timeout` failures, the most recent on Aug 10.
- The `prompt_injection_posthog_integration_attack` rule lives in warlock. The one sentence that tripped it for `data-warehouse-source-setup` is fixed in [posthog.com#19364](https://github.com/PostHog/posthog.com/pull/19364); the rule still treats any `PostHog-<word>` compound as a package name.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCHQJBJR5/p1786384037788729?thread_ts=1786384037.788729&cid=C0BCHQJBJR5)*