### PR TITLE
Make provider readiness follow the selected model

### DIFF
--- a/src/lib/agent/runner/__tests__/provider-readiness.test.ts
+++ b/src/lib/agent/runner/__tests__/provider-readiness.test.ts
@@ -1,0 +1,118 @@
+import { WizardReadiness } from '@lib/health-checks';
+import { Harness, Sequence } from '@lib/constants';
+import { buildSession } from '@lib/wizard-session';
+import type { ProgramRun } from '@lib/agent/runner/shared/types';
+import type { ProgramConfig } from '@lib/programs/program-step';
+
+const mocks = vi.hoisted(() => ({
+  bootstrapProgram: vi.fn(),
+  enforceProviderReadiness: vi.fn(),
+  resolveBinding: vi.fn(),
+  runSequence: vi.fn(),
+  flushScanReport: vi.fn(),
+  registerCleanup: vi.fn(),
+  setTag: vi.fn(),
+  wizardCapture: vi.fn(),
+}));
+
+vi.mock('@lib/agent/runner/shared/bootstrap', () => ({
+  bootstrapProgram: mocks.bootstrapProgram,
+}));
+
+vi.mock('@lib/health-checks/provider-readiness', () => ({
+  enforceModelProviderReadiness: mocks.enforceProviderReadiness,
+}));
+
+vi.mock('@lib/agent/runner/switchboard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@lib/agent/runner/switchboard')>()),
+  resolveBinding: mocks.resolveBinding,
+  getSequence: () => ({ run: mocks.runSequence }),
+}));
+
+vi.mock('@lib/yara-hooks', () => ({
+  flushScanReport: mocks.flushScanReport,
+}));
+
+vi.mock('@utils/wizard-abort', () => ({
+  registerCleanup: mocks.registerCleanup,
+  wizardAbort: vi.fn(),
+}));
+
+vi.mock('@utils/analytics', () => ({
+  analytics: {
+    setTag: mocks.setTag,
+    wizardCapture: mocks.wizardCapture,
+  },
+}));
+
+const RUN_CONFIG = {
+  integrationLabel: 'test',
+} as ProgramRun;
+
+function programWithSteps(steps: ProgramConfig['steps']): ProgramConfig {
+  return {
+    id: 'posthog-integration',
+    steps,
+  } as ProgramConfig;
+}
+
+describe('runner provider readiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.bootstrapProgram.mockResolvedValue({
+      skillsBaseUrl: 'https://example.com',
+      credentials: {},
+      wizardFlags: {},
+      wizardFlagPayloads: {},
+      wizardMetadata: {},
+      project: null,
+      triageProvider: undefined,
+    });
+    mocks.resolveBinding.mockReturnValue({
+      sequence: Sequence.linear,
+      harness: Harness.pi,
+      model: 'openai/gpt-5.6-terra',
+      thinkingLevel: undefined,
+    });
+    mocks.enforceProviderReadiness.mockResolvedValue(undefined);
+    mocks.runSequence.mockResolvedValue(undefined);
+  });
+
+  it('checks the resolved model even when the TUI cached readiness', async () => {
+    const session = buildSession({ installDir: '/tmp/project' });
+    session.readinessResult = {
+      decision: WizardReadiness.No,
+      health: {} as never,
+      reasons: ['cached pre-flight result'],
+    };
+
+    const { runProgram } = await import('@lib/agent/runner');
+    await runProgram(
+      session,
+      RUN_CONFIG,
+      programWithSteps([
+        { id: 'health-check', label: 'Health check', screenId: 'health-check' },
+      ]),
+    );
+
+    expect(mocks.enforceProviderReadiness).toHaveBeenCalledOnce();
+    expect(mocks.enforceProviderReadiness).toHaveBeenCalledWith(
+      'openai/gpt-5.6-terra',
+    );
+    expect(mocks.runSequence).toHaveBeenCalledOnce();
+  });
+
+  it('does not add provider checks to programs without health readiness', async () => {
+    const session = buildSession({ installDir: '/tmp/project' });
+
+    const { runProgram } = await import('@lib/agent/runner');
+    await runProgram(
+      session,
+      RUN_CONFIG,
+      programWithSteps([{ id: 'run', label: 'Run', screenId: 'run' }]),
+    );
+
+    expect(mocks.enforceProviderReadiness).not.toHaveBeenCalled();
+    expect(mocks.runSequence).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -36,6 +36,7 @@ import {
 } from './switchboard';
 import { flushScanReport } from '../../yara-hooks';
 import { registerCleanup } from '../../../utils/wizard-abort';
+import { enforceModelProviderReadiness } from '@lib/health-checks/provider-readiness';
 
 export type {
   ProgramRun,
@@ -82,6 +83,17 @@ export async function runProgram(
 ): Promise<void> {
   const boot = await bootstrapProgram(session, config, programConfig);
 
+  const binding = resolveProgramRunner(
+    session,
+    programConfig,
+    boot,
+    options.composed ?? false,
+  );
+
+  if (programConfig.steps.some((step) => step.screenId === 'health-check')) {
+    await enforceModelProviderReadiness(binding.model);
+  }
+
   // Flush the warlock scan report once, at this single seam, on every
   // termination path and for every harness (linear, orchestrator, or future):
   //   - registerCleanup covers the abort/cancel path (wizardAbort runs the
@@ -92,12 +104,6 @@ export async function runProgram(
   // harmless no-op. No harness has to know reporting exists.
   registerCleanup(() => flushScanReport(session));
   try {
-    const binding = resolveProgramRunner(
-      session,
-      programConfig,
-      boot,
-      options.composed ?? false,
-    );
     if (binding.sequence === Sequence.orchestrator) {
       getUI().log.info('Task-queue orchestrator enabled.');
     }

--- a/src/lib/health-checks/__tests__/health-checks.test.ts
+++ b/src/lib/health-checks/__tests__/health-checks.test.ts
@@ -1117,7 +1117,7 @@ describe('health-checks', () => {
       expect(result.decision).toBe(WizardReadiness.Yes);
     });
 
-    it('returns No when Anthropic is degraded (degradedBlocksRun)', async () => {
+    it('warns without blocking when Anthropic overall is degraded', async () => {
       const body = makeStatuspageStatus({
         pageId: 'tymt9n04zgry',
         pageName: 'Claude',
@@ -1136,7 +1136,7 @@ describe('health-checks', () => {
       const result = await evaluateWizardReadiness(
         DEFAULT_WIZARD_READINESS_CONFIG,
       );
-      expect(result.decision).toBe(WizardReadiness.No);
+      expect(result.decision).toBe(WizardReadiness.YesWithWarnings);
       expect(result.health.anthropic.status).toBe(ServiceHealthStatus.Degraded);
     });
 

--- a/src/lib/health-checks/__tests__/provider-readiness.test.ts
+++ b/src/lib/health-checks/__tests__/provider-readiness.test.ts
@@ -1,0 +1,98 @@
+import {
+  evaluateModelProviderReadiness,
+  ServiceHealthStatus,
+} from '@lib/health-checks';
+
+const ANTHROPIC_SUMMARY_URL = 'https://status.claude.com/api/v2/summary.json';
+const OPENAI_SUMMARY_URL = 'https://status.openai.com/api/v2/summary.json';
+
+function summary(name: string, status: string): Response {
+  return new Response(
+    JSON.stringify({
+      status: { indicator: status === 'operational' ? 'none' : 'minor' },
+      components: [{ id: 'component', name, status }],
+    }),
+    { status: 200 },
+  );
+}
+
+describe('model provider readiness', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('checks OpenAI Responses for an OpenAI model', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve(summary('Responses', 'operational')),
+    );
+
+    const result = await evaluateModelProviderReadiness('openai/gpt-5.6-terra');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      OPENAI_SUMMARY_URL,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result).toMatchObject({
+      provider: 'openai',
+      service: 'OpenAI Responses API',
+      health: { status: ServiceHealthStatus.Healthy },
+      blocksRun: false,
+    });
+  });
+
+  it('checks the Claude API component for an Anthropic model', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve(summary('Claude API (api.anthropic.com)', 'operational')),
+    );
+
+    const result = await evaluateModelProviderReadiness('claude-sonnet-4-6');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      ANTHROPIC_SUMMARY_URL,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result).toMatchObject({
+      provider: 'anthropic',
+      service: 'Anthropic API',
+      health: { status: ServiceHealthStatus.Healthy },
+      blocksRun: false,
+    });
+  });
+
+  it('blocks only a confirmed outage on the selected component', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve(summary('Responses', 'partial_outage')),
+    );
+
+    const result = await evaluateModelProviderReadiness('openai/gpt-5.6-terra');
+
+    expect(result.health.status).toBe(ServiceHealthStatus.Down);
+    expect(result.blocksRun).toBe(true);
+  });
+
+  it('keeps degraded provider status advisory', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve(summary('Responses', 'degraded_performance')),
+    );
+
+    const result = await evaluateModelProviderReadiness('openai/gpt-5.6-terra');
+
+    expect(result.health.status).toBe(ServiceHealthStatus.Degraded);
+    expect(result.blocksRun).toBe(false);
+  });
+
+  it('keeps status lookup failures advisory', async () => {
+    global.fetch = vi.fn(() => Promise.reject(new Error('ECONNRESET')));
+
+    const result = await evaluateModelProviderReadiness('openai/gpt-5.6-terra');
+
+    expect(result.health).toMatchObject({
+      status: ServiceHealthStatus.Degraded,
+      error: 'ECONNRESET',
+    });
+    expect(result.blocksRun).toBe(false);
+  });
+});

--- a/src/lib/health-checks/index.ts
+++ b/src/lib/health-checks/index.ts
@@ -9,6 +9,8 @@ export {
 
 export {
   checkAnthropicHealth,
+  checkAnthropicApiHealth,
+  checkOpenAiResponsesHealth,
   checkGithubHealth,
   checkNpmOverallHealth,
   checkNpmComponentHealth,
@@ -36,3 +38,9 @@ export {
   type WizardReadinessResult,
   evaluateWizardReadiness,
 } from './readiness';
+
+export {
+  type ModelProviderReadiness,
+  evaluateModelProviderReadiness,
+  enforceModelProviderReadiness,
+} from './provider-readiness';

--- a/src/lib/health-checks/provider-readiness.ts
+++ b/src/lib/health-checks/provider-readiness.ts
@@ -1,0 +1,92 @@
+import type { BaseHealthResult } from './types';
+import { ServiceHealthStatus } from './types';
+import {
+  checkAnthropicApiHealth,
+  checkOpenAiResponsesHealth,
+} from './statuspage';
+import { getUI } from '@ui';
+import { isNonInteractiveEnvironment } from '@utils/environment';
+import { logToFile } from '@utils/debug';
+import { wizardAbort } from '@utils/wizard-abort';
+
+export type ModelProviderReadiness = {
+  provider: 'anthropic' | 'openai';
+  service: string;
+  statusUrl: string;
+  health: BaseHealthResult;
+  blocksRun: boolean;
+};
+
+type ProviderTarget = Omit<ModelProviderReadiness, 'health' | 'blocksRun'> & {
+  check: () => Promise<BaseHealthResult>;
+};
+
+function providerTargetForModel(modelId: string): ProviderTarget {
+  if (modelId.startsWith('openai/')) {
+    return {
+      provider: 'openai',
+      service: 'OpenAI Responses API',
+      statusUrl: 'https://status.openai.com',
+      check: checkOpenAiResponsesHealth,
+    };
+  }
+
+  return {
+    provider: 'anthropic',
+    service: 'Anthropic API',
+    statusUrl: 'https://status.claude.com',
+    check: checkAnthropicApiHealth,
+  };
+}
+
+/**
+ * Check the exact upstream API selected by the final switchboard model.
+ * Only a confirmed component outage blocks. Degraded status, lookup failures,
+ * and unknown responses remain advisory so a status-page problem cannot stop a
+ * working gateway route.
+ */
+export async function evaluateModelProviderReadiness(
+  modelId: string,
+): Promise<ModelProviderReadiness> {
+  const target = providerTargetForModel(modelId);
+  const health = await target.check();
+  return {
+    provider: target.provider,
+    service: target.service,
+    statusUrl: target.statusUrl,
+    health,
+    blocksRun: health.status === ServiceHealthStatus.Down,
+  };
+}
+
+export async function enforceModelProviderReadiness(
+  modelId: string,
+): Promise<void> {
+  const readiness = await evaluateModelProviderReadiness(modelId);
+  const { health, service, statusUrl } = readiness;
+  logToFile(
+    `[health-checks] selected provider service=${service} status=${health.status}` +
+      `${health.error ? ` error=${health.error}` : ''}`,
+  );
+
+  if (health.status === ServiceHealthStatus.Healthy) return;
+
+  if (!readiness.blocksRun) {
+    const detail = health.error
+      ? `Status could not be confirmed: ${health.error}.`
+      : `Current status: ${health.status}.`;
+    getUI().log.warn(`${service} readiness warning. ${detail} Continuing.`);
+    return;
+  }
+
+  const message = `${service} is reporting an outage. Check ${statusUrl} and try again later.`;
+
+  // Keep CI behavior advisory, matching the existing infrastructure checks.
+  if (isNonInteractiveEnvironment()) {
+    getUI().log.warn(`${message} Continuing in non-interactive mode.`);
+    return;
+  }
+
+  getUI().log.error(message);
+  await wizardAbort({ message });
+}

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -58,14 +58,7 @@ export interface WizardReadinessConfig {
  * Adjust these arrays to change what blocks a wizard run.
  */
 export const DEFAULT_WIZARD_READINESS_CONFIG: WizardReadinessConfig = {
-  downBlocksRun: [
-    'anthropic',
-    'npmOverall',
-    'llmGateway',
-    'mcp',
-    'githubReleases',
-  ],
-  degradedBlocksRun: ['anthropic'],
+  downBlocksRun: ['npmOverall', 'llmGateway', 'mcp', 'githubReleases'],
 };
 
 /**

--- a/src/lib/health-checks/statuspage.ts
+++ b/src/lib/health-checks/statuspage.ts
@@ -116,12 +116,54 @@ async function fetchStatuspageSummary(
   }
 }
 
+async function fetchStatuspageComponent(
+  url: string,
+  componentName: string,
+  timeoutMs = 5000,
+): Promise<BaseHealthResult> {
+  try {
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(tid);
+
+    if (!res.ok) return errResult(`HTTP ${res.status}`);
+
+    const data = (await res.json()) as StatuspageSummaryResponse;
+    const component = data.components?.find((c) => c.name === componentName);
+    if (!component) {
+      return errResult(`Component not found: ${componentName}`);
+    }
+
+    return {
+      status: mapComponentRaw(component.status),
+      rawIndicator: component.status,
+    };
+  } catch (e) {
+    if (e instanceof Error && e.name === 'AbortError')
+      return errResult('Request timed out');
+    return errResult(e instanceof Error ? e.message : 'Unknown error');
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Individual statuspage-backed checks
 // ---------------------------------------------------------------------------
 
 export const checkAnthropicHealth = (): Promise<BaseHealthResult> =>
   fetchStatuspageIndicator('https://status.claude.com/api/v2/status.json');
+
+export const checkAnthropicApiHealth = (): Promise<BaseHealthResult> =>
+  fetchStatuspageComponent(
+    'https://status.claude.com/api/v2/summary.json',
+    'Claude API (api.anthropic.com)',
+  );
+
+export const checkOpenAiResponsesHealth = (): Promise<BaseHealthResult> =>
+  fetchStatuspageComponent(
+    'https://status.openai.com/api/v2/summary.json',
+    'Responses',
+  );
 
 export const checkGithubHealth = (): Promise<BaseHealthResult> =>
   fetchStatuspageIndicator('https://www.githubstatus.com/api/v2/status.json');


### PR DESCRIPTION
Fixes #918.

The early TUI check currently evaluates Anthropic before the switchboard has resolved the model, then the runner trusts that cached result. That can stop an OpenAI-only run because Anthropic happens to be degraded.

This keeps the early infrastructure checks, but moves provider gating to the point immediately after the final run binding is resolved. The fresh check targets the exact vendor API component selected by the model:

- Anthropic models check `Claude API (api.anthropic.com)`
- OpenAI models check `Responses`

Only a confirmed component outage blocks an interactive run. Degraded status, missing components, and status-page request failures stay advisory. CI and headless runs keep the existing advisory behavior.

Coverage includes the original cache seam: a stored TUI result does not prevent an OpenAI binding from receiving a fresh OpenAI provider check.

Verified with:

- `pnpm test` (1,755 tests)
- `pnpm build`
- `pnpm fix`