### PR TITLE
fix(mcp): tell the user when the MCP server or plugin is already installed

### DIFF
--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -4,6 +4,7 @@ import { LoggingUI } from '@ui/logging-ui';
 import { Program } from '@lib/programs/program-registry';
 import { VERSION } from '@lib/version';
 import type { Command } from '../command';
+import { isTUIUnavailable } from './tui-availability';
 
 export const mcpAddCommand: Command = {
   name: 'add',
@@ -54,18 +55,6 @@ function runMcpAdd(argv: Arguments): void {
       await addMCPServerToClientsStep({ local: localMcp, features, apiKey });
     }
   })();
-}
-
-/**
- * Ink throws "Raw mode is not supported" when stdin has no TTY (piped input,
- * CI, some IDE terminals). That is the only TUI failure we degrade to
- * LoggingUI for — any other error from the TUI path is a real bug and must
- * surface rather than be silently swallowed.
- */
-function isTUIUnavailable(error: unknown): boolean {
-  return (
-    error instanceof Error && /raw mode is not supported/i.test(error.message)
-  );
 }
 
 function parseFeatures(raw: unknown): string[] | undefined {

--- a/src/commands/mcp/remove.ts
+++ b/src/commands/mcp/remove.ts
@@ -4,6 +4,7 @@ import { LoggingUI } from '@ui/logging-ui';
 import { Program } from '@lib/programs/program-registry';
 import { VERSION } from '@lib/version';
 import type { Command } from '../command';
+import { isTUIUnavailable } from './tui-availability';
 
 export const mcpRemoveCommand: Command = {
   name: 'remove',
@@ -32,7 +33,10 @@ function runMcpRemove(argv: Arguments): void {
         localMcp,
         baseUrl: argv.baseUrl as string | undefined,
       });
-    } catch {
+    } catch (error) {
+      // Same guard as `mcp add`: only a missing TTY falls back to LoggingUI,
+      // so a genuine TUI bug surfaces instead of looking like a plain shell.
+      if (!isTUIUnavailable(error)) throw error;
       setUI(new LoggingUI());
       const { removeMCPServerFromClientsStep } = await import(
         '@steps/add-mcp-server-to-clients/index'

--- a/src/commands/mcp/tui-availability.ts
+++ b/src/commands/mcp/tui-availability.ts
@@ -1,0 +1,11 @@
+/**
+ * Ink throws "Raw mode is not supported" when stdin has no TTY (piped input,
+ * CI, some IDE terminals). That is the only TUI failure the mcp commands
+ * degrade to LoggingUI for — any other error from the TUI path is a real bug
+ * and must surface rather than be silently swallowed.
+ */
+export function isTUIUnavailable(error: unknown): boolean {
+  return (
+    error instanceof Error && /raw mode is not supported/i.test(error.message)
+  );
+}

--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -16,7 +16,7 @@ export abstract class MCPClient {
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult>;
-  abstract removeServer(local?: boolean): Promise<{ success: boolean }>;
+  abstract removeServer(local?: boolean): Promise<InstallResult>;
   abstract isClientSupported(): Promise<boolean>;
 }
 
@@ -130,12 +130,13 @@ export abstract class DefaultMCPClient extends MCPClient {
     }
   }
 
-  async removeServer(local?: boolean): Promise<{ success: boolean }> {
+  async removeServer(local?: boolean): Promise<InstallResult> {
+    let configPath = '';
     try {
-      const configPath = await this.getConfigPath();
+      configPath = await this.getConfigPath();
 
       if (!fs.existsSync(configPath)) {
-        return { success: false };
+        return { success: true, alreadyInstalled: true };
       }
 
       const configContent = await fs.promises.readFile(configPath, 'utf8');
@@ -166,10 +167,16 @@ export abstract class DefaultMCPClient extends MCPClient {
 
         return { success: true };
       }
-    } catch {
-      //
+      // No PostHog entry to delete — the config changed under us between the
+      // detection pass and now. Nothing failed, so don't report a failure.
+      return { success: true, alreadyInstalled: true };
+    } catch (error) {
+      return {
+        success: false,
+        reason: `${configPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
     }
-
-    return { success: false };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as jsonc from 'jsonc-parser';
 import { getDefaultServerConfig } from './defaults';
+import type { InstallResult } from './results';
 
 export type MCPServerConfig = Record<string, unknown>;
 
@@ -14,7 +15,7 @@ export abstract class MCPClient {
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
-  ): Promise<{ success: boolean }>;
+  ): Promise<InstallResult>;
   abstract removeServer(local?: boolean): Promise<{ success: boolean }>;
   abstract isClientSupported(): Promise<boolean>;
 }
@@ -63,7 +64,7 @@ export abstract class DefaultMCPClient extends MCPClient {
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
-  ): Promise<{ success: boolean }> {
+  ): Promise<InstallResult> {
     try {
       const configPath = await this.getConfigPath();
       const configDir = path.dirname(configPath);
@@ -89,6 +90,19 @@ export abstract class DefaultMCPClient extends MCPClient {
         typedConfig[serverPropertyName] = {};
       }
       const serverName = local ? 'posthog-local' : 'posthog';
+
+      // An identical entry means this config is already set up — leave the file
+      // untouched and report it, so a re-run says "already installed" instead of
+      // claiming a write that changed nothing. A differing entry (new features,
+      // new key) still gets overwritten and reported as installed.
+      const existingServerConfig = typedConfig[serverPropertyName][serverName];
+      if (
+        existingServerConfig !== undefined &&
+        JSON.stringify(existingServerConfig) === JSON.stringify(newServerConfig)
+      ) {
+        return { success: true, alreadyInstalled: true };
+      }
+
       typedConfig[serverPropertyName][serverName] = newServerConfig;
 
       const edits = jsonc.modify(
@@ -108,8 +122,11 @@ export abstract class DefaultMCPClient extends MCPClient {
       await fs.promises.writeFile(configPath, modifiedContent, 'utf8');
 
       return { success: true };
-    } catch {
-      return { success: false };
+    } catch (error) {
+      return {
+        success: false,
+        reason: error instanceof Error ? error.message : String(error),
+      };
     }
   }
 

--- a/src/steps/add-mcp-server-to-clients/__tests__/mcp-client.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/mcp-client.test.ts
@@ -1,0 +1,78 @@
+import { DefaultMCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
+import * as fs from 'fs';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  promises: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn(),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const CONFIG_PATH = '/home/test/.some-editor/mcp.json';
+
+class TestClient extends DefaultMCPClient {
+  name = 'Test Editor';
+  getConfigPath(): Promise<string> {
+    return Promise.resolve(CONFIG_PATH);
+  }
+  isClientSupported(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}
+
+describe('DefaultMCPClient — addServer', () => {
+  const existsSyncMock = fs.existsSync as Mock;
+  const readFileMock = fs.promises.readFile as Mock;
+  const writeFileMock = fs.promises.writeFile as Mock;
+
+  const serverConfigFor = () =>
+    new TestClient().getServerConfig(undefined, ['flags'], false);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('installs into a config that has no posthog entry yet', async () => {
+    existsSyncMock.mockReturnValue(false);
+
+    await expect(
+      new TestClient().addServer(undefined, ['flags']),
+    ).resolves.toEqual({ success: true });
+    expect(writeFileMock).toHaveBeenCalled();
+  });
+
+  it('reports already-installed and leaves the file alone when the entry is identical', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ mcpServers: { posthog: serverConfigFor() } }),
+    );
+
+    await expect(
+      new TestClient().addServer(undefined, ['flags'], false),
+    ).resolves.toEqual({ success: true, alreadyInstalled: true });
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it('rewrites the entry when the existing config differs', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ mcpServers: { posthog: { command: 'stale' } } }),
+    );
+
+    await expect(
+      new TestClient().addServer(undefined, ['flags'], false),
+    ).resolves.toEqual({ success: true });
+    expect(writeFileMock).toHaveBeenCalled();
+  });
+
+  it('returns the underlying error as the failure reason', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileMock.mockRejectedValue(new Error('EACCES: permission denied'));
+
+    await expect(
+      new TestClient().addServer(undefined, ['flags']),
+    ).resolves.toEqual({ success: false, reason: 'EACCES: permission denied' });
+  });
+});

--- a/src/steps/add-mcp-server-to-clients/__tests__/results.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/results.test.ts
@@ -11,14 +11,14 @@ describe('toClientResult', () => {
   it('maps a plain success to installed', () => {
     expect(toClientResult('Cursor', { success: true })).toEqual({
       name: 'Cursor',
-      status: McpClientStatus.Installed,
+      status: McpClientStatus.Changed,
     });
   });
 
   it('maps an already-installed success to its own status, not a silent no-op', () => {
     expect(
       toClientResult('Codex', { success: true, alreadyInstalled: true }),
-    ).toEqual({ name: 'Codex', status: McpClientStatus.AlreadyInstalled });
+    ).toEqual({ name: 'Codex', status: McpClientStatus.Unchanged });
   });
 
   it('keeps the failure reason so the user is told why', () => {
@@ -40,12 +40,10 @@ describe('toClientResult', () => {
 
 describe('isOk', () => {
   it('counts already-installed as a working install', () => {
-    expect(
-      isOk({ name: 'Codex', status: McpClientStatus.AlreadyInstalled }),
-    ).toBe(true);
-    expect(isOk({ name: 'Codex', status: McpClientStatus.Installed })).toBe(
+    expect(isOk({ name: 'Codex', status: McpClientStatus.Unchanged })).toBe(
       true,
     );
+    expect(isOk({ name: 'Codex', status: McpClientStatus.Changed })).toBe(true);
     expect(isOk({ name: 'Codex', status: McpClientStatus.Failed })).toBe(false);
   });
 });
@@ -92,11 +90,11 @@ describe('summarizeFailure', () => {
 describe('namesWithStatus', () => {
   it('filters by status', () => {
     const results = [
-      { name: 'Cursor', status: McpClientStatus.Installed },
-      { name: 'Codex', status: McpClientStatus.AlreadyInstalled },
+      { name: 'Cursor', status: McpClientStatus.Changed },
+      { name: 'Codex', status: McpClientStatus.Unchanged },
       { name: 'Zed', status: McpClientStatus.Failed },
     ];
-    expect(namesWithStatus(results, McpClientStatus.AlreadyInstalled)).toEqual([
+    expect(namesWithStatus(results, McpClientStatus.Unchanged)).toEqual([
       'Codex',
     ]);
   });

--- a/src/steps/add-mcp-server-to-clients/__tests__/results.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/results.test.ts
@@ -1,0 +1,103 @@
+import {
+  McpClientStatus,
+  isOk,
+  namesWithStatus,
+  redactSecrets,
+  summarizeFailure,
+  toClientResult,
+} from '@steps/add-mcp-server-to-clients/results';
+
+describe('toClientResult', () => {
+  it('maps a plain success to installed', () => {
+    expect(toClientResult('Cursor', { success: true })).toEqual({
+      name: 'Cursor',
+      status: McpClientStatus.Installed,
+    });
+  });
+
+  it('maps an already-installed success to its own status, not a silent no-op', () => {
+    expect(
+      toClientResult('Codex', { success: true, alreadyInstalled: true }),
+    ).toEqual({ name: 'Codex', status: McpClientStatus.AlreadyInstalled });
+  });
+
+  it('keeps the failure reason so the user is told why', () => {
+    expect(
+      toClientResult('Zed', { success: false, reason: 'EACCES: denied' }),
+    ).toEqual({
+      name: 'Zed',
+      status: McpClientStatus.Failed,
+      detail: 'EACCES: denied',
+    });
+  });
+
+  it('treats a missing result as a failure', () => {
+    expect(toClientResult('Zed', undefined).status).toBe(
+      McpClientStatus.Failed,
+    );
+  });
+});
+
+describe('isOk', () => {
+  it('counts already-installed as a working install', () => {
+    expect(
+      isOk({ name: 'Codex', status: McpClientStatus.AlreadyInstalled }),
+    ).toBe(true);
+    expect(isOk({ name: 'Codex', status: McpClientStatus.Installed })).toBe(
+      true,
+    );
+    expect(isOk({ name: 'Codex', status: McpClientStatus.Failed })).toBe(false);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('masks the bearer token the CLIs echo back in their error output', () => {
+    expect(
+      redactSecrets(
+        'Command failed: claude "mcp" "add" "--header" "Authorization: Bearer phx_live_abc123"',
+      ),
+    ).not.toContain('phx_live_abc123');
+  });
+
+  it('masks a bare personal API key', () => {
+    expect(redactSecrets('bad key phx_abc-123 rejected')).toBe(
+      'bad key [redacted] rejected',
+    );
+  });
+});
+
+describe('summarizeFailure', () => {
+  it('takes the first non-empty line', () => {
+    expect(summarizeFailure('\n\n  boom: it broke  \nstack trace\n')).toBe(
+      'boom: it broke',
+    );
+  });
+
+  it('truncates a very long line', () => {
+    expect(summarizeFailure('x'.repeat(200))).toHaveLength(120);
+  });
+
+  it('redacts before truncating, so a long line cannot smuggle a key through', () => {
+    expect(
+      summarizeFailure(`${'x'.repeat(80)} Authorization: Bearer phx_secret`),
+    ).not.toContain('phx_secret');
+  });
+
+  it('returns undefined when there is nothing to say', () => {
+    expect(summarizeFailure('   \n ')).toBeUndefined();
+    expect(summarizeFailure(undefined)).toBeUndefined();
+  });
+});
+
+describe('namesWithStatus', () => {
+  it('filters by status', () => {
+    const results = [
+      { name: 'Cursor', status: McpClientStatus.Installed },
+      { name: 'Codex', status: McpClientStatus.AlreadyInstalled },
+      { name: 'Zed', status: McpClientStatus.Failed },
+    ];
+    expect(namesWithStatus(results, McpClientStatus.AlreadyInstalled)).toEqual([
+      'Codex',
+    ]);
+  });
+});

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -113,7 +113,25 @@ describe('ClaudeCodeMCPClient — plugin methods', () => {
       });
     });
 
-    it('returns failure and captures exception on unexpected error', async () => {
+    it('returns already-installed without running the install when plugin list already has posthog', async () => {
+      execSyncMock.mockImplementation((cmd: string) => {
+        if (String(cmd).includes('plugin list'))
+          return Buffer.from('posthog  1.0.0\n');
+        return Buffer.from('');
+      });
+      const client = new ClaudeCodeMCPClient();
+      await expect(client.installPlugin()).resolves.toEqual({
+        success: true,
+        alreadyInstalled: true,
+      });
+      expect(
+        execSyncMock.mock.calls.some((c) =>
+          String(c[0]).includes('plugin install'),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns failure with the reason and captures exception on unexpected error', async () => {
       execSyncMock.mockImplementation((cmd: string) => {
         if (String(cmd).includes('plugin install')) {
           throw new Error('network timeout');
@@ -121,7 +139,10 @@ describe('ClaudeCodeMCPClient — plugin methods', () => {
         return Buffer.from('');
       });
       const client = new ClaudeCodeMCPClient();
-      await expect(client.installPlugin()).resolves.toEqual({ success: false });
+      await expect(client.installPlugin()).resolves.toEqual({
+        success: false,
+        reason: 'network timeout',
+      });
       expect(analytics.captureException).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('network timeout'),
@@ -129,12 +150,15 @@ describe('ClaudeCodeMCPClient — plugin methods', () => {
       );
     });
 
-    it('returns failure when no binary is found', async () => {
+    it('returns failure with a reason when no binary is found', async () => {
       execSyncMock.mockImplementation(() => {
         throw new Error('not found');
       });
       const client = new ClaudeCodeMCPClient();
-      await expect(client.installPlugin()).resolves.toEqual({ success: false });
+      await expect(client.installPlugin()).resolves.toEqual({
+        success: false,
+        reason: expect.stringContaining('PATH'),
+      });
     });
   });
 });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-web.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-web.test.ts
@@ -47,8 +47,10 @@ describe('ClaudeWebMCPClient', () => {
     );
   });
 
-  it('removeServer is a no-op that reports nothing removed', async () => {
-    await expect(client.removeServer()).resolves.toEqual({ success: false });
+  it('removeServer reports a failure that says where the connector lives', async () => {
+    const result = await client.removeServer();
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('claude.ai');
     expect(openTrackedLinkMock).not.toHaveBeenCalled();
   });
 });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -29,6 +29,10 @@ describe('CodexMCPClient', () => {
     vi.clearAllMocks();
     // Default: codex found via command -v
     execSyncMock.mockReturnValue(Buffer.from(CODEX_PATH + '\n'));
+    // Default: no plugin marketplace registered yet. clearAllMocks keeps
+    // implementations, so without this a config.toml fixture set by one test
+    // leaks into the next one's isPluginInstalled() check.
+    readFileSyncMock.mockReturnValue('');
   });
 
   describe('isClientSupported', () => {
@@ -124,7 +128,7 @@ describe('CodexMCPClient', () => {
       expect(call[2].env.POSTHOG_AUTH_HEADER).toBe('Bearer phx_test');
     });
 
-    it('treats "already" stderr as success', async () => {
+    it('reports "already" stderr as an already-installed success', async () => {
       spawnSyncMock.mockReturnValue({
         status: 1,
         stderr: "Server 'posthog' already exists",
@@ -132,14 +136,16 @@ describe('CodexMCPClient', () => {
       const client = new CodexMCPClient();
       await expect(client.addServer('phx_test')).resolves.toEqual({
         success: true,
+        alreadyInstalled: true,
       });
     });
 
-    it('returns failure and captures exception on unexpected error', async () => {
+    it('returns failure with the reason and captures exception on unexpected error', async () => {
       spawnSyncMock.mockReturnValue({ status: 1, stderr: 'network timeout' });
       const client = new CodexMCPClient();
       await expect(client.addServer('phx_test')).resolves.toEqual({
         success: false,
+        reason: 'network timeout',
       });
       expect(analytics.captureException).toHaveBeenCalled();
     });
@@ -209,10 +215,50 @@ describe('CodexMCPClient', () => {
       expect(spawnSyncMock).toHaveBeenCalledTimes(2);
     });
 
-    it('returns failure and captures exception on unexpected error', async () => {
+    it('returns already-installed without shelling out when config.toml already has the marketplace', async () => {
+      readFileSyncMock.mockReturnValue('[marketplaces.posthog]\n');
+      const client = new CodexMCPClient();
+      await expect(client.installPlugin()).resolves.toEqual({
+        success: true,
+        alreadyInstalled: true,
+      });
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('reports "already" stderr as already-installed rather than a failure', async () => {
+      spawnSyncMock.mockReturnValue({
+        status: 1,
+        stderr: "marketplace 'posthog' is already installed",
+      });
+      const client = new CodexMCPClient();
+      await expect(client.installPlugin()).resolves.toEqual({
+        success: true,
+        alreadyInstalled: true,
+      });
+      expect(analytics.captureException).not.toHaveBeenCalled();
+    });
+
+    it('still reports a failure when the stale-cache retry does not help', async () => {
+      // rmSync can fail (EPERM on Windows while codex is running), so the retry
+      // hits the same error — that means "not installed", not "already there".
+      spawnSyncMock.mockReturnValue({
+        status: 1,
+        stderr:
+          "Error: marketplace 'posthog' is already added from a different source",
+      });
+      const client = new CodexMCPClient();
+      const result = await client.installPlugin();
+      expect(result.success).toBe(false);
+      expect(analytics.captureException).toHaveBeenCalled();
+    });
+
+    it('returns failure with the reason and captures exception on unexpected error', async () => {
       spawnSyncMock.mockReturnValue({ status: 1, stderr: 'network timeout' });
       const client = new CodexMCPClient();
-      await expect(client.installPlugin()).resolves.toEqual({ success: false });
+      await expect(client.installPlugin()).resolves.toEqual({
+        success: false,
+        reason: 'network timeout',
+      });
       expect(analytics.captureException).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('network timeout'),

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -159,14 +159,28 @@ describe('CodexMCPClient', () => {
       expect(spawnSyncMock).toHaveBeenCalledWith(
         CODEX_PATH,
         ['mcp', 'remove', 'posthog'],
-        { stdio: 'ignore' },
+        { encoding: 'utf-8' },
       );
     });
 
-    it('returns false and captures exception on failure', async () => {
-      spawnSyncMock.mockReturnValue({ status: 1 });
+    it('targets the local server name when removing the local MCP', async () => {
+      spawnSyncMock.mockReturnValue({ status: 0 });
       const client = new CodexMCPClient();
-      await expect(client.removeServer()).resolves.toEqual({ success: false });
+      await client.removeServer(true);
+      expect(spawnSyncMock).toHaveBeenCalledWith(
+        CODEX_PATH,
+        ['mcp', 'remove', 'posthog-local'],
+        { encoding: 'utf-8' },
+      );
+    });
+
+    it('returns the failure reason and captures exception on failure', async () => {
+      spawnSyncMock.mockReturnValue({ status: 1, stderr: 'codex is locked' });
+      const client = new CodexMCPClient();
+      await expect(client.removeServer()).resolves.toEqual({
+        success: false,
+        reason: 'codex is locked',
+      });
       expect(analytics.captureException).toHaveBeenCalled();
     });
   });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/opencode.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/opencode.test.ts
@@ -227,10 +227,13 @@ describe('OpenCodeMCPClient', () => {
       expect(writtenContent).toContain('other-server');
     });
 
-    it('returns false when config file does not exist', async () => {
+    it('reports nothing-to-do (not a failure) when the config file does not exist', async () => {
       existsSyncMock.mockReturnValue(false);
       const client = new OpenCodeMCPClient();
-      await expect(client.removeServer()).resolves.toEqual({ success: false });
+      await expect(client.removeServer()).resolves.toEqual({
+        success: true,
+        alreadyInstalled: true,
+      });
     });
   });
 });

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -7,6 +7,10 @@ import {
   PluginCapable,
   PluginInstallResult,
 } from '@steps/add-mcp-server-to-clients/plugin-client';
+import {
+  redactSecrets,
+  type InstallResult,
+} from '@steps/add-mcp-server-to-clients/results';
 import { z } from 'zod';
 import { execSync } from 'child_process';
 import { analytics } from '@utils/analytics';
@@ -113,9 +117,13 @@ export class ClaudeCodeMCPClient
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
-  ): Promise<{ success: boolean }> {
+  ): Promise<InstallResult> {
     const binary = this.findClaudeBinary();
-    if (!binary) return Promise.resolve({ success: false });
+    if (!binary)
+      return Promise.resolve({
+        success: false,
+        reason: 'The claude CLI is no longer on your PATH.',
+      });
 
     const serverName = local ? 'posthog-local' : 'posthog';
     const url = buildMCPUrl(selectedFeatures, local);
@@ -139,14 +147,18 @@ export class ClaudeCodeMCPClient
       });
       return Promise.resolve({ success: true });
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      // The failing command echoes back the Authorization header we passed, so
+      // redact before this reaches a log, the screen, or an exception report.
+      const msg = redactSecrets(
+        error instanceof Error ? error.message : String(error),
+      );
       if (msg.includes('already exists')) {
-        return Promise.resolve({ success: true });
+        return Promise.resolve({ success: true, alreadyInstalled: true });
       }
       analytics.captureException(
         new Error(`Claude Code MCP add failed: ${msg}`),
       );
-      return Promise.resolve({ success: false });
+      return Promise.resolve({ success: false, reason: msg });
     }
   }
 
@@ -192,21 +204,32 @@ export class ClaudeCodeMCPClient
     }
   }
 
-  installPlugin(): Promise<PluginInstallResult> {
+  async installPlugin(): Promise<PluginInstallResult> {
     const binary = this.findClaudeBinary();
-    if (!binary) return Promise.resolve({ success: false });
+    if (!binary)
+      return {
+        success: false,
+        reason: 'The claude CLI is no longer on your PATH.',
+      };
+
+    // Ask before installing so a re-run reports "already installed" rather than
+    // relying on the CLI's error text to spot the no-op.
+    if (await this.isPluginInstalled()) {
+      return { success: true, alreadyInstalled: true };
+    }
+
     try {
       execSync(`${binary} plugin install posthog`, { stdio: 'pipe' });
-      return Promise.resolve({ success: true });
+      return { success: true };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       if (msg.includes('already installed') || msg.includes('already exists')) {
-        return Promise.resolve({ success: true, alreadyInstalled: true });
+        return { success: true, alreadyInstalled: true };
       }
       analytics.captureException(
         new Error(`Claude Code plugin install failed: ${msg}`),
       );
-      return Promise.resolve({ success: false });
+      return { success: false, reason: msg };
     }
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -162,26 +162,33 @@ export class ClaudeCodeMCPClient
     }
   }
 
-  removeServer(local?: boolean): Promise<{ success: boolean }> {
+  removeServer(local?: boolean): Promise<InstallResult> {
     const claudeBinary = this.findClaudeBinary();
     if (!claudeBinary) {
-      return Promise.resolve({ success: false });
+      return Promise.resolve({
+        success: false,
+        reason: 'The claude CLI is no longer on your PATH.',
+      });
     }
 
     const serverName = local ? 'posthog-local' : 'posthog';
     const command = `${claudeBinary} mcp remove --scope user ${serverName}`;
 
     try {
-      execSync(command);
+      execSync(command, { stdio: 'pipe' });
     } catch (error) {
-      analytics.captureException(
-        new Error(
-          `Failed to remove server from Claude Code: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        ),
+      const reason = redactSecrets(
+        error instanceof Error ? error.message : String(error),
       );
-      return Promise.resolve({ success: false });
+      // Removing something that isn't there is the requested end state, not a
+      // failure to report.
+      if (/no( such)? mcp server|not found/i.test(reason)) {
+        return Promise.resolve({ success: true, alreadyInstalled: true });
+      }
+      analytics.captureException(
+        new Error(`Failed to remove server from Claude Code: ${reason}`),
+      );
+      return Promise.resolve({ success: false, reason });
     }
 
     return Promise.resolve({ success: true });

--- a/src/steps/add-mcp-server-to-clients/clients/claude-web.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-web.ts
@@ -1,4 +1,5 @@
 import { MCPClient } from '@steps/add-mcp-server-to-clients/MCPClient';
+import type { InstallResult } from '@steps/add-mcp-server-to-clients/results';
 import { BrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
 import { openTrackedLink } from '@utils/links';
 
@@ -23,7 +24,7 @@ export class ClaudeWebMCPClient extends MCPClient implements BrowserFinishable {
     return Promise.resolve(false);
   }
 
-  addServer(): Promise<{ success: boolean }> {
+  addServer(): Promise<InstallResult> {
     // Not a PostHog property, so no UTMs — just the tracked open.
     openTrackedLink(this.connectorUrl, 'claude-web-connector', {
       auto: true,
@@ -32,8 +33,15 @@ export class ClaudeWebMCPClient extends MCPClient implements BrowserFinishable {
     return Promise.resolve({ success: true });
   }
 
-  removeServer(): Promise<{ success: boolean }> {
-    return Promise.resolve({ success: false });
+  removeServer(): Promise<InstallResult> {
+    // The connector lives in the user's Claude account, so `mcp remove` can't
+    // touch it. It never reaches here today (isServerInstalled is always
+    // false), but say where to go if it ever does.
+    return Promise.resolve({
+      success: false,
+      reason:
+        'This connector is managed in your Claude account — remove it at claude.ai/settings/connectors.',
+    });
   }
 
   getConfigPath(): Promise<string> {

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -13,8 +13,15 @@ import {
   PluginCapable,
   PluginInstallResult,
 } from '@steps/add-mcp-server-to-clients/plugin-client';
+import type { InstallResult } from '@steps/add-mcp-server-to-clients/results';
 
 import { analytics } from '@utils/analytics';
+
+/** Wording codex uses when the thing we're adding is already registered. */
+const ALREADY_INSTALLED_PATTERN =
+  /already (installed|exists|added|registered)/i;
+/** Wording that means the opposite: a cache entry exists but the plugin doesn't. */
+const STALE_MARKETPLACE_CACHE = /already added from a different source/i;
 
 export const CodexMCPConfig = DefaultMCPClientConfig;
 
@@ -67,9 +74,13 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
-  ): Promise<{ success: boolean }> {
+  ): Promise<InstallResult> {
     const binary = this.findCodexBinary();
-    if (!binary) return Promise.resolve({ success: false });
+    if (!binary)
+      return Promise.resolve({
+        success: false,
+        reason: 'The codex CLI is no longer on your PATH.',
+      });
 
     const serverName = local ? 'posthog-local' : 'posthog';
     const url = buildMCPUrl(selectedFeatures, local);
@@ -84,11 +95,11 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     const result = spawnSync(binary, args, { encoding: 'utf-8', env });
     if (result.status !== 0) {
       const stderr = result.stderr ?? '';
-      if (stderr.toLowerCase().includes('already')) {
-        return Promise.resolve({ success: true });
+      if (ALREADY_INSTALLED_PATTERN.test(stderr)) {
+        return Promise.resolve({ success: true, alreadyInstalled: true });
       }
       analytics.captureException(new Error(`Codex MCP add failed: ${stderr}`));
-      return Promise.resolve({ success: false });
+      return Promise.resolve({ success: false, reason: stderr });
     }
     return Promise.resolve({ success: true });
   }
@@ -128,9 +139,20 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     }
   }
 
-  installPlugin(): Promise<PluginInstallResult> {
+  async installPlugin(): Promise<PluginInstallResult> {
     const binary = this.findCodexBinary();
-    if (!binary) return Promise.resolve({ success: false });
+    if (!binary)
+      return {
+        success: false,
+        reason: 'The codex CLI is no longer on your PATH.',
+      };
+
+    // `codex plugin marketplace add` exits non-zero once the marketplace is
+    // registered, so ask config.toml first. Without this the second run of
+    // `mcp add` looked like a failure and reported nothing at all.
+    if (await this.isPluginInstalled()) {
+      return { success: true, alreadyInstalled: true };
+    }
 
     const run = () =>
       spawnSync(binary, ['plugin', 'marketplace', 'add', 'PostHog/ai-plugin'], {
@@ -142,7 +164,7 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     // Stale cache directory with no config.toml entry — clear it and retry
     if (
       result.status !== 0 &&
-      (result.stderr ?? '').includes('already added from a different source')
+      STALE_MARKETPLACE_CACHE.test(result.stderr ?? '')
     ) {
       const staleDir = path.join(
         os.homedir(),
@@ -160,13 +182,25 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     }
 
     if (result.status !== 0) {
+      const stderr = result.stderr ?? '';
+      // The marketplace was registered by something other than us (a manual
+      // `codex plugin marketplace add`, or a version that writes config.toml
+      // differently) — that's still "already installed", not a failure. The
+      // stale-cache wording above is deliberately excluded: that one means the
+      // plugin is NOT registered, and it only reaches here if the retry failed.
+      if (
+        ALREADY_INSTALLED_PATTERN.test(stderr) &&
+        !STALE_MARKETPLACE_CACHE.test(stderr)
+      ) {
+        return { success: true, alreadyInstalled: true };
+      }
       analytics.captureException(
-        new Error(`Codex plugin install failed: ${result.stderr ?? ''}`),
+        new Error(`Codex plugin install failed: ${stderr}`),
       );
-      return Promise.resolve({ success: false });
+      return { success: false, reason: stderr };
     }
 
-    return Promise.resolve({ success: true });
+    return { success: true };
   }
 }
 

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -13,7 +13,10 @@ import {
   PluginCapable,
   PluginInstallResult,
 } from '@steps/add-mcp-server-to-clients/plugin-client';
-import type { InstallResult } from '@steps/add-mcp-server-to-clients/results';
+import {
+  redactSecrets,
+  type InstallResult,
+} from '@steps/add-mcp-server-to-clients/results';
 
 import { analytics } from '@utils/analytics';
 
@@ -98,25 +101,36 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
       if (ALREADY_INSTALLED_PATTERN.test(stderr)) {
         return Promise.resolve({ success: true, alreadyInstalled: true });
       }
-      analytics.captureException(new Error(`Codex MCP add failed: ${stderr}`));
-      return Promise.resolve({ success: false, reason: stderr });
+      const reason = redactSecrets(stderr);
+      analytics.captureException(new Error(`Codex MCP add failed: ${reason}`));
+      return Promise.resolve({ success: false, reason });
     }
     return Promise.resolve({ success: true });
   }
 
-  removeServer(): Promise<{ success: boolean }> {
+  removeServer(local?: boolean): Promise<InstallResult> {
     const binary = this.findCodexBinary();
-    if (!binary) return Promise.resolve({ success: false });
+    if (!binary)
+      return Promise.resolve({
+        success: false,
+        reason: 'The codex CLI is no longer on your PATH.',
+      });
 
-    const result = spawnSync(binary, ['mcp', 'remove', 'posthog'], {
-      stdio: 'ignore',
+    // `local` was ignored here, so `mcp remove --local` reported success while
+    // leaving the posthog-local server in place.
+    const serverName = local ? 'posthog-local' : 'posthog';
+    const result = spawnSync(binary, ['mcp', 'remove', serverName], {
+      encoding: 'utf-8',
     });
 
     if (result.error || result.status !== 0) {
-      analytics.captureException(
-        new Error('Failed to remove server from Codex CLI.'),
+      const reason = redactSecrets(
+        result.error?.message ?? result.stderr ?? 'codex mcp remove failed',
       );
-      return Promise.resolve({ success: false });
+      analytics.captureException(
+        new Error(`Failed to remove server from Codex CLI: ${reason}`),
+      );
+      return Promise.resolve({ success: false, reason });
     }
 
     return Promise.resolve({ success: true });
@@ -194,10 +208,11 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
       ) {
         return { success: true, alreadyInstalled: true };
       }
+      const reason = redactSecrets(stderr);
       analytics.captureException(
-        new Error(`Codex plugin install failed: ${stderr}`),
+        new Error(`Codex plugin install failed: ${reason}`),
       );
-      return { success: false, reason: stderr };
+      return { success: false, reason };
     }
 
     return { success: true };

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -14,6 +14,12 @@ import { OpenCodeMCPClient } from './clients/opencode';
 import { ALL_FEATURE_VALUES } from './defaults';
 import { debug } from '@utils/debug';
 import { isPluginCapable, PluginCapable } from './plugin-client';
+import {
+  McpClientStatus,
+  namesWithStatus,
+  toClientResult,
+  type McpClientResult,
+} from './results';
 
 export const getSupportedClients = async (): Promise<MCPClient[]> => {
   const allClients = [
@@ -81,27 +87,56 @@ export const addMCPServerToClientsStep = async ({
   }
 
   // Auto-install to all supported clients
-  await withProgress('adding mcp servers', async () => {
-    await addMCPServer(
+  const results = await withProgress('adding mcp servers', () =>
+    addMCPServer(
       supportedClients,
       apiKey,
       features ?? [...ALL_FEATURE_VALUES],
       local,
-    );
-  });
-
-  ui.log.success(
-    `Added the MCP server to:
-  ${supportedClients.map((c) => `- ${c.name}`).join('\n  ')} `,
+    ),
   );
 
+  const installed = namesWithStatus(results, McpClientStatus.Installed);
+  const already = namesWithStatus(results, McpClientStatus.AlreadyInstalled);
+  const failed = results.filter((r) => r.status === McpClientStatus.Failed);
+
+  // Report each outcome on its own — a blanket "Added the MCP server to: ..."
+  // hid both the no-op re-runs and the outright failures.
+  if (installed.length > 0) {
+    ui.log.success(`Added the MCP server to:\n${bulletList(installed)}`);
+  }
+  if (already.length > 0) {
+    ui.log.info(
+      `The PostHog MCP server was already installed, so nothing changed for:\n${bulletList(
+        already,
+      )}`,
+    );
+  }
+  if (failed.length > 0) {
+    ui.log.warn(
+      `Couldn't add the MCP server to:\n${bulletList(
+        failed.map((r) => (r.detail ? `${r.name} — ${r.detail}` : r.name)),
+      )}`,
+    );
+  }
+
+  const withServer = [...installed, ...already];
+
   analytics.wizardCapture('mcp servers added', {
-    clients: supportedClients.map((c) => c.name),
+    // `clients` stays "every client that ended up with the MCP server", which is
+    // what it meant before — the new properties break that down.
+    clients: withServer,
+    already_installed_clients: already,
+    failed_clients: failed.map((r) => r.name),
+    attempted_clients: supportedClients.map((c) => c.name),
     integration,
   });
 
-  return supportedClients.map((c) => c.name);
+  return withServer;
 };
+
+const bulletList = (items: string[]): string =>
+  items.map((item) => `  - ${item}`).join('\n');
 
 export const removeMCPServerFromClientsStep = async ({
   integration,
@@ -152,10 +187,27 @@ export const addMCPServer = async (
   personalApiKey?: string,
   selectedFeatures?: string[],
   local?: boolean,
-): Promise<void> => {
+): Promise<McpClientResult[]> => {
+  const results: McpClientResult[] = [];
   for (const client of clients) {
-    await client.addServer(personalApiKey, selectedFeatures, local);
+    try {
+      const result = await client.addServer(
+        personalApiKey,
+        selectedFeatures,
+        local,
+      );
+      results.push(toClientResult(client.name, result));
+    } catch (err) {
+      debug(`[addMCPServer] addServer threw for ${client.name}: ${err}`);
+      results.push(
+        toClientResult(client.name, {
+          success: false,
+          reason: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
   }
+  return results;
 };
 
 export const getSupportedPluginClients = (
@@ -166,17 +218,22 @@ export const getSupportedPluginClients = (
 
 export const installPlugins = async (
   clients: Array<MCPClient & PluginCapable>,
-): Promise<string[]> => {
-  const installed: string[] = [];
+): Promise<McpClientResult[]> => {
+  const results: McpClientResult[] = [];
   for (const client of clients) {
     try {
-      const result = await client.installPlugin();
-      if (result.success) installed.push(client.name);
+      results.push(toClientResult(client.name, await client.installPlugin()));
     } catch (err) {
       debug(`[installPlugins] installPlugin threw for ${client.name}: ${err}`);
+      results.push(
+        toClientResult(client.name, {
+          success: false,
+          reason: err instanceof Error ? err.message : String(err),
+        }),
+      );
     }
   }
-  return installed;
+  return results;
 };
 
 export const removeMCPServer = async (

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -96,8 +96,8 @@ export const addMCPServerToClientsStep = async ({
     ),
   );
 
-  const installed = namesWithStatus(results, McpClientStatus.Installed);
-  const already = namesWithStatus(results, McpClientStatus.AlreadyInstalled);
+  const installed = namesWithStatus(results, McpClientStatus.Changed);
+  const already = namesWithStatus(results, McpClientStatus.Unchanged);
   const failed = results.filter((r) => r.status === McpClientStatus.Failed);
 
   // Report each outcome on its own — a blanket "Added the MCP server to: ..."
@@ -145,8 +145,12 @@ export const removeMCPServerFromClientsStep = async ({
   integration?: Integration;
   local?: boolean;
 }): Promise<string[]> => {
+  const ui = getUI();
   const installedClients = await getInstalledClients(local);
   if (installedClients.length === 0) {
+    ui.log.info(
+      'The PostHog MCP server is not installed for any supported client. Nothing to remove.',
+    );
     analytics.wizardCapture('mcp no servers to remove', {
       integration,
     });
@@ -154,17 +158,41 @@ export const removeMCPServerFromClientsStep = async ({
   }
 
   // Auto-remove from all installed clients
-  const results = await withProgress('removing mcp servers', async () => {
-    await removeMCPServer(installedClients, local);
-    return installedClients.map((c) => c.name);
-  });
+  const results = await withProgress('removing mcp servers', () =>
+    removeMCPServer(installedClients, local),
+  );
+
+  const removed = namesWithStatus(results, McpClientStatus.Changed);
+  const nothingToDo = namesWithStatus(results, McpClientStatus.Unchanged);
+  const failed = results.filter((r) => r.status === McpClientStatus.Failed);
+
+  // This step used to print nothing at all, so a non-TTY `mcp remove` gave no
+  // hint whether anything happened — let alone whether a client failed.
+  if (removed.length > 0) {
+    ui.log.success(`Removed the MCP server from:\n${bulletList(removed)}`);
+  }
+  if (nothingToDo.length > 0) {
+    ui.log.info(
+      `No PostHog MCP entry left to remove for:\n${bulletList(nothingToDo)}`,
+    );
+  }
+  if (failed.length > 0) {
+    ui.log.warn(
+      `Couldn't remove the MCP server from:\n${bulletList(
+        failed.map((r) => (r.detail ? `${r.name} — ${r.detail}` : r.name)),
+      )}`,
+    );
+  }
 
   analytics.wizardCapture('mcp servers removed', {
-    clients: results,
+    clients: removed,
+    nothing_to_remove_clients: nothingToDo,
+    failed_clients: failed.map((r) => r.name),
+    attempted_clients: installedClients.map((c) => c.name),
     integration,
   });
 
-  return results;
+  return removed;
 };
 
 export const getInstalledClients = async (
@@ -239,8 +267,22 @@ export const installPlugins = async (
 export const removeMCPServer = async (
   clients: MCPClient[],
   local?: boolean,
-): Promise<void> => {
+): Promise<McpClientResult[]> => {
+  const results: McpClientResult[] = [];
   for (const client of clients) {
-    await client.removeServer(local);
+    try {
+      results.push(
+        toClientResult(client.name, await client.removeServer(local)),
+      );
+    } catch (err) {
+      debug(`[removeMCPServer] removeServer threw for ${client.name}: ${err}`);
+      results.push(
+        toClientResult(client.name, {
+          success: false,
+          reason: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
   }
+  return results;
 };

--- a/src/steps/add-mcp-server-to-clients/plugin-client.ts
+++ b/src/steps/add-mcp-server-to-clients/plugin-client.ts
@@ -1,7 +1,6 @@
-export interface PluginInstallResult {
-  success: boolean;
-  alreadyInstalled?: boolean;
-}
+import type { InstallResult } from './results';
+
+export type PluginInstallResult = InstallResult;
 
 export interface PluginCapable {
   supportsPlugin(): boolean;

--- a/src/steps/add-mcp-server-to-clients/results.ts
+++ b/src/steps/add-mcp-server-to-clients/results.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-client outcome of an MCP server / plugin install attempt.
+ *
+ * "Already installed" is a first-class outcome rather than a silent no-op:
+ * re-running `mcp add` on a machine that's already set up is the common case,
+ * and collapsing it into an empty result set is what made the flow report
+ * "Installation skipped." with no explanation. Failures carry a short reason
+ * for the same reason — an empty list tells the user nothing.
+ */
+
+export enum McpClientStatus {
+  Installed = 'installed',
+  AlreadyInstalled = 'already-installed',
+  Failed = 'failed',
+}
+
+export interface McpClientResult {
+  name: string;
+  status: McpClientStatus;
+  /** Short, user-facing explanation. Set for failures. */
+  detail?: string;
+}
+
+/** Result shape every client's addServer/installPlugin returns. */
+export interface InstallResult {
+  success: boolean;
+  /** The PostHog server/plugin was already configured — nothing changed. */
+  alreadyInstalled?: boolean;
+  /** Raw failure text from the underlying CLI or filesystem error. */
+  reason?: string;
+}
+
+/**
+ * Failure text comes from CLIs we invoke with the user's personal API key on the
+ * command line (`--header "Authorization: Bearer phx_..."`), so it can carry the
+ * key into the log file, the TUI and exception reports. Mask it first.
+ */
+export const redactSecrets = (raw: string): string =>
+  raw
+    .replace(/Bearer\s+\S+/gi, 'Bearer [redacted]')
+    .replace(/ph[xspc]_[A-Za-z0-9_-]+/g, '[redacted]');
+
+/** First non-empty line of an error, trimmed to something a TUI line can hold. */
+export const summarizeFailure = (raw?: string): string | undefined => {
+  const line = redactSecrets(raw ?? '')
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!line) return undefined;
+  return line.length > 120 ? `${line.slice(0, 117)}...` : line;
+};
+
+export const toClientResult = (
+  name: string,
+  result: InstallResult | undefined,
+): McpClientResult => {
+  if (!result?.success) {
+    return {
+      name,
+      status: McpClientStatus.Failed,
+      detail: summarizeFailure(result?.reason),
+    };
+  }
+  return {
+    name,
+    status: result.alreadyInstalled
+      ? McpClientStatus.AlreadyInstalled
+      : McpClientStatus.Installed,
+  };
+};
+
+export const isOk = (r: McpClientResult): boolean =>
+  r.status !== McpClientStatus.Failed;
+
+export const namesWithStatus = (
+  results: McpClientResult[],
+  status: McpClientStatus,
+): string[] => results.filter((r) => r.status === status).map((r) => r.name);

--- a/src/steps/add-mcp-server-to-clients/results.ts
+++ b/src/steps/add-mcp-server-to-clients/results.ts
@@ -1,16 +1,21 @@
 /**
- * Per-client outcome of an MCP server / plugin install attempt.
+ * Per-client outcome of an MCP server / plugin install or removal.
  *
- * "Already installed" is a first-class outcome rather than a silent no-op:
+ * "Nothing to do" is a first-class outcome rather than a silent no-op:
  * re-running `mcp add` on a machine that's already set up is the common case,
  * and collapsing it into an empty result set is what made the flow report
  * "Installation skipped." with no explanation. Failures carry a short reason
  * for the same reason — an empty list tells the user nothing.
+ *
+ * The names are action-neutral because both `mcp add` and `mcp remove` report
+ * through them: `Changed` is "installed" or "removed" depending on the flow.
  */
 
 export enum McpClientStatus {
-  Installed = 'installed',
-  AlreadyInstalled = 'already-installed',
+  /** We made the change — wrote the config, installed or removed the server. */
+  Changed = 'changed',
+  /** Already in the requested state; nothing was touched. */
+  Unchanged = 'unchanged',
   Failed = 'failed',
 }
 
@@ -21,10 +26,10 @@ export interface McpClientResult {
   detail?: string;
 }
 
-/** Result shape every client's addServer/installPlugin returns. */
+/** Result shape every client's addServer/removeServer/installPlugin returns. */
 export interface InstallResult {
   success: boolean;
-  /** The PostHog server/plugin was already configured — nothing changed. */
+  /** Already in the requested state — nothing was written or removed. */
   alreadyInstalled?: boolean;
   /** Raw failure text from the underlying CLI or filesystem error. */
   reason?: string;
@@ -64,8 +69,8 @@ export const toClientResult = (
   return {
     name,
     status: result.alreadyInstalled
-      ? McpClientStatus.AlreadyInstalled
-      : McpClientStatus.Installed,
+      ? McpClientStatus.Unchanged
+      : McpClientStatus.Changed,
   };
 };
 

--- a/src/ui/tui/__tests__/mcp-installer.test.ts
+++ b/src/ui/tui/__tests__/mcp-installer.test.ts
@@ -28,13 +28,13 @@ vi.mock('../../../utils/analytics.js', () => ({
   analytics: { wizardCapture: vi.fn() },
 }));
 
-const installed = (name: string) => ({
+const changed = (name: string) => ({
   name,
-  status: McpClientStatus.Installed,
+  status: McpClientStatus.Changed,
 });
 const alreadyInstalled = (name: string) => ({
   name,
-  status: McpClientStatus.AlreadyInstalled,
+  status: McpClientStatus.Unchanged,
 });
 
 describe('createMcpInstaller — installPlugins', () => {
@@ -51,7 +51,7 @@ describe('createMcpInstaller — installPlugins', () => {
 
   it('calls installPlugins on plugin-capable clients and returns their results', async () => {
     mcpModule.getSupportedPluginClients.mockReturnValue([mockClaudeClient]);
-    mcpModule.installPlugins.mockResolvedValue([installed('Claude Code')]);
+    mcpModule.installPlugins.mockResolvedValue([changed('Claude Code')]);
 
     const installer = createMcpInstaller();
     await installer.detectClients();
@@ -62,12 +62,12 @@ describe('createMcpInstaller — installPlugins', () => {
       mockCursorClient,
     ]);
     expect(mcpModule.installPlugins).toHaveBeenCalledWith([mockClaudeClient]);
-    expect(result).toEqual([installed('Claude Code')]);
+    expect(result).toEqual([changed('Claude Code')]);
   });
 
   it('emits mcp plugins installed analytics with clients and attempted', async () => {
     mcpModule.getSupportedPluginClients.mockReturnValue([mockClaudeClient]);
-    mcpModule.installPlugins.mockResolvedValue([installed('Claude Code')]);
+    mcpModule.installPlugins.mockResolvedValue([changed('Claude Code')]);
 
     const installer = createMcpInstaller();
     await installer.detectClients();
@@ -143,7 +143,7 @@ describe('createMcpInstaller — installPlugins', () => {
       mockCursorClient,
     ]);
     mcpModule.installPlugins.mockResolvedValue([
-      installed('Claude Code'),
+      changed('Claude Code'),
       { name: 'Cursor', status: McpClientStatus.Failed, detail: 'boom' },
     ]);
 
@@ -152,7 +152,7 @@ describe('createMcpInstaller — installPlugins', () => {
     const result = await installer.installPlugins(['Claude Code', 'Cursor']);
 
     expect(result).toEqual([
-      installed('Claude Code'),
+      changed('Claude Code'),
       { name: 'Cursor', status: McpClientStatus.Failed, detail: 'boom' },
     ]);
   });
@@ -189,7 +189,7 @@ describe('createMcpInstaller — install', () => {
     const result = await installer.install(['Cursor', 'Codex', 'Zed']);
 
     expect(result).toEqual([
-      installed('Cursor'),
+      changed('Cursor'),
       alreadyInstalled('Codex'),
       {
         name: 'Zed',
@@ -213,6 +213,53 @@ describe('createMcpInstaller — install', () => {
     await expect(installer.install(['Cursor'])).resolves.toEqual([
       { name: 'Cursor', status: McpClientStatus.Failed, detail: 'disk full' },
     ]);
+  });
+});
+
+describe('createMcpInstaller — remove', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes the local flag through so `mcp remove --local` targets the right server', async () => {
+    mcpModule.getInstalledClients.mockResolvedValue([{ name: 'Codex' }]);
+    mcpModule.removeMCPServer.mockResolvedValue([changed('Codex')]);
+
+    const installer = createMcpInstaller();
+    await installer.remove(true);
+
+    expect(mcpModule.getInstalledClients).toHaveBeenCalledWith(true);
+    expect(mcpModule.removeMCPServer).toHaveBeenCalledWith(
+      [{ name: 'Codex' }],
+      true,
+    );
+  });
+
+  it('returns per-client removal results instead of assuming success', async () => {
+    mcpModule.getInstalledClients.mockResolvedValue([
+      { name: 'Cursor' },
+      { name: 'Codex' },
+    ]);
+    mcpModule.removeMCPServer.mockResolvedValue([
+      changed('Cursor'),
+      { name: 'Codex', status: McpClientStatus.Failed, detail: 'codex locked' },
+    ]);
+
+    const installer = createMcpInstaller();
+
+    await expect(installer.remove()).resolves.toEqual([
+      changed('Cursor'),
+      { name: 'Codex', status: McpClientStatus.Failed, detail: 'codex locked' },
+    ]);
+  });
+
+  it('returns nothing when no client has the server installed', async () => {
+    mcpModule.getInstalledClients.mockResolvedValue([]);
+
+    const installer = createMcpInstaller();
+
+    await expect(installer.remove()).resolves.toEqual([]);
+    expect(mcpModule.removeMCPServer).not.toHaveBeenCalled();
   });
 });
 

--- a/src/ui/tui/__tests__/mcp-installer.test.ts
+++ b/src/ui/tui/__tests__/mcp-installer.test.ts
@@ -1,4 +1,5 @@
 import { createMcpInstaller } from '@ui/tui/services/mcp-installer';
+import { McpClientStatus } from '@steps/add-mcp-server-to-clients/results';
 import * as mcpModuleReal from '@steps/add-mcp-server-to-clients/index';
 import { analytics } from '@utils/analytics';
 
@@ -27,6 +28,15 @@ vi.mock('../../../utils/analytics.js', () => ({
   analytics: { wizardCapture: vi.fn() },
 }));
 
+const installed = (name: string) => ({
+  name,
+  status: McpClientStatus.Installed,
+});
+const alreadyInstalled = (name: string) => ({
+  name,
+  status: McpClientStatus.AlreadyInstalled,
+});
+
 describe('createMcpInstaller — installPlugins', () => {
   const mockClaudeClient = { name: 'Claude Code' };
   const mockCursorClient = { name: 'Cursor' };
@@ -39,9 +49,9 @@ describe('createMcpInstaller — installPlugins', () => {
     ]);
   });
 
-  it('calls installPlugins on plugin-capable clients and returns installed names', async () => {
+  it('calls installPlugins on plugin-capable clients and returns their results', async () => {
     mcpModule.getSupportedPluginClients.mockReturnValue([mockClaudeClient]);
-    mcpModule.installPlugins.mockResolvedValue(['Claude Code']);
+    mcpModule.installPlugins.mockResolvedValue([installed('Claude Code')]);
 
     const installer = createMcpInstaller();
     await installer.detectClients();
@@ -52,12 +62,12 @@ describe('createMcpInstaller — installPlugins', () => {
       mockCursorClient,
     ]);
     expect(mcpModule.installPlugins).toHaveBeenCalledWith([mockClaudeClient]);
-    expect(result).toEqual(['Claude Code']);
+    expect(result).toEqual([installed('Claude Code')]);
   });
 
   it('emits mcp plugins installed analytics with clients and attempted', async () => {
     mcpModule.getSupportedPluginClients.mockReturnValue([mockClaudeClient]);
-    mcpModule.installPlugins.mockResolvedValue(['Claude Code']);
+    mcpModule.installPlugins.mockResolvedValue([installed('Claude Code')]);
 
     const installer = createMcpInstaller();
     await installer.detectClients();
@@ -67,6 +77,29 @@ describe('createMcpInstaller — installPlugins', () => {
       'mcp plugins installed',
       {
         clients: ['Claude Code'],
+        already_installed: [],
+        attempted: ['Claude Code'],
+      },
+    );
+  });
+
+  it('reports an already-installed plugin separately from a fresh install', async () => {
+    mcpModule.getSupportedPluginClients.mockReturnValue([mockClaudeClient]);
+    mcpModule.installPlugins.mockResolvedValue([
+      alreadyInstalled('Claude Code'),
+    ]);
+
+    const installer = createMcpInstaller();
+    await installer.detectClients();
+    const result = await installer.installPlugins(['Claude Code']);
+
+    expect(result).toEqual([alreadyInstalled('Claude Code')]);
+    // `clients` still counts it — the client ends up with the plugin either way.
+    expect(analytics.wizardCapture).toHaveBeenCalledWith(
+      'mcp plugins installed',
+      {
+        clients: ['Claude Code'],
+        already_installed: ['Claude Code'],
         attempted: ['Claude Code'],
       },
     );
@@ -85,6 +118,7 @@ describe('createMcpInstaller — installPlugins', () => {
       'mcp plugins installed',
       {
         clients: [],
+        already_installed: [],
         attempted: [],
       },
     );
@@ -108,13 +142,77 @@ describe('createMcpInstaller — installPlugins', () => {
       mockClaudeClient,
       mockCursorClient,
     ]);
-    mcpModule.installPlugins.mockResolvedValue(['Claude Code']); // Cursor failed
+    mcpModule.installPlugins.mockResolvedValue([
+      installed('Claude Code'),
+      { name: 'Cursor', status: McpClientStatus.Failed, detail: 'boom' },
+    ]);
 
     const installer = createMcpInstaller();
     await installer.detectClients();
     const result = await installer.installPlugins(['Claude Code', 'Cursor']);
 
-    expect(result).toEqual(['Claude Code']);
+    expect(result).toEqual([
+      installed('Claude Code'),
+      { name: 'Cursor', status: McpClientStatus.Failed, detail: 'boom' },
+    ]);
+  });
+});
+
+describe('createMcpInstaller — install', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports installed, already-installed and failed clients separately', async () => {
+    mcpModule.getSupportedClients.mockResolvedValue([
+      {
+        name: 'Cursor',
+        addServer: vi.fn().mockResolvedValue({ success: true }),
+      },
+      {
+        name: 'Codex',
+        addServer: vi
+          .fn()
+          .mockResolvedValue({ success: true, alreadyInstalled: true }),
+      },
+      {
+        name: 'Zed',
+        addServer: vi.fn().mockResolvedValue({
+          success: false,
+          reason: 'EACCES: permission denied',
+        }),
+      },
+    ]);
+
+    const installer = createMcpInstaller();
+    await installer.detectClients();
+    const result = await installer.install(['Cursor', 'Codex', 'Zed']);
+
+    expect(result).toEqual([
+      installed('Cursor'),
+      alreadyInstalled('Codex'),
+      {
+        name: 'Zed',
+        status: McpClientStatus.Failed,
+        detail: 'EACCES: permission denied',
+      },
+    ]);
+  });
+
+  it('turns a thrown addServer into a failed result carrying the message', async () => {
+    mcpModule.getSupportedClients.mockResolvedValue([
+      {
+        name: 'Cursor',
+        addServer: vi.fn().mockRejectedValue(new Error('disk full')),
+      },
+    ]);
+
+    const installer = createMcpInstaller();
+    await installer.detectClients();
+
+    await expect(installer.install(['Cursor'])).resolves.toEqual([
+      { name: 'Cursor', status: McpClientStatus.Failed, detail: 'disk full' },
+    ]);
   });
 });
 

--- a/src/ui/tui/playground/demos/McpDemo.tsx
+++ b/src/ui/tui/playground/demos/McpDemo.tsx
@@ -11,6 +11,7 @@ import type {
   McpInstaller,
   McpClientInfo,
 } from '@ui/tui/services/mcp-installer';
+import { McpClientStatus } from '@steps/add-mcp-server-to-clients/results';
 
 const MOCK_CLIENTS: McpClientInfo[] = [
   { name: 'Claude Code', supportsPlugin: true },
@@ -34,13 +35,20 @@ function createMockInstaller(): McpInstaller {
     },
     async install(clientNames) {
       await new Promise((r) => setTimeout(r, 1500));
-      return clientNames;
+      // Mixed outcomes so the demo shows every Done-phase section.
+      return clientNames.map((name, i) => ({
+        name,
+        status:
+          i === 1 ? McpClientStatus.AlreadyInstalled : McpClientStatus.Installed,
+      }));
     },
     async installPlugins(clientNames) {
       await new Promise((r) => setTimeout(r, 800));
-      return clientNames.filter(
-        (name) => MOCK_CLIENTS.find((c) => c.name === name)?.supportsPlugin,
-      );
+      return clientNames
+        .filter(
+          (name) => MOCK_CLIENTS.find((c) => c.name === name)?.supportsPlugin,
+        )
+        .map((name) => ({ name, status: McpClientStatus.Installed }));
     },
     async remove() {
       await new Promise((r) => setTimeout(r, 1000));

--- a/src/ui/tui/playground/demos/McpDemo.tsx
+++ b/src/ui/tui/playground/demos/McpDemo.tsx
@@ -39,7 +39,7 @@ function createMockInstaller(): McpInstaller {
       return clientNames.map((name, i) => ({
         name,
         status:
-          i === 1 ? McpClientStatus.AlreadyInstalled : McpClientStatus.Installed,
+          i === 1 ? McpClientStatus.Unchanged : McpClientStatus.Changed,
       }));
     },
     async installPlugins(clientNames) {
@@ -48,11 +48,20 @@ function createMockInstaller(): McpInstaller {
         .filter(
           (name) => MOCK_CLIENTS.find((c) => c.name === name)?.supportsPlugin,
         )
-        .map((name) => ({ name, status: McpClientStatus.Installed }));
+        .map((name) => ({ name, status: McpClientStatus.Changed }));
     },
     async remove() {
       await new Promise((r) => setTimeout(r, 1000));
-      return MOCK_CLIENTS.map((c) => c.name);
+      // Mixed outcomes so the demo shows the removal failure copy too.
+      return MOCK_CLIENTS.map((c, i) =>
+        i === 2
+          ? {
+              name: c.name,
+              status: McpClientStatus.Failed,
+              detail: 'EACCES: permission denied',
+            }
+          : { name: c.name, status: McpClientStatus.Changed },
+      );
     },
   };
 }

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Box, Text, useInput } from 'ink';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useSyncExternalStore } from 'react';
 import { type WizardStore, McpOutcome } from '@ui/tui/store';
 import {
@@ -92,7 +92,7 @@ const ResultGroup = ({
 }) => {
   if (items.length === 0) return null;
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" marginBottom={1}>
       <Text color={color} bold>
         {icon} {title}
       </Text>
@@ -124,6 +124,27 @@ const ConnectorContinue = ({ onContinue }: { onContinue: () => void }) => {
   );
 };
 
+/**
+ * Done-phase prompt — Enter dismisses the results screen and moves the flow on.
+ * Explicit acknowledgement instead of a timeout: the previous 2s auto-dismiss
+ * whipped past too fast to read on a normal install, especially when several
+ * result groups were stacked.
+ */
+const DoneContinue = ({ onContinue }: { onContinue: () => void }) => {
+  useInput((_input, key) => {
+    if (key.return) {
+      onContinue();
+    }
+  });
+  return (
+    <Box marginTop={1}>
+      <Text color={Colors.primary}>
+        Press enter to continue {Icons.triangleRight}
+      </Text>
+    </Box>
+  );
+};
+
 export const McpScreen = ({
   store,
   installer,
@@ -151,6 +172,10 @@ export const McpScreen = ({
   // "you selected nothing".
   const [detectError, setDetectError] = useState<string | null>(null);
   const [flowError, setFlowError] = useState<string | null>(null);
+  // The action that finishes the screen once the user has read the results.
+  // Held in a ref so the useInput handler inside DoneContinue can invoke the
+  // freshest closure without re-registering listeners on every render.
+  const finishFlow = useRef<null | (() => void)>(null);
 
   useEffect(() => {
     void (async () => {
@@ -165,8 +190,10 @@ export const McpScreen = ({
         }
       } catch (err) {
         setDetectError(errorText(err));
+        // Long error text — wait for enter instead of a 3s auto-dismiss the
+        // user can't finish reading.
+        finishFlow.current = () => markDone(store, McpOutcome.Failed);
         setPhase(Phase.None);
-        setTimeout(() => markDone(store, McpOutcome.Failed), 3000);
       }
     })();
   }, [installer]); // eslint-disable-line
@@ -285,23 +312,19 @@ export const McpScreen = ({
 
     setMcpResults(mcpResult);
     setPluginResults(pluginResult);
-    setPhase(Phase.Done);
     // Already-installed counts as installed: the user ends up with a working
     // MCP either way, so the follow-on steps (Slack, tutorial) still apply.
     const ready = [...mcpResult, ...pluginResult].filter(isOk);
-    const outcome =
-      ready.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
+    const outcome = ready.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
     const featuresReport = reportFeatures(features ?? [...ALL_FEATURE_VALUES]);
-    setTimeout(
-      () =>
-        markDone(
-          store,
-          outcome,
-          ready.map((r) => r.name),
-          featuresReport,
-        ),
-      2000,
-    );
+    finishFlow.current = () =>
+      markDone(
+        store,
+        outcome,
+        ready.map((r) => r.name),
+        featuresReport,
+      );
+    setPhase(Phase.Done);
   };
 
   const doRemove = async () => {
@@ -313,19 +336,16 @@ export const McpScreen = ({
       setFlowError(errorText(err));
     }
     setMcpResults(result);
-    setPhase(Phase.Done);
     const removed = result.filter(isOk);
     const outcome =
       removed.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
-    setTimeout(
-      () =>
-        markDone(
-          store,
-          outcome,
-          removed.map((r) => r.name),
-        ),
-      2000,
-    );
+    finishFlow.current = () =>
+      markDone(
+        store,
+        outcome,
+        removed.map((r) => r.name),
+      );
+    setPhase(Phase.Done);
   };
 
   // The "what you get" preview shown above the install confirmation —
@@ -404,6 +424,7 @@ export const McpScreen = ({
                 Run with --debug for the full output, or report it at
                 github.com/PostHog/wizard/issues.
               </Text>
+              <DoneContinue onContinue={() => finishFlow.current?.()} />
             </Box>
           ) : (
             <Text dimColor>
@@ -531,27 +552,7 @@ export const McpScreen = ({
 
         {phase === Phase.Done && (
           <Box flexDirection="column">
-            {!hasAnyResult ? (
-              flowError ? (
-                <Box flexDirection="column">
-                  <Text color="red" bold>
-                    {'\u2716'} {isRemove ? 'Removal' : 'Installation'} failed
-                  </Text>
-                  <Text dimColor> {flowError}</Text>
-                  <Text dimColor>
-                    {' '}
-                    Run with --debug for the full output, or report it at
-                    github.com/PostHog/wizard/issues.
-                  </Text>
-                </Box>
-              ) : (
-                <Text dimColor>
-                  {isRemove
-                    ? "Nothing to remove \u2014 the PostHog MCP server wasn't configured for any editor."
-                    : 'Nothing to install \u2014 no editor was selected.'}
-                </Text>
-              )
-            ) : (
+            {hasAnyResult ? (
               <>
                 <ResultGroup
                   title="Plugin installed for:"
@@ -590,7 +591,9 @@ export const McpScreen = ({
                   }
                 />
                 <ResultGroup
-                  title={`Couldn't ${isRemove ? 'remove from' : 'install for'}:`}
+                  title={`Couldn't ${
+                    isRemove ? 'remove from' : 'install for'
+                  }:`}
                   items={failures}
                   color="red"
                   icon={'\u2716'}
@@ -615,7 +618,26 @@ export const McpScreen = ({
                   </Box>
                 ))}
               </>
+            ) : flowError ? (
+              <Box flexDirection="column">
+                <Text color="red" bold>
+                  {'\u2716'} {isRemove ? 'Removal' : 'Installation'} failed
+                </Text>
+                <Text dimColor> {flowError}</Text>
+                <Text dimColor>
+                  {' '}
+                  Run with --debug for the full output, or report it at
+                  github.com/PostHog/wizard/issues.
+                </Text>
+              </Box>
+            ) : (
+              <Text dimColor>
+                {isRemove
+                  ? "Nothing to remove \u2014 the PostHog MCP server wasn't configured for any editor."
+                  : 'Nothing to install \u2014 no editor was selected.'}
+              </Text>
             )}
+            <DoneContinue onContinue={() => finishFlow.current?.()} />
           </Box>
         )}
       </Box>

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -30,6 +30,7 @@ import {
   McpClientStatus,
   namesWithStatus,
   isOk,
+  summarizeFailure,
 } from '@steps/add-mcp-server-to-clients/results';
 import {
   AVAILABLE_FEATURES,
@@ -67,6 +68,10 @@ const markDone = (
 
 const reportFeatures = (features: string[]): 'all' | string[] =>
   isAllFeaturesSelected(features) ? 'all' : features;
+
+const errorText = (err: unknown): string =>
+  summarizeFailure(err instanceof Error ? err.message : String(err)) ??
+  'unknown error';
 
 /**
  * One "✔ <title>" / "✖ <title>" block with a bullet per client, plus an optional
@@ -141,6 +146,11 @@ export const McpScreen = ({
   const [mcpResults, setMcpResults] = useState<McpClientResult[]>([]);
   const [pluginResults, setPluginResults] = useState<McpClientResult[]>([]);
   const [installMode, setInstallMode] = useState<'all' | 'custom'>('custom');
+  // Detection and the install/remove call can both blow up. Keep the reason so
+  // a crash reads as a crash instead of as "you have nothing installed" or
+  // "you selected nothing".
+  const [detectError, setDetectError] = useState<string | null>(null);
+  const [flowError, setFlowError] = useState<string | null>(null);
 
   useEffect(() => {
     void (async () => {
@@ -153,9 +163,10 @@ export const McpScreen = ({
           setClients(detected);
           setPhase(Phase.Ask);
         }
-      } catch {
+      } catch (err) {
+        setDetectError(errorText(err));
         setPhase(Phase.None);
-        setTimeout(() => markDone(store, McpOutcome.Failed), 1500);
+        setTimeout(() => markDone(store, McpOutcome.Failed), 3000);
       }
     })();
   }, [installer]); // eslint-disable-line
@@ -249,13 +260,14 @@ export const McpScreen = ({
           features,
           store.session.apiKey,
         );
-      } catch {
-        // mcpResult stays []
+      } catch (err) {
+        setFlowError(errorText(err));
       }
       try {
         pluginResult = await installer.installPlugins(pluginCapableNames);
-      } catch {
-        // best-effort
+      } catch (err) {
+        // Best-effort, but still say so rather than showing an empty screen.
+        setFlowError(errorText(err));
       }
     } else {
       // 'custom' — MCP-only for every selected client. Plugin install is
@@ -266,8 +278,8 @@ export const McpScreen = ({
           features,
           store.session.apiKey,
         );
-      } catch {
-        // mcpResult stays []
+      } catch (err) {
+        setFlowError(errorText(err));
       }
     }
 
@@ -294,19 +306,26 @@ export const McpScreen = ({
 
   const doRemove = async () => {
     setPhase(Phase.Working);
-    let result: string[] = [];
+    let result: McpClientResult[] = [];
     try {
-      result = await installer.remove();
-    } catch {
-      result = [];
+      result = await installer.remove(store.session.localMcp);
+    } catch (err) {
+      setFlowError(errorText(err));
     }
-    setMcpResults(
-      result.map((name) => ({ name, status: McpClientStatus.Installed })),
-    );
+    setMcpResults(result);
     setPhase(Phase.Done);
+    const removed = result.filter(isOk);
     const outcome =
-      result.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
-    setTimeout(() => markDone(store, outcome, result), 2000);
+      removed.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
+    setTimeout(
+      () =>
+        markDone(
+          store,
+          outcome,
+          removed.map((r) => r.name),
+        ),
+      2000,
+    );
   };
 
   // The "what you get" preview shown above the install confirmation —
@@ -331,19 +350,19 @@ export const McpScreen = ({
 
   const installedNow = namesWithStatus(
     mcpResults,
-    McpClientStatus.Installed,
+    McpClientStatus.Changed,
   ).filter((name) => !isConnectorName(name));
   const alreadyInstalled = namesWithStatus(
     mcpResults,
-    McpClientStatus.AlreadyInstalled,
+    McpClientStatus.Unchanged,
   ).filter((name) => !isConnectorName(name));
   const pluginInstalled = namesWithStatus(
     pluginResults,
-    McpClientStatus.Installed,
+    McpClientStatus.Changed,
   );
   const pluginAlreadyInstalled = namesWithStatus(
     pluginResults,
-    McpClientStatus.AlreadyInstalled,
+    McpClientStatus.Unchanged,
   );
   // A failure the user can act on — the name alone says nothing, so carry the
   // reason the underlying CLI or file write gave us.
@@ -373,12 +392,25 @@ export const McpScreen = ({
           <Text dimColor>Detecting supported editors...</Text>
         )}
 
-        {phase === Phase.None && (
-          <Text dimColor>
-            No {isRemove ? 'installed' : 'supported'} MCP clients detected.
-            Skipping...
-          </Text>
-        )}
+        {phase === Phase.None &&
+          (detectError ? (
+            <Box flexDirection="column">
+              <Text color="red" bold>
+                {'\u2716'} Couldn&apos;t check which editors are installed
+              </Text>
+              <Text dimColor> {detectError}</Text>
+              <Text dimColor>
+                {' '}
+                Run with --debug for the full output, or report it at
+                github.com/PostHog/wizard/issues.
+              </Text>
+            </Box>
+          ) : (
+            <Text dimColor>
+              No {isRemove ? 'installed' : 'supported'} MCP clients detected.
+              Skipping...
+            </Text>
+          ))}
 
         {phase === Phase.Ask && (
           <>
@@ -500,11 +532,25 @@ export const McpScreen = ({
         {phase === Phase.Done && (
           <Box flexDirection="column">
             {!hasAnyResult ? (
-              <Text dimColor>
-                {isRemove
-                  ? "Nothing to remove \u2014 the PostHog MCP server wasn't configured for any editor."
-                  : 'Nothing to install \u2014 no editor was selected.'}
-              </Text>
+              flowError ? (
+                <Box flexDirection="column">
+                  <Text color="red" bold>
+                    {'\u2716'} {isRemove ? 'Removal' : 'Installation'} failed
+                  </Text>
+                  <Text dimColor> {flowError}</Text>
+                  <Text dimColor>
+                    {' '}
+                    Run with --debug for the full output, or report it at
+                    github.com/PostHog/wizard/issues.
+                  </Text>
+                </Box>
+              ) : (
+                <Text dimColor>
+                  {isRemove
+                    ? "Nothing to remove \u2014 the PostHog MCP server wasn't configured for any editor."
+                    : 'Nothing to install \u2014 no editor was selected.'}
+                </Text>
+              )
             ) : (
               <>
                 <ResultGroup
@@ -529,11 +575,19 @@ export const McpScreen = ({
                   icon={'\u2714'}
                 />
                 <ResultGroup
-                  title="MCP server was already installed for:"
+                  title={
+                    isRemove
+                      ? 'No PostHog entry left to remove for:'
+                      : 'MCP server was already installed for:'
+                  }
                   items={alreadyInstalled}
                   color="green"
                   icon={'\u2714'}
-                  note="Left as-is. To change which PostHog areas it can reach, run `wizard mcp remove` first, then `wizard mcp add`."
+                  note={
+                    isRemove
+                      ? 'It was already gone, so nothing was changed.'
+                      : 'Left as-is. To change which PostHog areas it can reach, run `wizard mcp remove` first, then `wizard mcp add`.'
+                  }
                 />
                 <ResultGroup
                   title={`Couldn't ${isRemove ? 'remove from' : 'install for'}:`}

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -24,7 +24,13 @@ import { Colors, Icons } from '@ui/tui/styles';
 import type {
   McpInstaller,
   McpClientInfo,
+  McpClientResult,
 } from '@ui/tui/services/mcp-installer';
+import {
+  McpClientStatus,
+  namesWithStatus,
+  isOk,
+} from '@steps/add-mcp-server-to-clients/results';
 import {
   AVAILABLE_FEATURES,
   ALL_FEATURE_VALUES,
@@ -63,6 +69,40 @@ const reportFeatures = (features: string[]): 'all' | string[] =>
   isAllFeaturesSelected(features) ? 'all' : features;
 
 /**
+ * One "✔ <title>" / "✖ <title>" block with a bullet per client, plus an optional
+ * dim explanation underneath. Rendered only when it has something to say.
+ */
+const ResultGroup = ({
+  title,
+  items,
+  color,
+  icon,
+  note,
+}: {
+  title: string;
+  items: string[];
+  color: string;
+  icon: string;
+  note?: string;
+}) => {
+  if (items.length === 0) return null;
+  return (
+    <Box flexDirection="column">
+      <Text color={color} bold>
+        {icon} {title}
+      </Text>
+      {items.map((item, i) => (
+        <Text key={`${title}-${i}`}>
+          {' '}
+          {'•'} {item}
+        </Text>
+      ))}
+      {note && <Text dimColor> {note}</Text>}
+    </Box>
+  );
+};
+
+/**
  * Connector step prompt — Enter continues (opens the connector page). There's
  * no skip: picking the connector commits to opening it.
  */
@@ -98,8 +138,8 @@ export const McpScreen = ({
   const [phase, setPhase] = useState<Phase>(Phase.Detecting);
   const [clients, setClients] = useState<McpClientInfo[]>([]);
   const [selectedClientNames, setSelectedClientNames] = useState<string[]>([]);
-  const [resultClients, setResultClients] = useState<string[]>([]);
-  const [pluginClients, setPluginClients] = useState<string[]>([]);
+  const [mcpResults, setMcpResults] = useState<McpClientResult[]>([]);
+  const [pluginResults, setPluginResults] = useState<McpClientResult[]>([]);
   const [installMode, setInstallMode] = useState<'all' | 'custom'>('custom');
 
   useEffect(() => {
@@ -130,11 +170,11 @@ export const McpScreen = ({
     // (e.g. Claude Desktop/Web) just open their connector page here, same as
     // before — no extra screen.
     if (chosenMode === 'all') {
-      void doInstall(clientNames, [...ALL_FEATURE_VALUES]);
+      void doInstall(clientNames, [...ALL_FEATURE_VALUES], chosenMode);
       return;
     }
     if (store.session.mcpFeatures) {
-      void doInstall(clientNames, store.session.mcpFeatures);
+      void doInstall(clientNames, store.session.mcpFeatures, chosenMode);
       return;
     }
 
@@ -179,10 +219,20 @@ export const McpScreen = ({
     markDone(store, McpOutcome.Skipped);
   };
 
-  const doInstall = async (names: string[], features?: string[]) => {
+  /**
+   * `chosenMode` is passed in rather than read from `installMode`: the tri-state
+   * picker sets that state and installs in the same tick when a single client
+   * is detected, so the closure would still hold the previous value and a
+   * one-editor machine would silently get the MCP-only path.
+   */
+  const doInstall = async (
+    names: string[],
+    features?: string[],
+    chosenMode: 'all' | 'custom' = installMode,
+  ) => {
     setPhase(Phase.Working);
-    let mcpResult: string[] = [];
-    let pluginResult: string[] = [];
+    let mcpResult: McpClientResult[] = [];
+    let pluginResult: McpClientResult[] = [];
 
     const pluginCapableSet = new Set(
       clients.filter((c) => c.supportsPlugin).map((c) => c.name),
@@ -190,7 +240,7 @@ export const McpScreen = ({
     const pluginCapableNames = names.filter((n) => pluginCapableSet.has(n));
     const directNames = names.filter((n) => !pluginCapableSet.has(n));
 
-    if (installMode === 'all') {
+    if (chosenMode === 'all') {
       // Plugin-capable clients get the plugin (which bundles MCP).
       // Non-plugin-capable clients get a direct MCP config write.
       try {
@@ -221,18 +271,21 @@ export const McpScreen = ({
       }
     }
 
-    setResultClients(mcpResult);
-    setPluginClients(pluginResult);
+    setMcpResults(mcpResult);
+    setPluginResults(pluginResult);
     setPhase(Phase.Done);
-    const succeeded = mcpResult.length + pluginResult.length > 0;
-    const outcome = succeeded ? McpOutcome.Installed : McpOutcome.Failed;
+    // Already-installed counts as installed: the user ends up with a working
+    // MCP either way, so the follow-on steps (Slack, tutorial) still apply.
+    const ready = [...mcpResult, ...pluginResult].filter(isOk);
+    const outcome =
+      ready.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
     const featuresReport = reportFeatures(features ?? [...ALL_FEATURE_VALUES]);
     setTimeout(
       () =>
         markDone(
           store,
           outcome,
-          [...mcpResult, ...pluginResult],
+          ready.map((r) => r.name),
           featuresReport,
         ),
       2000,
@@ -244,10 +297,12 @@ export const McpScreen = ({
     let result: string[] = [];
     try {
       result = await installer.remove();
-      setResultClients(result);
     } catch {
-      setResultClients([]);
+      result = [];
     }
+    setMcpResults(
+      result.map((name) => ({ name, status: McpClientStatus.Installed })),
+    );
     setPhase(Phase.Done);
     const outcome =
       result.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
@@ -265,14 +320,45 @@ export const McpScreen = ({
   // Clients connected via a browser page (e.g. Claude Desktop/Web) aren't truly
   // "installed" — the user finishes in the browser. Split them out of the
   // "installed for" list and render the finish instructions separately.
+  const okMcpNames = mcpResults.filter(isOk).map((r) => r.name);
   const finishNotes = clients.flatMap((c) =>
-    c.finish && resultClients.includes(c.name)
+    c.finish && okMcpNames.includes(c.name)
       ? [{ name: c.name, url: c.finish.url, instruction: c.finish.instruction }]
       : [],
   );
-  const installedNow = resultClients.filter(
-    (name) => !finishNotes.some((n) => n.name === name),
+  const isConnectorName = (name: string) =>
+    finishNotes.some((n) => n.name === name);
+
+  const installedNow = namesWithStatus(
+    mcpResults,
+    McpClientStatus.Installed,
+  ).filter((name) => !isConnectorName(name));
+  const alreadyInstalled = namesWithStatus(
+    mcpResults,
+    McpClientStatus.AlreadyInstalled,
+  ).filter((name) => !isConnectorName(name));
+  const pluginInstalled = namesWithStatus(
+    pluginResults,
+    McpClientStatus.Installed,
   );
+  const pluginAlreadyInstalled = namesWithStatus(
+    pluginResults,
+    McpClientStatus.AlreadyInstalled,
+  );
+  // A failure the user can act on — the name alone says nothing, so carry the
+  // reason the underlying CLI or file write gave us.
+  const failures = [...mcpResults, ...pluginResults]
+    .filter((r) => r.status === McpClientStatus.Failed)
+    .map((r) => (r.detail ? `${r.name} — ${r.detail}` : r.name));
+
+  const hasAnyResult =
+    installedNow.length +
+      alreadyInstalled.length +
+      pluginInstalled.length +
+      pluginAlreadyInstalled.length +
+      failures.length +
+      finishNotes.length >
+    0;
 
   return (
     <Box flexDirection="column" flexGrow={1}>
@@ -413,40 +499,49 @@ export const McpScreen = ({
 
         {phase === Phase.Done && (
           <Box flexDirection="column">
-            {installedNow.length + pluginClients.length + finishNotes.length ===
-            0 ? (
+            {!hasAnyResult ? (
               <Text dimColor>
-                {isRemove ? 'Removal' : 'Installation'} skipped.
+                {isRemove
+                  ? "Nothing to remove \u2014 the PostHog MCP server wasn't configured for any editor."
+                  : 'Nothing to install \u2014 no editor was selected.'}
               </Text>
             ) : (
               <>
-                {pluginClients.length > 0 && (
-                  <>
-                    <Text color="green" bold>
-                      {'\u2714'} Plugin installed for:
-                    </Text>
-                    {pluginClients.map((name, i) => (
-                      <Text key={`p-${i}`}>
-                        {' '}
-                        {'\u2022'} {name}
-                      </Text>
-                    ))}
-                  </>
-                )}
-                {installedNow.length > 0 && (
-                  <>
-                    <Text color="green" bold>
-                      {'\u2714'} MCP server{' '}
-                      {isRemove ? 'removed from' : 'installed for'}:
-                    </Text>
-                    {installedNow.map((name, i) => (
-                      <Text key={`m-${i}`}>
-                        {' '}
-                        {'\u2022'} {name}
-                      </Text>
-                    ))}
-                  </>
-                )}
+                <ResultGroup
+                  title="Plugin installed for:"
+                  items={pluginInstalled}
+                  color="green"
+                  icon={'\u2714'}
+                />
+                <ResultGroup
+                  title="Plugin was already installed for:"
+                  items={pluginAlreadyInstalled}
+                  color="green"
+                  icon={'\u2714'}
+                  note="It was already set up, so nothing changed. You are good to go."
+                />
+                <ResultGroup
+                  title={`MCP server ${
+                    isRemove ? 'removed from' : 'installed for'
+                  }:`}
+                  items={installedNow}
+                  color="green"
+                  icon={'\u2714'}
+                />
+                <ResultGroup
+                  title="MCP server was already installed for:"
+                  items={alreadyInstalled}
+                  color="green"
+                  icon={'\u2714'}
+                  note="Left as-is. To change which PostHog areas it can reach, run `wizard mcp remove` first, then `wizard mcp add`."
+                />
+                <ResultGroup
+                  title={`Couldn't ${isRemove ? 'remove from' : 'install for'}:`}
+                  items={failures}
+                  color="red"
+                  icon={'\u2716'}
+                  note="Run with --debug for the full output, or report it at github.com/PostHog/wizard/issues."
+                />
                 {finishNotes.map((note) => (
                   <Box key={note.name} flexDirection="column" marginTop={1}>
                     <Text color="green" bold>

--- a/src/ui/tui/services/mcp-installer.ts
+++ b/src/ui/tui/services/mcp-installer.ts
@@ -13,6 +13,13 @@ import {
   installPlugins as runPluginInstall,
 } from '@steps/add-mcp-server-to-clients/index';
 import { ALL_FEATURE_VALUES } from '@steps/add-mcp-server-to-clients/defaults';
+import {
+  McpClientStatus,
+  namesWithStatus,
+  redactSecrets,
+  toClientResult,
+  type McpClientResult,
+} from '@steps/add-mcp-server-to-clients/results';
 import { isPluginCapable } from '@steps/add-mcp-server-to-clients/plugin-client';
 import { isBrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
 import { logToFile } from '@utils/debug';
@@ -28,22 +35,29 @@ export interface McpClientInfo {
   finish?: { url: string; instruction: string };
 }
 
+export { McpClientStatus };
+export type { McpClientResult };
+
 export interface McpInstaller {
   /** Detect which MCP-capable editors are available on this machine. */
   detectClients(): Promise<McpClientInfo[]>;
 
-  /** Install the PostHog MCP server to the given clients. Returns names of successfully installed clients. */
+  /**
+   * Install the PostHog MCP server to the given clients. Returns one result per
+   * client — including the ones that were already installed and the ones that
+   * failed, so the screen can say which happened and why.
+   */
   install(
     clientNames: string[],
     features?: string[],
     apiKey?: string,
-  ): Promise<string[]>;
+  ): Promise<McpClientResult[]>;
 
   /** Remove the PostHog MCP server from all installed clients. Returns names of removed clients. */
   remove(): Promise<string[]>;
 
   /** Install the PostHog AI plugin to supported clients. Best-effort: failures do not affect MCP outcome. */
-  installPlugins(clientNames: string[]): Promise<string[]>;
+  installPlugins(clientNames: string[]): Promise<McpClientResult[]>;
 }
 
 /**
@@ -70,7 +84,7 @@ export function createMcpInstaller(): McpInstaller {
       clientNames: string[],
       features?: string[],
       apiKey?: string,
-    ): Promise<string[]> {
+    ): Promise<McpClientResult[]> {
       const resolvedFeatures = features ?? [...ALL_FEATURE_VALUES];
       const toInstall = cachedClients
         .filter((c) => clientNames.includes(c.name))
@@ -86,30 +100,36 @@ export function createMcpInstaller(): McpInstaller {
         return [];
       }
 
-      const installed: string[] = [];
+      const results: McpClientResult[] = [];
       for (const client of toInstall) {
+        const name = client.name as string;
         try {
           const result = await client.addServer(
             apiKey,
             resolvedFeatures,
             false,
           );
-          if (result?.success) {
-            installed.push(client.name as string);
-          } else {
+          results.push(toClientResult(name, result));
+          if (!result?.success) {
+            // redactSecrets, not the raw reason: the CLIs we shell out to echo
+            // the Authorization header back in their error output.
             logToFile(
-              `[McpInstaller] addServer returned success=false for ${client.name}`,
+              `[McpInstaller] addServer returned success=false for ${name}: ${redactSecrets(
+                result?.reason ?? 'no reason given',
+              )}`,
             );
           }
         } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
           logToFile(
-            `[McpInstaller] addServer threw for ${client.name}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
+            `[McpInstaller] addServer threw for ${name}: ${redactSecrets(
+              reason,
+            )}`,
           );
+          results.push(toClientResult(name, { success: false, reason }));
         }
       }
-      return installed;
+      return results;
     },
 
     async remove(): Promise<string[]> {
@@ -119,21 +139,32 @@ export function createMcpInstaller(): McpInstaller {
       return installed.map((c) => c.name);
     },
 
-    async installPlugins(clientNames: string[]): Promise<string[]> {
+    async installPlugins(clientNames: string[]): Promise<McpClientResult[]> {
       const rawClients = cachedClients
         .filter((c) => clientNames.includes(c.name))
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .map((c) => c.raw as any);
 
       const pluginClients = getSupportedPluginClients(rawClients);
-      const installed = await runPluginInstall(pluginClients);
+      const results = await runPluginInstall(pluginClients);
 
+      const already = namesWithStatus(
+        results,
+        McpClientStatus.AlreadyInstalled,
+      );
       analytics.wizardCapture('mcp plugins installed', {
-        clients: installed,
+        // `clients` keeps its original meaning — every client that ended up with
+        // the plugin — so existing insights don't dip when a re-run reports
+        // already-installed instead of a fresh write.
+        clients: [
+          ...namesWithStatus(results, McpClientStatus.Installed),
+          ...already,
+        ],
+        already_installed: already,
         attempted: pluginClients.map((c) => c.name),
       });
 
-      return installed;
+      return results;
     },
   };
 }

--- a/src/ui/tui/services/mcp-installer.ts
+++ b/src/ui/tui/services/mcp-installer.ts
@@ -53,8 +53,11 @@ export interface McpInstaller {
     apiKey?: string,
   ): Promise<McpClientResult[]>;
 
-  /** Remove the PostHog MCP server from all installed clients. Returns names of removed clients. */
-  remove(): Promise<string[]>;
+  /**
+   * Remove the PostHog MCP server from every client that has it. Returns one
+   * result per client so a failed removal isn't reported as a success.
+   */
+  remove(local?: boolean): Promise<McpClientResult[]>;
 
   /** Install the PostHog AI plugin to supported clients. Best-effort: failures do not affect MCP outcome. */
   installPlugins(clientNames: string[]): Promise<McpClientResult[]>;
@@ -132,11 +135,12 @@ export function createMcpInstaller(): McpInstaller {
       return results;
     },
 
-    async remove(): Promise<string[]> {
-      const installed = await getInstalledClients();
+    async remove(local?: boolean): Promise<McpClientResult[]> {
+      // `local` was dropped here, so `mcp remove --local` looked at (and
+      // reported on) the wrong server name.
+      const installed = await getInstalledClients(local);
       if (installed.length === 0) return [];
-      await removeMCPServer(installed);
-      return installed.map((c) => c.name);
+      return removeMCPServer(installed, local);
     },
 
     async installPlugins(clientNames: string[]): Promise<McpClientResult[]> {
@@ -148,16 +152,13 @@ export function createMcpInstaller(): McpInstaller {
       const pluginClients = getSupportedPluginClients(rawClients);
       const results = await runPluginInstall(pluginClients);
 
-      const already = namesWithStatus(
-        results,
-        McpClientStatus.AlreadyInstalled,
-      );
+      const already = namesWithStatus(results, McpClientStatus.Unchanged);
       analytics.wizardCapture('mcp plugins installed', {
         // `clients` keeps its original meaning — every client that ended up with
         // the plugin — so existing insights don't dip when a re-run reports
         // already-installed instead of a fresh write.
         clients: [
-          ...namesWithStatus(results, McpClientStatus.Installed),
+          ...namesWithStatus(results, McpClientStatus.Changed),
           ...already,
         ],
         already_installed: already,


### PR DESCRIPTION
## Problem

Running `wizard mcp add` and picking an editor that already has PostHog set up printed a bare **"Installation skipped."** and exited immediately — no reason given, and the follow-on steps (Slack, suggested prompts) were skipped because the outcome was recorded as `Failed`.

Codex hit this reliably: `codex plugin marketplace add` exits non-zero once the marketplace is registered, so the install looked like a failure with an empty result set. Any client whose install genuinely failed produced the same message, so "skipped", "already there" and "broke" were indistinguishable.

## Changes

- Install results are per-client now — `installed` / `already-installed` / `failed`, with a short reason on failures — instead of a list of names that silently dropped everything else.
- The Done screen renders each group with copy that explains what happened ("Plugin was already installed for: …", "MCP server was already installed for: … Left as-is. To change which PostHog areas it can reach, run `wizard mcp remove` first", "Couldn't install for: … <reason>"). The non-interactive path reports the same three outcomes separately.
- Already-installed counts as a working install, so the flow continues rather than quitting early.
- Codex checks `config.toml` (and Claude Code checks `plugin list`) before installing, rather than inferring the no-op from CLI error text; the file-based clients compare the existing entry and skip the write when it's identical.

Two things found while tracing the same flow: CLI error text is redacted before it reaches the log/screen/exception reports (the failing command echoes back the `Authorization` header), and the chosen install mode is passed to the installer instead of read from state set in the same tick — which made a single-editor machine take the MCP-only path after choosing "Install with all features".

Analytics keep `clients` meaning "ended up with it", with `already_installed` / `failed` / `attempted` as new breakdowns.

## Test plan

`pnpm build && pnpm test && pnpm fix` — 1771 tests pass, no lint errors. New coverage for the already-installed and failure paths in Codex, Claude Code, the shared config-file client, the installer service, and the result helpers (including redaction).

### Follow-up: the rest of the failure states

An audit of every failure path in both flows found the same class of bug elsewhere, fixed in the second commit:

- **`mcp remove` claimed success unconditionally** — `removeMCPServer` discarded each client's result, so every client detected before the attempt was reported as removed even if the removal threw. Removals now carry per-client results and reasons.
- **The non-interactive `mcp remove` printed nothing at all** — no success, no failure, not even "nothing to remove".
- **Crashes read as user choices** — a detection crash showed "No supported MCP clients detected"; a crash mid-install showed "no editor was selected". Both now name the error and point at `--debug`.
- **`mcp remove --local` never targeted `posthog-local`** — the flag was dropped in `McpInstaller.remove()` and ignored by Codex's `removeServer`.
- `mcp remove` fell back to the non-TTY path on *any* TUI error, masking real bugs; it now uses the same `isTUIUnavailable` guard as `mcp add`.

Known gap, not addressed here: a client that's gated off by platform (e.g. Cursor on Linux) is silently absent from the detected list rather than explained — `isClientSupported()` returns a bare boolean with no channel for a reason.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1786386614651689?thread_ts=1786386614.651689&cid=C09GTQY5RLZ)*

