### PR TITLE
fix(debug): bound unbounded SDK message log writes

### DIFF
--- a/src/lib/agent/__tests__/sdk-message-log.test.ts
+++ b/src/lib/agent/__tests__/sdk-message-log.test.ts
@@ -1,0 +1,65 @@
+import {
+  formatSdkMessageForLog,
+  MAX_LOG_FIELD_CHARS,
+} from '@lib/agent/sdk-message-log';
+
+describe('formatSdkMessageForLog', () => {
+  it('truncates a 100 KB tool_result so the formatted line stays ≤ 8 KB', () => {
+    const big = 'x'.repeat(100 * 1024);
+    const message = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 't1',
+            content: big,
+          },
+        ],
+      },
+    };
+
+    const formatted = formatSdkMessageForLog(message);
+
+    expect(Buffer.byteLength(formatted, 'utf8')).toBeLessThanOrEqual(8 * 1024);
+    expect(formatted).toContain('[truncated');
+    expect(formatted).toContain('tool_result');
+    expect(formatted).toContain('"type":"user"');
+    expect(formatted).toContain(String(100 * 1024));
+  });
+
+  it('does not mutate the original message', () => {
+    const message = {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            content: 'a'.repeat(MAX_LOG_FIELD_CHARS + 100),
+          },
+        ],
+      },
+    };
+    const before = JSON.stringify(message);
+    formatSdkMessageForLog(message);
+    expect(JSON.stringify(message)).toBe(before);
+  });
+
+  it('preserves short API error strings in result messages', () => {
+    const msg = 'API Error: 401 {"detail":"Authentication required"}';
+    const formatted = formatSdkMessageForLog({
+      type: 'result',
+      is_error: true,
+      result: msg,
+    });
+    expect(formatted).toContain('API Error: 401');
+    expect(formatted).not.toContain('[truncated');
+  });
+
+  it('uses compact JSON (no pretty-print whitespace)', () => {
+    const formatted = formatSdkMessageForLog({ type: 'assistant', ok: true });
+    expect(formatted).not.toContain('\n');
+    expect(formatted).toBe('{"type":"assistant","ok":true}');
+  });
+});

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -13,6 +13,7 @@ import type { WizardRunOptions } from '@utils/types';
 import { analytics } from '@utils/analytics';
 import { runtimeEnv } from '@env';
 import type { AioCapture } from '@lib/agent/aio-capture';
+import { formatSdkMessageForLog } from '@lib/agent/sdk-message-log';
 import {
   Harness,
   Sequence,
@@ -1553,7 +1554,7 @@ function handleSDKMessage(
     );
     getUI().syncTodos(sorted);
   };
-  logToFile(`SDK Message: ${message.type}`, JSON.stringify(message, null, 2));
+  logToFile(`SDK Message: ${message.type}`, formatSdkMessageForLog(message));
 
   if (options.debug) {
     debug(`SDK Message type: ${message.type}`);

--- a/src/lib/agent/sdk-message-log.ts
+++ b/src/lib/agent/sdk-message-log.ts
@@ -1,0 +1,54 @@
+/**
+ * Format SDK stream messages for the wizard log file without unbounded growth.
+ *
+ * Lives next to agent code (not in `debug.ts`) so SDK message shape knowledge
+ * stays out of infra — same boundary as handoff text caps.
+ */
+
+/** Per-string field truncation before compact JSON.stringify. */
+export const MAX_LOG_FIELD_CHARS = 2 * 1024;
+
+function truncateField(value: string): string {
+  if (value.length <= MAX_LOG_FIELD_CHARS) return value;
+  return `${value.slice(0, MAX_LOG_FIELD_CHARS)}… [truncated, ${
+    value.length
+  } chars]`;
+}
+
+function sanitize(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === 'string') return truncateField(value);
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitize(item, seen));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = sanitize(child, seen);
+  }
+  return out;
+}
+
+/**
+ * Deep-clone `value` and truncate every string leaf longer than
+ * {@link MAX_LOG_FIELD_CHARS}. Never mutates the input.
+ */
+export function sanitizeSdkMessageForLog(value: unknown): unknown {
+  return sanitize(value, new WeakSet());
+}
+
+/**
+ * Compact JSON for `logToFile`. Drops pretty-printing and truncates large
+ * string fields so a 100 KB tool_result cannot allocate a multi-MB log line.
+ */
+export function formatSdkMessageForLog(message: unknown): string {
+  try {
+    return (
+      JSON.stringify(sanitizeSdkMessageForLog(message)) ?? '[unserializable]'
+    );
+  } catch {
+    return '[unserializable]';
+  }
+}

--- a/src/utils/__tests__/debug.test.ts
+++ b/src/utils/__tests__/debug.test.ts
@@ -6,6 +6,8 @@ import {
   getLogFilePath,
   initLogFile,
   logToFile,
+  MAX_LOG_FILE_BYTES,
+  MAX_LOG_LINE_BYTES,
 } from '@utils/debug';
 
 describe('log file writing', () => {
@@ -62,5 +64,35 @@ describe('log file writing', () => {
     const content = fs.readFileSync(logPath, 'utf8');
     expect(content).toContain('plain write');
     expect(content).toContain('second write');
+  });
+
+  it('caps a single log write at 8 KB', () => {
+    const logPath = path.join(tmpRoot, 'capped-line.log');
+    configureLogFile({ path: logPath, enabled: true });
+
+    logToFile('x'.repeat(100_000));
+
+    const written = fs.readFileSync(logPath, 'utf8');
+    expect(Buffer.byteLength(written, 'utf8')).toBeLessThanOrEqual(
+      MAX_LOG_LINE_BYTES,
+    );
+    expect(written).toContain('[truncated');
+  });
+
+  it('stops appending once the log file reaches 10 MB', () => {
+    const logPath = path.join(tmpRoot, 'capped-file.log');
+    // Tiny headroom so a normal log line forces the file-cap path.
+    const seedSize = MAX_LOG_FILE_BYTES - 16;
+    fs.writeFileSync(logPath, 'y'.repeat(seedSize));
+    configureLogFile({ path: logPath, enabled: true });
+
+    logToFile('x'.repeat(1000));
+    const sizeAfterFirst = fs.statSync(logPath).size;
+    expect(sizeAfterFirst).toBeLessThanOrEqual(MAX_LOG_FILE_BYTES);
+    expect(sizeAfterFirst).toBeGreaterThan(seedSize);
+
+    logToFile('should-not-grow');
+    expect(fs.statSync(logPath).size).toBe(sizeAfterFirst);
+    expect(fs.readFileSync(logPath, 'utf8')).not.toContain('should-not-grow');
   });
 });

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,9 +1,15 @@
-import { appendFileSync, mkdirSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync, statSync } from 'fs';
 import path from 'path';
 import { inspect } from 'node:util';
 import { getUI } from '@ui';
 import { IS_DEV, runtimeEnv } from '@env';
 import { WIZARD_LOG_FILE } from './paths';
+
+/** Soft ceiling for a single `logToFile` write (UTF-8 bytes). */
+export const MAX_LOG_LINE_BYTES = 8 * 1024;
+
+/** Soft ceiling for the whole wizard log file (UTF-8 bytes on disk). */
+export const MAX_LOG_FILE_BYTES = 10 * 1024 * 1024;
 
 // Dev builds may redirect the log so concurrent runs don't interleave one file.
 let logFilePath =
@@ -27,6 +33,33 @@ function renderLine(args: readonly unknown[]): string {
   return args.map(stringify).join(' ');
 }
 
+/**
+ * Truncate `text` so its UTF-8 byte length is at most `maxBytes`.
+ * Exported for unit tests.
+ */
+export function capLogLine(
+  text: string,
+  maxBytes: number = MAX_LOG_LINE_BYTES,
+): string {
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) return text;
+  const marker = `… [truncated, ${Buffer.byteLength(
+    text,
+    'utf8',
+  )} bytes total]`;
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  if (markerBytes >= maxBytes) {
+    // Pathological tiny cap — return a hard slice of the marker.
+    return Buffer.from(marker, 'utf8').subarray(0, maxBytes).toString('utf8');
+  }
+  const budget = maxBytes - markerBytes;
+  // Walk back from a char-index estimate until we fit the byte budget.
+  let end = Math.min(text.length, budget);
+  while (end > 0 && Buffer.byteLength(text.slice(0, end), 'utf8') > budget) {
+    end -= 1;
+  }
+  return `${text.slice(0, end)}${marker}`;
+}
+
 export function getLogFilePath(): string {
   return logFilePath;
 }
@@ -38,12 +71,14 @@ export function configureLogFile(opts: {
   if (opts.path !== undefined) {
     logFilePath = opts.path;
     ensuredLogDir = false;
+    logFileCapReached = false;
   }
   if (opts.enabled !== undefined) fileLoggingEnabled = opts.enabled;
 }
 
 let ensuredLogDir = false;
 let reportedLogFailure = false;
+let logFileCapReached = false;
 
 // Failed log writes go to error tracking, once per process. Dynamic import:
 // analytics logs through this module, so a static import would be a cycle.
@@ -69,8 +104,23 @@ function reportLogFailureOnce(err: unknown): void {
 // The log's directory isn't guaranteed to exist (Windows %TEMP%,
 // POSTHOG_WIZARD_LOG_DIR) — create it on first failure.
 function appendLine(text: string): void {
+  if (logFileCapReached) return;
+
+  let toWrite = text;
   try {
-    appendFileSync(logFilePath, text);
+    if (existsSync(logFilePath)) {
+      const size = statSync(logFilePath).size;
+      if (size >= MAX_LOG_FILE_BYTES) {
+        logFileCapReached = true;
+        return;
+      }
+      const writeBytes = Buffer.byteLength(toWrite, 'utf8');
+      if (size + writeBytes > MAX_LOG_FILE_BYTES) {
+        toWrite = capLogLine(toWrite, Math.max(0, MAX_LOG_FILE_BYTES - size));
+        logFileCapReached = true;
+      }
+    }
+    appendFileSync(logFilePath, toWrite);
   } catch (err) {
     if (ensuredLogDir) {
       reportLogFailureOnce(err);
@@ -79,7 +129,7 @@ function appendLine(text: string): void {
     ensuredLogDir = true;
     try {
       mkdirSync(path.dirname(logFilePath), { recursive: true });
-      appendFileSync(logFilePath, text);
+      appendFileSync(logFilePath, toWrite);
     } catch (retryErr) {
       reportLogFailureOnce(retryErr);
     }
@@ -104,7 +154,8 @@ export function initLogFile(): void {
 export function logToFile(...args: unknown[]): void {
   if (!fileLoggingEnabled) return;
   const ts = new Date().toISOString();
-  appendLine(`[${ts}] ${renderLine(args)}\n`);
+  const line = capLogLine(`[${ts}] ${renderLine(args)}\n`);
+  appendLine(line);
 }
 
 export function debug(...args: unknown[]): void {


### PR DESCRIPTION
## Problem

Agent sessions can write unbounded SDK payloads into `debug.log` (e.g. large `tool_result` content), so a single run can grow the log without a ceiling and make debugging slow or disk-heavy.

Closes #578

## Changes

- Sanitize SDK messages before logging: compact JSON, truncate large string leaves, avoid mutating the live message
- Cap each `logToFile` write at 8KB
- Stop appending once the log file reaches 10MB
- Keep short API/error payloads readable; signal extraction still runs on the raw SDK message

## Test plan

- [x] `pnpm exec vitest run src/lib/agent/__tests__/sdk-message-log.test.ts src/utils/__tests__/debug.test.ts`
- [x] Manual check: 100KB `tool_result` formats to ~2KB; original object unchanged
- [x] End-to-end write check: SDK-style `logToFile` stays under the 8KB line cap; further writes stop at the 10MB file ceiling

## LLM context

Co-authored with Cursor. Implemented and verified locally (unit tests + manual size-cap checks) against #578.