### PR TITLE
feat(orchestrator): optional warehouse task, runner-seeded with per-agent tool grants

### DIFF
--- a/src/lib/agent/__tests__/agent-prompt-loader.test.ts
+++ b/src/lib/agent/__tests__/agent-prompt-loader.test.ts
@@ -3,6 +3,8 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   agentRunTools,
+  allowsPostHogMcp,
+  assembleSeedPrompt,
   assembleTaskPrompt,
   buildRegistry,
   parseAgentPrompt,
@@ -119,6 +121,19 @@ Add at least one capture call.
     );
   });
 
+  it('marks the sink and the runner-seeded task from frontmatter', () => {
+    const p = parseAgentPrompt(
+      '---\nsink: true\nrunnerSeeded: true\n---\nx',
+      't',
+    );
+    expect(p.sink).toBe(true);
+    expect(p.runnerSeeded).toBe(true);
+
+    const plain = parseAgentPrompt('---\nmodel: x\n---\nx', 't');
+    expect(plain.sink).toBe(false);
+    expect(plain.runnerSeeded).toBe(false);
+  });
+
   it('defaults missing array fields to empty and models to undefined', () => {
     const p = parseAgentPrompt('no frontmatter at all', 'stub');
     expect(p.modelPi).toBeUndefined();
@@ -146,12 +161,25 @@ describe('agentRunTools', () => {
       'Bash',
     ]);
   });
+
+  it('qualifies wizard_ask against the wizard-tools server', () => {
+    const p = parseAgentPrompt(
+      '---\nallowedTools: [Read, wizard_ask]\n---\nx',
+      't',
+    );
+    expect(agentRunTools(p).allowedTools).toEqual([
+      'Read',
+      'mcp__wizard-tools__wizard_ask',
+    ]);
+  });
 });
 
 describe('buildRegistry', () => {
   const prompt = (over: Partial<AgentPrompt>): AgentPrompt => ({
     type: 'x',
     seed: false,
+    sink: false,
+    runnerSeeded: false,
     skills: [],
     allowedTools: [],
     disallowedTools: [],
@@ -175,6 +203,24 @@ describe('buildRegistry', () => {
     expect(registry.get('install')).toBeUndefined();
     // A flowless prompt (e.g. the documentation example) joins no registry.
     expect(registry.get('example')).toBeUndefined();
+  });
+
+  it('keeps a runner-seeded type out of what an agent may enqueue', () => {
+    const registry = buildRegistry(
+      [
+        prompt({ type: 'plan', flow: 'f', seed: true }),
+        prompt({ type: 'install', flow: 'f' }),
+        prompt({ type: 'warehouse', flow: 'f', runnerSeeded: true }),
+        prompt({ type: 'report', flow: 'f', sink: true }),
+      ],
+      'f',
+    );
+
+    // The type still runs — it is only the planner that cannot reach it.
+    expect(registry.types).toEqual(['install', 'warehouse', 'report']);
+    expect(registry.enqueueableTypes).toEqual(['install', 'report']);
+    expect(registry.runnerSeededTypes).toEqual(['warehouse']);
+    expect(registry.sinkTypes).toEqual(['report']);
   });
 
   it('drops harness-excluded types; unrestricted runs keep them', () => {
@@ -242,6 +288,8 @@ describe('resolveTask', () => {
   const prompt: AgentPrompt = {
     type: 'capture',
     seed: false,
+    sink: false,
+    runnerSeeded: false,
     modelPi: 'openai/gpt-5.6-luna',
     effortPi: 'low',
     modelSdk: 'claude-haiku-4-5-20251001',
@@ -462,5 +510,56 @@ describe('renderToolInventory', () => {
 
   it('is empty when the set is empty', () => {
     expect(renderToolInventory([])).toBe('');
+  });
+});
+
+describe('assembleSeedPrompt', () => {
+  it('names the tasks the wizard queued before the planner ran', () => {
+    const ctx = {
+      projectId: 1,
+      projectApiKey: 'k',
+      host: { apiHost: 'https://h' },
+    } as Parameters<typeof assembleSeedPrompt>[0];
+
+    const prompt = assembleSeedPrompt(ctx, 'plan it', [
+      { id: 'abc-123', type: 'warehouse' },
+    ]);
+    expect(prompt).toContain('warehouse (id: abc-123)');
+    expect(prompt).toContain('Do not queue them again');
+  });
+
+  it('says nothing about pre-queued tasks when there are none', () => {
+    const ctx = {
+      projectId: 1,
+      projectApiKey: 'k',
+      host: { apiHost: 'https://h' },
+    } as Parameters<typeof assembleSeedPrompt>[0];
+
+    expect(assembleSeedPrompt(ctx, 'plan it')).not.toContain(
+      'The queue already holds',
+    );
+  });
+});
+
+/**
+ * Every tool a task gets is granted by its own prompt, the PostHog MCP
+ * included. A task that never names it must not have the server wired in.
+ */
+describe('allowsPostHogMcp', () => {
+  it('grants only when the prompt asks for it', () => {
+    expect(allowsPostHogMcp(['Read', 'Glob', 'posthog_exec'])).toBe(true);
+    expect(allowsPostHogMcp(['Read', 'Glob'])).toBe(false);
+    expect(allowsPostHogMcp([])).toBe(false);
+    expect(allowsPostHogMcp(undefined)).toBe(false);
+  });
+
+  it('reads the expanded name the loader hands the harness', () => {
+    const p = parseAgentPrompt(
+      '---\nallowedTools: [Read, posthog_exec]\n---\nx',
+      't',
+    );
+    const { allowedTools } = agentRunTools(p);
+    expect(allowedTools).toEqual(['Read', 'mcp__posthog-wizard__exec']);
+    expect(allowsPostHogMcp(allowedTools)).toBe(true);
   });
 });

--- a/src/lib/agent/agent-prompt-loader.ts
+++ b/src/lib/agent/agent-prompt-loader.ts
@@ -28,6 +28,7 @@ import {
 import { logToFile } from '@utils/debug';
 import { analytics } from '@utils/analytics';
 import { fetchWithRetry } from '@lib/fetch-retry';
+import { WIZARD_TOOL_NAMES } from '@lib/wizard-tools/tools';
 
 /**
  * The basics the client injects around every agent-prompt body. The `/agents/`
@@ -83,7 +84,22 @@ export function renderToolInventory(toolNames: readonly string[]): string {
 
 const TASK_BASICS = `You are one step in a larger PostHog workflow made of several tasks, run as a fresh agent with no memory of the other tasks beyond the context you are given. Other tasks — before and after you — own the rest of the work, so stay strictly on your own task: do not do a neighbouring step's job, redo what an upstream handoff already did, or reach beyond what you were asked. Do only your task, then report exactly once by calling complete_task with a structured handoff: what your goal was, what you did, and what the next agent should know. When you are given context from previous steps, trust it — those agents already did their work, so do not re-verify or re-read what their handoffs tell you. Build on it and move fast. Read a file before you edit it, so your own changes do not duplicate what is already there. Work only inside this project's own directory: never read, list, or search (find, ls, grep, glob) outside it — not the OS, not other projects, not global package caches. If your task seems to need something outside this directory, it does not — skip that part and say so in your handoff rather than hunting across the filesystem. If your task does not apply to this project — there is genuinely nothing for it to do — report it with status \`not needed\` and say why, rather than marking it done.`;
 
-const SEED_BASICS = `You are the orchestrator. Plan the work and seed the queue with enqueue_task — each call returns an id you can pass as a dependency to a later task. Give each task a short label for the UI — the action in a few words, not file names, class names, or other specifics. You are not a task yourself: do not call complete_task and do not edit the project.`;
+const SEED_BASICS = `You are the orchestrator. Plan the work and seed the queue with enqueue_task — each call returns an id you can pass as a dependency to a later task. Give each task a short label for the UI — the action in a few words, not file names, class names, or other specifics. The last task you queue, the one that reports on the run, must depend on every other task in the queue — directly, or through a task it already depends on. You are not a task yourself: do not call complete_task and do not edit the project.`;
+
+/**
+ * Tasks the wizard queued before the planner ran. It has to see them: they are
+ * part of the run it is planning around, and the task that reports last has to
+ * depend on them. Their ids are real, so it can wire the edge directly.
+ */
+function preQueuedTasks(
+  tasks: readonly { id: string; type: string }[],
+): string | null {
+  if (tasks.length === 0) return null;
+  const lines = tasks.map((t) => `- ${t.type} (id: ${t.id})`);
+  return `The queue already holds these tasks, placed by the wizard from what it found in this project. Do not queue them again — plan around them, and make sure the reporting task ends up depending on each one:\n${lines.join(
+    '\n',
+  )}`;
+}
 
 /**
  * Points the agent at its installed task instructions (the HOW). They live under
@@ -118,8 +134,11 @@ export function assembleTaskPrompt(
 export function assembleSeedPrompt(
   ctx: OrchestratorPromptContext,
   body: string,
+  preQueued: readonly { id: string; type: string }[] = [],
 ): string {
-  return [projectContext(ctx), SEED_BASICS, body].join('\n\n');
+  return [projectContext(ctx), SEED_BASICS, preQueuedTasks(preQueued), body]
+    .filter(Boolean)
+    .join('\n\n');
 }
 
 /** Orchestrator tools are MCP tools under the `posthog-wizard` server. Frontmatter
@@ -130,6 +149,28 @@ const ORCHESTRATOR_TOOLS = new Set([
   'complete_task',
   'read_handoffs',
 ]);
+
+/** The one tool that stops a task until a person answers. Named short in frontmatter. */
+export const ASK_TOOL = 'wizard_ask';
+
+/**
+ * The PostHog MCP, as an agent asks for it in frontmatter. Every tool a task
+ * gets is granted by its own prompt, this one included: a task that never names
+ * it never has the server wired in, and one that does gets it under this name
+ * on both harnesses.
+ */
+export const POSTHOG_MCP_TOOL = 'posthog_exec';
+/** The same tool as the anthropic SDK names it, on the hosted PostHog server. */
+const POSTHOG_MCP_SDK_TOOL = 'mcp__posthog-wizard__exec';
+
+/** Whether a task asked for the PostHog MCP — accepts either spelling. */
+export function allowsPostHogMcp(
+  allowedTools: readonly string[] | undefined,
+): boolean {
+  return (allowedTools ?? []).some(
+    (name) => name === POSTHOG_MCP_TOOL || name === POSTHOG_MCP_SDK_TOOL,
+  );
+}
 
 /** The queue tools a task holds — all of them minus its disallows. Short names.
  *  Single source for both the injected inventory and the harness's tool grant. */
@@ -149,6 +190,14 @@ export interface AgentPrompt {
   flow?: string;
   /** Marks the flow's planner: it seeds the queue and is not an enqueueable task. */
   seed: boolean;
+  /** Marks a task that runs last: it must depend on every other task in the queue. */
+  sink: boolean;
+  /**
+   * Marks a task only the wizard may queue. The planner never sees the type, so
+   * whether it runs is a decision the client makes from what it detected, not
+   * one an agent can reach — it can neither invent the task nor forget it.
+   */
+  runnerSeeded: boolean;
   /** Per-profile model + effort. `pi` = the gpt/pi harness, `sdk` = the anthropic
    * harness. The mapping is not 1:1 across providers, so each agent names both. */
   modelPi?: string;
@@ -176,8 +225,14 @@ export function promptModelFor(
 }
 
 export interface AgentRegistry {
-  /** The flow's enqueueable task types — every prompt except the seed. */
+  /** The flow's task types — every prompt except the seed. */
   readonly types: string[];
+  /** The types an agent may enqueue: `types` minus the runner-seeded ones. */
+  readonly enqueueableTypes: string[];
+  /** The types that run last and must depend on the whole queue. */
+  readonly sinkTypes: string[];
+  /** The types only the wizard queues, from what it detected before the run. */
+  readonly runnerSeededTypes: string[];
   /** The flow's planner, the one prompt marked `seed: true` in its frontmatter. */
   readonly seed?: AgentPrompt;
   get(type: string): AgentPrompt | undefined;
@@ -212,8 +267,12 @@ export function buildRegistry(
       };
     });
   const byType = new Map(inFlow.map((p) => [p.type, p]));
+  const tasks = inFlow.filter((p) => !p.seed);
   return {
-    types: inFlow.filter((p) => !p.seed).map((p) => p.type),
+    types: tasks.map((p) => p.type),
+    enqueueableTypes: tasks.filter((p) => !p.runnerSeeded).map((p) => p.type),
+    sinkTypes: tasks.filter((p) => p.sink).map((p) => p.type),
+    runnerSeededTypes: tasks.filter((p) => p.runnerSeeded).map((p) => p.type),
     seed: inFlow.find((p) => p.seed),
     get: (type) => byType.get(type),
   };
@@ -224,8 +283,10 @@ interface AgentMenu {
   agents: { id: string; flow?: string; downloadUrl: string }[];
 }
 
-/** A native tool passes through; an orchestrator tool gets its MCP-qualified name. */
+/** A native tool passes through; an MCP tool gets its fully-qualified name. */
 function expandToolName(name: string): string {
+  if (name === ASK_TOOL) return WIZARD_TOOL_NAMES.wizardAsk;
+  if (name === POSTHOG_MCP_TOOL) return POSTHOG_MCP_SDK_TOOL;
   return ORCHESTRATOR_TOOLS.has(name)
     ? `${ORCHESTRATOR_TOOL_PREFIX}${name}`
     : name;
@@ -301,6 +362,8 @@ export function parseAgentPrompt(
     label: typeof fields.label === 'string' ? fields.label : undefined,
     flow: typeof fields.flow === 'string' ? fields.flow : fallbackFlow,
     seed: fields.seed === 'true',
+    sink: fields.sink === 'true',
+    runnerSeeded: fields.runnerSeeded === 'true',
     modelPi: str(fields.model_pi),
     effortPi: effort(fields.effort_pi, 'effort_pi'),
     modelSdk: str(fields.model_sdk),
@@ -407,6 +470,9 @@ function renderHandoffContext(task: QueuedTask, store: QueueStore): string {
     }
     if (handoff.assumptions) {
       lines.push(`- assumed: ${handoff.assumptions}`);
+    }
+    if (handoff.reportSection) {
+      lines.push(`- report section:\n${handoff.reportSection}`);
     }
     lines.push('');
   }

--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -112,6 +112,7 @@ export const anthropicBackend: AgentHarness = {
       model,
       allowedTools,
       disallowedTools,
+      askBridge,
       orchestrator,
       spinnerMessage,
       successMessage,
@@ -143,6 +144,9 @@ export const anthropicBackend: AgentHarness = {
         wizardFlags: boot.wizardFlags,
         wizardMetadata: boot.wizardMetadata,
         integrationLabel: programConfig.id,
+        // Only a task allowed to ask carries a bridge, so the Write/Edit pause
+        // that rides on a pending question stays inside that task's agent.
+        askBridge,
         orchestrator,
         capture,
       },

--- a/src/lib/agent/runner/harness/pi/__tests__/task-tools.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/task-tools.test.ts
@@ -7,8 +7,35 @@ import { describe, it, expect } from 'vitest';
 import {
   allowedPiCodingTools,
   allowedOrchestratorTools,
+  allowedPiWizardTools,
   fenceDisallowList,
 } from '../task';
+
+describe('allowedPiWizardTools', () => {
+  const always = ['check_env_keys', 'set_env_values', 'detect_package_manager'];
+
+  it('withholds wizard_ask from a task that did not ask for it', () => {
+    const tools = allowedPiWizardTools(['Read', 'Edit']);
+    for (const name of always) expect(tools.has(name)).toBe(true);
+    expect(tools.has('wizard_ask')).toBe(false);
+  });
+
+  it('grants wizard_ask to a task whose prompt allows it', () => {
+    expect(allowedPiWizardTools(['Read', 'wizard_ask']).has('wizard_ask')).toBe(
+      true,
+    );
+  });
+
+  it('reads the MCP-qualified name the loader emits', () => {
+    expect(
+      allowedPiWizardTools(['mcp__wizard-tools__wizard_ask']).has('wizard_ask'),
+    ).toBe(true);
+  });
+
+  it('withholds wizard_ask when a task states no tools at all', () => {
+    expect(allowedPiWizardTools(undefined).has('wizard_ask')).toBe(false);
+  });
+});
 
 describe('allowedPiCodingTools', () => {
   it('maps the wizard vocabulary to pi tool names', () => {

--- a/src/lib/agent/runner/harness/pi/mcp.ts
+++ b/src/lib/agent/runner/harness/pi/mcp.ts
@@ -7,9 +7,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createJiti } from 'jiti';
-import { Type } from 'typebox';
-import { defineTool } from '@earendil-works/pi-coding-agent';
-import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import { VERSION } from '@lib/version';
 import { logToFile } from '@utils/debug';
 
@@ -48,99 +45,6 @@ export async function fetchInstructions(
   } finally {
     await client.close().catch(() => undefined);
   }
-}
-
-/**
- * `posthog_exec` as a native pi tool for orchestrator tasks, speaking to the
- * PostHog MCP through the same SDK client `fetchInstructions` uses.
- *
- * The adapter cannot surface this tool in a task session: it registers direct
- * tools from its on-disk metadata cache at factory time, and the cache is keyed
- * on the bearer token (`computeServerHash`), which is fresh every run — so the
- * cache never validates, only the proxy `mcp` tool registers, and a task that
- * was granted `posthog_exec` finds nothing by that name. Registering the tool
- * natively puts its availability in our hands instead of a cache's.
- *
- * Connects lazily on first call; one client serves the whole task session.
- */
-export function createPostHogExecTool(opts: {
-  mcpUrl: string;
-  accessToken: string;
-  userAgent: string;
-}): { tool: ToolDefinition; cleanup: () => Promise<void> } {
-  const { mcpUrl, accessToken, userAgent } = opts;
-  let connecting: Promise<Client> | undefined;
-
-  const client = (): Promise<Client> => {
-    connecting ??= (async () => {
-      const c = new Client({ name: 'posthog-wizard', version: VERSION });
-      const transport = new StreamableHTTPClientTransport(new URL(mcpUrl), {
-        requestInit: {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'User-Agent': userAgent,
-          },
-        },
-      });
-      await c.connect(transport);
-      logToFile('[pi-mcp] posthog_exec connected');
-      return c;
-    })().catch((err: unknown) => {
-      // A failed connect must not poison the memo — the next call retries.
-      connecting = undefined;
-      throw err;
-    });
-    return connecting;
-  };
-
-  const tool = defineTool({
-    name: 'posthog_exec',
-    label: 'PostHog',
-    description:
-      'Run a PostHog command. Pass a CLI-style string in `command`: `search <term>` to find a tool, `schema <tool>` to read its input, `call <tool> <json>` to run it.',
-    promptSnippet:
-      'posthog_exec(command) — search, inspect, and call PostHog tools',
-    parameters: Type.Object({
-      command: Type.String({
-        description:
-          'e.g. `search external-data-sources`, `schema external-data-sources-create`, `call external-data-sources-create {...}`',
-      }),
-    }),
-    async execute(_id, args) {
-      const result = (await (
-        await client()
-      ).callTool({
-        name: 'exec',
-        arguments: { command: args.command },
-      })) as { content?: { type: string; text?: string }[]; isError?: boolean };
-      const rendered = (result.content ?? [])
-        .map((part) => (part.type === 'text' ? part.text ?? '' : ''))
-        .join('\n')
-        .trim();
-      logToFile(
-        `[pi-mcp] posthog_exec "${args.command.slice(0, 80)}" → ${
-          rendered.length
-        } chars${result.isError ? ' (error)' : ''}`,
-      );
-      return {
-        content: [{ type: 'text' as const, text: rendered }],
-        details: {},
-        isError: result.isError,
-      };
-    },
-  });
-
-  return {
-    tool: tool as ToolDefinition,
-    cleanup: async () => {
-      if (!connecting) return;
-      await connecting.then(
-        (c) => c.close().catch(() => undefined),
-        () => undefined,
-      );
-      connecting = undefined;
-    },
-  };
 }
 
 export async function setupPostHogMcp(opts: {

--- a/src/lib/agent/runner/harness/pi/mcp.ts
+++ b/src/lib/agent/runner/harness/pi/mcp.ts
@@ -7,6 +7,9 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { createJiti } from 'jiti';
+import { Type } from 'typebox';
+import { defineTool } from '@earendil-works/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import { VERSION } from '@lib/version';
 import { logToFile } from '@utils/debug';
 
@@ -45,6 +48,99 @@ export async function fetchInstructions(
   } finally {
     await client.close().catch(() => undefined);
   }
+}
+
+/**
+ * `posthog_exec` as a native pi tool for orchestrator tasks, speaking to the
+ * PostHog MCP through the same SDK client `fetchInstructions` uses.
+ *
+ * The adapter cannot surface this tool in a task session: it registers direct
+ * tools from its on-disk metadata cache at factory time, and the cache is keyed
+ * on the bearer token (`computeServerHash`), which is fresh every run — so the
+ * cache never validates, only the proxy `mcp` tool registers, and a task that
+ * was granted `posthog_exec` finds nothing by that name. Registering the tool
+ * natively puts its availability in our hands instead of a cache's.
+ *
+ * Connects lazily on first call; one client serves the whole task session.
+ */
+export function createPostHogExecTool(opts: {
+  mcpUrl: string;
+  accessToken: string;
+  userAgent: string;
+}): { tool: ToolDefinition; cleanup: () => Promise<void> } {
+  const { mcpUrl, accessToken, userAgent } = opts;
+  let connecting: Promise<Client> | undefined;
+
+  const client = (): Promise<Client> => {
+    connecting ??= (async () => {
+      const c = new Client({ name: 'posthog-wizard', version: VERSION });
+      const transport = new StreamableHTTPClientTransport(new URL(mcpUrl), {
+        requestInit: {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'User-Agent': userAgent,
+          },
+        },
+      });
+      await c.connect(transport);
+      logToFile('[pi-mcp] posthog_exec connected');
+      return c;
+    })().catch((err: unknown) => {
+      // A failed connect must not poison the memo — the next call retries.
+      connecting = undefined;
+      throw err;
+    });
+    return connecting;
+  };
+
+  const tool = defineTool({
+    name: 'posthog_exec',
+    label: 'PostHog',
+    description:
+      'Run a PostHog command. Pass a CLI-style string in `command`: `search <term>` to find a tool, `schema <tool>` to read its input, `call <tool> <json>` to run it.',
+    promptSnippet:
+      'posthog_exec(command) — search, inspect, and call PostHog tools',
+    parameters: Type.Object({
+      command: Type.String({
+        description:
+          'e.g. `search external-data-sources`, `schema external-data-sources-create`, `call external-data-sources-create {...}`',
+      }),
+    }),
+    async execute(_id, args) {
+      const result = (await (
+        await client()
+      ).callTool({
+        name: 'exec',
+        arguments: { command: args.command },
+      })) as { content?: { type: string; text?: string }[]; isError?: boolean };
+      const rendered = (result.content ?? [])
+        .map((part) => (part.type === 'text' ? part.text ?? '' : ''))
+        .join('\n')
+        .trim();
+      logToFile(
+        `[pi-mcp] posthog_exec "${args.command.slice(0, 80)}" → ${
+          rendered.length
+        } chars${result.isError ? ' (error)' : ''}`,
+      );
+      return {
+        content: [{ type: 'text' as const, text: rendered }],
+        details: {},
+        isError: result.isError,
+      };
+    },
+  });
+
+  return {
+    tool: tool as ToolDefinition,
+    cleanup: async () => {
+      if (!connecting) return;
+      await connecting.then(
+        (c) => c.close().catch(() => undefined),
+        () => undefined,
+      );
+      connecting = undefined;
+    },
+  };
 }
 
 export async function setupPostHogMcp(opts: {

--- a/src/lib/agent/runner/harness/pi/task.ts
+++ b/src/lib/agent/runner/harness/pi/task.ts
@@ -35,7 +35,6 @@ import { REMARK_INSTRUCTION } from '@lib/agent/signals';
 import { AgentOutputSignals } from '@lib/agent/output-signals';
 import { TaskStatus } from '../../sequence/orchestrator/queue';
 import type { OrchestratorToolsContext } from '../../sequence/orchestrator/queue-tools';
-import type { ToolDefinition as PiToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { AgentResult, TaskRunInputs } from '../types';
 import { buildGatewayProvider, GATEWAY_PROVIDER } from './gateway';
 import { assembleCommandments } from '../../switchboard/commandments';
@@ -243,23 +242,34 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     const { prewarmYaraScanner } = await import('@lib/yara-hooks');
     void prewarmYaraScanner();
 
-    // PostHog MCP, for the tasks that asked for it in their prompt — as a
-    // native tool, so the granted name is registered by us, not resolved from
-    // the adapter's token-keyed cache that never validates in a task session.
+    // PostHog MCP, for the tasks whose prompt requests it. Tasks that never
+    // asked skip the handshake and never see a posthog tool.
     const extensionFactories = [security.factory] as Array<
       (pi: unknown) => void
     >;
-    let mcpCleanup: (() => Promise<void>) | undefined;
-    let posthogTool: PiToolDefinition | undefined;
+    let mcpCleanup: (() => void) | undefined;
+    let posthogMcp = false;
     if (allowsPostHogMcp(allowedTools)) {
-      const { createPostHogExecTool } = await import('./mcp');
-      const mcp = createPostHogExecTool({
-        mcpUrl: boot.credentials.host.mcpUrl,
-        accessToken: boot.credentials.accessToken,
-        userAgent: WIZARD_USER_AGENT,
-      });
-      posthogTool = mcp.tool;
-      mcpCleanup = mcp.cleanup;
+      try {
+        const { setupPostHogMcp } = await import('./mcp');
+        const mcp = await setupPostHogMcp({
+          mcpUrl: boot.credentials.host.mcpUrl,
+          accessToken: boot.credentials.accessToken,
+          userAgent: WIZARD_USER_AGENT,
+        });
+        extensionFactories.push(mcp.extensionFactory);
+        mcpCleanup = mcp.cleanup;
+        posthogMcp = true;
+      } catch (err) {
+        // Silent here reads as a task failure minutes later: a task that asked
+        // for this tool can only skip or fail without it.
+        logToFile(`[pi-task] PostHog MCP setup skipped: ${String(err)}`);
+        analytics.wizardCapture('mcp setup failed', {
+          harness: 'pi',
+          scope: 'task',
+          error: String(err).slice(0, 300),
+        });
+      }
     }
 
     const codingTools = allowedPiCodingTools(allowedTools);
@@ -272,7 +282,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
         program: programConfig.id,
         sequence: Sequence.orchestrator,
         harness: Harness.pi,
-        caps: { bash: codingTools.has('bash'), posthogMcp: !!posthogTool },
+        caps: { bash: codingTools.has('bash'), posthogMcp },
       }),
       noExtensions: true,
       noSkills: true,
@@ -325,12 +335,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
       orchestratorTools.has(t.name),
     );
 
-    const customTools = [
-      ...codingToolDefs,
-      ...wizardTools,
-      ...queueTools,
-      ...(posthogTool ? [posthogTool] : []),
-    ];
+    const customTools = [...codingToolDefs, ...wizardTools, ...queueTools];
     const { session: agentSession } = await createAgentSession({
       model,
       modelRegistry: registry,
@@ -344,8 +349,11 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     await agentSession.bindExtensions({});
 
     // The one complete list: exactly the tools registered on this session, in
-    // the names the agent will call them by.
-    const toolNames = customTools.map((t) => t.name);
+    // the names the agent will call them by. posthog_exec binds as an extension.
+    const toolNames = [
+      ...customTools.map((t) => t.name),
+      ...(posthogMcp ? ['posthog_exec'] : []),
+    ];
     logToFile(`[pi-task] tools passed to model: ${toolNames.join(', ')}`);
     const taskPrompt = `${prompt}\n\n${renderToolInventory(toolNames)}`;
 
@@ -429,7 +437,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
       }
     } finally {
       unsubscribe();
-      void mcpCleanup?.();
+      mcpCleanup?.();
     }
 
     if (security.state.criticalViolation) {

--- a/src/lib/agent/runner/harness/pi/task.ts
+++ b/src/lib/agent/runner/harness/pi/task.ts
@@ -26,6 +26,7 @@ import {
   WIZARD_USER_AGENT,
 } from '@lib/constants';
 import {
+  allowsPostHogMcp,
   queueTools,
   renderToolInventory,
 } from '@lib/agent/agent-prompt-loader';
@@ -34,6 +35,7 @@ import { REMARK_INSTRUCTION } from '@lib/agent/signals';
 import { AgentOutputSignals } from '@lib/agent/output-signals';
 import { TaskStatus } from '../../sequence/orchestrator/queue';
 import type { OrchestratorToolsContext } from '../../sequence/orchestrator/queue-tools';
+import type { ToolDefinition as PiToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { AgentResult, TaskRunInputs } from '../types';
 import { buildGatewayProvider, GATEWAY_PROVIDER } from './gateway';
 import { assembleCommandments } from '../../switchboard/commandments';
@@ -56,9 +58,9 @@ const CODING_TOOL_MAP: Record<string, readonly string[]> = {
   Grep: ['grep'],
 };
 
-/** `mcp__posthog-wizard__enqueue_task` → `enqueue_task`; native names pass through. */
+/** `mcp__wizard-tools__wizard_ask` → `wizard_ask`; native names pass through. */
 function shortToolName(name: string): string {
-  return name.replace(/^mcp__posthog-wizard__/, '');
+  return name.replace(/^mcp__.+?__/, '');
 }
 
 /**
@@ -84,6 +86,30 @@ export function allowedOrchestratorTools(
   disallowedTools: readonly string[] | undefined,
 ): Set<string> {
   return new Set(queueTools(disallowedTools ?? []));
+}
+
+/**
+ * The wizard tools a task gets. Four are always on — their handlers are fenced
+ * and the coding tasks depend on them. `wizard_ask` is opt-in per task: it
+ * stops the run until a person answers, so only a task whose prompt asks for it
+ * may open that overlay.
+ */
+const ALWAYS_ON_WIZARD_TOOLS = [
+  'check_env_keys',
+  'set_env_values',
+  'detect_package_manager',
+  'publish_handoff',
+];
+
+export function allowedPiWizardTools(
+  allowedTools: readonly string[] | undefined,
+): Set<string> {
+  const allowed = (allowedTools ?? []).map(shortToolName);
+  return new Set(
+    allowed.includes('wizard_ask')
+      ? [...ALWAYS_ON_WIZARD_TOOLS, 'wizard_ask']
+      : ALWAYS_ON_WIZARD_TOOLS,
+  );
 }
 
 /**
@@ -134,6 +160,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     effort,
     allowedTools,
     disallowedTools,
+    askBridge,
     orchestrator,
     spinnerMessage,
     successMessage,
@@ -216,32 +243,23 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     const { prewarmYaraScanner } = await import('@lib/yara-hooks');
     void prewarmYaraScanner();
 
-    // PostHog MCP, best-effort — the dashboard task creates real dashboards
-    // through it; every other task simply never calls a posthog_* tool.
+    // PostHog MCP, for the tasks that asked for it in their prompt — as a
+    // native tool, so the granted name is registered by us, not resolved from
+    // the adapter's token-keyed cache that never validates in a task session.
     const extensionFactories = [security.factory] as Array<
       (pi: unknown) => void
     >;
-    let mcpCleanup: (() => void) | undefined;
-    let posthogMcp = false;
-    try {
-      const { setupPostHogMcp } = await import('./mcp');
-      const mcp = await setupPostHogMcp({
+    let mcpCleanup: (() => Promise<void>) | undefined;
+    let posthogTool: PiToolDefinition | undefined;
+    if (allowsPostHogMcp(allowedTools)) {
+      const { createPostHogExecTool } = await import('./mcp');
+      const mcp = createPostHogExecTool({
         mcpUrl: boot.credentials.host.mcpUrl,
         accessToken: boot.credentials.accessToken,
         userAgent: WIZARD_USER_AGENT,
       });
-      extensionFactories.push(mcp.extensionFactory);
+      posthogTool = mcp.tool;
       mcpCleanup = mcp.cleanup;
-      posthogMcp = true;
-    } catch (err) {
-      // Silent here reads as a task failure minutes later: dashboard and report
-      // need `posthog_exec` and can only skip or fail without it.
-      logToFile(`[pi-task] PostHog MCP setup skipped: ${String(err)}`);
-      analytics.wizardCapture('mcp setup failed', {
-        harness: 'pi',
-        scope: 'task',
-        error: String(err).slice(0, 300),
-      });
     }
 
     const codingTools = allowedPiCodingTools(allowedTools);
@@ -254,7 +272,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
         program: programConfig.id,
         sequence: Sequence.orchestrator,
         harness: Harness.pi,
-        caps: { bash: codingTools.has('bash'), posthogMcp },
+        caps: { bash: codingTools.has('bash'), posthogMcp: !!posthogTool },
       }),
       noExtensions: true,
       noSkills: true,
@@ -292,25 +310,27 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     // fenced, and init/build tasks depend on them. publish_handoff rides
     // along (store-only handler) so the report task can publish the handoff.
     const { createWizardPiTools } = await import('./tools');
+    const wizardToolNames = allowedPiWizardTools(allowedTools);
     const wizardTools = createWizardPiTools({
       workingDirectory: dir,
       skillsBaseUrl: boot.skillsBaseUrl,
       triageProvider: boot.triageProvider,
-    }).filter((t) =>
-      [
-        'check_env_keys',
-        'set_env_values',
-        'detect_package_manager',
-        'publish_handoff',
-      ].includes(t.name),
-    );
+      // Present only for a task allowed to ask; without it wizard_ask errors
+      // instead of hanging on a prompt nobody will ever see.
+      askBridge,
+    }).filter((t) => wizardToolNames.has(t.name));
 
     const { createPiOrchestratorTools } = await import('./orchestrator-tools');
     const queueTools = createPiOrchestratorTools(orchestrator).filter((t) =>
       orchestratorTools.has(t.name),
     );
 
-    const customTools = [...codingToolDefs, ...wizardTools, ...queueTools];
+    const customTools = [
+      ...codingToolDefs,
+      ...wizardTools,
+      ...queueTools,
+      ...(posthogTool ? [posthogTool] : []),
+    ];
     const { session: agentSession } = await createAgentSession({
       model,
       modelRegistry: registry,
@@ -324,11 +344,8 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     await agentSession.bindExtensions({});
 
     // The one complete list: exactly the tools registered on this session, in
-    // the names the agent will call them by. posthog_exec binds as an extension.
-    const toolNames = [
-      ...customTools.map((t) => t.name),
-      ...(posthogMcp ? ['posthog_exec'] : []),
-    ];
+    // the names the agent will call them by.
+    const toolNames = customTools.map((t) => t.name);
     logToFile(`[pi-task] tools passed to model: ${toolNames.join(', ')}`);
     const taskPrompt = `${prompt}\n\n${renderToolInventory(toolNames)}`;
 
@@ -412,7 +429,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
       }
     } finally {
       unsubscribe();
-      mcpCleanup?.();
+      void mcpCleanup?.();
     }
 
     if (security.state.criticalViolation) {

--- a/src/lib/agent/runner/harness/types.ts
+++ b/src/lib/agent/runner/harness/types.ts
@@ -89,6 +89,12 @@ export interface TaskRunInputs {
   /** Per-task tool overrides from the agent prompt's frontmatter. */
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];
+  /**
+   * Interactive question bridge, passed only for a task whose prompt allows
+   * `wizard_ask`. Absent everywhere else, so a task that was never meant to ask
+   * cannot open an overlay while its neighbours run.
+   */
+  askBridge?: WizardAskBridge;
   /** Queue-tools context threaded into the in-process wizard-tools MCP. */
   orchestrator: OrchestratorToolsContext;
   /** Spinner copy. Empty strings suppress the per-task line (queue panel shows progress). */

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/sink-closure.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/sink-closure.test.ts
@@ -1,0 +1,173 @@
+/**
+ * The sink guard: a task marked `sink: true` runs last, so it must wait for
+ * every other task in the queue. It is what stops a task the wizard seeded
+ * before the planner ran from being left un-awaited by the reporting step.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('@utils/analytics', () => ({
+  analytics: { wizardCapture: vi.fn() },
+}));
+
+import { QueueStore } from '@lib/agent/runner/sequence/orchestrator/queue';
+import { displayOrder } from '@lib/agent/runner/sequence/orchestrator/orchestrator-runner';
+import {
+  applyEnqueue,
+  checkEnqueueGuards,
+  dependencyClosure,
+  uncoveredBySink,
+  type OrchestratorToolsContext,
+} from '@lib/agent/runner/sequence/orchestrator/queue-tools';
+
+const VALID = ['warehouse', 'install', 'capture', 'report'];
+const SINKS = ['report'];
+
+describe('sink closure', () => {
+  let dir: string;
+  let store: QueueStore;
+  let ctx: OrchestratorToolsContext;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sink-closure-test-'));
+    store = new QueueStore(dir, 'run-1');
+    ctx = { store, validTypes: VALID, sinkTypes: SINKS };
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('walks the whole transitive chain, not just direct dependencies', () => {
+    const a = store.enqueue({ type: 'install' });
+    const b = store.enqueue({ type: 'capture', dependsOn: [a.id] });
+    expect([...dependencyClosure(store, [b.id])].sort()).toEqual(
+      [a.id, b.id].sort(),
+    );
+  });
+
+  it('rejects a sink that misses a task the wizard seeded before the planner', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const install = store.enqueue({ type: 'install' });
+
+    const r = checkEnqueueGuards(ctx, {
+      type: 'report',
+      dependsOn: [install.id],
+      reason: 'write the report',
+    });
+
+    expect(r).toMatchObject({ ok: false, guard: 'sink-closure' });
+    expect(r.ok === false && r.message).toContain(warehouse.id);
+  });
+
+  it('accepts a sink that reaches every task through its dependencies', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const install = store.enqueue({ type: 'install' });
+    const capture = store.enqueue({
+      type: 'capture',
+      dependsOn: [install.id, warehouse.id],
+    });
+
+    const r = checkEnqueueGuards(ctx, {
+      type: 'report',
+      dependsOn: [capture.id],
+      reason: 'write the report',
+    });
+
+    expect(r).toEqual({ ok: true });
+  });
+
+  it('leaves a non-sink type alone', () => {
+    store.enqueue({ type: 'warehouse' });
+    const r = checkEnqueueGuards(ctx, { type: 'capture', reason: 'x' });
+    expect(r).toEqual({ ok: true });
+  });
+
+  it('does not apply when the flow declares no sink', () => {
+    store.enqueue({ type: 'warehouse' });
+    const r = checkEnqueueGuards(
+      { store, validTypes: VALID },
+      { type: 'report', reason: 'x' },
+    );
+    expect(r).toEqual({ ok: true });
+  });
+
+  it('reports what a queued sink fails to wait for', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const install = store.enqueue({ type: 'install' });
+    const report = applyEnqueue(
+      { store, validTypes: VALID },
+      { type: 'report', dependsOn: [install.id], reason: 'x' },
+    );
+
+    expect(report.ok).toBe(true);
+    const uncovered = uncoveredBySink(ctx, {
+      type: 'report',
+      dependsOn: report.ok ? report.task.dependsOn : [],
+    }).filter((t) => t.type !== 'report');
+
+    expect(uncovered.map((t) => t.id)).toEqual([warehouse.id]);
+  });
+});
+
+/**
+ * Display order is not queue order. A task the wizard seeded runs first but is
+ * an optional side quest, so it must not head the list the user reads.
+ */
+describe('displayOrder', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'display-order-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const optional = (t: { type: string }) => t.type === 'warehouse';
+
+  it('puts an optional task after the work it runs alongside', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const install = store.enqueue({ type: 'install' });
+    const init = store.enqueue({ type: 'init' });
+    const capture = store.enqueue({
+      type: 'capture',
+      dependsOn: [install.id, init.id],
+    });
+    store.enqueue({ type: 'report', dependsOn: [capture.id, warehouse.id] });
+
+    expect(displayOrder(store.list(), optional).map((t) => t.type)).toEqual([
+      'install',
+      'init',
+      'warehouse',
+      'capture',
+      'report',
+    ]);
+    // The optional task still has nothing to wait for, so it starts at once.
+    expect(store.nextRunnable().map((t) => t.type)).toContain('warehouse');
+  });
+
+  it('leaves a queue without optional tasks in dependency order', () => {
+    const install = store.enqueue({ type: 'install' });
+    const capture = store.enqueue({ type: 'capture', dependsOn: [install.id] });
+    store.enqueue({ type: 'report', dependsOn: [capture.id] });
+
+    expect(displayOrder(store.list(), optional).map((t) => t.type)).toEqual([
+      'install',
+      'capture',
+      'report',
+    ]);
+  });
+
+  it('keeps enqueue order among tasks at the same depth', () => {
+    const install = store.enqueue({ type: 'install' });
+    store.enqueue({ type: 'identify', dependsOn: [install.id] });
+    store.enqueue({ type: 'error-tracking', dependsOn: [install.id] });
+
+    expect(displayOrder(store.list(), optional).map((t) => t.type)).toEqual([
+      'install',
+      'identify',
+      'error-tracking',
+    ]);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -55,6 +55,9 @@ import {
 } from './queue';
 import { drainQueue, type RunTask } from './executor';
 import { RunMetrics } from './run-metrics';
+import { uncoveredBySink } from './queue-tools';
+import { createWizardAskBridge } from '@lib/wizard-ask-bridge';
+import { shouldDisableAsk } from '../../shared/bootstrap';
 import {
   agentRunTools,
   assembleSeedPrompt,
@@ -63,6 +66,8 @@ import {
   promptModelFor,
   resolveTask,
   taskModelSpec,
+  ASK_TOOL,
+  type AgentPrompt,
   type OrchestratorPromptContext,
 } from '@lib/agent/agent-prompt-loader';
 
@@ -175,6 +180,62 @@ function resolveReferenceSkillId(
   framework: string,
 ): string | undefined {
   return resolveSkillVariantId(entries, 'integration', framework);
+}
+
+/**
+ * A task that asks the user waits on a person, not on a model: long enough to
+ * open a database console or mint a restricted API key. The drain waits it out
+ * — the executor holds the task's promise — so the only real limit is this one.
+ */
+const TASK_ASK_TIMEOUT_MS = 20 * 60 * 1000;
+
+/** Whether a task's prompt lets it ask the user, and so needs the ask bridge. */
+function canAsk(prompt: AgentPrompt | undefined): boolean {
+  return (prompt?.allowedTools ?? []).includes(ASK_TOOL);
+}
+
+/** How many tasks deep in the graph a task sits — 0 when it depends on nothing. */
+function graphDepth(
+  task: QueuedTask,
+  byId: ReadonlyMap<string, QueuedTask>,
+  memo: Map<string, number>,
+): number {
+  const cached = memo.get(task.id);
+  if (cached !== undefined) return cached;
+  memo.set(task.id, 0); // breaks a cycle rather than recursing forever
+  const depth = task.dependsOn.reduce((deepest, id) => {
+    const dep = byId.get(id);
+    return dep ? Math.max(deepest, graphDepth(dep, byId, memo) + 1) : deepest;
+  }, 0);
+  memo.set(task.id, depth);
+  return depth;
+}
+
+/**
+ * The queue in the order the user should read it, which is not the order tasks
+ * were queued. Tasks the wizard seeded before the planner ran are queued first
+ * but are optional side quests, so they sit at the end of the tier they run in
+ * — the list reads as the run unfolds, and the first line is work that actually
+ * started. Ordering only; nothing here changes what runs when.
+ */
+export function displayOrder(
+  tasks: readonly QueuedTask[],
+  isOptional: (task: QueuedTask) => boolean,
+): QueuedTask[] {
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+  const memo = new Map<string, number>();
+  const rank = tasks.map((task, index) => ({
+    task,
+    depth: graphDepth(task, byId, memo),
+    optional: isOptional(task) ? 1 : 0,
+    index,
+  }));
+  return rank
+    .sort(
+      (a, b) =>
+        a.depth - b.depth || a.optional - b.optional || a.index - b.index,
+    )
+    .map((entry) => entry.task);
 }
 
 export async function runOrchestrator(
@@ -399,7 +460,9 @@ export async function runOrchestrator(
     t.label ?? registry.get(t.type)?.label ?? t.type;
   const renderQueue = () =>
     getUI().syncTodos(
-      store.list().map((t) => ({
+      displayOrder(store.list(), (t) =>
+        registry.runnerSeededTypes.includes(t.type),
+      ).map((t) => ({
         content: labelFor(t),
         status: toTodoStatus(t.status),
         activeForm: labelFor(t),
@@ -412,9 +475,76 @@ export async function runOrchestrator(
   // context has no task id.
   const orchestratorCtx = (currentTaskId?: string) => ({
     store,
-    validTypes: registry.types,
+    // The planner is offered only the types an agent may queue. A runner-seeded
+    // type is not among them, so an attempt to queue one trips the unknown-type
+    // guard instead of duplicating work the wizard already placed.
+    validTypes: registry.enqueueableTypes,
+    sinkTypes: registry.sinkTypes,
     currentTaskId,
   });
+
+  // Tasks the wizard queues itself, from what detection found. They exist
+  // before the planner runs, so the sink guard forces the reporting task to
+  // depend on them, and no prompt has to remember they are there.
+  const seededTypes: string[] = [];
+  for (const seeded of programConfig.seedTasks?.(session) ?? []) {
+    if (!registry.runnerSeededTypes.includes(seeded.type)) {
+      logToFile(
+        `[orchestrator] skipping runner-seeded task "${seeded.type}": not a runner-seeded type in this flow`,
+      );
+      continue;
+    }
+    // A task that stops for the user is offered, not imposed: show its notice
+    // and drop it entirely when the user would rather not. Declining before
+    // the queue is planned is cheaper than skipping it once it is in there.
+    if (seeded.notice) {
+      const keep = await getUI().showTaskNotice(seeded.notice);
+      analytics.wizardCapture('orchestrator task notice answered', {
+        type: seeded.type,
+        kept: keep,
+      });
+      if (!keep) {
+        logToFile(`[orchestrator] user declined runner-seeded ${seeded.type}`);
+        continue;
+      }
+    }
+    store.enqueue({
+      type: seeded.type,
+      label: seeded.label,
+      inputs: seeded.inputs,
+      enqueuedBy: 'orchestrator',
+    });
+    seededTypes.push(seeded.type);
+    logToFile(`[orchestrator] runner-seeded task ${seeded.type}`);
+  }
+
+  // A run that stops to ask a person is not comparable with one that does not
+  // — its wall-clock is the user's, not the model's. Tag every event of the run
+  // from here on, so those runs filter out cleanly.
+  const askingTypes = seededTypes.filter((type) => canAsk(registry.get(type)));
+  analytics.setTag('orchestrator_awaits_user', askingTypes.length > 0);
+  analytics.setTag(
+    'orchestrator_runner_seeded_types',
+    seededTypes.join(',') || 'none',
+  );
+  if (askingTypes.length > 0) {
+    analytics.wizardCapture('orchestrator awaits user', {
+      task_types: askingTypes,
+      ask_timeout_ms: TASK_ASK_TIMEOUT_MS,
+    });
+  }
+
+  // One bridge for the run, handed only to a task whose prompt allows asking.
+  // Absent in CI and signup, where nobody can answer.
+  const askBridge = shouldDisableAsk(session)
+    ? undefined
+    : createWizardAskBridge({
+        getSource: () => session.skillId ?? programConfig.id,
+        showQuestion: (q) => getUI().requestQuestion(q),
+        cancelQuestion: () => getUI().cancelPendingQuestion(),
+        richLinks: false,
+        timeoutMs: TASK_ASK_TIMEOUT_MS,
+      });
 
   const spinner = getUI().spinner();
 
@@ -432,7 +562,7 @@ export async function runOrchestrator(
     session,
     programConfig,
     boot,
-    prompt: assembleSeedPrompt(promptContext, seedPrompt.body),
+    prompt: assembleSeedPrompt(promptContext, seedPrompt.body, store.list()),
     spinner,
     model: requireKnownModel(seedModel.model, seedPick.model),
     effort: seedModel.effort,
@@ -455,6 +585,34 @@ export async function runOrchestrator(
     types: store.list().map((t) => t.type),
   });
   renderQueue();
+
+  // The enqueue guard rejects a sink that misses part of the queue, so a
+  // planner that respected its errors cannot get here with a broken graph.
+  // Check it again anyway: a run whose report never sees a task's handoff is
+  // worse than a run that stops and says so.
+  const unwaited = store
+    .list()
+    .filter((t) => registry.sinkTypes.includes(t.type))
+    .flatMap((sink) =>
+      uncoveredBySink(
+        { store, validTypes: registry.types, sinkTypes: registry.sinkTypes },
+        { type: sink.type, dependsOn: sink.dependsOn },
+      ).filter((t) => t.id !== sink.id),
+    );
+  if (unwaited.length > 0) {
+    analytics.wizardCapture('orchestrator sink invariant violated', {
+      uncovered_types: unwaited.map((t) => t.type),
+    });
+    await wizardAbort({
+      message: `The wizard could not plan this setup: the final step would have skipped ${unwaited
+        .map((t) => t.type)
+        .join(', ')}.\n\nPlease report this to: ${WIZARD_CONTACT_EMAIL}`,
+      error: new WizardError('orchestrator sink does not cover the queue', {
+        uncovered: unwaited.map((t) => `${t.type} (${t.id})`).join(', '),
+        queue_state: JSON.stringify(store.list()),
+      }),
+    });
+  }
 
   // 2. Drain the queue, one fresh agent per task; independent tasks run in
   // parallel, the seed's graph being the only schedule. Each task resolves to
@@ -537,6 +695,7 @@ export async function runOrchestrator(
         effort: taskModel.effort,
         allowedTools: resolved.allowedTools,
         disallowedTools: resolved.disallowedTools,
+        askBridge: canAsk(registry.get(task.type)) ? askBridge : undefined,
         orchestrator: orchestratorCtx(task.id),
         spinnerMessage: '',
         successMessage: '',

--- a/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
@@ -28,6 +28,13 @@ export interface OrchestratorToolsContext {
   /** Task types the registry knows about. enqueue_task rejects anything else. */
   validTypes: readonly string[];
   /**
+   * Types marked `sink: true` — the ones that run last and must therefore
+   * depend, transitively, on every other task in the queue. Enqueuing one with
+   * an incomplete closure is rejected, so a task the runner seeded before the
+   * planner ran can never be left un-awaited.
+   */
+  sinkTypes?: readonly string[];
+  /**
    * The id of the task this tool server is bound to. Each task agent gets its
    * own wizard-tools server, so attribution holds when independent tasks run
    * in parallel. Absent for the seed, which is not a task.
@@ -71,10 +78,41 @@ function dedupKey(type: string, inputs: Record<string, unknown>): string {
  */
 const MAX_QUEUE_TASKS = 30;
 
+/** Every task id reachable from `roots` through dependsOn edges, roots included. */
+export function dependencyClosure(
+  store: QueueStore,
+  roots: readonly string[],
+): Set<string> {
+  const seen = new Set<string>();
+  const visit = (id: string): void => {
+    if (seen.has(id)) return;
+    seen.add(id);
+    for (const dep of store.get(id)?.dependsOn ?? []) visit(dep);
+  };
+  for (const id of roots) visit(id);
+  return seen;
+}
+
+/**
+ * Tasks a sink would fail to wait for. A sink runs last by definition, so any
+ * queued task outside its dependency closure is work whose handoff the sink
+ * would miss — the exact failure mode of a task seeded before the planner ran.
+ * Empty for a non-sink type, and for a sink that covers everything.
+ */
+export function uncoveredBySink(
+  ctx: OrchestratorToolsContext,
+  args: Pick<EnqueueArgs, 'type' | 'dependsOn'>,
+): QueuedTask[] {
+  if (!ctx.sinkTypes?.includes(args.type)) return [];
+  const covered = dependencyClosure(ctx.store, args.dependsOn ?? []);
+  return ctx.store.list().filter((t) => !covered.has(t.id));
+}
+
 /**
  * Validate an enqueue. Structural checks only — a real type, real dependencies,
- * not a literal duplicate, and not past the runaway backstop. How much runs,
- * and in what shape, is the task graph's business, not a knob's.
+ * a sink that waits for everything, not a literal duplicate, and not past the
+ * runaway backstop. How much runs, and in what shape, is the task graph's
+ * business, not a knob's.
  */
 export function checkEnqueueGuards(
   ctx: OrchestratorToolsContext,
@@ -121,6 +159,21 @@ export function checkEnqueueGuards(
         message: `Dependency "${dep}" is not a known task id.`,
       };
     }
+  }
+
+  const uncovered = uncoveredBySink(ctx, args);
+  if (uncovered.length > 0) {
+    return {
+      ok: false,
+      guard: 'sink-closure',
+      message: `A "${
+        args.type
+      }" task runs last, so it must depend on every other task — directly or through its dependencies. These are not covered: ${uncovered
+        .map((t) => `${t.type} (${t.id})`)
+        .join(
+          ', ',
+        )}. Add them to dependsOn, or to a task already in dependsOn, and enqueue it again.`,
+    };
   }
 
   const key = dedupKey(args.type, args.inputs ?? {});
@@ -260,6 +313,13 @@ const HANDOFF_SHAPE = {
     .optional()
     .describe(
       'A one-line summary of any conflict you could not cleanly resolve (e.g. a dependency or build conflict). Put full detail in your work; this line is surfaced to the user.',
+    ),
+  reportSection: z
+    .string()
+    .max(HANDOFF_TEXT_MAX)
+    .optional()
+    .describe(
+      'A finished markdown section about your work for the run report, written only when your task instructions ask for one. The reporting task includes it as its own section instead of rewriting it.',
     ),
 };
 

--- a/src/lib/agent/runner/sequence/orchestrator/queue.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue.ts
@@ -72,6 +72,8 @@ export interface TaskHandoff {
   assumptions?: string;
   /** A one-line summary of any unresolved conflict, surfaced in the outro. */
   conflict?: string;
+  /** A finished section for the run's report, written by the task that owns the subject. */
+  reportSection?: string;
 }
 
 export interface EnqueueInput {

--- a/src/lib/oauth/__tests__/program-scopes.test.ts
+++ b/src/lib/oauth/__tests__/program-scopes.test.ts
@@ -1,0 +1,20 @@
+/**
+ * The integration run's token must cover the warehouse task it can carry:
+ * source creation 403s without the external-data-source pair, on a consent
+ * the user already granted.
+ */
+import { getOAuthScopesForProgram } from '@lib/oauth/program-scopes';
+
+describe('posthog-integration scopes', () => {
+  it('includes the warehouse pair for the orchestrator warehouse task', () => {
+    const scopes = getOAuthScopesForProgram('posthog-integration');
+    expect(scopes).toContain('external_data_source:read');
+    expect(scopes).toContain('external_data_source:write');
+  });
+
+  it('keeps the Slack outro scope', () => {
+    expect(getOAuthScopesForProgram('posthog-integration')).toContain(
+      'integration:read',
+    );
+  });
+});

--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -238,7 +238,14 @@ const PROGRAM_SCOPE_ADDITIONS: Partial<Record<ProgramId, readonly string[]>> = {
   'agent-skill': AGENT_SKILL_SCOPE_ADDITIONS,
   'self-driving': SELF_DRIVING_SCOPE_ADDITIONS,
   'warehouse-source': WAREHOUSE_SOURCE_SCOPE_ADDITIONS,
-  'posthog-integration': CONNECT_SLACK_SCOPE_ADDITIONS,
+  // The integration run carries the Slack outro step, and — when detection
+  // finds data sources — the orchestrator's warehouse task, which creates
+  // sources through `external-data-sources-create`. Without the warehouse pair
+  // that call 403s on a token the user already granted.
+  'posthog-integration': [
+    ...CONNECT_SLACK_SCOPE_ADDITIONS,
+    ...WAREHOUSE_SOURCE_SCOPE_ADDITIONS,
+  ],
   slack: CONNECT_SLACK_SCOPE_ADDITIONS,
 };
 

--- a/src/lib/programs/__tests__/warehouse-seed-task.test.ts
+++ b/src/lib/programs/__tests__/warehouse-seed-task.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Which runs carry the warehouse task. It waits on a person for credentials,
+ * so it belongs only in a run that has both something to connect and someone
+ * to answer — and the wizard, not the planner, is what decides that.
+ */
+import type { WizardSession } from '@lib/wizard-session';
+import type { DetectedSource } from '@lib/warehouse-sources/types';
+
+vi.mock('@utils/analytics', () => ({
+  analytics: {
+    wizardCapture: vi.fn(),
+    setTag: vi.fn(),
+    capture: vi.fn(),
+    captureException: vi.fn(),
+  },
+}));
+
+import { posthogIntegrationConfig } from '@lib/programs/posthog-integration/index';
+import { DETECTED_WAREHOUSE_SOURCES_KEY } from '@lib/programs/warehouse-source/detect';
+
+const POSTGRES: DetectedSource = {
+  kind: 'Postgres',
+  label: 'Postgres',
+  mode: 'in-cli',
+  matchedSignal: 'pg in package.json',
+};
+
+function session(over: Partial<WizardSession> = {}): WizardSession {
+  return {
+    installDir: '/tmp/app',
+    frameworkContext: {},
+    ...over,
+  } as WizardSession;
+}
+
+function seed(sess: WizardSession) {
+  return posthogIntegrationConfig.seedTasks?.(sess) ?? [];
+}
+
+describe('warehouse seed task', () => {
+  it('queues one task carrying every detected source', () => {
+    const tasks = seed(
+      session({
+        frameworkContext: { [DETECTED_WAREHOUSE_SOURCES_KEY]: [POSTGRES] },
+      }),
+    );
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].type).toBe('warehouse');
+    expect(tasks[0].inputs?.sources).toEqual([
+      {
+        kind: 'Postgres',
+        label: 'Postgres',
+        mode: 'in-cli',
+        matchedSignal: 'pg in package.json',
+      },
+    ]);
+  });
+
+  it('queues nothing when detection found no source', () => {
+    expect(seed(session())).toEqual([]);
+  });
+
+  it('queues nothing in CI, where nobody can answer', () => {
+    const tasks = seed(
+      session({
+        ci: true,
+        frameworkContext: { [DETECTED_WAREHOUSE_SOURCES_KEY]: [POSTGRES] },
+      }),
+    );
+    expect(tasks).toEqual([]);
+  });
+
+  it('queues nothing during signup, where asking is disabled', () => {
+    const tasks = seed(
+      session({
+        signup: true,
+        frameworkContext: { [DETECTED_WAREHOUSE_SOURCES_KEY]: [POSTGRES] },
+      }),
+    );
+    expect(tasks).toEqual([]);
+  });
+});
+
+describe('warehouse task notice', () => {
+  const notice = () =>
+    seed(
+      session({
+        frameworkContext: { [DETECTED_WAREHOUSE_SOURCES_KEY]: [POSTGRES] },
+      }),
+    )[0].notice;
+
+  it('tells the user the run will stop to ask, and offers to skip', () => {
+    const n = notice();
+    expect(n?.body[0]).toContain(
+      'We detected some warehouse sources we can connect to enrich your PostHog data',
+    );
+    expect(n?.body[1]).toContain('[Skip]');
+    expect(n?.docsUrl).toBe('https://posthog.com/docs/data-warehouse/sources');
+    expect(n?.cancelLabel).toContain('Skip');
+  });
+
+  it('names what was detected', () => {
+    expect(notice()?.items).toEqual(['Postgres']);
+  });
+});

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -20,12 +20,16 @@ import { requestDeepLink } from '@utils/provisioning';
 import { openTrackedLink, withUtm } from '@utils/links';
 import type { HostResolution } from '@lib/host-resolution';
 import { getDetectedWarehouseSources } from '@lib/programs/warehouse-source/detect';
+import { shouldDisableAsk } from '@lib/agent/runner/shared/bootstrap';
 import { POSTHOG_INTEGRATION_PROGRAM } from './steps.js';
 import { getContentBlocks } from './content/index.js';
 import { buildCodingAgentPrompt } from './handoff.js';
 import { EVENT_PLAN_FILE } from './constants.js';
 
 const DASHBOARD_DEEP_LINK_KEY = 'dashboardDeepLink';
+
+const WAREHOUSE_SOURCES_DOCS_URL =
+  'https://posthog.com/docs/data-warehouse/sources';
 
 function resolveContinueUrl(
   sess: WizardSession,
@@ -83,6 +87,54 @@ function warehouseReportInstruction(sess: WizardSession): string {
   return `Finally: this project also contains data sources PostHog can import (${labels}). In the setup report's "Verify before merging" checklist, add one item noting these were found and that \`npx @posthog/wizard warehouse\` will connect them to PostHog's data warehouse. Do not attempt to set them up yourself in this run.`;
 }
 
+/**
+ * The orchestrator task that connects the data sources detection found in the
+ * project — the one step of the flow that stops to ask the user for
+ * credentials. Queued here rather than by the planner: whether it belongs in
+ * the run is a fact about the project the wizard already scanned, so a model
+ * can neither invent it nor forget it.
+ *
+ * Empty when nothing was detected, and in CI, signup, and any other run where
+ * `wizard_ask` is disabled — a credential prompt nobody can answer would burn
+ * the task's whole timeout and then fail the run.
+ */
+const warehouseSeedTasks: NonNullable<ProgramConfig['seedTasks']> = (sess) => {
+  if (shouldDisableAsk(sess)) return [];
+  const sources = getDetectedWarehouseSources(sess);
+  if (sources.length === 0) return [];
+
+  analytics.wizardCapture('orchestrator warehouse task queued', {
+    warehouse_source_count: sources.length,
+    warehouse_source_kinds: sources.map((s) => s.kind),
+  });
+  return [
+    {
+      type: 'warehouse',
+      inputs: {
+        sources: sources.map((s) => ({
+          kind: s.kind,
+          label: s.label,
+          mode: s.mode,
+          matchedSignal: s.matchedSignal,
+        })),
+      },
+      notice: {
+        title: 'Connect your data sources',
+        body: [
+          "We detected some warehouse sources we can connect to enrich your PostHog data. To connect them, stick around, we'll prompt you to provide some credentials to setup warehouse sources.",
+          "You can select [Skip] if you'd like to do this later in PostHog.",
+        ],
+        items: sources.map((s) => s.label),
+        docsLabel: 'Learn more about warehouse sources',
+        docsUrl: WAREHOUSE_SOURCES_DOCS_URL,
+        prompt: 'Connect these during setup?',
+        confirmLabel: 'Continue [Enter]',
+        cancelLabel: 'Skip [Esc]',
+      },
+    },
+  ];
+};
+
 export const SETUP_REPORT_FILE = 'posthog-setup-report.md';
 export { EVENT_PLAN_FILE } from './constants.js';
 
@@ -99,6 +151,8 @@ export const posthogIntegrationConfig: ProgramConfig = {
   // list to the general-purpose subagent as well, so dispatched subagents
   // can't reach around the parent and ask either.
   disallowedTools: [WIZARD_TOOL_NAMES.wizardAsk],
+
+  seedTasks: warehouseSeedTasks,
 
   // CI-mode prerequisite work: the headless equivalent of the detect step's
   // onReady hook. Auto-detect the framework, then gather context.

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -1,4 +1,8 @@
-import type { WizardSession, DiscoveredFeature } from '@lib/wizard-session';
+import type {
+  WizardSession,
+  DiscoveredFeature,
+  TaskNotice,
+} from '@lib/wizard-session';
 import type { WizardReadinessResult } from '@lib/health-checks/readiness';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { Integration } from '@lib/constants';
@@ -233,6 +237,24 @@ export interface ProgramConfig {
    * detection) that the TUI performs via step onReady callbacks.
    */
   ciPreRun?: (session: WizardSession) => Promise<void>;
+  /**
+   * Tasks the orchestrator queues itself, before the planner runs, from what
+   * the wizard detected. Their types are marked `runnerSeeded: true` in the
+   * agent prompt, so the planner never sees them: whether such a task runs is
+   * decided here, in code, not by a model that could invent it or forget it.
+   * Return an empty list to queue none.
+   */
+  seedTasks?: (session: WizardSession) => Array<{
+    type: string;
+    label?: string;
+    inputs?: Record<string, unknown>;
+    /**
+     * Shown before the run starts, letting the user decline the task. The
+     * program owns the words — the runner and the modal only carry them. A
+     * task without one is queued silently.
+     */
+    notice?: TaskNotice;
+  }>;
   /** Prerequisites: other program ids that must have run first */
   requires?: string[];
   /**

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -141,6 +141,24 @@ export interface AskQuestion {
   sensitive?: boolean;
 }
 
+/**
+ * Copy for a modal shown before an optional step runs, so the user can decline
+ * it. The program that owns the step supplies the words; the runner and the
+ * screen only carry them.
+ */
+export interface TaskNotice {
+  title: string;
+  /** Paragraphs, in order. */
+  body: string[];
+  /** Optional highlighted list, e.g. what was detected. */
+  items?: string[];
+  docsLabel?: string;
+  docsUrl?: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  prompt: string;
+}
+
 /** Map of question id → answer (string for single/text, string[] for multi). */
 export type AskAnswers = Record<string, string | string[]>;
 
@@ -337,6 +355,8 @@ export interface WizardSession {
     port: number;
     user: string;
   } | null;
+  /** Copy for the task-notice modal, set while it is open. */
+  taskNotice: TaskNotice | null;
   outroData: OutroData | null;
   dashboardUrl: string | null;
   notebookUrl: string | null;
@@ -436,6 +456,7 @@ export function buildSession(args: {
     settingsConflicts: null,
     authErrorDetail: null,
     portConflictProcess: null,
+    taskNotice: null,
     outroData: null,
     dashboardUrl: null,
     notebookUrl: null,

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -24,6 +24,7 @@ import type {
   Credentials,
   OutroData,
   PendingQuestion,
+  TaskNotice,
 } from '@lib/wizard-session';
 
 export class LoggingUI implements WizardUI {
@@ -161,6 +162,10 @@ export class LoggingUI implements WizardUI {
     return new Promise<string>(() => {
       /* intentionally never resolves */
     });
+  }
+
+  showTaskNotice(_notice: TaskNotice): Promise<boolean> {
+    return Promise.resolve(false);
   }
 
   showSettingsOverride(

--- a/src/ui/tui/__tests__/task-notice.test.ts
+++ b/src/ui/tui/__tests__/task-notice.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The modal shown before an optional step runs. It is the user's only chance to
+ * decline a step that will stop and ask them for credentials, so the copy has
+ * to reach the screen and both answers have to come back.
+ */
+import type { TaskNotice } from '@lib/wizard-session';
+
+vi.mock('../../../utils/analytics.js', () => ({
+  analytics: {
+    capture: vi.fn(),
+    wizardCapture: vi.fn(),
+    setTag: vi.fn(),
+    captureException: vi.fn(),
+  },
+  sessionProperties: vi.fn(() => ({})),
+}));
+
+import { WizardStore, Overlay } from '@ui/tui/store';
+
+const NOTICE: TaskNotice = {
+  title: 'Connect your data sources',
+  body: [
+    "We detected some warehouse sources we can connect to enrich your PostHog data. To connect them, stick around, we'll prompt you to provide some credentials to setup warehouse sources.",
+    "You can select [Skip] if you'd like to do this later in PostHog.",
+  ],
+  items: ['Postgres', 'Stripe'],
+  docsLabel: 'Learn more about warehouse sources',
+  docsUrl: 'https://posthog.com/docs/data-warehouse/sources',
+  prompt: 'Connect these during setup?',
+  confirmLabel: 'Continue [Enter]',
+  cancelLabel: 'Skip [Esc]',
+};
+
+describe('task notice', () => {
+  it('resolves true when kept and false when skipped, closing the overlay', async () => {
+    const store = new WizardStore();
+
+    const kept = store.showTaskNotice(NOTICE);
+    expect(store.router.resolve(store.session)).toBe(Overlay.TaskNotice);
+    store.resolveTaskNotice(true);
+    await expect(kept).resolves.toBe(true);
+    expect(store.session.taskNotice).toBeNull();
+    expect(store.router.resolve(store.session)).not.toBe(Overlay.TaskNotice);
+
+    const skipped = store.showTaskNotice(NOTICE);
+    store.resolveTaskNotice(false);
+    await expect(skipped).resolves.toBe(false);
+  });
+
+  it('leaves no notice behind for the next step to inherit', () => {
+    const store = new WizardStore();
+    expect(store.session.taskNotice).toBeNull();
+  });
+});

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -21,6 +21,7 @@ import type {
   Credentials,
   OutroData,
   PendingQuestion,
+  TaskNotice,
 } from '@lib/wizard-session';
 import { RunPhase, OutroKind } from '@lib/wizard-session';
 
@@ -150,6 +151,10 @@ export class InkUI implements WizardUI {
 
   waitForManualAuthCode(): Promise<string> {
     return this.store.waitForManualAuthCode();
+  }
+
+  showTaskNotice(notice: TaskNotice): Promise<boolean> {
+    return this.store.showTaskNotice(notice);
   }
 
   showSettingsOverride(

--- a/src/ui/tui/router.ts
+++ b/src/ui/tui/router.ts
@@ -36,6 +36,7 @@ export enum Overlay {
   AuthError = 'auth-error',
   SessionTimeout = 'session-timeout',
   WizardAsk = 'wizard-ask',
+  TaskNotice = 'task-notice',
 }
 
 /** Union of all screen names */

--- a/src/ui/tui/screen-registry.tsx
+++ b/src/ui/tui/screen-registry.tsx
@@ -18,6 +18,7 @@ import { DoctorReportScreen } from './screens/doctor/DoctorReportScreen.js';
 import { SettingsOverrideScreen } from './screens/SettingsOverrideScreen.js';
 import { ManagedSettingsScreen } from './screens/ManagedSettingsScreen.js';
 import { PortConflictScreen } from './screens/PortConflictScreen.js';
+import { TaskNoticeScreen } from './screens/TaskNoticeScreen.js';
 import { ManualAuthCodeScreen } from './screens/ManualAuthCodeScreen.js';
 import { PostHogIntegrationIntroScreen } from './screens/PostHogIntegrationIntroScreen.js';
 import { RevenueIntroScreen } from './screens/RevenueIntroScreen.js';
@@ -74,6 +75,7 @@ export function createScreens(
     [Overlay.SettingsOverride]: <SettingsOverrideScreen store={store} />,
     [Overlay.ManagedSettings]: <ManagedSettingsScreen store={store} />,
     [Overlay.PortConflict]: <PortConflictScreen store={store} />,
+    [Overlay.TaskNotice]: <TaskNoticeScreen store={store} />,
     [Overlay.ManualAuthCode]: <ManualAuthCodeScreen store={store} />,
     [Overlay.AuthError]: <AuthErrorScreen store={store} />,
     [Overlay.SessionTimeout]: <SessionTimeoutScreen store={store} />,

--- a/src/ui/tui/screens/TaskNoticeScreen.tsx
+++ b/src/ui/tui/screens/TaskNoticeScreen.tsx
@@ -1,0 +1,62 @@
+/**
+ * TaskNoticeScreen — Modal shown before an optional step runs.
+ *
+ * Some steps stop to ask the user for something. This tells them so before the
+ * step starts, and lets them decline it. The copy comes from the program that
+ * owns the step; this screen only renders what it is given.
+ */
+
+import { Box, Text } from 'ink';
+import { useSyncExternalStore } from 'react';
+import type { WizardStore } from '@ui/tui/store';
+import { Colors } from '@ui/tui/styles';
+import { ConfirmationInput, ModalOverlay } from '@ui/tui/primitives/index';
+
+interface TaskNoticeScreenProps {
+  store: WizardStore;
+}
+
+export const TaskNoticeScreen = ({ store }: TaskNoticeScreenProps) => {
+  useSyncExternalStore(
+    (cb) => store.subscribe(cb),
+    () => store.getSnapshot(),
+  );
+
+  const notice = store.session.taskNotice;
+  if (!notice) return null;
+
+  return (
+    <ModalOverlay
+      borderColor={Colors.primary}
+      title={notice.title}
+      width={76}
+      footer={
+        <ConfirmationInput
+          message={notice.prompt}
+          confirmLabel={notice.confirmLabel}
+          cancelLabel={notice.cancelLabel}
+          onConfirm={() => store.resolveTaskNotice(true)}
+          onCancel={() => store.resolveTaskNotice(false)}
+        />
+      }
+    >
+      <Box flexDirection="column" gap={1}>
+        {notice.body.map((paragraph) => (
+          <Text key={paragraph}>{paragraph}</Text>
+        ))}
+      </Box>
+      {notice.items && notice.items.length > 0 && (
+        <Box marginTop={1} paddingLeft={2}>
+          <Text bold>{notice.items.join(', ')}</Text>
+        </Box>
+      )}
+      {notice.docsUrl && (
+        <Box marginTop={1}>
+          <Text dimColor>
+            {notice.docsLabel ?? 'Learn more'}: {notice.docsUrl}
+          </Text>
+        </Box>
+      )}
+    </ModalOverlay>
+  );
+};

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -32,6 +32,7 @@ import {
   McpOutcome,
   RunPhase,
   buildSession,
+  type TaskNotice,
 } from '@lib/wizard-session';
 import type { SettingsConflict } from '@lib/agent/claude-settings';
 import {
@@ -219,6 +220,8 @@ export class WizardStore {
   private _resolveSettingsOverride: (() => void) | null = null;
   private _backupAndFixSettings: (() => boolean) | null = null;
 
+  /** Blocks the run until an optional step's notice is answered. */
+  private _resolveTaskNotice: ((keep: boolean) => void) | null = null;
   /** Blocks OAuth flow until the port-conflict overlay is dismissed. */
   private _resolvePortConflict: (() => void) | null = null;
 
@@ -568,6 +571,26 @@ export class WizardStore {
     this.popOverlay();
     this._resolvePortConflict?.();
     this._resolvePortConflict = null;
+  }
+
+  /**
+   * Show an optional step's notice and return whether to keep that step.
+   * Asked before the step runs, so nobody is surprised by a prompt mid-run.
+   */
+  showTaskNotice(notice: TaskNotice): Promise<boolean> {
+    this.$session.setKey('taskNotice', notice);
+    this.pushOverlay(Overlay.TaskNotice);
+    return new Promise((resolve) => {
+      this._resolveTaskNotice = resolve;
+    });
+  }
+
+  /** Dismiss the notice, keeping (`true`) or skipping (`false`) the step. */
+  resolveTaskNotice(keep: boolean): void {
+    this.$session.setKey('taskNotice', null);
+    this.popOverlay();
+    this._resolveTaskNotice?.(keep);
+    this._resolveTaskNotice = null;
   }
 
   /**

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -11,7 +11,7 @@
 import type { SettingsConflict } from '@lib/agent/claude-settings';
 import type { WizardReadinessResult } from '@lib/health-checks/readiness';
 import type { ApiUser } from '@lib/api';
-import type { Credentials } from '@lib/wizard-session';
+import type { Credentials, TaskNotice } from '@lib/wizard-session';
 import type {
   AskAnswers,
   OutroData,
@@ -171,6 +171,12 @@ export interface WizardUI {
     conflicts: SettingsConflict[],
     backupAndFix: () => boolean,
   ): Promise<void>;
+
+  /**
+   * Show an optional step's notice and return whether to keep that step. Hosts
+   * that cannot prompt resolve false: a step nobody can answer must not run.
+   */
+  showTaskNotice(notice: TaskNotice): Promise<boolean>;
 
   /** Show auth error overlay when Anthropic API returns 401. */
   showAuthError(detail?: AuthErrorDetail): void;


### PR DESCRIPTION

https://github.com/user-attachments/assets/6eabc327-5a15-4eb6-8a7f-accd92a8e9a0

Allows warehouse task to be dynamically enqueued based on _static detection mechanisms_

- Never enqueues for headless wizard -> they should do it in app since its a cloud run
- This will require a second migration when we move all tasks to orchestrator
- Doesn't cover linear agent, it's a legacy fallback

https://github.com/PostHog/context-mill/pull/333