### PR TITLE
feat(orchestrator): flag-gate the warehouse task, isolate its failure, measure the path

### DIFF
--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/optional-tasks.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/optional-tasks.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The optional-task verdict: a runner-seeded task's failure is reported, never
+ * inherited by the run. Only required failures and blocked work abort.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('@utils/analytics', () => ({
+  analytics: { wizardCapture: vi.fn(), captureException: vi.fn() },
+}));
+
+import { QueueStore } from '@lib/agent/runner/sequence/orchestrator/queue';
+import { drainVerdict } from '@lib/agent/runner/sequence/orchestrator/orchestrator-runner';
+
+describe('drainVerdict', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const finish = (id: string, ok: boolean) => {
+    store.start(id);
+    if (ok) store.complete(id);
+    else store.fail(id, { type: 'boom', message: 'x' });
+  };
+
+  it('a failed optional task does not fail the run', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+    const report = store.enqueue({
+      type: 'report',
+      dependsOn: [install.id, warehouse.id],
+    });
+    finish(warehouse.id, false);
+    finish(install.id, true);
+    finish(report.id, true);
+
+    const v = drainVerdict(store.list());
+    expect(v.requiredFailedTypes).toEqual([]);
+    expect(v.optionalFailedTypes).toEqual(['warehouse']);
+    expect(v.blocked).toBe(0);
+  });
+
+  it('a failed required task still fails the run', () => {
+    const install = store.enqueue({ type: 'install' });
+    store.enqueue({ type: 'report', dependsOn: [install.id] });
+    finish(install.id, false);
+
+    const v = drainVerdict(store.list());
+    expect(v.requiredFailedTypes).toEqual(['install']);
+    expect(v.blocked).toBe(1);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
@@ -183,3 +183,45 @@ describe('QueueStore', () => {
     expect(listened.get(t.id)?.status).toBe('done');
   });
 });
+
+/**
+ * An optional task's failure is an outcome, not a verdict: dependents proceed
+ * as if it were skipped. A required task's failure still dams the graph.
+ */
+describe('optional task failure', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'queue-optional-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const failTerminally = (id: string) => {
+    store.start(id);
+    store.fail(id, { type: 'boom', message: 'x' });
+  };
+
+  it('does not block a dependent', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const report = store.enqueue({
+      type: 'report',
+      dependsOn: [warehouse.id],
+    });
+    failTerminally(warehouse.id);
+
+    expect(store.nextRunnable().map((t) => t.id)).toEqual([report.id]);
+    expect(store.isDrained()).toBe(false);
+  });
+
+  it('a required task failing still blocks its dependents', () => {
+    const install = store.enqueue({ type: 'install' });
+    store.enqueue({ type: 'report', dependsOn: [install.id] });
+    failTerminally(install.id);
+
+    expect(store.nextRunnable()).toEqual([]);
+    expect(store.isDrained()).toBe(true);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -37,9 +37,10 @@ import { analytics } from '@utils/analytics';
 import { ciExcludedTaskTypes } from '@utils/ci-flag-overrides';
 import { logToFile } from '@utils/debug';
 import { wizardAbort, WizardError } from '@utils/wizard-abort';
-import type { ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramConfig, SeedTaskEntry } from '@lib/programs/program-step';
 import type { BootstrapResult } from '../../shared/types';
 import {
+  areSeededTasksEnabled,
   getHarness,
   resolveHarness,
   resolveStageOverrides,
@@ -192,6 +193,28 @@ const TASK_ASK_TIMEOUT_MS = 20 * 60 * 1000;
 /** Whether a task's prompt lets it ask the user, and so needs the ask bridge. */
 function canAsk(prompt: AgentPrompt | undefined): boolean {
   return (prompt?.allowedTools ?? []).includes(ASK_TOOL);
+}
+
+/**
+ * The drain's verdict: which failures fail the run. An optional task's
+ * failure is reported as analytics and kept out of the verdict; a required
+ * task's failure, or a task still pending behind one, aborts as before.
+ */
+export function drainVerdict(tasks: readonly QueuedTask[]): {
+  requiredFailedTypes: string[];
+  optionalFailedTypes: string[];
+  blocked: number;
+} {
+  const failed = tasks.filter((t) => t.status === TaskStatus.Failed);
+  return {
+    requiredFailedTypes: failed
+      .filter((t) => t.optional !== true)
+      .map((t) => t.type),
+    optionalFailedTypes: failed
+      .filter((t) => t.optional === true)
+      .map((t) => t.type),
+    blocked: tasks.filter((t) => t.status === TaskStatus.Pending).length,
+  };
 }
 
 /** How many tasks deep in the graph a task sits — 0 when it depends on nothing. */
@@ -487,7 +510,19 @@ export async function runOrchestrator(
   // before the planner runs, so the sink guard forces the reporting task to
   // depend on them, and no prompt has to remember they are there.
   const seededTypes: string[] = [];
-  for (const seeded of programConfig.seedTasks?.(session) ?? []) {
+  const seedVerifiers = new Map<string, NonNullable<SeedTaskEntry['verify']>>();
+  // Kill switch for the whole runner-seeded mechanism, so the optional step
+  // can be turned off in the field without a release. Off (or unset), no task
+  // is queued and the run is byte-identical to a project with no sources.
+  const seedTasksEnabled = areSeededTasksEnabled(boot.wizardFlags);
+  const seedEntries = programConfig.seedTasks?.(session) ?? [];
+  if (!seedTasksEnabled && seedEntries.length > 0) {
+    logToFile('[orchestrator] runner-seeded tasks gated off by flag');
+    analytics.wizardCapture('orchestrator seeded tasks gated', {
+      types: seedEntries.map((t) => t.type),
+    });
+  }
+  for (const seeded of seedTasksEnabled ? seedEntries : []) {
     if (!registry.runnerSeededTypes.includes(seeded.type)) {
       logToFile(
         `[orchestrator] skipping runner-seeded task "${seeded.type}": not a runner-seeded type in this flow`,
@@ -502,18 +537,23 @@ export async function runOrchestrator(
       analytics.wizardCapture('orchestrator task notice answered', {
         type: seeded.type,
         kept: keep,
+        items_count: seeded.notice.items?.length ?? 0,
       });
       if (!keep) {
         logToFile(`[orchestrator] user declined runner-seeded ${seeded.type}`);
         continue;
       }
     }
-    store.enqueue({
+    const task = store.enqueue({
       type: seeded.type,
       label: seeded.label,
       inputs: seeded.inputs,
       enqueuedBy: 'orchestrator',
+      // Its failure is reported, never inherited by the run: the user was
+      // promised an integration, and the side quest failing must not undo it.
+      optional: true,
     });
+    if (seeded.verify) seedVerifiers.set(task.id, seeded.verify);
     seededTypes.push(seeded.type);
     logToFile(`[orchestrator] runner-seeded task ${seeded.type}`);
   }
@@ -774,6 +814,54 @@ export async function runOrchestrator(
     `[orchestrator] DONE done=${summary.done} failed=${summary.failed} total=${summary.total}`,
   );
 
+  // An optional task's failure is reported here in full — with the run's
+  // shape intact around it — and then kept out of the run's verdict below.
+  const optionalTasks = store.list().filter((t) => t.optional === true);
+  const optionalFailed = optionalTasks.filter(
+    (t) => t.status === TaskStatus.Failed,
+  );
+  for (const task of optionalFailed) {
+    analytics.wizardCapture('orchestrator optional task failed', {
+      type: task.type,
+      attempts: task.attempts,
+      duration_ms: durationMs(task),
+      error: task.error?.type,
+      error_message: task.error?.message?.slice(0, 300),
+      run_continued: true,
+    });
+    logToFile(
+      `[orchestrator] optional ${task.type} failed; run continues (${
+        task.error?.type ?? 'unknown'
+      })`,
+    );
+  }
+
+  // Did the optional work actually land? The program owns the check (e.g.
+  // listing the sources it claims to have created); the runner only reports.
+  for (const task of optionalTasks) {
+    const verify = seedVerifiers.get(task.id);
+    if (!verify) continue;
+    try {
+      const props = await verify(session, boot.credentials, {
+        status: task.status,
+        inputs: task.inputs,
+      });
+      if (props) {
+        analytics.wizardCapture('orchestrator seeded task verified', {
+          type: task.type,
+          task_status: task.status,
+          duration_ms: durationMs(task),
+          ...props,
+        });
+      }
+    } catch (err) {
+      analytics.captureException(
+        err instanceof Error ? err : new Error(String(err)),
+        { step: 'orchestrator_seed_verify', task_type: task.type },
+      );
+    }
+  }
+
   analytics.wizardCapture('orchestrator run finished', {
     tasks_total: summary.total,
     tasks_done: summary.done,
@@ -785,6 +873,15 @@ export async function runOrchestrator(
       .list()
       .filter((t) => t.enqueuedBy !== 'orchestrator').length,
     retried_task_count: store.list().filter((t) => t.attempts > 1).length,
+    // The optional path, sliceable on its own: how the seeded work ended and
+    // how long it held the run, next to the totals it sat inside.
+    optional_task_count: optionalTasks.length,
+    optional_tasks_failed: optionalFailed.length,
+    optional_task_statuses: optionalTasks.map((t) => `${t.type}:${t.status}`),
+    optional_task_duration_ms: optionalTasks.reduce(
+      (sum, t) => sum + (durationMs(t) ?? 0),
+      0,
+    ),
   });
 
   // The review step flags any unresolved conflict in its handoff; surface the
@@ -799,14 +896,13 @@ export async function runOrchestrator(
 
   // A drain that ends with failed tasks (retries exhausted) or tasks still
   // pending (blocked behind a failed dependency) did NOT set PostHog up —
-  // abort like a linear agent failure instead of claiming success.
-  const blocked = summary[TaskStatus.Pending];
-  if (summary.failed > 0 || blocked > 0) {
-    const failedTypes = store
-      .list()
-      .filter((t) => t.status === TaskStatus.Failed)
-      .map((t) => t.type)
-      .join(', ');
+  // abort like a linear agent failure instead of claiming success. Optional
+  // tasks are exempt: their failure was reported above, their dependents were
+  // never blocked (see nextRunnable), and the integration itself stands.
+  const verdict = drainVerdict(store.list());
+  const blocked = verdict.blocked;
+  if (verdict.requiredFailedTypes.length > 0 || blocked > 0) {
+    const failedTypes = verdict.requiredFailedTypes.join(', ');
     await wizardAbort({
       message: `The wizard was unable to set up PostHog: ${
         failedTypes
@@ -822,12 +918,20 @@ export async function runOrchestrator(
     });
   }
 
+  // A failed optional step leaves the denominator (the promised work is the
+  // required steps) and is named instead, so the count still reads as whole.
+  const stepNotes = [
+    notRequired > 0 ? `${notRequired} skipped as not required` : '',
+    optionalFailed.length > 0
+      ? `${optionalFailed.length} optional step failed`
+      : '',
+  ].filter(Boolean);
   const message = conflict
     ? 'PostHog set up, with one conflict to review.'
     : `PostHog set up: ${summary.done}/${
-        summary.total - notRequired
+        summary.total - notRequired - optionalFailed.length
       } steps completed${
-        notRequired > 0 ? ` (${notRequired} skipped as not required)` : ''
+        stepNotes.length > 0 ? ` (${stepNotes.join(', ')})` : ''
       }.`;
   getUI().setOutroData({
     kind: OutroKind.Success,

--- a/src/lib/agent/runner/sequence/orchestrator/queue.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue.ts
@@ -48,6 +48,13 @@ export interface QueuedTask {
   handoff?: TaskHandoff;
   /** 'orchestrator' for seeded tasks, or the id of the task that enqueued this one. */
   enqueuedBy: string;
+  /**
+   * An optional task's terminal failure is an outcome, not a verdict on the
+   * run: dependents proceed as if it were skipped, and the drain's failure
+   * check does not count it. Set by the wizard on the tasks it seeds itself —
+   * the run's own work is never optional.
+   */
+  optional?: boolean;
   createdAt: string;
   startedAt?: string;
   finishedAt?: string;
@@ -84,6 +91,7 @@ export interface EnqueueInput {
   model?: string;
   maxAttempts?: number;
   enqueuedBy?: string;
+  optional?: boolean;
 }
 
 export const QUEUE_DIR_NAME = '.posthog-wizard-cache';
@@ -154,11 +162,16 @@ export class QueueStore {
    * `skipped`). A skipped dependency does not block downstream work.
    */
   nextRunnable(): QueuedTask[] {
+    // A failed optional dependency satisfies like a skipped one: the work it
+    // would have contributed is absent either way, and its dependents read
+    // handoffs defensively. Only a required task's failure dams the graph.
     const doneIds = new Set(
       this.tasks
         .filter(
           (t) =>
-            t.status === TaskStatus.Done || t.status === TaskStatus.Skipped,
+            t.status === TaskStatus.Done ||
+            t.status === TaskStatus.Skipped ||
+            (t.status === TaskStatus.Failed && t.optional === true),
         )
         .map((t) => t.id),
     );
@@ -215,6 +228,7 @@ export class QueueStore {
       attempts: 0,
       maxAttempts: input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
       enqueuedBy: input.enqueuedBy ?? 'orchestrator',
+      optional: input.optional,
       createdAt: nowIso(),
     };
     this.tasks.push(task);

--- a/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
@@ -16,6 +16,7 @@ import {
   SONNET_5_MODEL,
 } from '@lib/constants';
 import {
+  areSeededTasksEnabled,
   resolveBinding,
   resolveStageOverrides,
   type SwitchboardCtx,
@@ -318,4 +319,17 @@ describe('seam scan — routing reads live only in flags/', () => {
       expect(src).not.toMatch(/WIZARD_\w+_FLAG_KEY/);
     });
   }
+});
+
+describe('areSeededTasksEnabled', () => {
+  // Off or unset, the orchestrator queues no runner-seeded task at all.
+  it("only literal 'true' enables the runner-seeded mechanism", () => {
+    expect(constants.WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY).toBeTruthy();
+    const key = constants.WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY;
+    expect(areSeededTasksEnabled({ [key]: 'true' })).toBe(true);
+    expect(areSeededTasksEnabled({ [key]: 'false' })).toBe(false);
+    expect(areSeededTasksEnabled({ [key]: 'banana' })).toBe(false);
+    expect(areSeededTasksEnabled({})).toBe(false);
+    expect(areSeededTasksEnabled()).toBe(false);
+  });
 });

--- a/src/lib/agent/runner/switchboard/flags/index.ts
+++ b/src/lib/agent/runner/switchboard/flags/index.ts
@@ -74,7 +74,7 @@ export function resolveStageOverrides(
   return overrides;
 }
 
-export { isOrchestratorEnabled } from './orchestrator';
+export { isOrchestratorEnabled, areSeededTasksEnabled } from './orchestrator';
 export type {
   ConfigFlag,
   FlagRoute,

--- a/src/lib/agent/runner/switchboard/flags/orchestrator.ts
+++ b/src/lib/agent/runner/switchboard/flags/orchestrator.ts
@@ -4,6 +4,7 @@ import {
   Sequence,
   WIZARD_ORCHESTRATOR_FLAG_KEY,
   WIZARD_ORCHESTRATOR_OVERRIDE_FLAG_KEY,
+  WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY,
 } from '@lib/constants';
 import type { HarnessExperiment, SequenceExperiment } from './schemes';
 
@@ -24,6 +25,17 @@ export const ORCHESTRATOR_STAGE_OVERRIDES = {
   programs: ORCHESTRATOR_SEQUENCE_ROUTE.programs,
   flag: WIZARD_ORCHESTRATOR_OVERRIDE_FLAG_KEY,
 } as const;
+
+/**
+ * Kill switch for the runner-seeded task mechanism (the optional warehouse
+ * step). Off or unset, the orchestrator queues nothing itself and the run is
+ * identical to a project with no detected sources.
+ */
+export function areSeededTasksEnabled(
+  flags: Record<string, string> = {},
+): boolean {
+  return flags[WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY] === 'true';
+}
 
 /** Raw flag read — for telemetry/log lines only, never for routing. */
 export function isOrchestratorEnabled(

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -164,4 +164,8 @@ export {
   resolveSequence,
   type SequenceRunner,
 } from './sequence';
-export { isOrchestratorEnabled, resolveStageOverrides } from './flags';
+export {
+  isOrchestratorEnabled,
+  areSeededTasksEnabled,
+  resolveStageOverrides,
+} from './flags';

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -261,6 +261,35 @@ export async function fetchSlackConnected(
   return parsed.data.results.some((i) => i.kind === 'slack');
 }
 
+/** Minimal shape of `/api/environments/:id/external_data_sources/` — we only read `source_type`. */
+const ExternalDataSourcesResponseSchema = z.object({
+  results: z.array(z.object({ source_type: z.string() })),
+});
+
+/**
+ * The source types currently connected to the project's data warehouse. Used
+ * to verify that sources a run claims to have created actually exist. Throws
+ * on transport/auth errors; callers treat verification as best-effort.
+ */
+export async function fetchExternalDataSourceTypes(
+  accessToken: string,
+  projectId: number,
+  baseUrl: string,
+): Promise<string[]> {
+  const response = await axios.get(
+    `${baseUrl}/api/environments/${projectId}/external_data_sources/`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'User-Agent': WIZARD_USER_AGENT,
+      },
+    },
+  );
+  const parsed = ExternalDataSourcesResponseSchema.safeParse(response.data);
+  if (!parsed.success) return [];
+  return parsed.data.results.map((r) => r.source_type);
+}
+
 export function handleApiError(error: unknown, operation: string): ApiError {
   if (axios.isAxiosError(error)) {
     const axiosError = error as AxiosError<{ detail?: string }>;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -245,11 +245,15 @@ export const WIZARD_SELF_DRIVING_USE_PI_HARNESS_FLAG_KEY =
 /** Boolean flag: agentic project scoping for non-interactive basic-integration runs. */
 export const WIZARD_BASIC_INTEGRATION_AGENTIC_DETECTION_FLAG_KEY =
   'wizard-basic-integration-agentic-detection';
+/** Boolean flag: the orchestrator queues the program's runner-seeded tasks (the warehouse step). Off, no task is queued and the run is byte-identical to a no-sources project. */
+export const WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY =
+  'wizard-orchestrator-seeded-tasks';
 // Reading a flag enters this run into that flag's experiment, so a closed set — not a
 // `wizard-` prefix anyone can name into — decides what a run evaluates. Test-pinned exhaustive.
 export const WIZARD_FLAG_KEYS = [
   WIZARD_ORCHESTRATOR_FLAG_KEY,
   WIZARD_ORCHESTRATOR_OVERRIDE_FLAG_KEY,
+  WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY,
   WIZARD_SELF_DRIVING_USE_PI_HARNESS_FLAG_KEY,
   WIZARD_BASIC_INTEGRATION_AGENTIC_DETECTION_FLAG_KEY,
 ] as const;

--- a/src/lib/programs/__tests__/warehouse-seed-task.test.ts
+++ b/src/lib/programs/__tests__/warehouse-seed-task.test.ts
@@ -15,6 +15,8 @@ vi.mock('@utils/analytics', () => ({
   },
 }));
 
+vi.mock('@lib/api', () => ({ fetchExternalDataSourceTypes: vi.fn() }));
+
 import { posthogIntegrationConfig } from '@lib/programs/posthog-integration/index';
 import { DETECTED_WAREHOUSE_SOURCES_KEY } from '@lib/programs/warehouse-source/detect';
 
@@ -102,5 +104,56 @@ describe('warehouse task notice', () => {
 
   it('names what was detected', () => {
     expect(notice()?.items).toEqual(['Postgres']);
+  });
+});
+
+describe('warehouse task verification', () => {
+  it('reports which detected in-cli kinds actually landed in the project', async () => {
+    const { fetchExternalDataSourceTypes } = await import('@lib/api');
+    vi.mocked(fetchExternalDataSourceTypes).mockResolvedValue([
+      'Postgres',
+      'Hubspot',
+    ]);
+
+    const sess = session({
+      frameworkContext: {
+        [DETECTED_WAREHOUSE_SOURCES_KEY]: [
+          POSTGRES,
+          {
+            kind: 'Stripe',
+            label: 'Stripe',
+            mode: 'in-cli',
+            matchedSignal: 's',
+          },
+          {
+            kind: 'Hubspot',
+            label: 'HubSpot',
+            mode: 'deep-link',
+            matchedSignal: 'h',
+          },
+        ],
+      },
+    });
+    const entry = seed(sess)[0];
+    const props = await entry.verify?.(
+      sess,
+      {
+        accessToken: 't',
+        projectApiKey: 'phc',
+        projectId: 1,
+        host: { apiHost: 'https://us.posthog.com' },
+      } as never,
+      { status: 'done', inputs: {} },
+    );
+
+    expect(props).toMatchObject({
+      detected_count: 3,
+      detected_in_cli_count: 2,
+      sources_connected_count: 1,
+      sources_connected_kinds: ['Postgres'],
+      sources_missing_kinds: ['Stripe'],
+      all_in_cli_connected: false,
+      task_status: 'done',
+    });
   });
 });

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -20,6 +20,7 @@ import { requestDeepLink } from '@utils/provisioning';
 import { openTrackedLink, withUtm } from '@utils/links';
 import type { HostResolution } from '@lib/host-resolution';
 import { getDetectedWarehouseSources } from '@lib/programs/warehouse-source/detect';
+import { fetchExternalDataSourceTypes } from '@lib/api';
 import { shouldDisableAsk } from '@lib/agent/runner/shared/bootstrap';
 import { POSTHOG_INTEGRATION_PROGRAM } from './steps.js';
 import { getContentBlocks } from './content/index.js';
@@ -117,6 +118,31 @@ const warehouseSeedTasks: NonNullable<ProgramConfig['seedTasks']> = (sess) => {
           mode: s.mode,
           matchedSignal: s.matchedSignal,
         })),
+      },
+      // Did the sources land? Compare what the warehouse claims against what
+      // the project actually has connected, and report the delta.
+      verify: async (s, credentials, task) => {
+        const detected = getDetectedWarehouseSources(s);
+        const inCli = detected.filter((d) => d.mode === 'in-cli');
+        const connectedTypes = await fetchExternalDataSourceTypes(
+          credentials.accessToken,
+          credentials.projectId,
+          credentials.host.apiHost,
+        );
+        const connected = new Set(connectedTypes);
+        const added = inCli.filter((d) => connected.has(d.kind));
+        return {
+          detected_count: detected.length,
+          detected_in_cli_count: inCli.length,
+          sources_connected_count: added.length,
+          sources_connected_kinds: added.map((d) => d.kind),
+          sources_missing_kinds: inCli
+            .filter((d) => !connected.has(d.kind))
+            .map((d) => d.kind),
+          all_in_cli_connected:
+            inCli.length > 0 && added.length === inCli.length,
+          task_status: task.status,
+        };
       },
       notice: {
         title: 'Connect your data sources',

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -2,6 +2,7 @@ import type {
   WizardSession,
   DiscoveredFeature,
   TaskNotice,
+  Credentials,
 } from '@lib/wizard-session';
 import type { WizardReadinessResult } from '@lib/health-checks/readiness';
 import type { ProgramRun } from '@lib/agent/agent-runner';
@@ -56,6 +57,31 @@ export interface ProgramReadyContext {
   }) => void;
   readonly addDiscoveredFeature: (feature: DiscoveredFeature) => void;
   readonly setDetectionComplete: () => void;
+}
+
+/** One task the wizard queues itself before the planner runs. */
+export interface SeedTaskEntry {
+  type: string;
+  label?: string;
+  inputs?: Record<string, unknown>;
+  /**
+   * Shown before the run starts, letting the user decline the task. The
+   * program owns the words — the runner and the modal only carry them. A
+   * task without one is queued silently.
+   */
+  notice?: TaskNotice;
+  /**
+   * Post-drain check that the task's work actually landed (the program owns
+   * what "landed" means — e.g. the sources it created exist in PostHog).
+   * Returns analytics properties for the runner's verification event, or
+   * undefined when nothing could be verified. Best-effort: a throw is
+   * reported, never fatal.
+   */
+  verify?: (
+    session: WizardSession,
+    credentials: Credentials,
+    task: { status: string; inputs: Record<string, unknown> },
+  ) => Promise<Record<string, unknown> | undefined>;
 }
 
 export interface ProgramStep {
@@ -244,17 +270,7 @@ export interface ProgramConfig {
    * decided here, in code, not by a model that could invent it or forget it.
    * Return an empty list to queue none.
    */
-  seedTasks?: (session: WizardSession) => Array<{
-    type: string;
-    label?: string;
-    inputs?: Record<string, unknown>;
-    /**
-     * Shown before the run starts, letting the user decline the task. The
-     * program owns the words — the runner and the modal only carry them. A
-     * task without one is queued silently.
-     */
-    notice?: TaskNotice;
-  }>;
+  seedTasks?: (session: WizardSession) => SeedTaskEntry[];
   /** Prerequisites: other program ids that must have run first */
   requires?: string[];
   /**


### PR DESCRIPTION
Follow-up to #1077 (merged). The optional warehouse task becomes safe to dark-launch: flag-gated, failure-isolated, and measured end to end.

- Flag: `wizard-orchestrator-seeded-tasks` (read in `flags/orchestrator.ts`, per the seam rule). Off or unset, no runner-seeded task is queued and the run is byte-identical to a no-sources project; the gated types are captured (`orchestrator seeded tasks gated`).
- Failure isolation: runner-seeded tasks are `optional` on the queue. A failed optional dependency satisfies dependents like a skipped one (`nextRunnable`), and `drainVerdict` keeps optional failures out of the abort — the run succeeds, the outro says "1 optional step failed", and one `orchestrator optional task failed` event carries type/attempts/duration/error.
- Do or skip: `orchestrator task notice answered` (`kept: true|false`, `items_count`) fires on the consent modal.
- Duration: `orchestrator run finished` gains `optional_task_count/_statuses/_duration_ms` and `optional_tasks_failed` next to the existing totals, so runs with the warehouse path slice cleanly against runs without it (plus the existing `orchestrator_awaits_user` tag on every event).
- Did the sources land: a `verify` hook per seeded task (program-owned). posthog-integration lists the project's `external_data_sources` after the drain and reports detected vs connected kinds in `orchestrator seeded task verified` (`sources_connected_kinds`, `sources_missing_kinds`, `all_in_cli_connected`).

## How to run

Same setup as #1077 (local context-mill on :8765, ci-flavor build), plus the flag:

```
WIZARD_CI_FLAG_OVERRIDES='{"wizard-orchestrator-seeded-tasks": true}' \
MCP_URL=https://mcp.posthog.com/mcp node <wizard>/dist/bin.js --local-mcp --sequence orchestrator --harness pi
```

Without the override (or with the PostHog flag off), the "Connect your data sources" modal and task must not appear at all. With it on, fail the warehouse step (e.g. decline every credential prompt after a validation error) and the run must still end at the success outro with "1 optional step failed".
