### PR TITLE
feat(orchestrator): flag-gate runner-seeded tasks

### DIFF
--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/executor.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/executor.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   QueueStore,
+  TaskStatus,
   type QueuedTask,
   type TaskHandoff,
 } from '@lib/agent/runner/sequence/orchestrator/queue';
@@ -149,5 +150,113 @@ describe('drainQueue', () => {
     };
     await drainQueue(q, neverReports, { maxStarts: 3 });
     expect(q.get(a.id)?.attempts).toBeLessThanOrEqual(3);
+  });
+});
+
+/** The drain waits a failing optional task to terminal state; nothing is silently skipped. */
+describe('drainQueue — optional task failure', () => {
+  let dir: string;
+  let q: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'executor-optional-test-'));
+    q = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const HANDOFF: TaskHandoff = { goals: 'g', did: 'd', forNextAgent: 'n' };
+
+  it('retries a failing optional task to terminal failure, then runs the dependent', async () => {
+    const warehouse = q.enqueue({ type: 'warehouse', optional: true });
+    const report = q.enqueue({ type: 'report', dependsOn: [warehouse.id] });
+
+    const order: string[] = [];
+    const runTask: RunTask = (task) => {
+      order.push(`${task.type}#${task.attempts}`);
+      if (task.type === 'warehouse') {
+        q.fail(task.id, { type: 'boom', message: 'x' });
+      } else {
+        // The dependent starts only against a settled outcome.
+        expect(q.get(warehouse.id)?.status).toBe(TaskStatus.Failed);
+        expect(q.get(warehouse.id)?.attempts).toBe(
+          q.get(warehouse.id)?.maxAttempts,
+        );
+        q.complete(task.id, HANDOFF);
+      }
+      return Promise.resolve();
+    };
+
+    await drainQueue(q, runTask);
+
+    // Both warehouse attempts ran before report started — waited, not skipped.
+    expect(order).toEqual(['warehouse#1', 'warehouse#2', 'report#1']);
+    expect(q.get(warehouse.id)?.status).toBe(TaskStatus.Failed);
+    expect(q.get(report.id)?.status).toBe(TaskStatus.Done);
+    // Every task reached a terminal state; none left pending or running.
+    expect(
+      q
+        .list()
+        .every(
+          (t) =>
+            t.status === TaskStatus.Done ||
+            t.status === TaskStatus.Failed ||
+            t.status === TaskStatus.Skipped,
+        ),
+    ).toBe(true);
+  });
+
+  it('a slow failing optional task holds the whole drain open', async () => {
+    const warehouse = q.enqueue({ type: 'warehouse', optional: true });
+    const install = q.enqueue({ type: 'install' });
+    const report = q.enqueue({
+      type: 'report',
+      dependsOn: [warehouse.id, install.id],
+    });
+
+    let releaseWarehouse!: () => void;
+    const gate = new Promise<void>((r) => (releaseWarehouse = r));
+    const runTask: RunTask = async (task) => {
+      if (task.type === 'warehouse') {
+        if (task.attempts === 1) await gate;
+        q.fail(task.id, { type: 'boom', message: 'x' });
+        return;
+      }
+      q.complete(task.id, HANDOFF);
+    };
+
+    const drain = drainQueue(q, runTask);
+    // Give install time to finish while warehouse hangs on its first attempt.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(q.get(install.id)?.status).toBe(TaskStatus.Done);
+    // The drain is still open and report has not started: waiting, not skipping.
+    expect(q.get(report.id)?.status).toBe(TaskStatus.Pending);
+
+    releaseWarehouse();
+    await drain;
+
+    expect(q.get(warehouse.id)?.status).toBe(TaskStatus.Failed);
+    expect(q.get(report.id)?.status).toBe(TaskStatus.Done);
+  });
+
+  it('an optional task that succeeds on retry feeds its dependent normally', async () => {
+    const warehouse = q.enqueue({ type: 'warehouse', optional: true });
+    const report = q.enqueue({ type: 'report', dependsOn: [warehouse.id] });
+
+    const runTask: RunTask = (task) => {
+      if (task.type === 'warehouse' && task.attempts === 1) {
+        q.fail(task.id, { type: 'boom', message: 'x' });
+      } else if (task.type === 'warehouse') {
+        q.complete(task.id, { ...HANDOFF, reportSection: '## Sources' });
+      } else {
+        expect(q.readHandoff(warehouse.id)?.reportSection).toBe('## Sources');
+        q.complete(task.id, HANDOFF);
+      }
+      return Promise.resolve();
+    };
+
+    await drainQueue(q, runTask);
+    expect(q.get(warehouse.id)?.status).toBe(TaskStatus.Done);
+    expect(q.get(report.id)?.status).toBe(TaskStatus.Done);
   });
 });

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/optional-tasks.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/optional-tasks.test.ts
@@ -1,0 +1,56 @@
+/** Only required failures and blocked work abort; optional failures never do. */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('@utils/analytics', () => ({
+  analytics: { wizardCapture: vi.fn(), captureException: vi.fn() },
+}));
+
+import { QueueStore } from '@lib/agent/runner/sequence/orchestrator/queue';
+import { drainVerdict } from '@lib/agent/runner/sequence/orchestrator/orchestrator-runner';
+
+describe('drainVerdict', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const finish = (id: string, ok: boolean) => {
+    store.start(id);
+    if (ok) store.complete(id);
+    else store.fail(id, { type: 'boom', message: 'x' });
+  };
+
+  it('a failed optional task does not fail the run', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+    const report = store.enqueue({
+      type: 'report',
+      dependsOn: [install.id, warehouse.id],
+    });
+    finish(warehouse.id, false);
+    finish(install.id, true);
+    finish(report.id, true);
+
+    const v = drainVerdict(store.list());
+    expect(v.requiredFailedTypes).toEqual([]);
+    expect(v.optionalFailedTypes).toEqual(['warehouse']);
+    expect(v.blocked).toBe(0);
+  });
+
+  it('a failed required task still fails the run', () => {
+    const install = store.enqueue({ type: 'install' });
+    store.enqueue({ type: 'report', dependsOn: [install.id] });
+    finish(install.id, false);
+
+    const v = drainVerdict(store.list());
+    expect(v.requiredFailedTypes).toEqual(['install']);
+    expect(v.blocked).toBe(1);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
@@ -183,3 +183,63 @@ describe('QueueStore', () => {
     expect(listened.get(t.id)?.status).toBe('done');
   });
 });
+
+/** A terminally failed optional dep unblocks dependents; a required one dams the graph. */
+describe('optional task failure', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'queue-optional-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const failOnce = (id: string) => {
+    store.start(id);
+    store.fail(id, { type: 'boom', message: 'x' });
+  };
+  const failTerminally = (id: string) => {
+    const t = store.get(id);
+    while ((store.get(id)?.attempts ?? 0) < (t?.maxAttempts ?? 0)) {
+      failOnce(id);
+    }
+  };
+
+  it('does not block a dependent once terminally failed', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const report = store.enqueue({
+      type: 'report',
+      dependsOn: [warehouse.id],
+    });
+    failTerminally(warehouse.id);
+
+    expect(store.nextRunnable().map((t) => t.id)).toEqual([report.id]);
+    expect(store.isDrained()).toBe(false);
+  });
+
+  it('still blocks a dependent while a retry is possible', () => {
+    // Agents can self-report failure mid-session, before the executor requeues.
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    store.enqueue({ type: 'report', dependsOn: [warehouse.id] });
+    failOnce(warehouse.id);
+
+    expect(store.get(warehouse.id)?.attempts).toBeLessThan(
+      store.get(warehouse.id)?.maxAttempts ?? 0,
+    );
+    expect(store.nextRunnable()).toEqual([]);
+  });
+
+  it('a required task failing still blocks its dependents', () => {
+    const install = store.enqueue({ type: 'install' });
+    store.enqueue({ type: 'report', dependsOn: [install.id] });
+    failTerminally(install.id);
+    expect(store.get(install.id)?.attempts).toBe(
+      store.get(install.id)?.maxAttempts,
+    );
+
+    expect(store.nextRunnable()).toEqual([]);
+    expect(store.isDrained()).toBe(true);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -40,6 +40,7 @@ import { wizardAbort, WizardError } from '@utils/wizard-abort';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { BootstrapResult } from '../../shared/types';
 import {
+  areSeededTasksEnabled,
   getHarness,
   resolveHarness,
   resolveStageOverrides,
@@ -486,8 +487,13 @@ export async function runOrchestrator(
   // Tasks the wizard queues itself, from what detection found. They exist
   // before the planner runs, so the sink guard forces the reporting task to
   // depend on them, and no prompt has to remember they are there.
+  // Kill switch: off (or unset), the wizard queues nothing itself and the run
+  // is byte-identical to a project with no detected sources.
+  const seedEntries = areSeededTasksEnabled(boot.wizardFlags)
+    ? programConfig.seedTasks?.(session) ?? []
+    : [];
   const seededTypes: string[] = [];
-  for (const seeded of programConfig.seedTasks?.(session) ?? []) {
+  for (const seeded of seedEntries) {
     if (!registry.runnerSeededTypes.includes(seeded.type)) {
       logToFile(
         `[orchestrator] skipping runner-seeded task "${seeded.type}": not a runner-seeded type in this flow`,

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -195,6 +195,24 @@ function canAsk(prompt: AgentPrompt | undefined): boolean {
   return (prompt?.allowedTools ?? []).includes(ASK_TOOL);
 }
 
+/** Splits terminal failures into run-failing (required) and reported-only (optional). */
+export function drainVerdict(tasks: readonly QueuedTask[]): {
+  requiredFailedTypes: string[];
+  optionalFailedTypes: string[];
+  blocked: number;
+} {
+  const failed = tasks.filter((t) => t.status === TaskStatus.Failed);
+  return {
+    requiredFailedTypes: failed
+      .filter((t) => t.optional !== true)
+      .map((t) => t.type),
+    optionalFailedTypes: failed
+      .filter((t) => t.optional === true)
+      .map((t) => t.type),
+    blocked: tasks.filter((t) => t.status === TaskStatus.Pending).length,
+  };
+}
+
 /** How many tasks deep in the graph a task sits — 0 when it depends on nothing. */
 function graphDepth(
   task: QueuedTask,
@@ -312,6 +330,8 @@ export async function runOrchestrator(
         type: task.type,
         model: isValidModel(specModel) ? specModel : pick.model,
         attempts: task.attempts,
+        // A failed optional task aborts nothing (see drainVerdict).
+        optional: task.optional === true,
       };
       switch (event) {
         case 'enqueue':
@@ -519,6 +539,8 @@ export async function runOrchestrator(
       label: seeded.label,
       inputs: seeded.inputs,
       enqueuedBy: 'orchestrator',
+      // Terminal failure is reported per-task and never aborts the run.
+      optional: true,
     });
     seededTypes.push(seeded.type);
     logToFile(`[orchestrator] runner-seeded task ${seeded.type}`);
@@ -806,13 +828,11 @@ export async function runOrchestrator(
   // A drain that ends with failed tasks (retries exhausted) or tasks still
   // pending (blocked behind a failed dependency) did NOT set PostHog up —
   // abort like a linear agent failure instead of claiming success.
-  const blocked = summary[TaskStatus.Pending];
-  if (summary.failed > 0 || blocked > 0) {
-    const failedTypes = store
-      .list()
-      .filter((t) => t.status === TaskStatus.Failed)
-      .map((t) => t.type)
-      .join(', ');
+  // A failed optional task is exempt: reported per-task, never run-failing.
+  const verdict = drainVerdict(store.list());
+  const blocked = verdict.blocked;
+  if (verdict.requiredFailedTypes.length > 0 || blocked > 0) {
+    const failedTypes = verdict.requiredFailedTypes.join(', ');
     await wizardAbort({
       message: `The wizard was unable to set up PostHog: ${
         failedTypes
@@ -828,12 +848,20 @@ export async function runOrchestrator(
     });
   }
 
+  // A failed optional step leaves the denominator and is named instead.
+  const optionalFailedCount = verdict.optionalFailedTypes.length;
+  const stepNotes = [
+    notRequired > 0 ? `${notRequired} skipped as not required` : '',
+    optionalFailedCount > 0
+      ? `${optionalFailedCount} optional step failed`
+      : '',
+  ].filter(Boolean);
   const message = conflict
     ? 'PostHog set up, with one conflict to review.'
     : `PostHog set up: ${summary.done}/${
-        summary.total - notRequired
+        summary.total - notRequired - optionalFailedCount
       } steps completed${
-        notRequired > 0 ? ` (${notRequired} skipped as not required)` : ''
+        stepNotes.length > 0 ? ` (${stepNotes.join(', ')})` : ''
       }.`;
   getUI().setOutroData({
     kind: OutroKind.Success,

--- a/src/lib/agent/runner/sequence/orchestrator/queue.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue.ts
@@ -48,6 +48,8 @@ export interface QueuedTask {
   handoff?: TaskHandoff;
   /** 'orchestrator' for seeded tasks, or the id of the task that enqueued this one. */
   enqueuedBy: string;
+  /** Wizard-seeded only: terminal failure unblocks dependents and never fails the run. */
+  optional?: boolean;
   createdAt: string;
   startedAt?: string;
   finishedAt?: string;
@@ -84,6 +86,7 @@ export interface EnqueueInput {
   model?: string;
   maxAttempts?: number;
   enqueuedBy?: string;
+  optional?: boolean;
 }
 
 export const QUEUE_DIR_NAME = '.posthog-wizard-cache';
@@ -154,11 +157,16 @@ export class QueueStore {
    * `skipped`). A skipped dependency does not block downstream work.
    */
   nextRunnable(): QueuedTask[] {
+    // A TERMINALLY failed optional dep satisfies like skipped; retryable failure still blocks.
     const doneIds = new Set(
       this.tasks
         .filter(
           (t) =>
-            t.status === TaskStatus.Done || t.status === TaskStatus.Skipped,
+            t.status === TaskStatus.Done ||
+            t.status === TaskStatus.Skipped ||
+            (t.status === TaskStatus.Failed &&
+              t.optional === true &&
+              t.attempts >= t.maxAttempts),
         )
         .map((t) => t.id),
     );
@@ -215,6 +223,7 @@ export class QueueStore {
       attempts: 0,
       maxAttempts: input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
       enqueuedBy: input.enqueuedBy ?? 'orchestrator',
+      optional: input.optional,
       createdAt: nowIso(),
     };
     this.tasks.push(task);

--- a/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
@@ -16,6 +16,7 @@ import {
   SONNET_5_MODEL,
 } from '@lib/constants';
 import {
+  areSeededTasksEnabled,
   resolveBinding,
   resolveStageOverrides,
   type SwitchboardCtx,
@@ -318,4 +319,17 @@ describe('seam scan — routing reads live only in flags/', () => {
       expect(src).not.toMatch(/WIZARD_\w+_FLAG_KEY/);
     });
   }
+});
+
+describe('areSeededTasksEnabled', () => {
+  // Off or unset, the orchestrator queues no runner-seeded task at all.
+  it("only literal 'true' enables the runner-seeded mechanism", () => {
+    expect(constants.WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY).toBeTruthy();
+    const key = constants.WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY;
+    expect(areSeededTasksEnabled({ [key]: 'true' })).toBe(true);
+    expect(areSeededTasksEnabled({ [key]: 'false' })).toBe(false);
+    expect(areSeededTasksEnabled({ [key]: 'banana' })).toBe(false);
+    expect(areSeededTasksEnabled({})).toBe(false);
+    expect(areSeededTasksEnabled()).toBe(false);
+  });
 });

--- a/src/lib/agent/runner/switchboard/flags/index.ts
+++ b/src/lib/agent/runner/switchboard/flags/index.ts
@@ -74,7 +74,7 @@ export function resolveStageOverrides(
   return overrides;
 }
 
-export { isOrchestratorEnabled } from './orchestrator';
+export { isOrchestratorEnabled, areSeededTasksEnabled } from './orchestrator';
 export type {
   ConfigFlag,
   FlagRoute,

--- a/src/lib/agent/runner/switchboard/flags/orchestrator.ts
+++ b/src/lib/agent/runner/switchboard/flags/orchestrator.ts
@@ -4,6 +4,7 @@ import {
   Sequence,
   WIZARD_ORCHESTRATOR_FLAG_KEY,
   WIZARD_ORCHESTRATOR_OVERRIDE_FLAG_KEY,
+  WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY,
 } from '@lib/constants';
 import type { HarnessExperiment, SequenceExperiment } from './schemes';
 
@@ -24,6 +25,17 @@ export const ORCHESTRATOR_STAGE_OVERRIDES = {
   programs: ORCHESTRATOR_SEQUENCE_ROUTE.programs,
   flag: WIZARD_ORCHESTRATOR_OVERRIDE_FLAG_KEY,
 } as const;
+
+/**
+ * Kill switch for the runner-seeded task mechanism (the optional warehouse
+ * step). Off or unset, the orchestrator queues nothing itself and the run is
+ * identical to a project with no detected sources.
+ */
+export function areSeededTasksEnabled(
+  flags: Record<string, string> = {},
+): boolean {
+  return flags[WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY] === 'true';
+}
 
 /** Raw flag read — for telemetry/log lines only, never for routing. */
 export function isOrchestratorEnabled(

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -164,4 +164,8 @@ export {
   resolveSequence,
   type SequenceRunner,
 } from './sequence';
-export { isOrchestratorEnabled, resolveStageOverrides } from './flags';
+export {
+  isOrchestratorEnabled,
+  areSeededTasksEnabled,
+  resolveStageOverrides,
+} from './flags';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -245,11 +245,15 @@ export const WIZARD_SELF_DRIVING_USE_PI_HARNESS_FLAG_KEY =
 /** Boolean flag: agentic project scoping for non-interactive basic-integration runs. */
 export const WIZARD_BASIC_INTEGRATION_AGENTIC_DETECTION_FLAG_KEY =
   'wizard-basic-integration-agentic-detection';
+/** Boolean flag: the orchestrator queues the program's runner-seeded tasks (the warehouse step). Off, no task is queued and the run is byte-identical to a no-sources project. */
+export const WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY =
+  'wizard-orchestrator-seeded-tasks';
 // Reading a flag enters this run into that flag's experiment, so a closed set — not a
 // `wizard-` prefix anyone can name into — decides what a run evaluates. Test-pinned exhaustive.
 export const WIZARD_FLAG_KEYS = [
   WIZARD_ORCHESTRATOR_FLAG_KEY,
   WIZARD_ORCHESTRATOR_OVERRIDE_FLAG_KEY,
+  WIZARD_ORCHESTRATOR_SEEDED_TASKS_FLAG_KEY,
   WIZARD_SELF_DRIVING_USE_PI_HARNESS_FLAG_KEY,
   WIZARD_BASIC_INTEGRATION_AGENTIC_DETECTION_FLAG_KEY,
 ] as const;


### PR DESCRIPTION
Kill switch `wizard-orchestrator-seeded-tasks`: off or unset, the orchestrator queues no runner-seeded task (no warehouse step, no consent modal) and the run is byte-identical to a project with no detected sources.

## How to run

Same setup as #1077. Force the flag locally on a ci-flavor build (`pnpm build:ci`):

```
WIZARD_CI_FLAG_OVERRIDES='{"wizard-orchestrator-seeded-tasks": true}' \
MCP_URL=https://mcp.posthog.com/mcp node <wizard>/dist/bin.js --local-mcp --sequence orchestrator --harness pi
```

Without the override the data-sources modal and task must not appear at all.