### PR TITLE
feat(self-driving): key step events by step, not by the agent's wording

### DIFF
--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -682,6 +682,11 @@ export async function runAgent(
      * `ProgramRun.trackStepProgress`; defaults off for every other caller.
      */
     emitStepEvents?: boolean;
+    /**
+     * Maps an agent-authored step label to a stable `step_key`. Threaded from
+     * `ProgramRun.resolveStepKey`; absent for programs that don't define one.
+     */
+    resolveStepKey?: (stepName: string | undefined) => string | undefined;
     /** Request the end-of-run reflection remark. Defaults to true. */
     requestRemark?: boolean;
     /** Scan-triage classifier resolved in bootstrap. Absent → rebuilt from the gateway auth on the env. */
@@ -703,6 +708,7 @@ export async function runAgent(
     errorMessage = 'Integration failed',
     abortCases = [],
     emitStepEvents = false,
+    resolveStepKey,
   } = config ?? {};
 
   logToFile('Starting agent run');
@@ -1092,6 +1098,7 @@ export async function runAgent(
         tasks,
         agentConfig.suppressTaskRender ?? false,
         emitStepEvents,
+        resolveStepKey,
       );
 
       // [ABORT] detection: the skill emits "[ABORT] <reason>" when it
@@ -1339,6 +1346,8 @@ interface TaskStore {
   sync: () => void;
   /** When true, emit a `wizard: step` event on each status transition. */
   emitStepEvents?: boolean;
+  /** Supplies the stable `step_key` for that event, when the program defines one. */
+  resolveStepKey?: (stepName: string | undefined) => string | undefined;
 }
 
 interface ToolUseBlock {
@@ -1391,18 +1400,23 @@ function handleTaskUpdate(block: ToolUseBlock, store: TaskStore): void {
       (input.status === 'in_progress' || input.status === 'completed')
     ) {
       const keys = [...store.tasks.keys()];
+      // The task's display label lives on `activeForm` (what the TUI renders,
+      // e.g. "Checking access"); `content`/`subject` are typically empty on a
+      // status-only TaskUpdate. Prefer the stored entry, then the update, so
+      // the name is never null. Named `step_name` (not `step`): a bare
+      // `properties.step` doesn't resolve in HogQL — `step_name` queries
+      // cleanly, like `step_index` / `step_count`.
+      const stepName =
+        existing.activeForm ??
+        input.activeForm ??
+        existing.content ??
+        input.subject;
       analytics.wizardCapture('step', {
-        // The task's display label lives on `activeForm` (what the TUI renders,
-        // e.g. "Checking access"); `content`/`subject` are typically empty on a
-        // status-only TaskUpdate. Prefer the stored entry, then the update, so
-        // the name is never null. Named `step_name` (not `step`): a bare
-        // `properties.step` doesn't resolve in HogQL — `step_name` queries
-        // cleanly, like `step_index` / `step_count`.
-        step_name:
-          existing.activeForm ??
-          input.activeForm ??
-          existing.content ??
-          input.subject,
+        step_name: stepName,
+        // The agent words its own labels, so `step_name` drifts run to run and a funnel keyed on
+        // it quietly loses runs. Programs that care supply a mapping to a stable key; the ones
+        // that don't ship this undefined, exactly as before.
+        step_key: store.resolveStepKey?.(stepName),
         status: input.status,
         step_index: keys.indexOf(input.taskId),
         step_count: keys.length,
@@ -1536,6 +1550,8 @@ function handleSDKMessage(
   // Opt-in per-step analytics, threaded from runAgent's `emitStepEvents`
   // (ProgramRun.trackStepProgress). Off for every program that doesn't opt in.
   emitStepEvents = false,
+  // Program-supplied label -> stable key mapping for the same events.
+  resolveStepKey?: (stepName: string | undefined) => string | undefined,
 ): void {
   // Map preserves insertion order (the order the agent created the tasks).
   // Within that, group by status: completed first, then in_progress, then
@@ -1629,6 +1645,7 @@ function handleSDKMessage(
               tasks,
               sync: syncTasks,
               emitStepEvents,
+              resolveStepKey,
             });
           }
 

--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -96,6 +96,7 @@ export const anthropicBackend: AgentHarness = {
         additionalFeatureQueue: config.additionalFeatureQueue ?? [],
         abortCases: config.abortCases,
         emitStepEvents: config.trackStepProgress ?? false,
+        resolveStepKey: config.resolveStepKey,
         triageProvider: boot.triageProvider,
       },
       middleware,

--- a/src/lib/agent/runner/shared/types.ts
+++ b/src/lib/agent/runner/shared/types.ts
@@ -86,6 +86,13 @@ export interface ProgramRun {
    * analytics change; opt in per program.
    */
   trackStepProgress?: boolean;
+  /**
+   * Map an agent-authored step label to a stable key, shipped on `wizard: step` as `step_key`.
+   * The runner knows nothing about any program's steps, so a program that wants its funnel to
+   * survive the agent rewording a task supplies the mapping itself. Omit it and only the label
+   * ships, as before.
+   */
+  resolveStepKey?: (stepName: string | undefined) => string | undefined;
 }
 
 /**

--- a/src/lib/programs/self-driving/__tests__/step-keys.test.ts
+++ b/src/lib/programs/self-driving/__tests__/step-keys.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSelfDrivingStepKey } from '../step-keys.js';
+
+describe('resolveSelfDrivingStepKey', () => {
+  // Every label below is one real runs have emitted. They are the point of the mapping: the agent
+  // words its own tasks, so the GitHub step alone has arrived under six spellings.
+  it.each([
+    ['Connect GitHub', 'connect_github'],
+    ['Connecting GitHub', 'connect_github'],
+    ['Connect GitHub (required)', 'connect_github'],
+    ['Connecting GitHub integration', 'connect_github'],
+    ['Connect GitHub integration', 'connect_github'],
+    // Reads as an access check, but it is the GitHub step deciding whether to prompt.
+    ['Checking GitHub connection', 'connect_github'],
+    ['Checking Self-driving access', 'check_access'],
+    ['Reading project state', 'read_context'],
+    ['Reading project and Self-driving state', 'read_context'],
+    ['Enabling products', 'enable_products'],
+    ['Enabling signal sources', 'enable_signal_sources'],
+    ['Configuring scout troop', 'configure_scouts'],
+    ['Designing custom scouts', 'design_custom_scouts'],
+    ['Setting up Replay Vision scanners', 'setup_replay_vision'],
+    ['Writing the report', 'write_report'],
+  ])('maps %j to %j', (label, expected) => {
+    expect(resolveSelfDrivingStepKey(label)).toBe(expected);
+  });
+
+  // The ordering trap: these all contain "connect", and two mention GitHub's issue tracker. Letting
+  // them reach `connect_github` would inflate the GitHub connect funnel with issue-tracker steps.
+  it.each([
+    'Connecting issue trackers',
+    'Connecting issue-tracker integrations',
+    'Setting up issue-tracker integrations',
+    'Offering issue-tracker integrations',
+  ])('keeps %j out of the GitHub step', (label) => {
+    expect(resolveSelfDrivingStepKey(label)).toBe('connect_issue_trackers');
+  });
+
+  it('leaves an unrecognized step unkeyed rather than bucketing it', () => {
+    expect(resolveSelfDrivingStepKey('Polishing the hedgehog')).toBeUndefined();
+    expect(resolveSelfDrivingStepKey(undefined)).toBeUndefined();
+    expect(resolveSelfDrivingStepKey('')).toBeUndefined();
+  });
+});

--- a/src/lib/programs/self-driving/index.ts
+++ b/src/lib/programs/self-driving/index.ts
@@ -10,6 +10,7 @@ import {
   getSelfDrivingDetectedTools,
 } from './detect.js';
 import { buildSelfDrivingPrompt } from './prompt.js';
+import { resolveSelfDrivingStepKey } from './step-keys.js';
 import {
   NO_DEFAULT_LIMIT,
   PRICE_PER_PR_USD,
@@ -78,6 +79,10 @@ const buildRun = (session: WizardSession): Promise<ProgramRun> =>
     // scout enable, etc.), including silent steps with no wizard_ask. Opt-in, so
     // only self-driving runs emit these; every other program is unchanged.
     trackStepProgress: true,
+
+    // Key those events by step as well as by label, so a funnel over them (GitHub connect
+    // conversion, scout enable rate) keeps counting when a run words its tasks differently.
+    resolveStepKey: resolveSelfDrivingStepKey,
 
     postRun: async (session) => {
       await removeInstalledSkill(session.installDir);

--- a/src/lib/programs/self-driving/step-keys.ts
+++ b/src/lib/programs/self-driving/step-keys.ts
@@ -1,0 +1,61 @@
+/**
+ * Canonical step keys for the Self-driving run's `wizard: step` analytics.
+ *
+ * The agent writes its own task labels, so the same step reaches analytics under whatever wording
+ * that run's model picked — "Connect GitHub", "Connecting GitHub", "Connect GitHub (required)" and
+ * "Checking GitHub connection" are all STEP 3. A funnel keyed on that label silently loses runs the
+ * moment the wording drifts, which is invisible: the number just drops.
+ *
+ * These rules map a label back to the step it belongs to, so a funnel can key on `step_key` and stay
+ * correct across rewordings. `step_name` still ships alongside it, unchanged, for anything that wants
+ * the label the user actually saw.
+ */
+
+/** Canonical keys, in the order the prompt's STEPs run. Frozen: these are event property values. */
+export const SELF_DRIVING_STEP_KEYS = [
+  'check_access',
+  'read_context',
+  'connect_github',
+  'enable_products',
+  'enable_signal_sources',
+  'connect_issue_trackers',
+  'configure_scouts',
+  'design_custom_scouts',
+  'setup_replay_vision',
+  'write_report',
+] as const;
+
+export type SelfDrivingStepKey = (typeof SELF_DRIVING_STEP_KEYS)[number];
+
+/**
+ * First match wins, so order is the rule. Entity words come before verbs: "Checking GitHub
+ * connection" is the GitHub step, not the access-check step, and "Connecting issue trackers" must
+ * not fall through to GitHub just because a later run words it "Connecting GitHub issues".
+ */
+const RULES: readonly { key: SelfDrivingStepKey; match: RegExp }[] = [
+  { key: 'connect_issue_trackers', match: /issue[\s-]?track/i },
+  { key: 'setup_replay_vision', match: /replay vision|vision scanner/i },
+  { key: 'design_custom_scouts', match: /custom scout|designing scout/i },
+  {
+    key: 'configure_scouts',
+    match: /scout troop|tun(e|ing) .*scout|configur\w* .*scout/i,
+  },
+  { key: 'enable_signal_sources', match: /signal source/i },
+  { key: 'connect_github', match: /github/i },
+  { key: 'enable_products', match: /product/i },
+  { key: 'write_report', match: /report/i },
+  { key: 'check_access', match: /access/i },
+  { key: 'read_context', match: /read|context|project state/i },
+];
+
+/**
+ * The canonical key for an agent-authored step label, or `undefined` when nothing matches — an
+ * unmatched step is left unkeyed rather than bucketed, so a new step shows up as a gap to name
+ * instead of quietly inflating whichever key it landed nearest.
+ */
+export function resolveSelfDrivingStepKey(
+  stepName: string | undefined,
+): SelfDrivingStepKey | undefined {
+  if (!stepName) return undefined;
+  return RULES.find((rule) => rule.match.test(stepName))?.key;
+}


### PR DESCRIPTION
## Problem

A funnel over the Self-driving run's steps loses runs whenever the agent rewords a task, and it loses them silently: the count just falls, with nothing to show that anything broke.

- `wizard: step` carries the step only as `step_name`, and the agent writes that label itself.
- The GitHub connect step has reached analytics under six spellings: `Connect GitHub`, `Connecting GitHub`, `Connect GitHub (required)`, `Connecting GitHub integration`, `Connect GitHub integration`, `Checking GitHub connection`.
- Every other step drifts the same way. `Reading project state` and `Reading project and Self-driving state` are one step; so are `Configuring scout troop` and `Configuring the scout troop`.
- A substring match is not a fix. It has to be wide enough to catch all six spellings and narrow enough to keep issue-tracker steps out of the GitHub bucket, and each new wording moves that line.

## Changes

- Self-driving events now also carry `step_key`, a stable key for the step the label belongs to.
- `step_name` ships unchanged, so anything reading the label the user saw keeps working.
- `ProgramRun` gains an optional `resolveStepKey`, threaded to the emit site the same way `trackStepProgress` already is.
- The label to key mapping lives in the Self-driving program, not the runner. AGENTS.md keeps product knowledge out of infrastructure, and the runner has no idea what any program's steps are.
- Programs that define no resolver ship `step_key` undefined. Their events do not change.
- An unrecognized label stays unkeyed rather than falling into the nearest bucket, so a new step shows up as a gap to name instead of quietly inflating its neighbor.

Rule order carries the correctness here: entity words are matched before verbs, so `Checking GitHub connection` resolves to the GitHub step rather than the access check.

## Test plan

- Covered by CI.
- Added 20 cases over `resolveSelfDrivingStepKey`, written from labels that runs actually emitted rather than invented ones.
- The regression they catch is rule order putting a label in the wrong bucket. Four issue-tracker labels assert they stay out of `connect_github`, and `Checking GitHub connection` asserts it does not fall through to `check_access`.
- Not run: the wizard end to end against a live agent. The resolver is a pure function and the threading is typed, so I checked those; I did not watch a real run emit the property.
- Repo typecheck reports the same 25 pre-existing errors before and after this branch, none in the files it touches.

## LLM context

I (actually Claude, driven by Georgiy) wrote this. It came out of instrumenting GitHub connect across PostHog and building a Self-driving connect funnel: that funnel needs one stable predicate for the GitHub step, and `step_name` could not be one.

- Skills invoked: `writing-tests` to gate whether the test earned its place, `writing-code-comments` for the comments, `writing-pr-descriptions` for this body.
- The six spellings above came from querying the emitted events, not from reading the prompt.
- Scope was checked against `AGENTS.md` before writing: the first draft put the mapping in `agent-interface.ts`, which the design discipline forbids, so it moved into the program behind a typed config surface.
