### PR TITLE
feat(audit): check cross-runtime session correlation

### DIFF
--- a/src/lib/programs/__tests__/audit-seed.test.ts
+++ b/src/lib/programs/__tests__/audit-seed.test.ts
@@ -15,6 +15,19 @@ describe('AUDIT_SEED_CHECKS', () => {
     expect(new Set(ids(AUDIT_SEED_CHECKS)).size).toBe(AUDIT_SEED_CHECKS.length);
   });
 
+  it('keeps cross-runtime identity and session checks together', () => {
+    const order = ids(AUDIT_SEED_CHECKS);
+    const distinctId = order.indexOf('cross-runtime-distinct-id');
+    const sessionId = order.indexOf('cross-runtime-session-id');
+
+    expect(distinctId).toBeGreaterThan(-1);
+    expect(sessionId).toBe(distinctId + 1);
+    expect(AUDIT_SEED_CHECKS[sessionId]).toMatchObject({
+      area: 'Identification',
+      status: 'pending',
+    });
+  });
+
   it('sweeps PostHog for open findings before writing the report', () => {
     const order = ids(AUDIT_SEED_CHECKS);
     const sweep = order.indexOf('live-data-findings');

--- a/src/lib/programs/audit/seed.ts
+++ b/src/lib/programs/audit/seed.ts
@@ -4,7 +4,7 @@ import { logToFile } from '@utils/debug';
 import { AUDIT_CHECKS_FILE, type AuditCheck } from './types.js';
 
 /**
- * The 10 source-tree checks the audit runs, plus one row for the PostHog-side
+ * The 11 source-tree checks the audit runs, plus one row for the PostHog-side
  * sweep and two workflow rows at the end (so the skill's
  * `audit_resolve_checks` calls for `write-report` and `upload-notebook`
  * succeed — the skill writes the report to disk, then mirrors it into a
@@ -52,6 +52,12 @@ export const AUDIT_SEED_CHECKS: AuditCheck[] = [
     id: 'cross-runtime-distinct-id',
     area: 'Identification',
     label: 'Same distinct_id across client and server',
+    status: 'pending',
+  },
+  {
+    id: 'cross-runtime-session-id',
+    area: 'Identification',
+    label: 'Same $session_id across client and server',
     status: 'pending',
   },
   {


### PR DESCRIPTION
## Summary
- seed a `cross-runtime-session-id` check next to the existing cross-runtime identity check
- show the check in the comprehensive audit ledger
- cover check ordering and metadata with a focused test

## Test plan
- `pnpm build`
- `pnpm vitest run src/lib/programs/__tests__/audit-seed.test.ts`
- `pnpm exec prettier --check src/lib/programs/audit/seed.ts src/lib/programs/__tests__/audit-seed.test.ts`
- `git diff --check`

## Companion change
Depends on https://github.com/PostHog/context-mill/pull/335, which defines the audit rule.

## Note
`pnpm typecheck` currently fails on pre-existing errors in unrelated files; this change adds no new type errors.