### PR TITLE
fix(orchestrator): give pi agents the reportSection handoff field

### DIFF
--- a/src/lib/agent/runner/harness/pi/orchestrator-tools.ts
+++ b/src/lib/agent/runner/harness/pi/orchestrator-tools.ts
@@ -18,6 +18,7 @@ import {
   applyComplete,
   applyEnqueue,
   applyReadHandoffs,
+  HANDOFF_FIELDS,
   REMARK_ASK,
   type EnqueueArgs,
   type OrchestratorToolsContext,
@@ -31,38 +32,32 @@ function text(s: string): {
   return { content: [{ type: 'text', text: s }], details: {} };
 }
 
+/** Mirrors the zod `HANDOFF_SHAPE`; both read their text from HANDOFF_FIELDS. */
 const HANDOFF_PARAMS = Type.Object({
-  goals: Type.String({ description: 'What this task was asked to achieve.' }),
-  did: Type.String({
-    description:
-      'What you actually did — for each file you edited: the change, the intention behind it, and the analytics it should feed (the insight, funnel, or dashboard tile it becomes part of).',
-  }),
-  forNextAgent: Type.String({
-    description: 'What the next agent should know.',
-  }),
+  goals: Type.String({ description: HANDOFF_FIELDS.goals }),
+  did: Type.String({ description: HANDOFF_FIELDS.did }),
+  forNextAgent: Type.String({ description: HANDOFF_FIELDS.forNextAgent }),
   filesTouched: Type.Optional(
-    Type.Array(Type.String(), {
-      description: 'Paths of every file you edited.',
-    }),
+    Type.Array(Type.String(), { description: HANDOFF_FIELDS.filesTouched }),
   ),
   evidence: Type.Optional(
-    Type.String({
-      description:
-        'How you know it worked — what you ran or observed, not what you expect.',
-    }),
+    Type.String({ description: HANDOFF_FIELDS.evidence }),
   ),
   assumptions: Type.Optional(
-    Type.String({
-      description: 'What you assumed about the app and could not verify.',
-    }),
+    Type.String({ description: HANDOFF_FIELDS.assumptions }),
   ),
   conflict: Type.Optional(
-    Type.String({
-      description:
-        'A one-line summary of any conflict you could not cleanly resolve (e.g. a dependency or build conflict). Put full detail in your work; this line is surfaced to the user.',
-    }),
+    Type.String({ description: HANDOFF_FIELDS.conflict }),
+  ),
+  reportSection: Type.Optional(
+    Type.String({ description: HANDOFF_FIELDS.reportSection }),
   ),
 });
+
+/** Exported so the parity test can compare both harnesses' field sets. */
+export const PI_HANDOFF_PARAM_KEYS: readonly string[] = Object.keys(
+  HANDOFF_PARAMS.properties,
+);
 
 /** The three queue tools bound to one agent's orchestrator context. */
 export function createPiOrchestratorTools(

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/handoff-schema-parity.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/handoff-schema-parity.test.ts
@@ -1,0 +1,24 @@
+/**
+ * `complete_task` exists twice — a zod shape for the MCP/anthropic path and a
+ * typebox mirror for pi — and the orchestrator runs on pi. When the two drifted,
+ * `reportSection` was reachable only on the path nobody runs, so every task
+ * asked for a report section it could not submit.
+ */
+import { describe, it, expect } from 'vitest';
+import { HANDOFF_SHAPE_KEYS } from '../queue-tools';
+import { PI_HANDOFF_PARAM_KEYS } from '../../../harness/pi/orchestrator-tools';
+
+describe('complete_task handoff schema', () => {
+  it('exposes the same fields on both harnesses', () => {
+    expect([...PI_HANDOFF_PARAM_KEYS].sort()).toEqual(
+      [...HANDOFF_SHAPE_KEYS].sort(),
+    );
+  });
+
+  it.each(['reportSection', 'conflict', 'evidence', 'assumptions'])(
+    'offers the optional field %s to pi agents',
+    (field) => {
+      expect(PI_HANDOFF_PARAM_KEYS).toContain(field);
+    },
+  );
+});

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/handoff-schema-parity.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/handoff-schema-parity.test.ts
@@ -5,7 +5,7 @@
  * asked for a report section it could not submit.
  */
 import { describe, it, expect } from 'vitest';
-import { HANDOFF_SHAPE_KEYS } from '../queue-tools';
+import { HANDOFF_FIELDS, HANDOFF_SHAPE_KEYS } from '../queue-tools';
 import { PI_HANDOFF_PARAM_KEYS } from '../../../harness/pi/orchestrator-tools';
 
 describe('complete_task handoff schema', () => {
@@ -13,6 +13,17 @@ describe('complete_task handoff schema', () => {
     expect([...PI_HANDOFF_PARAM_KEYS].sort()).toEqual(
       [...HANDOFF_SHAPE_KEYS].sort(),
     );
+  });
+
+  // The check above only holds the two schemas level with *each other*, so both
+  // could drop the same field and still agree. `HANDOFF_FIELDS` is the anchor:
+  // tsc already ties it to `TaskHandoff`, so tying the schemas to it closes the
+  // loop — a field the interface declares can't end up described but unsendable.
+  it.each([
+    ['zod', HANDOFF_SHAPE_KEYS],
+    ['pi', PI_HANDOFF_PARAM_KEYS],
+  ])('offers every described field on the %s schema', (_name, keys) => {
+    expect([...keys].sort()).toEqual(Object.keys(HANDOFF_FIELDS).sort());
   });
 
   it.each(['reportSection', 'conflict', 'evidence', 'assumptions'])(

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -38,7 +38,7 @@ import { ciExcludedTaskTypes } from '@utils/ci-flag-overrides';
 import { logToFile } from '@utils/debug';
 import { wizardAbort, WizardError } from '@utils/wizard-abort';
 import type { ProgramConfig } from '@lib/programs/program-step';
-import type { BootstrapResult } from '../../shared/types';
+import type { BootstrapResult, ProgramRun } from '../../shared/types';
 import {
   areSeededTasksEnabled,
   getHarness,
@@ -259,6 +259,7 @@ export function displayOrder(
 
 export async function runOrchestrator(
   session: WizardSession,
+  config: ProgramRun,
   programConfig: ProgramConfig,
   boot: BootstrapResult,
 ): Promise<void> {
@@ -570,7 +571,7 @@ export async function runOrchestrator(
         getSource: () => session.skillId ?? programConfig.id,
         showQuestion: (q) => getUI().requestQuestion(q),
         cancelQuestion: () => getUI().cancelPendingQuestion(),
-        richLinks: false,
+        richLinks: config.richLinks ?? false,
         timeoutMs: TASK_ASK_TIMEOUT_MS,
       });
 

--- a/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
@@ -275,53 +275,63 @@ export function applyReadHandoffs(
 // Caps each LLM-authored free-text field; queue.json rewrites whole per transition.
 const HANDOFF_TEXT_MAX = 8_000;
 
+/**
+ * The one description of every handoff field, shared by both harnesses'
+ * `complete_task` schemas — the zod shape below and the typebox mirror in
+ * `harness/pi/orchestrator-tools.ts`. A field an agent cannot see is a field it
+ * cannot fill, so the two drifting silently drops whatever the missing field
+ * carried; `__tests__/handoff-schema-parity.test.ts` holds them level.
+ */
+export const HANDOFF_FIELDS = {
+  goals: 'What this task was asked to achieve.',
+  did: 'What you actually did — for each file you edited: the change, the intention behind it, and the analytics it should feed (the insight, funnel, or dashboard tile it becomes part of).',
+  forNextAgent: 'What the next agent should know.',
+  filesTouched: 'Paths of every file you edited.',
+  evidence:
+    'How you know it worked — what you ran or observed, not what you expect.',
+  assumptions: 'What you assumed about the app and could not verify.',
+  conflict:
+    'A one-line summary of any conflict you could not cleanly resolve (e.g. a dependency or build conflict). Put full detail in your work; this line is surfaced to the user.',
+  reportSection:
+    'A finished markdown section about your work for the run report, written only when your task instructions ask for one. The reporting task includes it as its own section instead of rewriting it.',
+} as const satisfies Record<keyof Required<TaskHandoff>, string>;
+
 const HANDOFF_SHAPE = {
-  goals: z
-    .string()
-    .max(HANDOFF_TEXT_MAX)
-    .describe('What this task was asked to achieve.'),
-  did: z
-    .string()
-    .max(HANDOFF_TEXT_MAX)
-    .describe(
-      'What you actually did — for each file you edited: the change, the intention behind it, and the analytics it should feed (the insight, funnel, or dashboard tile it becomes part of).',
-    ),
+  goals: z.string().max(HANDOFF_TEXT_MAX).describe(HANDOFF_FIELDS.goals),
+  did: z.string().max(HANDOFF_TEXT_MAX).describe(HANDOFF_FIELDS.did),
   forNextAgent: z
     .string()
     .max(HANDOFF_TEXT_MAX)
-    .describe('What the next agent should know.'),
+    .describe(HANDOFF_FIELDS.forNextAgent),
   filesTouched: z
     .array(z.string().max(1_000))
     .max(200)
     .optional()
-    .describe('Paths of every file you edited.'),
+    .describe(HANDOFF_FIELDS.filesTouched),
   evidence: z
     .string()
     .max(HANDOFF_TEXT_MAX)
     .optional()
-    .describe(
-      'How you know it worked — what you ran or observed, not what you expect.',
-    ),
+    .describe(HANDOFF_FIELDS.evidence),
   assumptions: z
     .string()
     .max(HANDOFF_TEXT_MAX)
     .optional()
-    .describe('What you assumed about the app and could not verify.'),
+    .describe(HANDOFF_FIELDS.assumptions),
   conflict: z
     .string()
     .max(HANDOFF_TEXT_MAX)
     .optional()
-    .describe(
-      'A one-line summary of any conflict you could not cleanly resolve (e.g. a dependency or build conflict). Put full detail in your work; this line is surfaced to the user.',
-    ),
+    .describe(HANDOFF_FIELDS.conflict),
   reportSection: z
     .string()
     .max(HANDOFF_TEXT_MAX)
     .optional()
-    .describe(
-      'A finished markdown section about your work for the run report, written only when your task instructions ask for one. The reporting task includes it as its own section instead of rewriting it.',
-    ),
+    .describe(HANDOFF_FIELDS.reportSection),
 };
+
+/** Exported so the parity test can compare both harnesses' field sets. */
+export const HANDOFF_SHAPE_KEYS: readonly string[] = Object.keys(HANDOFF_SHAPE);
 
 type SdkTool = (
   name: string,

--- a/src/lib/agent/runner/switchboard/sequence.ts
+++ b/src/lib/agent/runner/switchboard/sequence.ts
@@ -47,8 +47,8 @@ export const SEQUENCE_OPTIONS: Partial<Record<Sequence, SequenceRunner>> = {
   },
   [Sequence.orchestrator]: {
     name: Sequence.orchestrator,
-    run: (session, _config, programConfig, boot, _composed) =>
-      runOrchestrator(session, programConfig, boot),
+    run: (session, config, programConfig, boot, _composed) =>
+      runOrchestrator(session, config, programConfig, boot),
   },
 };
 

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -247,6 +247,10 @@ export const posthogIntegrationConfig: ProgramConfig = {
       docsUrl: config.metadata.docsUrl,
       errorMessage: 'Integration failed',
       additionalFeatureQueue: session.additionalFeatureQueue,
+      // The seeded warehouse task's fallback, when a user cannot hand over a
+      // credential, is to give them the pre-filled new-source URL. That only
+      // works if the overlay renders it as a link they can open or copy.
+      richLinks: true,
 
       customPrompt: (ctx) => {
         const additionalLines = config.prompts.getAdditionalContextLines


### PR DESCRIPTION
## Problem

Every agent that runs a warehouse task is told to write a report section it cannot submit, so the section never reaches the user's run report.

- The orchestrator runs all tasks on the pi harness. All 33 warehouse task runs since 12 Aug used it.
- `complete_task` exists twice: a zod schema for the MCP path, and a typebox mirror for pi. Only the zod one had `reportSection`.
- `renderHandoffContext` reads `handoff.reportSection` to build the run report, so on pi it always reads nothing.
- Agents noticed. 6 of the 22 remarks filed by warehouse tasks report this exact mismatch, each costing turns while the agent worked around it.

The second problem is the fallback path. When a user cannot hand over a credential, the warehouse task gives them the pre-filled new-source URL. The orchestrator ask bridge hardcoded `richLinks: false`, so that URL rendered as plain text with no way to open or copy it.

## Changes

- Add `reportSection` to the pi `complete_task` schema.
- Move every handoff field description into one `HANDOFF_FIELDS` record that both schemas read.
- Type `HANDOFF_FIELDS` against `keyof Required<TaskHandoff>`, so a new field on the interface fails the typecheck until it is described.
- Pass the program's `ProgramRun` into `runOrchestrator` and read `richLinks` from it, instead of hardcoding false.
- Set `richLinks: true` on `posthog-integration`, the only program the orchestrator route serves.

I kept the two schemas separate rather than generating one from the other. Zod carries length caps that typebox does not, and pi must stay out of the static module graph. The parity test is the cheaper guard.

## Test plan

- New `handoff-schema-parity.test.ts` fails if the two harnesses' `complete_task` field sets diverge again. That is the regression this PR fixes, and no existing test covered it.
- Ran the orchestrator, pi harness, programs and TUI suites locally: 924 pass.
- Compared `tsc --noEmit` output before and after. Same errors, all pre-existing on `main`.
- Not tested: the rendered ask overlay with `richLinks: true`. I did not run the TUI.

## LLM context

I (actually Claude Opus 5) wrote this while investigating why the seeded warehouse task rarely produces a source. The `reportSection` gap surfaced from the agent remarks on the rollout dashboard, then confirmed against the two schema definitions.
