### PR TITLE
feat(warehouse): hand over a pre-filled link per detected source

### DIFF
--- a/src/lib/programs/__tests__/warehouse-suggestion.test.ts
+++ b/src/lib/programs/__tests__/warehouse-suggestion.test.ts
@@ -1,10 +1,11 @@
 /**
  * Data-warehouse-source suggestion in the default integration flow.
  *
- * The flow detects connectable sources and *points at* `wizard warehouse` —
- * it does not run it. These tests pin the two properties that matter:
- * projects with no detected source see a byte-identical flow, and the
- * suggestion never turns into an inline run.
+ * The flow detects connectable sources and *points at* them — it does not
+ * connect them. These tests pin the three properties that matter: the outro
+ * hands over a link that opens the right source's form, projects with no
+ * detected source see a byte-identical flow, and the suggestion never turns
+ * into an inline run.
  */
 
 import { posthogIntegrationConfig } from '@lib/programs/posthog-integration/index';
@@ -68,17 +69,39 @@ async function resolveRun(session: WizardSession) {
 }
 
 describe('outro suggestion', () => {
-  it('names the detected sources and points at the standalone command', async () => {
+  it('gives every detected source its own pre-filled link', async () => {
     const s = sessionWith([POSTGRES, STRIPE]);
     const runDef = await resolveRun(s);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const outro = runDef.buildOutroData!(s, CREDENTIALS as any);
+    const text = outro.nextSteps!.items.join('\n');
 
-    expect(outro.nextSteps).toBeDefined();
-    expect(outro.nextSteps!.items.join(' ')).toContain('Postgres, Stripe');
-    expect(outro.nextSteps!.items.join(' ')).toContain(
-      'npx @posthog/wizard warehouse',
+    // The project segment and the kind are what land the user on the source's
+    // own form. Drop the segment and the app renders 404; drop the kind and it
+    // renders the catalog.
+    expect(text).toContain(
+      'https://us.posthog.com/project/1/data-warehouse/new-source?kind=postgres',
     );
+    expect(text).toContain('kind=stripe');
+    expect(text).toContain('npx @posthog/wizard warehouse');
+  });
+
+  it('summarizes the tail instead of listing every link', async () => {
+    const many = ['a', 'b', 'c', 'd', 'e'].map((k) => ({
+      ...POSTGRES,
+      kind: k,
+      label: k.toUpperCase(),
+    }));
+    const s = sessionWith(many);
+    const runDef = await resolveRun(s);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const outro = runDef.buildOutroData!(s, CREDENTIALS as any);
+    const links = outro.nextSteps!.items.filter((i) =>
+      i.includes('new-source'),
+    );
+
+    expect(links).toHaveLength(3);
+    expect(outro.nextSteps!.items.join('\n')).toContain('And 2 more');
   });
 
   it('is absent when nothing was detected — outro unchanged', async () => {

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -41,32 +41,68 @@ function resolveContinueUrl(
   return withUtm(`${host.appHost}/products?source=wizard`, 'outro-continue');
 }
 
+/** Sources listed with their own link before the outro falls back to a summary line. */
+const WAREHOUSE_LINK_LIMIT = 3;
+
+/**
+ * The app's new-source page, pre-selected to one source kind.
+ *
+ * `kind` is matched case-insensitively against the connector list, and a kind
+ * the app cannot resolve lands on the source catalog rather than erroring. So a
+ * source we detect but the app has not shipped a connector for still takes the
+ * user somewhere useful.
+ */
+function warehouseSourceUrl(
+  host: HostResolution,
+  projectId: number | string,
+  kind: string,
+): string {
+  const path = `${
+    host.appHost
+  }/project/${projectId}/data-warehouse/new-source?kind=${encodeURIComponent(
+    kind,
+  )}`;
+  return withUtm(path, 'outro-warehouse');
+}
+
 /**
  * Outro suggestion for data sources found in the project but not connected.
  *
- * A pointer at `wizard warehouse`, not an inline flow. Connecting a source
- * needs interactive credential collection, and chaining that as a second agent
- * run before the outro would let any of its terminal failure paths
- * `process.exit()` — costing the user the success outro and the post-outro
- * MCP / Slack steps on a run where PostHog installed fine.
+ * A pointer at the app, not an inline flow. Connecting a source needs
+ * interactive credential collection, and chaining that as a second agent run
+ * before the outro would let any of its terminal failure paths `process.exit()`
+ * — costing the user the success outro and the post-outro MCP / Slack steps on
+ * a run where PostHog installed fine.
+ *
+ * Each source gets its own pre-filled link, because the alternative we shipped
+ * first — naming the `wizard warehouse` command — asks the user to start a
+ * second CLI run before they can connect anything. A link opens the form for
+ * that one source. The command line stays for anyone who wants every source in
+ * one pass, and it is the only route offered once the list is too long to read.
  *
  * Returns undefined when nothing was detected, so the outro is unchanged for
  * projects with no connectable source.
  */
 function buildWarehouseNextSteps(
   sess: WizardSession,
+  host: HostResolution,
+  projectId: number | string,
 ): { heading: string; items: string[] } | undefined {
   const sources = getDetectedWarehouseSources(sess);
   if (sources.length === 0) return undefined;
 
-  const labels = sources.map((s) => s.label).join(', ');
-  return {
-    heading: 'Query your other data in PostHog:',
-    items: [
-      `Found in this project: ${labels}`,
-      'Import it into the data warehouse with: npx @posthog/wizard warehouse',
-    ],
-  };
+  const listed = sources.slice(0, WAREHOUSE_LINK_LIMIT);
+  const items = listed.map(
+    (s) => `Connect ${s.label}: ${warehouseSourceUrl(host, projectId, s.kind)}`,
+  );
+
+  const remaining = sources.length - listed.length;
+  if (remaining > 0) {
+    items.push(`And ${remaining} more we found in this project.`);
+  }
+  items.push('Connect them all at once with: npx @posthog/wizard warehouse');
+
+  return { heading: 'Query your other data in PostHog:', items };
 }
 
 /**
@@ -375,7 +411,11 @@ ${warehouseReportInstruction(session)}
           changes,
           docsUrl: config.metadata.docsUrl,
           continueUrl,
-          nextSteps: buildWarehouseNextSteps(sess),
+          nextSteps: buildWarehouseNextSteps(
+            sess,
+            credentials.host,
+            credentials.projectId,
+          ),
           // Set once the agent mirrors the report into a notebook and emits [NOTEBOOK_URL].
           notebookUrl: sess.notebookUrl ?? undefined,
           // No report file — the prompt points at the notebook, when the run captured one.

--- a/src/ui/tui/components/TipsCard.tsx
+++ b/src/ui/tui/components/TipsCard.tsx
@@ -67,7 +67,9 @@ export const DEFAULT_TIPS: Tip[] = [
     id: 'stripe',
     title: 'You can track Stripe revenue with PostHog',
     description: 'Add Stripe as a data source while you wait:',
-    url: 'https://app.posthog.com/project/data-warehouse/new-source?kind=Stripe',
+    // No project segment: `/project/` without a team id matches no route and
+    // renders the 404 scene. Without it the app resolves the current project.
+    url: 'https://app.posthog.com/data-warehouse/new-source?kind=Stripe',
     visible: (store) =>
       store.session.discoveredFeatures.includes(DiscoveredFeature.Stripe),
   },

--- a/src/ui/tui/screens/OutroScreen.tsx
+++ b/src/ui/tui/screens/OutroScreen.tsx
@@ -12,6 +12,7 @@ import type { WizardStore } from '@ui/tui/store';
 import { OutroKind } from '@lib/wizard-session';
 import { Colors } from '@ui/tui/styles';
 import { withUtm } from '@utils/links';
+import { LinkText } from '@ui/tui/primitives/LinkText';
 import { useDismissOnAnyKey } from '@ui/tui/hooks/useDismissOnAnyKey';
 
 interface OutroScreenProps {
@@ -60,8 +61,14 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
               <Text color="cyan" bold>
                 {outroData.nextSteps.heading}
               </Text>
+              {/* Items can carry a URL, so render through LinkText: it keeps the
+                  full address as the click target and shortens the visible label
+                  instead of wrapping it across lines. */}
               {outroData.nextSteps.items.map((item, i) => (
-                <Text key={i}>• {item}</Text>
+                <Box key={i} flexDirection="row">
+                  <Text>• </Text>
+                  <LinkText text={item} />
+                </Box>
               ))}
             </Box>
           )}


### PR DESCRIPTION
## Problem

A user finishes the install wizard, is told their project has a Postgres and a Stripe to connect, and the only route offered is starting a second CLI run. Most never do: of the people who saw that suggestion, 3.7% went on to run `npx @posthog/wizard warehouse`.

- The outro names the detected sources, then prints `Import it into the data warehouse with: npx @posthog/wizard warehouse`.
- Around 60% of install runs detect at least one connectable source, so this text is the only warehouse prompt most users ever see.
- It is also the only route for the runs the orchestrator never reaches, for CI and signup runs, and for anyone who skips the in-run task.

Separately, the Stripe tip shown during the agent run links to a URL that 404s.

## Changes

- Give each detected source its own link to its form in the app: `<appHost>/project/<id>/data-warehouse/new-source?kind=<kind>`.
- Cap the list at 3 links, then say how many more we found, so a 9-source project does not print 9 URLs.
- Keep the `npx @posthog/wizard warehouse` line for connecting everything in one pass.
- Render outro next steps through `LinkText`, so a URL becomes an OSC 8 hyperlink and its label is shortened rather than wrapped across lines.
- Fix the Stripe tip URL. `https://app.posthog.com/project/data-warehouse/new-source?kind=Stripe` has a `/project/` segment with no team id, which matches no route and renders the 404 scene.

`kind` is matched case-insensitively by the app, and a kind it cannot resolve falls back to the source catalog rather than erroring, so a source we detect before the app ships a connector still lands somewhere useful.

## Test plan

- Two new cases in `warehouse-suggestion.test.ts`: the link carries the project segment and the source kind, and a 5-source project yields 3 links plus a summary line. The existing test asserted the joined label list, which no longer describes the output.
- Ran the full suite locally: 1845 pass.
- Verified the rendering path by feeding a real outro item through `splitPromptIntoSegments`. It splits into `Connect Postgres:` plus the URL, which is what puts the address on its own line with the full target preserved.
- Not tested: the outro rendered in a real terminal. This repo has no ink render test to extend, and I did not add one for this.

## LLM context

I (actually Claude Opus 5) wrote this while looking for the reason the warehouse flow converts poorly. The in-run task reaches only the share of runs the orchestrator serves, so the outro is where the remaining runs can be reached.
