### PR TITLE
fix(tui): make grouped picker's "N more" rows read as scroll, not a control

### DIFF
--- a/src/ui/tui/primitives/ConfirmButton.tsx
+++ b/src/ui/tui/primitives/ConfirmButton.tsx
@@ -22,14 +22,22 @@ interface ConfirmButtonProps {
   focused: boolean;
   /** Optional selected-item count, rendered as "Label (n)" when > 0. */
   count?: number;
+  /**
+   * Noun for the count, rendered as "Label (n noun)". A bare "Confirm (31)"
+   * reads as a queue of 31 actions about to run rather than the size of the
+   * selection, which makes people hesitate to submit.
+   */
+  countNoun?: string;
 }
 
 export const ConfirmButton = ({
   label = 'Confirm',
   focused,
   count,
+  countNoun,
 }: ConfirmButtonProps) => {
-  const text = count && count > 0 ? `${label} (${count})` : label;
+  const suffix = countNoun ? ` ${countNoun}` : '';
+  const text = count && count > 0 ? `${label} (${count}${suffix})` : label;
   return (
     <Text
       color={focused ? Colors.accent : undefined}

--- a/src/ui/tui/primitives/GroupedPickerMenu.tsx
+++ b/src/ui/tui/primitives/GroupedPickerMenu.tsx
@@ -9,7 +9,10 @@
  * PickerMenu mode="multi".
  *
  * When content exceeds available terminal height, the list scrolls
- * to keep the focused item visible with up/down indicators.
+ * to keep the focused item visible with up/down indicators. Those indicators
+ * spell out that arrows scroll: a bare "N more" row reads as a "show more"
+ * control, and the obvious move on it — space — is bound to toggle-selection,
+ * so it silently ticks an option instead of revealing anything.
  *
  * Key bindings are declared via useKeyBindings, which auto-registers
  * hints in the KeyboardHintsBar.
@@ -33,6 +36,8 @@ interface GroupedPickerMenuProps {
   message?: string;
   groups: Record<string, GroupOption[]>;
   initialSelected?: string[];
+  /** Noun for the Confirm button's selected count, e.g. "areas". */
+  countNoun?: string;
   onSelect: (values: string[]) => void;
 }
 
@@ -60,6 +65,8 @@ const MENU_CHROME = 6;
  * PickerMenu's MAX_LIST_ROWS.
  */
 const MAX_LIST_ROWS = 12;
+/** Spelled out on the scroll indicators so "N more" doesn't read as a control. */
+const SCROLL_HINT = '↑↓ to scroll';
 
 /** Count the visual rows occupied by rows[start..end), accounting for header margins. */
 function countVisualRows(rows: Row[], start: number, end: number): number {
@@ -125,6 +132,7 @@ export const GroupedPickerMenu = ({
   message,
   groups,
   initialSelected,
+  countNoun,
   onSelect,
 }: GroupedPickerMenuProps) => {
   const [termCols, termRows] = useStdoutDimensions();
@@ -273,13 +281,25 @@ export const GroupedPickerMenu = ({
     ? selectableIndices.filter((s) => s >= visibleEnd).length
     : 0;
 
+  // The keys that reveal the hidden rows, spelled out on one indicator \u2014 the
+  // bottom one while there's anything below, since that's the one users meet
+  // first. Truncated rather than wrapped so a narrow terminal can't turn an
+  // indicator into two rows and overflow the height budget.
+  const scrollHint = ` \u2014 ${SCROLL_HINT}`;
+  const aboveText =
+    hiddenAbove > 0
+      ? `\u2191 ${hiddenAbove} more above${hiddenBelow > 0 ? '' : scrollHint}`
+      : ' ';
+  const belowText =
+    hiddenBelow > 0 ? `\u2193 ${hiddenBelow} more below${scrollHint}` : ' ';
+
   return (
     <Box flexDirection="column">
       <PromptLabel message={message} />
       <Box flexDirection="column" marginTop={message ? 1 : 0} marginLeft={2}>
         {needsScroll && (
-          <Text dimColor>
-            {hiddenAbove > 0 ? `\u2191 ${hiddenAbove} more` : ' '}
+          <Text dimColor wrap="truncate">
+            {aboveText}
           </Text>
         )}
         {visibleRows.map((row, relIdx) => {
@@ -326,13 +346,17 @@ export const GroupedPickerMenu = ({
           );
         })}
         {needsScroll && (
-          <Text dimColor>
-            {hiddenBelow > 0 ? `\u2193 ${hiddenBelow} more` : ' '}
+          <Text dimColor wrap="truncate">
+            {belowText}
           </Text>
         )}
       </Box>
       <Box marginTop={1} marginLeft={2}>
-        <ConfirmButton focused={onButton} count={selected.size} />
+        <ConfirmButton
+          focused={onButton}
+          count={selected.size}
+          countNoun={countNoun}
+        />
       </Box>
     </Box>
   );

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -524,6 +524,10 @@ export const McpScreen = ({
             message="Select the PostHog areas your agent can reach"
             groups={AVAILABLE_FEATURES}
             initialSelected={[]}
+            // Without the noun the button reads "Confirm (31)", which people
+            // take as "31 things are about to happen" rather than the number
+            // of areas they've granted.
+            countNoun="areas"
             onSelect={(features) => {
               void doInstall(selectedClientNames, features);
             }}


### PR DESCRIPTION
## Problem

Closes #1092

On the "Select the PostHog areas your agent can reach" step the option list is taller than the viewport, so `GroupedPickerMenu` renders a bare `↓ N more` row under the options. Two things went wrong in a real run:

- That row reads like a "show more" control, but nothing says how to reveal the hidden entries. The natural key to try is space — which is bound to toggle-selection, so it silently ticks the focused option instead of expanding anything. `PickerMenu` already appends `[N] for next page` to the same indicators; the grouped variant had no hint at all.
- With everything selected the confirm button said `Confirm (31)`, which reads as "31 things are about to happen" and caused real hesitation before submitting.

## Changes

- The `↑/↓ N more` indicators now name their direction and spell out that arrows scroll (`↓ 25 more below — ↑↓ to scroll`). The hint sits on the bottom indicator while anything is hidden below, so it appears exactly once, and both rows truncate rather than wrap so a narrow terminal can't overflow the height budget.
- `ConfirmButton` takes an optional `countNoun`; the MCP feature picker passes `areas`, so the button reads `Confirm (31 areas)` — scope, not a task queue.

Still **WIP** — copy and hint placement are the parts worth arguing about, and the second half of the report (the wait after confirming, before the full picture appears) isn't addressed here.

## Test plan

`pnpm build && pnpm test && pnpm fix` — 1839 tests pass, lint clean (pre-existing warnings only). Needs a manual pass over the picker at a few terminal heights.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1786971843310169?thread_ts=1786971843.310169&cid=C09GTQY5RLZ)*
