### PR TITLE
fix(mcp): request workflow scopes when the wizard hands off to consent

### DIFF
--- a/src/lib/oauth/__tests__/program-scopes.test.ts
+++ b/src/lib/oauth/__tests__/program-scopes.test.ts
@@ -18,3 +18,23 @@ describe('posthog-integration scopes', () => {
     );
   });
 });
+
+/**
+ * Picking "Workflows" in the MCP feature list only narrows the MCP URL — it
+ * never widens the grant. Without these, the consent screen the user is sent
+ * to carries no workflow scope at all, and every workflow tool 403s after a
+ * successful install.
+ */
+describe('mcp-tutorial scopes', () => {
+  it('covers authoring workflows, not just reading them', () => {
+    const scopes = getOAuthScopesForProgram('mcp-tutorial');
+    expect(scopes).toContain('hog_flow:read');
+    expect(scopes).toContain('hog_flow:write');
+  });
+
+  it('resolves both actor types the workflow tools filter on', () => {
+    const scopes = getOAuthScopesForProgram('mcp-tutorial');
+    expect(scopes).toContain('person:read');
+    expect(scopes).toContain('group:read');
+  });
+});

--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -13,7 +13,8 @@
  * Current additions: `McpTutorial` layers read-only on every product
  * surface (feature flags, experiments, surveys, replays, errors, web
  * analytics, LLM analytics, cohorts, persons) plus read/write on
- * annotations; `AgentSkill` adds feature-flag read/write; the default
+ * annotations and workflows; `AgentSkill` adds feature-flag read/write;
+ * the default
  * `PostHogIntegration` run and the standalone `slack` flow add
  * `integration:read` for the Connect-Slack step. Persistence writes (dashboard:write,
  * insight:write, notebook:write, query:read) come for free from the
@@ -53,6 +54,8 @@ import { WIZARD_OAUTH_SCOPES } from '@lib/constants';
  *   • feature_flag:write, experiment:write, survey:write,
  *     cohort:write, session_recording:write, error_tracking:write,
  *     alert:write, subscription:write
+ *
+ * `hog_flow:write` is the one exception — see the Workflows block below.
  */
 export const MCP_TUTORIAL_SCOPE_ADDITIONS = [
   // Explicit reads on the persistence surfaces. `*:write` usually
@@ -101,6 +104,15 @@ export const MCP_TUTORIAL_SCOPE_ADDITIONS = [
   'alert:read',
   'subscription:read',
   'integration:read',
+
+  // Workflows. The only write surface here, because "Workflows" in the
+  // MCP feature picker means authoring them — a read-only grant makes
+  // the feature useless. `group:read` pairs with the `person:read`
+  // above: the workflow tools resolve both when building trigger and
+  // filter conditions, and 403 on the group half without it.
+  'hog_flow:read',
+  'hog_flow:write',
+  'group:read',
 ] as const;
 
 /**


### PR DESCRIPTION
## Problem

Selecting **Workflows** in the MCP feature picker only narrows the MCP URL (`?features=workflows`). It never widens the OAuth grant.

The grant is resolved per-*program* in `getOAuthScopesForProgram`. The `mcp-add` flow hands off to consent as `Program.McpTutorial` (`src/ui/tui/services/mcp-suggested-prompts-services.ts:124`), and `MCP_TUTORIAL_SCOPE_ADDITIONS` covered every product surface except workflows — before this change, `hog_flow` appeared nowhere in the repo.

So a user who picks only Workflows is sent to a consent screen carrying **no workflow scope at all**, grants everything asked of them, and gets a working install where every workflow tool 403s. The MCP server then tells them to re-authorize with the scopes the wizard should have requested in the first place.

## Evidence

Reported in a support ticket. The user's own OAuth trail, project 2, 2026-08-15 (US/Pacific):

| Time | Client | Granted |
|---|---|---|
| 16:21 | PostHog Wizard, `mcp_features_selected: ["workflows"]` | **36/36 scopes — none dropped, none of them `hog_flow`** |
| 16:47 → 17:05 | Claude Code | 5 → 1 → 5 → 6 → 5 → 1, six more consent round trips |
| 17:14 | Claude Code | `oauth_authorization_denied` — gave up |

Seven authorize round trips in 58 minutes. No `oauth_token_rejected` and no `$mcp_auth_failed` anywhere in the window: nothing was rejected or clamped server-side. The wizard simply never asked.

## Change

Adds three scopes to `MCP_TUTORIAL_SCOPE_ADDITIONS`:

- `hog_flow:read`, `hog_flow:write`
- `group:read` — pairs with the `person:read` already in the list

These are the exact scopes the MCP server names when a workflow call fails, so they're confirmed rather than inferred.

`hog_flow:write` is the only write on an otherwise read-only list. That's deliberate and called out in the comment: authoring is the point of the Workflows feature, and a read-only grant makes it useless. Flagging it for reviewer judgement since it cuts against the surrounding "writes deliberately omitted" convention.

No new machinery — there is no feature→scope mapping in this repo, and this PR doesn't add one. It widens the program's existing addition list, matching how `self-driving`, `warehouse-source` and `agent-skill` already work.

No OAuth-ceiling edit needed: `hog_flow:*` and `group:read` are ordinary unprivileged scopes, and the live wizard apps' ceiling is the `@default` sentinel that auto-tracks them (see the `SELF_DRIVING_SCOPE_ADDITIONS` note).

## Testing

Two cases added to `src/lib/oauth/__tests__/program-scopes.test.ts`, matching the existing `posthog-integration` block's style.

⚠️ **Not run.** There is no Node runtime in the environment this was authored in, so `pnpm build && pnpm test && pnpm fix` could not execute. The change is three string literals in an `as const` array plus a test using existing helpers, but CI is the first real verification — please don't merge on a green read of the diff alone.

## Not addressed here

The same ticket reports `Got new credentials, but posthog rejected them on reconnect`. That is **not** a server-side rejection — all seven of this user's tokens were issued successfully. Different root cause, still unknown, needs its own investigation.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
