### PR TITLE
fix(wizard-ask): frame the adjacency cap as a retryable nudge, not a refusal

### DIFF
--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -320,12 +320,22 @@ describe('evaluateAskCap', () => {
     }
   });
 
-  it('returns the adjacency error once the threshold is hit', () => {
+  it('returns the adjacency nudge once the threshold is hit', () => {
     expect(evaluateAskCap(ASK_BATCH_THRESHOLD, MAX)).toEqual({
       kind: 'capped',
       reason: 'adjacency',
       message: expect.stringMatching(/batch/i),
     });
+  });
+
+  it('frames the adjacency nudge as retryable, not a refusal', () => {
+    // Agents abandon the source to browser fallback when this reads as a hard
+    // error — it must not start with "Error" and must say the ask can be re-sent.
+    const decision = evaluateAskCap(ASK_BATCH_THRESHOLD, MAX);
+    if (decision.kind !== 'capped') throw new Error('expected capped');
+    expect(decision.message).not.toMatch(/^Error/);
+    expect(decision.message).toMatch(/not an error/i);
+    expect(decision.message).toMatch(/not sent|again/i);
   });
 
   it('fires the adjacency nudge only once — later calls proceed up to the cap', () => {

--- a/src/lib/wizard-tools/mcp.ts
+++ b/src/lib/wizard-tools/mcp.ts
@@ -677,7 +677,11 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         });
         return {
           content: [{ type: 'text' as const, text: capDecision.message }],
-          isError: true,
+          // The adjacency nudge is a one-time, retryable hint, not a failure:
+          // flagging it isError makes the model read it as a hard refusal and
+          // abandon the source to browser fallback. The max_questions cap is a
+          // genuine stop, so it stays an error.
+          isError: capDecision.reason !== 'adjacency',
         };
       }
 

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -311,9 +311,14 @@ export type AskCapDecision =
 
 /**
  * Pure decision function for the wizard_ask caps. Returns whether the
- * upcoming call should proceed and, if not, the error message to surface
- * to the agent. Extracted so the policy can be unit-tested without
- * spinning up an MCP server.
+ * upcoming call should proceed and, if not, the message to surface to the
+ * agent. Extracted so the policy can be unit-tested without spinning up an
+ * MCP server.
+ *
+ * The two capped reasons are surfaced differently: `max_questions` is a hard
+ * stop, but `adjacency` is a one-time nudge the caller must not present as a
+ * failure — an agent that reads it as a refusal abandons the source instead
+ * of re-asking with batched questions.
  *
  * The adjacency nudge fires exactly once per run (the caller records it
  * via `adjacencyNudged`) — flows that legitimately need several
@@ -338,7 +343,7 @@ export function evaluateAskCap(
     return {
       kind: 'capped',
       reason: 'adjacency',
-      message: `Error: too many wizard_ask calls in a row (${callCount} so far). Batch the remaining questions into a single call — the schema accepts up to 8 questions per invocation. If the remaining questions truly depend on earlier answers, ask again and they will go through.`,
+      message: `Not an error — this ask was not sent (a one-time nudge). You've made ${callCount} wizard_ask calls in a row. Batch the questions you still need into a single call (the schema accepts up to 8 questions per invocation) and call wizard_ask again now; or, if they genuinely depend on earlier answers, just ask again as-is. Either way the next call goes through. Do not abandon the task or fall back to browser setup because of this message.`,
     };
   }
   return { kind: 'ok' };


### PR DESCRIPTION
## Problem

**Why:** the warehouse-connect task's telemetry shows the single most common lossy pattern is the `wizard_ask` consecutive-call cap being read as a hard refusal. When a run has several detected data sources, the agent asks one question per source; on the 4th consecutive ask the one-time adjacency nudge fires — and the agent treats it as terminal, dropping the remaining source(s) to browser fallback instead of re-asking. The nudge fired in ~26 runs in the window and each one costs a source connection, even though the cap is a *one-time* nudge and the very next call always goes through.

Two things made the nudge read as a failure:
- the shared cap message began with `Error: too many wizard_ask calls in a row`;
- the MCP path returned it with `isError: true`.

## Changes

- Reword the adjacency message: it now states plainly that it is **not** an error, that the ask was not sent, and to re-issue it (batched into a single call — up to 8 questions — or as-is if the questions depend on earlier answers), explicitly telling the agent not to abandon the task or fall back to browser setup.
- In the MCP `wizard_ask` handler, only flag `isError` for the `max_questions` cap (a genuine hard stop); the one-time `adjacency` nudge is returned as a normal result.
- The pi harness already returned the message as a normal (non-error) result, so it just inherits the reworded text — no behaviour split between harnesses.

The cap *policy* (thresholds, one-time firing) is unchanged; only how it is presented to the model.

## Test plan

- `pnpm test` (1840 passing). Added a case asserting the adjacency message is framed as retryable — does not start with "Error", says it is not an error, and points at re-asking.
- `pnpm build` and `pnpm fix` clean.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*