### PR TITLE
fix(orchestrator): surface the app host to task prompts for browser links

### DIFF
--- a/src/lib/agent/__tests__/agent-prompt-loader.test.ts
+++ b/src/lib/agent/__tests__/agent-prompt-loader.test.ts
@@ -497,6 +497,20 @@ describe('assembleTaskPrompt', () => {
     const assembled = assembleTaskPrompt(ctx, 'do the task', []);
     expect(assembled).not.toContain('Your tools for this task');
   });
+
+  it('surfaces the app host for browser links, distinct from the ingestion host', () => {
+    // A cloud ingestion host resolves an app host on a different origin, so a
+    // task that builds a user-facing link must not reuse the ingestion host.
+    const cloudCtx: OrchestratorPromptContext = {
+      projectId: 1,
+      projectApiKey: 'phc_x',
+      host: HostResolution.fromApiHost('https://eu.i.posthog.com'),
+    };
+    const assembled = assembleTaskPrompt(cloudCtx, 'do the task');
+    expect(assembled).toContain('PostHog Host: https://eu.i.posthog.com');
+    expect(assembled).toContain('PostHog app URL');
+    expect(assembled).toContain('https://eu.posthog.com');
+  });
 });
 
 describe('renderToolInventory', () => {

--- a/src/lib/agent/agent-prompt-loader.ts
+++ b/src/lib/agent/agent-prompt-loader.ts
@@ -47,12 +47,17 @@ export interface OrchestratorPromptContext {
 }
 
 function projectContext(ctx: OrchestratorPromptContext): string {
+  // Both hosts, distinctly labelled: `apiHost` is the ingestion/API origin the
+  // SDK talks to, `appHost` the user-facing web app. A task that hands the user
+  // a link (e.g. the data-warehouse new-source fallback) must build it from the
+  // app host — the ingestion host does not serve those pages.
   return `You have access to the PostHog MCP server and the wizard tools.
 
 Project context:
 - PostHog Project ID: ${ctx.projectId}
 - PostHog public token: ${ctx.projectApiKey}
-- PostHog Host: ${ctx.host.apiHost}`;
+- PostHog Host: ${ctx.host.apiHost}
+- PostHog app URL (base for any link you show the user in a browser): ${ctx.host.appHost}`;
 }
 
 /** Points the agent at the framework's reference integration to learn patterns from. */


### PR DESCRIPTION
## Problem

The seeded warehouse-connection task can fall back to handing the user a pre-filled new-source **browser link** when they can't provide a credential inline. Those app pages live on the user-facing app host (e.g. `eu.posthog.com`), but the orchestrator task/seed prompt only surfaced the **ingestion** host (`apiHost`, e.g. `eu.i.posthog.com`) labelled generically as "PostHog Host". A task building a link from that value points the user at a host that doesn't serve the page.

Telemetry on this task surfaced the browser-link fallback using the ingestion host as its base — a dead-end link for the one path meant to rescue a run where the user can't hand over credentials.

`HostResolution` already distinguishes the two hosts, and the wizard's own outro (`warehouseSourceUrl`) already uses `appHost` for the identical new-source URL. Only the orchestrator prompt was dropping it.

## Changes

Add a distinctly-labelled app-URL line (`ctx.host.appHost`) to the shared `projectContext` that every orchestrator seed/task prompt injects, alongside the existing (unchanged) ingestion-host line. Any task that hands the user a browser link now has the correct base to build it from.

## Test plan

- New unit test in `agent-prompt-loader.test.ts` asserts the assembled task prompt keeps the ingestion host and also surfaces the distinct app host for a cloud ingestion origin.
- `pnpm build` and the full `src/lib/agent` vitest suite (415 tests) pass; prettier + eslint clean on the changed files.

## Why

Grounded in telemetry for the seeded data-source connection task: the browser-link fallback was built from the ingestion host, leaving users a link that doesn't resolve to the app.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*