### PR TITLE
feat: add the replay-vision command

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -54,6 +54,7 @@ import { auditCommand } from './src/commands/audit';
 import { doctorCommand } from './src/commands/doctor';
 import { migrateCommand } from './src/commands/migrate';
 import { revenueCommand } from './src/commands/revenue';
+import { replayVisionCommand } from './src/commands/replay-vision';
 import { warehouseCommand } from './src/commands/warehouse';
 import { selfDrivingCommand } from './src/commands/self-driving';
 import { slackCommand } from './src/commands/slack';
@@ -86,6 +87,7 @@ Wizard.use(basicIntegrationCommand)
   .use(doctorCommand)
   .use(migrateCommand)
   .use(revenueCommand)
+  .use(replayVisionCommand)
   .use(warehouseCommand)
   .use(selfDrivingCommand)
   .use(slackCommand)

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -21,6 +21,7 @@ import type { MockedFunction } from 'vitest';
 import { auditCommand } from '../commands/audit';
 import { migrateCommand } from '../commands/migrate';
 import { mcpAnalyticsCommand } from '../commands/mcp-analytics';
+import { replayVisionCommand } from '../commands/replay-vision';
 import { revenueCommand } from '../commands/revenue';
 import { warehouseCommand } from '../commands/warehouse';
 import { uploadSourcemapsCommand } from '../commands/upload-sourcemaps';
@@ -83,6 +84,11 @@ describe('top-level command shapes', () => {
   test('mcp-analytics is a flat skill command', () => {
     expect(mcpAnalyticsCommand.name).toBe('mcp-analytics');
     expect(mcpAnalyticsCommand.children).toBeUndefined();
+  });
+
+  test('replay-vision is a flat skill command', () => {
+    expect(replayVisionCommand.name).toBe('replay-vision');
+    expect(replayVisionCommand.children).toBeUndefined();
   });
 
   test('warehouse is a flat skill command', () => {
@@ -182,6 +188,12 @@ describe('flat skill commands', () => {
     mcpAnalyticsCommand.handler!(makeArgv({ debug: true }));
     const [config] = mockRunWizard.mock.calls[0] as [{ skillId?: string }];
     expect(config.skillId).toBe('mcp-analytics');
+  });
+
+  test('replay-vision dispatches with replay-vision-setup skillId', () => {
+    replayVisionCommand.handler!(makeArgv({ debug: true }));
+    const [config] = mockRunWizard.mock.calls[0] as [{ skillId?: string }];
+    expect(config.skillId).toBe('replay-vision-setup');
   });
 
   test('warehouse dispatches with data-warehouse-source-setup skillId', () => {

--- a/src/commands/replay-vision.ts
+++ b/src/commands/replay-vision.ts
@@ -1,0 +1,13 @@
+import { replayVisionConfig } from '@lib/programs/replay-vision/index';
+
+import type { Command } from './command';
+import { nativeCommandFactory } from './factories/native-command-factory';
+
+/**
+ * `wizard replay-vision` — flat skill command, scanner setup today.
+ *
+ * Enables session replay if needed, then creates Replay Vision scanners
+ * scoped from the repo. Stays flat while setup is the only action.
+ */
+export const replayVisionCommand: Command =
+  nativeCommandFactory(replayVisionConfig);

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -135,6 +135,7 @@ export const PROGRAM_BINDINGS: Partial<Record<ProgramId, ProgramBinding>> = {
   'mcp-remove': DEFAULT_BINDING,
   'mcp-tutorial': DEFAULT_BINDING,
   'mcp-analytics': DEFAULT_BINDING,
+  'replay-vision': DEFAULT_BINDING,
   'ai-observability': {
     sequence: Sequence.linear,
     harness: Harness.anthropic,

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -30,6 +30,7 @@ import {
   mcpTutorialConfig,
 } from './mcp/index.js';
 import { mcpAnalyticsConfig } from './mcp-analytics/index.js';
+import { replayVisionConfig } from './replay-vision/index.js';
 import { aiObservabilityConfig } from './ai-observability/index.js';
 import { slackConnectConfig } from './slack/index.js';
 
@@ -79,6 +80,7 @@ export const PROGRAM_REGISTRY = [
   mcpRemoveConfig,
   mcpTutorialConfig,
   mcpAnalyticsConfig,
+  replayVisionConfig,
   aiObservabilityConfig,
   slackConnectConfig,
 ] as const satisfies readonly ProgramConfig[];
@@ -104,6 +106,7 @@ export const Program = {
   McpRemove: mcpRemoveConfig.id,
   McpTutorial: mcpTutorialConfig.id,
   McpAnalytics: mcpAnalyticsConfig.id,
+  ReplayVision: replayVisionConfig.id,
   AiObservability: aiObservabilityConfig.id,
   SlackConnect: slackConnectConfig.id,
 } as const;

--- a/src/lib/programs/replay-vision/index.ts
+++ b/src/lib/programs/replay-vision/index.ts
@@ -1,0 +1,56 @@
+import type { AbortCase } from '@lib/agent/agent-runner';
+import { createSkillProgram } from '@lib/programs/agent-skill/index';
+
+const REPLAY_VISION_REPORT_FILE = 'posthog-replay-vision-report.md';
+
+/**
+ * `[ABORT]` reasons the replay-vision skill emits when setup can't proceed.
+ * Kept in sync with the stop conditions in the skill's `description.md`
+ * (context-mill `context/skills/replay-vision`).
+ */
+export const REPLAY_VISION_ABORT_CASES: AbortCase[] = [
+  {
+    match: /^posthog not integrated - run the base wizard first$/i,
+    message: 'PostHog is not integrated in this project yet',
+    body:
+      'Replay Vision scans session recordings, so PostHog (with session ' +
+      'replay) has to be installed first. Run `npx @posthog/wizard` to set ' +
+      'up PostHog, then run `wizard replay-vision` again.',
+  },
+  {
+    match: /^replay vision not available for this project$/i,
+    message: 'Replay Vision is not available for this project',
+    body:
+      "This PostHog instance doesn't expose the Replay Vision scanner API, " +
+      'so there is nothing to configure. See ' +
+      'https://posthog.com/docs/replay-vision for availability.',
+  },
+];
+
+/**
+ * `wizard replay-vision` — flat skill command.
+ *
+ * Turns on session replay if needed, then reads the repo to create Replay
+ * Vision scanners scoped to the product's key flows. Flat while setup is the
+ * only action.
+ */
+export const replayVisionConfig = createSkillProgram({
+  skillId: 'replay-vision-setup',
+  command: 'replay-vision',
+  id: 'replay-vision',
+  description: 'Set up PostHog Replay Vision scanners for your key flows',
+  integrationLabel: 'replay-vision',
+  customPrompt:
+    'Set up PostHog Replay Vision for this project. Run the ' +
+    '`replay-vision-setup` skill end-to-end: make sure session replay is ' +
+    'recording (server-side enable plus the posthog-js init check), then ' +
+    'read the repo to scope and create the scanner skeletons the skill ' +
+    'defines. Make only the additive code change the skill allows. The ' +
+    `final report is written to ./${REPLAY_VISION_REPORT_FILE}.`,
+  successMessage: `Replay Vision configured! View the report at ./${REPLAY_VISION_REPORT_FILE}`,
+  reportFile: REPLAY_VISION_REPORT_FILE,
+  docsUrl: 'https://posthog.com/docs/replay-vision',
+  spinnerMessage: 'Setting up Replay Vision...',
+  estimatedDurationMinutes: 5,
+  abortCases: REPLAY_VISION_ABORT_CASES,
+});


### PR DESCRIPTION
## Problem

PostHog/context-mill#341 adds a `replay-vision-setup` skill, and the Replay Vision in-app empty state (PostHog/posthog#84191) shows `npx @posthog/wizard replay-vision` as its install command. The skill needs the wizard-side wiring: a native command, program registration, and a harness binding.

## Changes

- `wizard replay-vision`: a flat skill command via `nativeCommandFactory`, dispatching the `replay-vision-setup` context-mill skill through the standard agent-skill TUI steps.
- New `replay-vision` program config (`createSkillProgram`) with abort cases matching the skill's `[ABORT]` reasons (PostHog not integrated, Replay Vision unavailable) and report file `posthog-replay-vision-report.md`.
- Registered in `PROGRAM_REGISTRY`, the `Program` map, `bin.ts`, and `PROGRAM_BINDINGS` (default binding), so the switchboard lockstep test passes.
- Tests: flat-command shape and skillId dispatch cases mirroring `mcp-analytics`.

No new OAuth scopes: self-driving's step 6c already creates Vision scanners with the same token and MCP tools.

Merge order: context-mill #341 first (the skill this dispatches), then this, then the posthog empty state.

## How did you test this code?

`vitest run` on `programs-cli`, `program-registry`, and `switchboard` suites (55 passing). `tsc --noEmit` reports only failures that exist on main.
