### PR TITLE
fix(mcp): auth once in the client — update stale server URLs on re-run, stop injecting credentials

### DIFF
--- a/src/__tests__/mcp-cli.test.ts
+++ b/src/__tests__/mcp-cli.test.ts
@@ -73,21 +73,17 @@ describe('mcp add handler', () => {
     );
   });
 
-  test('passes --api-key through to buildSession', async () => {
+  test('never puts credentials in the session — auth belongs to the MCP client', async () => {
+    // Even with a key on argv and one sitting in .env, the install flow must
+    // stay credential-free: a wizard-injected key overrides the editor's OAuth
+    // tokens forever and locks it into a rejected-reconnect loop.
+    mockReadApiKeyFromEnvMcp.mockReturnValueOnce('phx_from_env');
     mcpAddCommand.handler!(makeArgv({ apiKey: 'phx_from_flag' }));
     await flush();
-    expect(mockBuildSessionMcp).toHaveBeenCalledWith(
-      expect.objectContaining({ apiKey: 'phx_from_flag' }),
+    expect(mockBuildSessionMcp).not.toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: expect.anything() }),
     );
-  });
-
-  test('falls back to readApiKeyFromEnv when --api-key is omitted', async () => {
-    mockReadApiKeyFromEnvMcp.mockReturnValueOnce('phx_from_env');
-    mcpAddCommand.handler!(makeArgv());
-    await flush();
-    expect(mockBuildSessionMcp).toHaveBeenCalledWith(
-      expect.objectContaining({ apiKey: 'phx_from_env' }),
-    );
+    expect(mockReadApiKeyFromEnvMcp).not.toHaveBeenCalled();
   });
 
   test('parses --features into a trimmed array', async () => {
@@ -100,12 +96,11 @@ describe('mcp add handler', () => {
 });
 
 describe('mcp parsing (end-to-end yargs)', () => {
-  test('mcp add camelCases --api-key and parses its flags', async () => {
+  test('mcp add parses its flags', async () => {
     const argv = await parseCommand(
       mcpCommand,
-      'mcp add --api-key phx_x --local --features flags,errors',
+      'mcp add --local --features flags,errors',
     );
-    expect(argv.apiKey).toBe('phx_x');
     expect(argv.local).toBe(true);
     expect(argv.features).toBe('flags,errors');
   });

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -19,10 +19,6 @@ export const mcpAddCommand: Command = {
       describe: 'Comma-separated list of features to enable (default: all)',
       type: 'string',
     },
-    'api-key': {
-      describe: 'PostHog personal API key (phx_xxx) for MCP authentication',
-      type: 'string',
-    },
   },
   handler: runMcpAdd,
 };
@@ -30,8 +26,6 @@ export const mcpAddCommand: Command = {
 function runMcpAdd(argv: Arguments): void {
   const features = parseFeatures(argv.features);
   void (async () => {
-    const { readApiKeyFromEnv } = await import('@utils/env-api-key');
-    const apiKey = (argv.apiKey as string | undefined) || readApiKeyFromEnv();
     const debug = argv.debug as boolean | undefined;
     const localMcp = argv.local as boolean | undefined;
 
@@ -43,7 +37,6 @@ function runMcpAdd(argv: Arguments): void {
         debug,
         localMcp,
         mcpFeatures: features,
-        apiKey,
         baseUrl: argv.baseUrl as string | undefined,
       });
     } catch (error) {
@@ -52,7 +45,7 @@ function runMcpAdd(argv: Arguments): void {
       const { addMCPServerToClientsStep } = await import(
         '@steps/add-mcp-server-to-clients/index'
       );
-      await addMCPServerToClientsStep({ local: localMcp, features, apiKey });
+      await addMCPServerToClientsStep({ local: localMcp, features });
     }
   })();
 }

--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -12,7 +12,6 @@ export abstract class MCPClient {
   abstract getServerPropertyName(): string;
   abstract isServerInstalled(local?: boolean): Promise<boolean>;
   abstract addServer(
-    apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult>;
@@ -32,11 +31,10 @@ export abstract class DefaultMCPClient extends MCPClient {
   }
 
   getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
-    return getDefaultServerConfig(apiKey, selectedFeatures, local);
+    return getDefaultServerConfig(selectedFeatures, local);
   }
 
   async isServerInstalled(local?: boolean): Promise<boolean> {
@@ -61,7 +59,6 @@ export abstract class DefaultMCPClient extends MCPClient {
   }
 
   async addServer(
-    apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult> {
@@ -80,11 +77,7 @@ export abstract class DefaultMCPClient extends MCPClient {
         existingConfig = jsonc.parse(configContent) || {};
       }
 
-      const newServerConfig = this.getServerConfig(
-        apiKey,
-        selectedFeatures,
-        local,
-      );
+      const newServerConfig = this.getServerConfig(selectedFeatures, local);
       const typedConfig = existingConfig as Record<string, any>;
       if (!typedConfig[serverPropertyName]) {
         typedConfig[serverPropertyName] = {};

--- a/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
@@ -25,50 +25,35 @@ describe('defaults', () => {
   });
 
   describe('getDefaultServerConfig', () => {
-    it('should return config with auth header when API key provided', () => {
-      const config = getDefaultServerConfig('phx_test123');
-      expect(config).toEqual({
-        command: 'npx',
-        args: [
-          '-y',
-          'mcp-remote@latest',
-          'https://mcp.posthog.com/mcp',
-          '--header',
-          'Authorization:${POSTHOG_AUTH_HEADER}',
-        ],
-        env: {
-          POSTHOG_AUTH_HEADER: 'Bearer phx_test123',
-        },
-      });
-    });
-
-    it('should return config without auth header for OAuth mode (no API key)', () => {
-      const config = getDefaultServerConfig(undefined);
+    it("should return a credential-free mcp-remote config (auth is the client's job)", () => {
+      const config = getDefaultServerConfig();
       expect(config).toEqual({
         command: 'npx',
         args: ['-y', 'mcp-remote@latest', 'https://mcp.posthog.com/mcp'],
       });
       expect(config).not.toHaveProperty('env');
     });
+
+    it('should encode the feature selection in the URL', () => {
+      const config = getDefaultServerConfig(['workflows']);
+      expect(config.args).toContain(
+        'https://mcp.posthog.com/mcp?features=workflows',
+      );
+    });
   });
 
   describe('getNativeHTTPServerConfig', () => {
-    it('should return config with headers when API key provided', () => {
-      const config = getNativeHTTPServerConfig('phx_test123');
-      expect(config).toEqual({
-        url: 'https://mcp.posthog.com/mcp',
-        headers: {
-          Authorization: 'Bearer phx_test123',
-        },
-      });
-    });
-
-    it('should return config without headers for OAuth mode (no API key)', () => {
-      const config = getNativeHTTPServerConfig(undefined);
+    it("should return a URL-only config with no headers (auth is the client's job)", () => {
+      const config = getNativeHTTPServerConfig();
       expect(config).toEqual({
         url: 'https://mcp.posthog.com/mcp',
       });
       expect(config).not.toHaveProperty('headers');
+    });
+
+    it('should encode the feature selection in the URL', () => {
+      const config = getNativeHTTPServerConfig(['workflows']);
+      expect(config.url).toBe('https://mcp.posthog.com/mcp?features=workflows');
     });
   });
 });

--- a/src/steps/add-mcp-server-to-clients/__tests__/mcp-client.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/mcp-client.test.ts
@@ -28,7 +28,7 @@ describe('DefaultMCPClient — addServer', () => {
   const writeFileMock = fs.promises.writeFile as Mock;
 
   const serverConfigFor = () =>
-    new TestClient().getServerConfig(undefined, ['flags'], false);
+    new TestClient().getServerConfig(['flags'], false);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -37,9 +37,9 @@ describe('DefaultMCPClient — addServer', () => {
   it('installs into a config that has no posthog entry yet', async () => {
     existsSyncMock.mockReturnValue(false);
 
-    await expect(
-      new TestClient().addServer(undefined, ['flags']),
-    ).resolves.toEqual({ success: true });
+    await expect(new TestClient().addServer(['flags'])).resolves.toEqual({
+      success: true,
+    });
     expect(writeFileMock).toHaveBeenCalled();
   });
 
@@ -49,9 +49,9 @@ describe('DefaultMCPClient — addServer', () => {
       JSON.stringify({ mcpServers: { posthog: serverConfigFor() } }),
     );
 
-    await expect(
-      new TestClient().addServer(undefined, ['flags'], false),
-    ).resolves.toEqual({ success: true, alreadyInstalled: true });
+    await expect(new TestClient().addServer(['flags'], false)).resolves.toEqual(
+      { success: true, alreadyInstalled: true },
+    );
     expect(writeFileMock).not.toHaveBeenCalled();
   });
 
@@ -61,9 +61,9 @@ describe('DefaultMCPClient — addServer', () => {
       JSON.stringify({ mcpServers: { posthog: { command: 'stale' } } }),
     );
 
-    await expect(
-      new TestClient().addServer(undefined, ['flags'], false),
-    ).resolves.toEqual({ success: true });
+    await expect(new TestClient().addServer(['flags'], false)).resolves.toEqual(
+      { success: true },
+    );
     expect(writeFileMock).toHaveBeenCalled();
   });
 
@@ -71,8 +71,9 @@ describe('DefaultMCPClient — addServer', () => {
     existsSyncMock.mockReturnValue(true);
     readFileMock.mockRejectedValue(new Error('EACCES: permission denied'));
 
-    await expect(
-      new TestClient().addServer(undefined, ['flags']),
-    ).resolves.toEqual({ success: false, reason: 'EACCES: permission denied' });
+    await expect(new TestClient().addServer(['flags'])).resolves.toEqual({
+      success: false,
+      reason: 'EACCES: permission denied',
+    });
   });
 });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -18,6 +18,117 @@ vi.mock('../../../../utils/debug', () => ({
   debug: vi.fn(),
 }));
 
+describe('ClaudeCodeMCPClient — addServer', () => {
+  const execSyncMock = execSync as Mock;
+  const BASE_URL = 'https://mcp.posthog.com/mcp';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (cmd === 'command -v claude') return Buffer.from('');
+      return Buffer.from('');
+    });
+  });
+
+  const callsMatching = (fragment: string) =>
+    execSyncMock.mock.calls.filter((c) => String(c[0]).includes(fragment));
+
+  it('adds the server without any credentials in the command', async () => {
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: true,
+    });
+    const addCall = callsMatching('mcp" "add')[0]!;
+    expect(String(addCall[0])).toContain(`${BASE_URL}?features=workflows`);
+    expect(String(addCall[0])).not.toContain('Authorization');
+  });
+
+  it('leaves an existing entry alone when it already points at the same URL', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) throw new Error('already exists');
+      if (c.includes('mcp get')) return Buffer.from(`  URL: ${BASE_URL}\n`);
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer()).resolves.toEqual({
+      success: true,
+      alreadyInstalled: true,
+    });
+    expect(callsMatching('mcp remove')).toHaveLength(0);
+  });
+
+  it('replaces the entry when it exists with a different URL', async () => {
+    let adds = 0;
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) {
+        adds += 1;
+        if (adds === 1) throw new Error('already exists');
+        return Buffer.from('');
+      }
+      if (c.includes('mcp get'))
+        return Buffer.from(`  URL: ${BASE_URL}?features=flags\n`);
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: true,
+    });
+    expect(callsMatching('mcp remove')).toHaveLength(1);
+    expect(adds).toBe(2);
+  });
+
+  it('replaces the entry when the existing URL cannot be determined', async () => {
+    let adds = 0;
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) {
+        adds += 1;
+        if (adds === 1) throw new Error('already exists');
+        return Buffer.from('');
+      }
+      if (c.includes('mcp get')) throw new Error('unknown command');
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: true,
+    });
+    expect(callsMatching('mcp remove')).toHaveLength(1);
+  });
+
+  it('reports a failed replacement with its reason', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) throw new Error('already exists');
+      if (c.includes('mcp get'))
+        return Buffer.from(`  URL: ${BASE_URL}?features=flags\n`);
+      if (c.includes('mcp remove')) throw new Error('remove blew up');
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: false,
+      reason: 'remove blew up',
+    });
+    expect(analytics.captureException).toHaveBeenCalled();
+  });
+
+  it('returns failure with the reason on an unexpected add error', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (String(cmd).includes('mcp" "add')) throw new Error('spawn EPERM');
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer()).resolves.toEqual({
+      success: false,
+      reason: 'spawn EPERM',
+    });
+    expect(analytics.captureException).toHaveBeenCalled();
+  });
+});
+
 describe('ClaudeCodeMCPClient — plugin methods', () => {
   const execSyncMock = execSync as Mock;
 

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
@@ -31,11 +31,9 @@ vi.mock('../../defaults', () => ({
 describe('ClaudeMCPClient', () => {
   let client: ClaudeMCPClient;
   const mockHomeDir = '/mock/home';
-  const mockApiKey = 'test-api-key';
   const mockServerConfig = {
     command: 'npx',
-    args: ['-y', 'mcp-remote@latest'],
-    env: { POSTHOG_AUTH_HEADER: `Bearer ${mockApiKey}` },
+    args: ['-y', 'mcp-remote@latest', 'https://mcp.posthog.com/mcp'],
   };
 
   const mkdirMock = fs.promises.mkdir as Mock;
@@ -222,7 +220,7 @@ describe('ClaudeMCPClient', () => {
     it('should create config directory and add server when config file does not exist', async () => {
       existsSyncMock.mockReturnValue(false);
 
-      await client.addServer(mockApiKey);
+      await client.addServer();
 
       const expectedConfigPath = path.join(
         mockHomeDir,
@@ -265,7 +263,7 @@ describe('ClaudeMCPClient', () => {
       };
       readFileMock.mockResolvedValue(JSON.stringify(existingConfig));
 
-      await client.addServer(mockApiKey);
+      await client.addServer();
 
       expect(writeFileMock).toHaveBeenCalledWith(
         expect.any(String),
@@ -298,7 +296,7 @@ describe('ClaudeMCPClient', () => {
         }),
       );
 
-      await client.addServer(mockApiKey);
+      await client.addServer();
 
       expect(writeFileMock).toHaveBeenCalledWith(
         expect.any(String),
@@ -323,27 +321,14 @@ describe('ClaudeMCPClient', () => {
       );
     });
 
-    it('should call getDefaultServerConfig with the provided API key', async () => {
+    it('should forward the feature selection and local flag to getDefaultServerConfig', async () => {
       existsSyncMock.mockReturnValue(false);
 
-      await client.addServer(mockApiKey);
+      await client.addServer(['workflows'], false);
 
       expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
-        mockApiKey,
-        undefined,
-        undefined,
-      );
-    });
-
-    it('should call getDefaultServerConfig with undefined API key for OAuth mode', async () => {
-      existsSyncMock.mockReturnValue(false);
-
-      await client.addServer(undefined);
-
-      expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
+        ['workflows'],
+        false,
       );
     });
   });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -108,10 +108,10 @@ describe('CodexMCPClient', () => {
   });
 
   describe('addServer', () => {
-    it('runs codex mcp add with the resolved URL and returns success on exit 0', async () => {
+    it('runs codex mcp add with the resolved URL and no credentials, and returns success on exit 0', async () => {
       spawnSyncMock.mockReturnValue({ status: 0, stderr: '' });
       const client = new CodexMCPClient();
-      await expect(client.addServer('phx_test')).resolves.toEqual({
+      await expect(client.addServer()).resolves.toEqual({
         success: true,
       });
       const call = spawnSyncMock.mock.calls[0]!;
@@ -122,28 +122,93 @@ describe('CodexMCPClient', () => {
         'posthog',
         '--url',
         'https://mcp.posthog.com/mcp',
-        '--bearer-token-env-var',
-        'POSTHOG_AUTH_HEADER',
       ]);
-      expect(call[2].env.POSTHOG_AUTH_HEADER).toBe('Bearer phx_test');
     });
 
-    it('reports "already" stderr as an already-installed success', async () => {
+    it('reports "already" stderr as already-installed when the entry has the same URL', async () => {
       spawnSyncMock.mockReturnValue({
         status: 1,
         stderr: "Server 'posthog' already exists",
       });
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp"\n',
+      );
       const client = new CodexMCPClient();
-      await expect(client.addServer('phx_test')).resolves.toEqual({
+      await expect(client.addServer()).resolves.toEqual({
         success: true,
         alreadyInstalled: true,
       });
+      // Only the add ran — the matching entry is left untouched.
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('replaces the entry when it exists with a different URL', async () => {
+      spawnSyncMock
+        .mockReturnValueOnce({
+          status: 1,
+          stderr: "Server 'posthog' already exists",
+        })
+        .mockReturnValueOnce({ status: 0, stderr: '' }) // mcp remove
+        .mockReturnValueOnce({ status: 0, stderr: '' }); // mcp add retry
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp?features=flags"\n',
+      );
+      const client = new CodexMCPClient();
+      await expect(client.addServer(['workflows'])).resolves.toEqual({
+        success: true,
+      });
+      expect(spawnSyncMock.mock.calls[1]![1]).toEqual([
+        'mcp',
+        'remove',
+        'posthog',
+      ]);
+      expect(spawnSyncMock.mock.calls[2]![1]).toEqual([
+        'mcp',
+        'add',
+        'posthog',
+        '--url',
+        'https://mcp.posthog.com/mcp?features=workflows',
+      ]);
+    });
+
+    it('replaces the entry when the existing URL cannot be determined', async () => {
+      spawnSyncMock
+        .mockReturnValueOnce({
+          status: 1,
+          stderr: "Server 'posthog' already exists",
+        })
+        .mockReturnValueOnce({ status: 0, stderr: '' })
+        .mockReturnValueOnce({ status: 0, stderr: '' });
+      readFileSyncMock.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      const client = new CodexMCPClient();
+      await expect(client.addServer()).resolves.toEqual({ success: true });
+      expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns failure when the replacement remove fails', async () => {
+      spawnSyncMock
+        .mockReturnValueOnce({
+          status: 1,
+          stderr: "Server 'posthog' already exists",
+        })
+        .mockReturnValueOnce({ status: 1, stderr: 'remove failed' });
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp?features=flags"\n',
+      );
+      const client = new CodexMCPClient();
+      await expect(client.addServer()).resolves.toEqual({
+        success: false,
+        reason: 'remove failed',
+      });
+      expect(analytics.captureException).toHaveBeenCalled();
     });
 
     it('returns failure with the reason and captures exception on unexpected error', async () => {
       spawnSyncMock.mockReturnValue({ status: 1, stderr: 'network timeout' });
       const client = new CodexMCPClient();
-      await expect(client.addServer('phx_test')).resolves.toEqual({
+      await expect(client.addServer()).resolves.toEqual({
         success: false,
         reason: 'network timeout',
       });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/opencode.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/opencode.test.ts
@@ -127,34 +127,9 @@ describe('OpenCodeMCPClient', () => {
   });
 
   describe('addServer (inherited from DefaultMCPClient)', () => {
-    it('writes server config with type:remote to the config file', async () => {
+    it('writes a credential-free type:remote server config', async () => {
       existsSyncMock.mockReturnValue(false);
       readFileMock.mockRejectedValue(new Error('should not be called'));
-      writeFileMock.mockResolvedValue(undefined);
-      mkdirMock.mockResolvedValue(undefined);
-
-      const client = new OpenCodeMCPClient();
-      await expect(client.addServer('phx_test123')).resolves.toEqual({
-        success: true,
-      });
-
-      const writtenContent = writeFileMock.mock.calls[0][1];
-      const parsed = JSON.parse(writtenContent);
-      expect(parsed).toEqual({
-        mcp: {
-          posthog: {
-            type: 'remote',
-            url: 'https://mcp.posthog.com/mcp',
-            headers: {
-              Authorization: 'Bearer phx_test123',
-            },
-          },
-        },
-      });
-    });
-
-    it('writes without headers when no apiKey provided', async () => {
-      existsSyncMock.mockReturnValue(false);
       writeFileMock.mockResolvedValue(undefined);
       mkdirMock.mockResolvedValue(undefined);
 
@@ -163,9 +138,15 @@ describe('OpenCodeMCPClient', () => {
 
       const writtenContent = writeFileMock.mock.calls[0][1];
       const parsed = JSON.parse(writtenContent);
-      expect(parsed.mcp.posthog.type).toBe('remote');
-      expect(parsed.mcp.posthog.url).toBe('https://mcp.posthog.com/mcp');
-      expect(parsed.mcp.posthog.headers).toBeUndefined();
+      // Auth lives in the client (OAuth), never in the config we write.
+      expect(parsed).toEqual({
+        mcp: {
+          posthog: {
+            type: 'remote',
+            url: 'https://mcp.posthog.com/mcp',
+          },
+        },
+      });
     });
 
     it('uses posthog-local for local server', async () => {
@@ -174,9 +155,9 @@ describe('OpenCodeMCPClient', () => {
       mkdirMock.mockResolvedValue(undefined);
 
       const client = new OpenCodeMCPClient();
-      await expect(
-        client.addServer(undefined, undefined, true),
-      ).resolves.toEqual({ success: true });
+      await expect(client.addServer(undefined, true)).resolves.toEqual({
+        success: true,
+      });
 
       const writtenContent = writeFileMock.mock.calls[0][1];
       const parsed = JSON.parse(writtenContent);

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -114,7 +114,6 @@ export class ClaudeCodeMCPClient
   }
 
   addServer(
-    apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult> {
@@ -127,7 +126,8 @@ export class ClaudeCodeMCPClient
 
     const serverName = local ? 'posthog-local' : 'posthog';
     const url = buildMCPUrl(selectedFeatures, local);
-    const args = [
+    const addCommand = [
+      binary,
       'mcp',
       'add',
       '--transport',
@@ -136,29 +136,76 @@ export class ClaudeCodeMCPClient
       'user',
       serverName,
       url,
-    ];
-    if (apiKey) {
-      args.push('--header', `Authorization: Bearer ${apiKey}`);
-    }
+    ]
+      .map((a) => JSON.stringify(a))
+      .join(' ');
 
     try {
-      execSync(`${binary} ${args.map((a) => JSON.stringify(a)).join(' ')}`, {
-        stdio: 'pipe',
-      });
+      execSync(addCommand, { stdio: 'pipe' });
       return Promise.resolve({ success: true });
     } catch (error) {
-      // The failing command echoes back the Authorization header we passed, so
-      // redact before this reaches a log, the screen, or an exception report.
+      // Redact before this reaches a log, the screen, or an exception report —
+      // the failing command echoes its arguments back in the error output.
       const msg = redactSecrets(
         error instanceof Error ? error.message : String(error),
       );
       if (msg.includes('already exists')) {
-        return Promise.resolve({ success: true, alreadyInstalled: true });
+        // The URL encodes the feature selection, so an existing entry with a
+        // different URL must be replaced — leaving it "as is" means the user's
+        // new selection silently never takes effect, and their next OAuth in
+        // Claude Code authorizes the wrong toolset. An entry that already
+        // points at this exact URL is left untouched: removing it would throw
+        // away the OAuth credentials Claude Code holds for it and force a
+        // needless re-auth.
+        if (this.installedServerUrl(binary, serverName) === url) {
+          return Promise.resolve({ success: true, alreadyInstalled: true });
+        }
+        return Promise.resolve(
+          this.replaceServer(binary, serverName, addCommand),
+        );
       }
       analytics.captureException(
         new Error(`Claude Code MCP add failed: ${msg}`),
       );
       return Promise.resolve({ success: false, reason: msg });
+    }
+  }
+
+  /** URL the existing entry points at, or null when it can't be determined. */
+  private installedServerUrl(
+    binary: string,
+    serverName: string,
+  ): string | null {
+    try {
+      const output = execSync(`${binary} mcp get ${serverName}`, {
+        stdio: 'pipe',
+      }).toString();
+      const match = output.match(/URL:\s*(\S+)/i);
+      return match ? match[1]! : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private replaceServer(
+    binary: string,
+    serverName: string,
+    addCommand: string,
+  ): InstallResult {
+    try {
+      execSync(`${binary} mcp remove --scope user ${serverName}`, {
+        stdio: 'pipe',
+      });
+      execSync(addCommand, { stdio: 'pipe' });
+      return { success: true };
+    } catch (error) {
+      const msg = redactSecrets(
+        error instanceof Error ? error.message : String(error),
+      );
+      analytics.captureException(
+        new Error(`Claude Code MCP update failed: ${msg}`),
+      );
+      return { success: false, reason: msg };
     }
   }
 

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -74,7 +74,6 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
   }
 
   addServer(
-    apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult> {
@@ -88,24 +87,69 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     const serverName = local ? 'posthog-local' : 'posthog';
     const url = buildMCPUrl(selectedFeatures, local);
     const args = ['mcp', 'add', serverName, '--url', url];
-    const env = { ...process.env };
-    if (apiKey) {
-      const tokenVar = 'POSTHOG_AUTH_HEADER';
-      env[tokenVar] = `Bearer ${apiKey}`;
-      args.push('--bearer-token-env-var', tokenVar);
-    }
 
-    const result = spawnSync(binary, args, { encoding: 'utf-8', env });
+    const result = spawnSync(binary, args, { encoding: 'utf-8' });
     if (result.status !== 0) {
       const stderr = result.stderr ?? '';
       if (ALREADY_INSTALLED_PATTERN.test(stderr)) {
-        return Promise.resolve({ success: true, alreadyInstalled: true });
+        // The URL encodes the feature selection — an existing entry pointing
+        // elsewhere must be replaced or the new selection never takes effect.
+        // An identical entry is left untouched so codex keeps whatever auth
+        // state it holds for the server.
+        if (this.installedServerUrl(serverName) === url) {
+          return Promise.resolve({ success: true, alreadyInstalled: true });
+        }
+        return Promise.resolve(this.replaceServer(binary, serverName, args));
       }
       const reason = redactSecrets(stderr);
       analytics.captureException(new Error(`Codex MCP add failed: ${reason}`));
       return Promise.resolve({ success: false, reason });
     }
     return Promise.resolve({ success: true });
+  }
+
+  /**
+   * URL the existing entry points at, read from `~/.codex/config.toml` (where
+   * `codex mcp add` writes `[mcp_servers.<name>]` sections). Null when it
+   * can't be determined — the caller then replaces the entry, which converges
+   * on the right state either way.
+   */
+  private installedServerUrl(serverName: string): string | null {
+    try {
+      const contents = fs.readFileSync(
+        path.join(os.homedir(), '.codex', 'config.toml'),
+        'utf-8',
+      );
+      const section = contents
+        .split(/^\[/m)
+        .find((s) => s.startsWith(`mcp_servers.${serverName}]`));
+      const match = section?.match(/^\s*url\s*=\s*"([^"]+)"/m);
+      return match ? match[1]! : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private replaceServer(
+    binary: string,
+    serverName: string,
+    addArgs: string[],
+  ): InstallResult {
+    const removed = spawnSync(binary, ['mcp', 'remove', serverName], {
+      encoding: 'utf-8',
+    });
+    const retried =
+      removed.status === 0
+        ? spawnSync(binary, addArgs, { encoding: 'utf-8' })
+        : removed;
+    if (retried.status !== 0) {
+      const reason = redactSecrets(retried.stderr ?? 'codex mcp update failed');
+      analytics.captureException(
+        new Error(`Codex MCP update failed: ${reason}`),
+      );
+      return { success: false, reason };
+    }
+    return { success: true };
   }
 
   removeServer(local?: boolean): Promise<InstallResult> {

--- a/src/steps/add-mcp-server-to-clients/clients/cursor.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/cursor.ts
@@ -32,10 +32,9 @@ export class CursorMCPClient extends DefaultMCPClient {
   }
 
   getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
-    return getNativeHTTPServerConfig(apiKey, selectedFeatures, local);
+    return getNativeHTTPServerConfig(selectedFeatures, local);
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/opencode.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/opencode.ts
@@ -72,13 +72,12 @@ export class OpenCodeMCPClient extends DefaultMCPClient {
   }
 
   override getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       type: 'remote',
-      ...getNativeHTTPServerConfig(apiKey, selectedFeatures, local),
+      ...getNativeHTTPServerConfig(selectedFeatures, local),
     };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
@@ -82,13 +82,12 @@ export class VisualStudioCodeClient extends DefaultMCPClient {
   }
 
   getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       type: 'http',
-      ...getNativeHTTPServerConfig(apiKey, selectedFeatures, local),
+      ...getNativeHTTPServerConfig(selectedFeatures, local),
     };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -73,13 +73,12 @@ export class ZedClient extends DefaultMCPClient {
   }
 
   getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       enabled: true,
-      ...getNativeHTTPServerConfig(apiKey, selectedFeatures, local),
+      ...getNativeHTTPServerConfig(selectedFeatures, local),
     };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/defaults.ts
+++ b/src/steps/add-mcp-server-to-clients/defaults.ts
@@ -260,52 +260,26 @@ export const buildMCPUrl = (selectedFeatures?: string[], local?: boolean) => {
   return params.length > 0 ? `${baseUrl}?${params.join('&')}` : baseUrl;
 };
 
+/**
+ * The wizard never writes credentials into MCP client configs. The client owns
+ * auth: it runs the OAuth flow against mcp.posthog.com the first time it
+ * connects (e.g. `/mcp` in Claude Code), which is the only place that knows
+ * which scopes each feature needs. A wizard-injected Authorization header
+ * would be sent forever — even after the client obtains fresh OAuth tokens —
+ * so a stale or under-scoped key locks the server into a rejected-reconnect
+ * loop the user can't escape without editing the config by hand.
+ */
 export const getNativeHTTPServerConfig = (
-  apiKey: string | undefined,
   selectedFeatures?: string[],
   local?: boolean,
-) => {
-  const config: Record<string, unknown> = {
-    url: buildMCPUrl(selectedFeatures, local),
-  };
-
-  // Only add auth header if API key is provided (not OAuth mode)
-  if (apiKey) {
-    config.headers = {
-      Authorization: `Bearer ${apiKey}`,
-    };
-  }
-
-  return config;
-};
+) => ({
+  url: buildMCPUrl(selectedFeatures, local),
+});
 
 export const getDefaultServerConfig = (
-  apiKey: string | undefined,
   selectedFeatures?: string[],
   local?: boolean,
-) => {
-  const urlWithFeatures = buildMCPUrl(selectedFeatures, local);
-
-  // OAuth mode: no auth header, let MCP handle OAuth
-  if (!apiKey) {
-    return {
-      command: 'npx',
-      args: ['-y', 'mcp-remote@latest', urlWithFeatures],
-    };
-  }
-
-  // API key mode: include auth header
-  return {
-    command: 'npx',
-    args: [
-      '-y',
-      'mcp-remote@latest',
-      urlWithFeatures,
-      '--header',
-      `Authorization:\${POSTHOG_AUTH_HEADER}`,
-    ],
-    env: {
-      POSTHOG_AUTH_HEADER: `Bearer ${apiKey}`,
-    },
-  };
-};
+) => ({
+  command: 'npx',
+  args: ['-y', 'mcp-remote@latest', buildMCPUrl(selectedFeatures, local)],
+});

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -60,14 +60,12 @@ export const addMCPServerToClientsStep = async ({
   ci = false,
   cloudRegion: _cloudRegion,
   features,
-  apiKey,
 }: {
   integration?: Integration;
   local?: boolean;
   ci?: boolean;
   cloudRegion?: CloudRegion;
   features?: string[];
-  apiKey?: string;
 }): Promise<string[]> => {
   const ui = getUI();
 
@@ -88,12 +86,7 @@ export const addMCPServerToClientsStep = async ({
 
   // Auto-install to all supported clients
   const results = await withProgress('adding mcp servers', () =>
-    addMCPServer(
-      supportedClients,
-      apiKey,
-      features ?? [...ALL_FEATURE_VALUES],
-      local,
-    ),
+    addMCPServer(supportedClients, features ?? [...ALL_FEATURE_VALUES], local),
   );
 
   const installed = namesWithStatus(results, McpClientStatus.Changed);
@@ -104,6 +97,9 @@ export const addMCPServerToClientsStep = async ({
   // hid both the no-op re-runs and the outright failures.
   if (installed.length > 0) {
     ui.log.success(`Added the MCP server to:\n${bulletList(installed)}`);
+    ui.log.info(
+      'Your editor handles authentication — approve the PostHog connection when it prompts (in Claude Code, run /mcp).',
+    );
   }
   if (already.length > 0) {
     ui.log.info(
@@ -212,18 +208,13 @@ export const getInstalledClients = async (
 
 export const addMCPServer = async (
   clients: MCPClient[],
-  personalApiKey?: string,
   selectedFeatures?: string[],
   local?: boolean,
 ): Promise<McpClientResult[]> => {
   const results: McpClientResult[] = [];
   for (const client of clients) {
     try {
-      const result = await client.addServer(
-        personalApiKey,
-        selectedFeatures,
-        local,
-      );
+      const result = await client.addServer(selectedFeatures, local);
       results.push(toClientResult(client.name, result));
     } catch (err) {
       debug(`[addMCPServer] addServer threw for ${client.name}: ${err}`);

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -282,11 +282,7 @@ export const McpScreen = ({
       // Plugin-capable clients get the plugin (which bundles MCP).
       // Non-plugin-capable clients get a direct MCP config write.
       try {
-        mcpResult = await installer.install(
-          directNames,
-          features,
-          store.session.apiKey,
-        );
+        mcpResult = await installer.install(directNames, features);
       } catch (err) {
         setFlowError(errorText(err));
       }
@@ -300,11 +296,7 @@ export const McpScreen = ({
       // 'custom' — MCP-only for every selected client. Plugin install is
       // skipped so the user's feature selection is actually respected.
       try {
-        mcpResult = await installer.install(
-          names,
-          features,
-          store.session.apiKey,
-        );
+        mcpResult = await installer.install(names, features);
       } catch (err) {
         setFlowError(errorText(err));
       }
@@ -587,7 +579,7 @@ export const McpScreen = ({
                   note={
                     isRemove
                       ? 'It was already gone, so nothing was changed.'
-                      : 'Left as-is. To change which PostHog areas it can reach, run `wizard mcp remove` first, then `wizard mcp add`.'
+                      : 'It already matched this exact setup, so nothing changed — including any login your editor already holds.'
                   }
                 />
                 <ResultGroup
@@ -599,6 +591,17 @@ export const McpScreen = ({
                   icon={'\u2716'}
                   note="Run with --debug for the full output, or report it at github.com/PostHog/wizard/issues."
                 />
+                {!isRemove &&
+                  installedNow.length + alreadyInstalled.length > 0 && (
+                    <Box marginBottom={1}>
+                      <Text dimColor>
+                        Your editor handles authentication — approve the
+                        PostHog connection when it prompts (in Claude Code, run
+                        /mcp). Changing the enabled areas later means
+                        authenticating once more.
+                      </Text>
+                    </Box>
+                  )}
                 {finishNotes.map((note) => (
                   <Box key={note.name} flexDirection="column" marginTop={1}>
                     <Text color="green" bold>

--- a/src/ui/tui/services/mcp-installer.ts
+++ b/src/ui/tui/services/mcp-installer.ts
@@ -50,7 +50,6 @@ export interface McpInstaller {
   install(
     clientNames: string[],
     features?: string[],
-    apiKey?: string,
   ): Promise<McpClientResult[]>;
 
   /**
@@ -86,7 +85,6 @@ export function createMcpInstaller(): McpInstaller {
     async install(
       clientNames: string[],
       features?: string[],
-      apiKey?: string,
     ): Promise<McpClientResult[]> {
       const resolvedFeatures = features ?? [...ALL_FEATURE_VALUES];
       const toInstall = cachedClients
@@ -107,11 +105,7 @@ export function createMcpInstaller(): McpInstaller {
       for (const client of toInstall) {
         const name = client.name as string;
         try {
-          const result = await client.addServer(
-            apiKey,
-            resolvedFeatures,
-            false,
-          );
+          const result = await client.addServer(resolvedFeatures, false);
           results.push(toClientResult(name, result));
           if (!result?.success) {
             // redactSecrets, not the raw reason: the CLIs we shell out to echo


### PR DESCRIPTION
## Problem

Users who re-run the MCP wizard with a different feature selection get stuck in a broken auth loop:

- For Claude Code and Codex, a re-run of `mcp add` hit "already exists" and reported success **without updating the server URL** — but the URL encodes the feature selection, so the next OAuth in the editor authorized the wrong toolset. The Done screen even told users to `wizard mcp remove` and re-add by hand.
- The wizard could bake a personal API key into the client config (`--api-key`, or a silent `POSTHOG_PERSONAL_API_KEY` pickup from the project's `.env`). A static `Authorization` header keeps being sent even after the editor obtains fresh OAuth tokens, so a stale or under-scoped key locks the connection into a rejected-on-reconnect loop the user can't escape without hand-editing the config.

Net effect: users had to authenticate repeatedly, against the wrong scopes, and gave up. Raised via user feedback about the `workflows`-only install flow.

## Changes

- **Update in place on re-run** (Claude Code, Codex): on "already exists", compare the installed entry's URL with the target; identical → leave untouched (preserves the editor's existing OAuth tokens, no needless re-auth); different → remove + re-add so the new feature selection actually takes effect. File-based clients (Cursor, VS Code, Zed, OpenCode, Claude Desktop) already overwrote correctly.
- **Auth is the client's job, exactly once**: removed all credential injection from the MCP install path — no `--api-key` on `mcp add`, no `.env` pickup, no `Authorization` headers or bearer env vars in any generated config. The editor's own OAuth (e.g. `/mcp` in Claude Code) is the single auth path; the OAuth server is the only party that knows the feature→scope mapping.
- Install screens now say so: successful installs point users at their editor's auth prompt, and the "already installed" note no longer tells them to remove and re-add.

The global `--api-key` for the integration/CI flows is untouched — only MCP client configs stop carrying credentials.

## Test plan

`pnpm build && pnpm test && pnpm lint` — 1859 tests pass, including new coverage for URL-changed replacement, identical-entry no-op (verifying the editor's login is preserved), replacement failure reporting, and credential-free config generation across all clients.

## LLM context

Written from user feedback about `wizard mcp add` re-runs leaving a stale features URL in Claude Code and repeated failed re-auth ("posthog rejected them on reconnect").

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*