### PR TITLE
feat(replay-vision): replay-vision command on the orchestrator sequence

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -49,6 +49,7 @@ import { Wizard } from './src/wizard';
 import { basicIntegrationCommand } from './src/commands/basic-integration';
 import { mcpCommand } from './src/commands/mcp';
 import { mcpAnalyticsCommand } from './src/commands/mcp-analytics';
+import { replayVisionCommand } from './src/commands/replay-vision';
 import { aiObservabilityCommand } from './src/commands/ai-observability';
 import { auditCommand } from './src/commands/audit';
 import { doctorCommand } from './src/commands/doctor';
@@ -80,6 +81,7 @@ function resolveInstallDir(): string {
 Wizard.use(basicIntegrationCommand)
   .use(mcpCommand)
   .use(mcpAnalyticsCommand)
+  .use(replayVisionCommand)
   .use(aiObservabilityCommand)
   .use(cliCommand)
   .use(auditCommand)

--- a/e2e-harness/profiles.ts
+++ b/e2e-harness/profiles.ts
@@ -17,11 +17,13 @@ import {
 } from './e2e-profile.js';
 import posthogIntegrationE2e from '@lib/programs/posthog-integration/test/e2e.json';
 import aiObservabilityE2e from '@lib/programs/ai-observability/test/e2e.json';
+import replayVisionE2e from '@lib/programs/replay-vision/test/e2e.json';
 
 const PROFILES: Partial<Record<ProgramId, WizardE2eProfile>> = {
   [Program.PostHogIntegration]:
     posthogIntegrationE2e.profile as WizardE2eProfile,
   [Program.AiObservability]: aiObservabilityE2e.profile as WizardE2eProfile,
+  [Program.ReplayVision]: replayVisionE2e.profile as WizardE2eProfile,
 };
 
 const VARIATIONS: Partial<Record<ProgramId, WizardE2eVariation[]>> = {
@@ -29,6 +31,7 @@ const VARIATIONS: Partial<Record<ProgramId, WizardE2eVariation[]>> = {
     posthogIntegrationE2e.variations as WizardE2eVariation[],
   [Program.AiObservability]:
     aiObservabilityE2e.variations as WizardE2eVariation[],
+  [Program.ReplayVision]: replayVisionE2e.variations as WizardE2eVariation[],
 };
 
 /** The e2e profile for a program, or the happy-path default if none is set. */

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -21,6 +21,7 @@ import type { MockedFunction } from 'vitest';
 import { auditCommand } from '../commands/audit';
 import { migrateCommand } from '../commands/migrate';
 import { mcpAnalyticsCommand } from '../commands/mcp-analytics';
+import { replayVisionCommand } from '../commands/replay-vision';
 import { revenueCommand } from '../commands/revenue';
 import { warehouseCommand } from '../commands/warehouse';
 import { uploadSourcemapsCommand } from '../commands/upload-sourcemaps';
@@ -83,6 +84,11 @@ describe('top-level command shapes', () => {
   test('mcp-analytics is a flat skill command', () => {
     expect(mcpAnalyticsCommand.name).toBe('mcp-analytics');
     expect(mcpAnalyticsCommand.children).toBeUndefined();
+  });
+
+  test('replay-vision is a flat skill command', () => {
+    expect(replayVisionCommand.name).toBe('replay-vision');
+    expect(replayVisionCommand.children).toBeUndefined();
   });
 
   test('warehouse is a flat skill command', () => {
@@ -182,6 +188,12 @@ describe('flat skill commands', () => {
     mcpAnalyticsCommand.handler!(makeArgv({ debug: true }));
     const [config] = mockRunWizard.mock.calls[0] as [{ skillId?: string }];
     expect(config.skillId).toBe('mcp-analytics');
+  });
+
+  test('replay-vision dispatches with replay-vision skillId', () => {
+    replayVisionCommand.handler!(makeArgv({ debug: true }));
+    const [config] = mockRunWizard.mock.calls[0] as [{ skillId?: string }];
+    expect(config.skillId).toBe('replay-vision');
   });
 
   test('warehouse dispatches with data-warehouse-source-setup skillId', () => {

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -190,10 +190,10 @@ describe('flat skill commands', () => {
     expect(config.skillId).toBe('mcp-analytics');
   });
 
-  test('replay-vision dispatches with replay-vision skillId', () => {
+  test('replay-vision dispatches with replay-vision-setup skillId', () => {
     replayVisionCommand.handler!(makeArgv({ debug: true }));
     const [config] = mockRunWizard.mock.calls[0] as [{ skillId?: string }];
-    expect(config.skillId).toBe('replay-vision');
+    expect(config.skillId).toBe('replay-vision-setup');
   });
 
   test('warehouse dispatches with data-warehouse-source-setup skillId', () => {

--- a/src/__tests__/wizard.test.ts
+++ b/src/__tests__/wizard.test.ts
@@ -4,6 +4,7 @@ import { mcpCommand } from '../commands/mcp';
 import { auditCommand } from '../commands/audit';
 import { doctorCommand } from '../commands/doctor';
 import { migrateCommand } from '../commands/migrate';
+import { replayVisionCommand } from '../commands/replay-vision';
 import { revenueCommand } from '../commands/revenue';
 import { uploadSourcemapsCommand } from '../commands/upload-sourcemaps';
 import { skillCommand } from '../commands/skill';
@@ -85,6 +86,7 @@ describe('production command tree', () => {
       auditCommand,
       doctorCommand,
       migrateCommand,
+      replayVisionCommand,
       revenueCommand,
       uploadSourcemapsCommand,
       skillCommand,

--- a/src/commands/replay-vision.ts
+++ b/src/commands/replay-vision.ts
@@ -1,0 +1,15 @@
+import { replayVisionConfig } from '@lib/programs/replay-vision/index';
+
+import type { Command } from './command';
+import { nativeCommandFactory } from './factories/native-command-factory';
+
+/**
+ * `wizard replay-vision` — flat skill command, set up Replay vision today.
+ *
+ * Enables session replay recording and creates vision scanners tailored to
+ * the product's key flows. Runs the `replay-vision` orchestrator flow, which
+ * reuses the integration-v2 install/init mini-agents when the repo has no
+ * PostHog integration yet.
+ */
+export const replayVisionCommand: Command =
+  nativeCommandFactory(replayVisionConfig);

--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -61,6 +61,7 @@ describe('switchboard PROGRAM_BINDINGS', () => {
   it('resolves every program, unflagged, to the same default binding', () => {
     for (const program of PROGRAM_IDS) {
       if (program === 'ai-observability') continue; // pinned below
+      if (program === 'replay-vision') continue; // pinned below
       expect(resolveBinding({ program, flags: {} })).toEqual(DEFAULT_RESOLVED);
     }
   });
@@ -73,6 +74,17 @@ describe('switchboard PROGRAM_BINDINGS', () => {
         sequence: Sequence.linear,
         harness: Harness.anthropic,
         model: SONNET_5_MODEL,
+        thinkingLevel: undefined,
+      },
+      trace: { harness: 'binding', model: 'binding', sequence: 'binding' },
+    },
+    {
+      name: 'binds replay-vision to the orchestrator sequence',
+      ctx: { program: 'replay-vision', flags: {} },
+      binding: {
+        sequence: Sequence.orchestrator,
+        harness: Harness.anthropic,
+        model: DEFAULT_AGENT_MODEL,
         thinkingLevel: undefined,
       },
       trace: { harness: 'binding', model: 'binding', sequence: 'binding' },

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -384,8 +384,15 @@ export async function runOrchestrator(
   let commandmentsPath: string | undefined;
   let referenceInstallPath: string | undefined;
   const menuSkillEntries = await fetchSkillMenuEntries(boot.skillsBaseUrl);
-  const referenceSkillId = session.skillId
-    ? resolveReferenceSkillId(menuSkillEntries, session.skillId)
+  // The framework key for reference + variant resolution. `session.integration`
+  // is the detected framework and always wins; `session.skillId` is the
+  // fallback for the basic-integration path, where bootstrap sets it to the
+  // framework label. Programs whose run config carries their own skill id
+  // (agent-skill commands like replay-vision) would otherwise leak that id in
+  // here as a bogus framework after bootstrap overwrites the detect result.
+  const framework = session.integration ?? session.skillId ?? undefined;
+  const referenceSkillId = framework
+    ? resolveReferenceSkillId(menuSkillEntries, framework)
     : undefined;
   if (referenceSkillId) {
     const ref = await installSkillById(
@@ -412,9 +419,9 @@ export async function runOrchestrator(
         `[orchestrator] reference unavailable: ${ref.kind} (${referenceSkillId})`,
       );
     }
-  } else if (session.skillId) {
+  } else if (framework) {
     logToFile(
-      `[orchestrator] no integration skill for framework "${session.skillId}"`,
+      `[orchestrator] no integration skill for framework "${framework}"`,
     );
   }
 
@@ -422,26 +429,26 @@ export async function runOrchestrator(
   const missingVariants: string[] = [];
   for (const type of registry.types) {
     for (const skillId of registry.get(type)?.skills ?? []) {
-      if (resolveSkillVariantId(menuSkillEntries, skillId, session.skillId)) {
+      if (resolveSkillVariantId(menuSkillEntries, skillId, framework)) {
         continue;
       }
       missingVariants.push(`${type}/${skillId}`);
       logToFile(
         `[orchestrator] no skill variant type=${type} skill=${skillId} framework=${
-          session.skillId ?? 'none'
+          framework ?? 'none'
         }`,
       );
       analytics.wizardCapture('orchestrator skill variant missing', {
         task_type: type,
         skill: skillId,
-        framework: session.skillId,
+        framework,
       });
     }
   }
   if (missingVariants.length > 0) {
     // The framework's own docs page from its config; generic docs when detection found none.
-    const docsUrl = session.skillId
-      ? FRAMEWORK_REGISTRY[session.skillId as Integration]?.docsUrl
+    const docsUrl = framework
+      ? FRAMEWORK_REGISTRY[framework as Integration]?.docsUrl
       : undefined;
     await wizardAbort({
       message:
@@ -453,7 +460,7 @@ export async function runOrchestrator(
         `  ${docsUrl ?? POSTHOG_DOCS_URL}`,
       error: new WizardError('Orchestrator preflight: skill variant missing', {
         missing: missingVariants.join(', '),
-        framework: session.skillId,
+        framework,
       }),
     });
   }
@@ -671,13 +678,13 @@ export async function runOrchestrator(
         const variantId = resolveSkillVariantId(
           menuSkillEntries,
           skillId,
-          session.skillId,
+          framework,
         );
         if (!variantId) {
           logToFile(
             `[orchestrator] no skill variant type=${
               task.type
-            } skill=${skillId} framework=${session.skillId ?? 'none'}`,
+            } skill=${skillId} framework=${framework ?? 'none'}`,
           );
           continue;
         }

--- a/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
@@ -277,6 +277,19 @@ describe('isolation — everything on at once', () => {
           ...LINEAR_ANTHROPIC_DEFAULT,
           model: SONNET_5_MODEL,
         });
+      } else if (program === 'replay-vision') {
+        // Orchestrator from its OWN binding, not the flag — the
+        // wizard-orchestrator experiment does not cover this program, so it
+        // lands here whether the flag is on or off. Anthropic, not pi.
+        expect(resolved).toEqual({
+          ...LINEAR_ANTHROPIC_DEFAULT,
+          sequence: Sequence.orchestrator,
+        });
+        expect(ctx.trace).toEqual({
+          harness: 'binding',
+          model: 'binding',
+          sequence: 'binding',
+        });
       } else {
         expect(resolved).toEqual(LINEAR_ANTHROPIC_DEFAULT);
         expect(ctx.trace).toEqual({

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -135,6 +135,11 @@ export const PROGRAM_BINDINGS: Partial<Record<ProgramId, ProgramBinding>> = {
   'mcp-remove': DEFAULT_BINDING,
   'mcp-tutorial': DEFAULT_BINDING,
   'mcp-analytics': DEFAULT_BINDING,
+  'replay-vision': {
+    sequence: Sequence.orchestrator,
+    harness: Harness.anthropic,
+    model: DEFAULT_AGENT_MODEL,
+  },
   'ai-observability': {
     sequence: Sequence.linear,
     harness: Harness.anthropic,

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -83,6 +83,27 @@ export const SIGNUP_WIZARD_READINESS_CONFIG: WizardReadinessConfig = {
 // ---------------------------------------------------------------------------
 
 export async function checkAllExternalServices(): Promise<AllServicesHealth> {
+  // Deterministic-run escape hatch for the e2e/snapshot harness: a live
+  // status-page incident (e.g. Anthropic degraded) turns the health screen
+  // into a hard block whose any-key handler exits the process, killing the
+  // run before the screen under test ever renders. Snapshots assert our
+  // screens, not vendor status pages.
+  if (process.env.POSTHOG_WIZARD_ASSUME_HEALTHY === 'true') {
+    const healthy = { status: ServiceHealthStatus.Healthy };
+    return {
+      anthropic: healthy,
+      posthogOverall: healthy,
+      posthogComponents: { ...healthy, degradedOrDownComponents: [] },
+      github: healthy,
+      npmOverall: healthy,
+      npmComponents: { ...healthy, degradedOrDownComponents: [] },
+      cloudflareOverall: healthy,
+      cloudflareComponents: { ...healthy, degradedOrDownComponents: [] },
+      llmGateway: healthy,
+      mcp: healthy,
+      githubReleases: healthy,
+    };
+  }
   const [
     anthropic,
     posthogOverall,

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -83,27 +83,6 @@ export const SIGNUP_WIZARD_READINESS_CONFIG: WizardReadinessConfig = {
 // ---------------------------------------------------------------------------
 
 export async function checkAllExternalServices(): Promise<AllServicesHealth> {
-  // Deterministic-run escape hatch for the e2e/snapshot harness: a live
-  // status-page incident (e.g. Anthropic degraded) turns the health screen
-  // into a hard block whose any-key handler exits the process, killing the
-  // run before the screen under test ever renders. Snapshots assert our
-  // screens, not vendor status pages.
-  if (process.env.POSTHOG_WIZARD_ASSUME_HEALTHY === 'true') {
-    const healthy = { status: ServiceHealthStatus.Healthy };
-    return {
-      anthropic: healthy,
-      posthogOverall: healthy,
-      posthogComponents: { ...healthy, degradedOrDownComponents: [] },
-      github: healthy,
-      npmOverall: healthy,
-      npmComponents: { ...healthy, degradedOrDownComponents: [] },
-      cloudflareOverall: healthy,
-      cloudflareComponents: { ...healthy, degradedOrDownComponents: [] },
-      llmGateway: healthy,
-      mcp: healthy,
-      githubReleases: healthy,
-    };
-  }
   const [
     anthropic,
     posthogOverall,

--- a/src/lib/oauth/__tests__/program-scopes.test.ts
+++ b/src/lib/oauth/__tests__/program-scopes.test.ts
@@ -18,3 +18,28 @@ describe('posthog-integration scopes', () => {
     );
   });
 });
+
+/**
+ * Run 69afc6f8 requested only the base set, so the PostHog MCP served a
+ * catalog without the scanner tools: every scanner task took its "tool
+ * unknown" skip path and the run reported success having created nothing.
+ */
+describe('replay-vision scopes', () => {
+  it('covers scanner create/list', () => {
+    const scopes = getOAuthScopesForProgram('replay-vision');
+    expect(scopes).toContain('replay_scanner:read');
+    expect(scopes).toContain('replay_scanner:write');
+  });
+
+  it('pairs session_recording:read with the scanner scopes', () => {
+    expect(getOAuthScopesForProgram('replay-vision')).toContain(
+      'session_recording:read',
+    );
+  });
+
+  it('can turn on session replay server-side', () => {
+    expect(getOAuthScopesForProgram('replay-vision')).toContain(
+      'product_enablement:write',
+    );
+  });
+});

--- a/src/lib/oauth/program-scopes.ts
+++ b/src/lib/oauth/program-scopes.ts
@@ -219,6 +219,35 @@ export const WAREHOUSE_SOURCE_SCOPE_ADDITIONS = [
 export const CONNECT_SLACK_SCOPE_ADDITIONS = ['integration:read'] as const;
 
 /**
+ * Extra scopes the replay-vision program needs on top of `WIZARD_OAUTH_SCOPES`.
+ * The same set self-driving's step 6c uses, narrowed to just this flow:
+ *   • replay_scanner:read / replay_scanner:write — the scanner tasks list the
+ *     team's existing scanners and create the ones scoped to the product's key
+ *     flows (`vision-scanners-list` / `-create`, plus the advisory
+ *     `vision-scanners-estimate-create` / `vision-quota-retrieve`). The scope
+ *     OBJECT is `replay_scanner`; `vision-scanners-*` are MCP tool names.
+ *   • session_recording:read — the scanner API pairs it with
+ *     `replay_scanner:*`, since a scanner's config indirectly exposes
+ *     recording contents. Configuring a scanner fails without it.
+ *   • product_enablement:write — the enable-replay task's server half turns on
+ *     Session Replay (`products-enable`) so there are recordings to scan.
+ *
+ * Without these the PostHog MCP omits the tools from the catalog it serves
+ * this token, every scanner task takes its "tool unknown" skip path, and the
+ * run reports success having created nothing (run 69afc6f8).
+ *
+ * No OAuth-ceiling edit needed — all are unprivileged public scope objects
+ * covered by the apps' `@default` sentinel, and self-driving already requests
+ * every one of them.
+ */
+export const REPLAY_VISION_SCOPE_ADDITIONS = [
+  'session_recording:read',
+  'product_enablement:write',
+  'replay_scanner:read',
+  'replay_scanner:write',
+] as const;
+
+/**
  * Per-program scope additions, layered on top of `WIZARD_OAUTH_SCOPES`.
  *
  * Programs not listed here request the unchanged base set. Use this
@@ -247,6 +276,7 @@ const PROGRAM_SCOPE_ADDITIONS: Partial<Record<ProgramId, readonly string[]>> = {
     ...WAREHOUSE_SOURCE_SCOPE_ADDITIONS,
   ],
   slack: CONNECT_SLACK_SCOPE_ADDITIONS,
+  'replay-vision': REPLAY_VISION_SCOPE_ADDITIONS,
 };
 
 /**

--- a/src/lib/programs/__tests__/replay-vision.test.ts
+++ b/src/lib/programs/__tests__/replay-vision.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+
+import { Integration } from '@lib/constants';
+import {
+  replayVisionConfig,
+  REPLAY_VISION_SUPPORTED,
+} from '@lib/programs/replay-vision/index';
+
+describe('replay-vision program', () => {
+  test('runs the replay-vision agent flow', () => {
+    expect(replayVisionConfig.agentFlow).toBe('replay-vision');
+  });
+
+  test('detects the framework before the agent-skill steps', () => {
+    expect(replayVisionConfig.steps[0]?.id).toBe('detect');
+    expect(replayVisionConfig.steps[0]?.onReady).toBeDefined();
+  });
+
+  test('declares ci prerequisite work for headless runs', () => {
+    expect(replayVisionConfig.ciPreRun).toBeDefined();
+  });
+});
+
+describe('replay-vision platform support', () => {
+  test('covers every Integration with an explicit verdict', () => {
+    // The gate is an allow-list: a new Integration enum entry is unsupported
+    // until someone decides otherwise. This test only pins that the set
+    // contains real Integration values.
+    for (const integration of REPLAY_VISION_SUPPORTED) {
+      expect(Object.values(Integration)).toContain(integration);
+    }
+  });
+
+  test('supports web and replay-capable mobile platforms', () => {
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.nextjs)).toBe(true);
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.javascript_web)).toBe(true);
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.reactNative)).toBe(true);
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.android)).toBe(true);
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.swift)).toBe(true);
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.flutter)).toBe(true);
+  });
+
+  test('rejects platforms replay cannot record on', () => {
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.javascriptNode)).toBe(false);
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.python)).toBe(false);
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.ruby)).toBe(false);
+    expect(REPLAY_VISION_SUPPORTED.has(Integration.kmp)).toBe(false);
+  });
+});

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -30,6 +30,7 @@ import {
   mcpTutorialConfig,
 } from './mcp/index.js';
 import { mcpAnalyticsConfig } from './mcp-analytics/index.js';
+import { replayVisionConfig } from './replay-vision/index.js';
 import { aiObservabilityConfig } from './ai-observability/index.js';
 import { slackConnectConfig } from './slack/index.js';
 
@@ -79,6 +80,7 @@ export const PROGRAM_REGISTRY = [
   mcpRemoveConfig,
   mcpTutorialConfig,
   mcpAnalyticsConfig,
+  replayVisionConfig,
   aiObservabilityConfig,
   slackConnectConfig,
 ] as const satisfies readonly ProgramConfig[];
@@ -104,6 +106,7 @@ export const Program = {
   McpRemove: mcpRemoveConfig.id,
   McpTutorial: mcpTutorialConfig.id,
   McpAnalytics: mcpAnalyticsConfig.id,
+  ReplayVision: replayVisionConfig.id,
   AiObservability: aiObservabilityConfig.id,
   SlackConnect: slackConnectConfig.id,
 } as const;

--- a/src/lib/programs/replay-vision/index.ts
+++ b/src/lib/programs/replay-vision/index.ts
@@ -1,0 +1,195 @@
+import type { AbortCase } from '@lib/agent/agent-runner';
+import { Integration } from '@lib/constants';
+import { detectFramework, gatherFrameworkContext } from '@lib/detection/index';
+import { scopeInstallDirToProject } from '@lib/detection/project-scope';
+import { FRAMEWORK_REGISTRY } from '@lib/registry';
+import { createSkillProgram } from '@lib/programs/agent-skill/index';
+import { AGENT_SKILL_STEPS } from '@lib/programs/agent-skill/steps';
+import { detectPostHogIntegration } from '@lib/programs/posthog-integration/detect';
+import type {
+  ProgramConfig,
+  ProgramReadyContext,
+  ProgramStep,
+} from '@lib/programs/program-step';
+import type { WizardSession } from '@lib/wizard-session';
+import { analytics } from '@utils/analytics';
+import { wizardAbort } from '@utils/wizard-abort';
+
+const REPLAY_VISION_REPORT_FILE = 'posthog-replay-vision-report.md';
+
+/**
+ * The platforms session replay can actually record on. Replay vision watches
+ * recordings, so a platform with no recordings has nothing to set up — the
+ * run must stop before any work, not after a pointless agent run.
+ *
+ * Web frameworks record through posthog-js (server-rendered frameworks
+ * included — they serve pages), and the mobile SDKs with replay support are
+ * React Native, Android, iOS, and Flutter. Excluded: pure backend targets
+ * (`javascript_node`, `python`, `ruby`) and KMP, which has no replay support
+ * yet.
+ */
+export const REPLAY_VISION_SUPPORTED: ReadonlySet<Integration> = new Set([
+  Integration.nextjs,
+  Integration.nuxt,
+  Integration.vue,
+  Integration.reactRouter,
+  Integration.tanstackStart,
+  Integration.tanstackRouter,
+  Integration.angular,
+  Integration.astro,
+  Integration.sveltekit,
+  Integration.javascript_web,
+  Integration.django,
+  Integration.flask,
+  Integration.fastapi,
+  Integration.laravel,
+  Integration.rails,
+  Integration.reactNative,
+  Integration.android,
+  Integration.swift,
+  Integration.flutter,
+]);
+
+async function abortUnsupportedPlatform(
+  integration: Integration,
+): Promise<void> {
+  const name = FRAMEWORK_REGISTRY[integration]?.metadata.name ?? integration;
+  await wizardAbort({
+    message:
+      `Session replay isn't available for ${name} projects, and Replay ` +
+      'vision needs session recordings to watch — so there is nothing to ' +
+      'set up here.\n\n' +
+      'If this repo also contains a web or mobile app, run the command from ' +
+      'that project directory instead. See what replay supports at:\n' +
+      '  https://posthog.com/docs/session-replay',
+    error: new Error(`Replay vision unsupported platform: ${integration}`),
+  });
+}
+
+/**
+ * `[ABORT]` reasons the replay-vision skill emits when the run can't proceed.
+ * Kept in sync with the stop conditions in the skill's `description.md`
+ * (context-mill `context/skills/replay-vision`).
+ */
+export const REPLAY_VISION_ABORT_CASES: AbortCase[] = [
+  {
+    match: /^replay vision not available for this project$/i,
+    message: 'Replay vision is not available for this project',
+    body:
+      'Every Replay vision scanner endpoint reported that the feature is not ' +
+      'available here yet. Session replay setup done so far is kept. See ' +
+      'https://posthog.com/docs/replay-vision for availability.',
+  },
+];
+
+/**
+ * Framework detection ahead of the run, exactly like the default integration
+ * program. The orchestrator requires it: `session.skillId` must hold the
+ * detected framework id before the run arm starts, because the runner
+ * resolves the reference integration skill and every task's mini-skill
+ * variants (`integration-v2-install`, `integration-v2-init`, …) against it in
+ * preflight. Without this step the session would still carry the program's
+ * own skill id and preflight would abort.
+ */
+const DETECT_STEP: ProgramStep = {
+  id: 'detect',
+  label: 'Detecting framework',
+  // The platform gate runs on a direct detectFramework call BEFORE the full
+  // detect writes to the store: store setters replace the session with a
+  // shallow copy, so `ctx.session` read after detectPostHogIntegration would
+  // be the stale pre-copy object (see the warning in detect.ts).
+  onReady: async (ctx: ProgramReadyContext) => {
+    const integration = await detectFramework(ctx.session.installDir);
+    if (integration && !REPLAY_VISION_SUPPORTED.has(integration)) {
+      await abortUnsupportedPlatform(integration);
+      return;
+    }
+    await detectPostHogIntegration(ctx);
+  },
+};
+
+const base = createSkillProgram({
+  skillId: 'replay-vision',
+  command: 'replay-vision',
+  id: 'replay-vision',
+  description: 'Set up PostHog Replay vision scanners for your product',
+  integrationLabel: 'replay-vision',
+  customPrompt:
+    'Set up PostHog Replay vision. Run the `replay-vision` skill end-to-end: ' +
+    'make sure session replay is recording (server-side enable plus a ' +
+    'posthog-js init check), then create the vision scanners the skill ' +
+    "defines, scoped to this product's key flows read out of the repo. If " +
+    'PostHog is not integrated yet, install and initialize the SDK first as ' +
+    'the skill instructs — do not abort. The final report is written to ' +
+    `./${REPLAY_VISION_REPORT_FILE}.`,
+  successMessage: `Replay vision configured! View the report at ./${REPLAY_VISION_REPORT_FILE}`,
+  reportFile: REPLAY_VISION_REPORT_FILE,
+  docsUrl: 'https://posthog.com/docs/replay-vision',
+  spinnerMessage: 'Setting up Replay vision...',
+  estimatedDurationMinutes: 6,
+  abortCases: REPLAY_VISION_ABORT_CASES,
+});
+
+/**
+ * `wizard replay-vision` — flat skill command on the orchestrator sequence.
+ *
+ * Makes session replay record (server toggle + client init check), then
+ * creates vision scanners scoped to the product's key flows, read out of the
+ * repo. The orchestrator runs the `replay-vision` agent flow (context-mill
+ * `context/agents/replay-vision`): the seed enqueues the install/init tasks
+ * (copied from integration-v2, sharing its step-skills) when the project has
+ * no PostHog yet, so the command works on uninstrumented repos instead of
+ * aborting.
+ *
+ * Departures from a plain `createSkillProgram`:
+ * - `DETECT_STEP` in front, so `session.skillId` carries the framework id the
+ *   orchestrator's preflight resolves reference + mini-skill variants with.
+ * - `agentFlow` pinned (the id would default to the same value — explicit so
+ *   renaming the program can't silently detach the flow).
+ * - `ciPreRun` mirrors the default integration program: scope the install dir
+ *   to the right project (monorepos), then detect the framework — the
+ *   headless equivalent of the detect step's onReady hook.
+ */
+export const replayVisionConfig: ProgramConfig = {
+  ...base,
+  agentFlow: 'replay-vision',
+  steps: [DETECT_STEP, ...AGENT_SKILL_STEPS],
+
+  ciPreRun: async (session: WizardSession): Promise<void> => {
+    await scopeInstallDirToProject(session);
+
+    const integration = await detectFramework(session.installDir);
+    if (!integration) {
+      await wizardAbort({
+        message: 'Could not auto-detect your framework for this project.',
+      });
+      return;
+    }
+    if (!REPLAY_VISION_SUPPORTED.has(integration)) {
+      await abortUnsupportedPlatform(integration);
+      return;
+    }
+    session.integration = integration;
+    analytics.setTag('integration', integration);
+
+    const frameworkConfig = FRAMEWORK_REGISTRY[integration];
+    session.frameworkConfig = frameworkConfig;
+    session.skillId = integration;
+
+    const context = await gatherFrameworkContext(frameworkConfig, {
+      installDir: session.installDir,
+      debug: session.debug,
+      default: false,
+      signup: session.signup,
+      localMcp: session.localMcp,
+      ci: true,
+      benchmark: session.benchmark,
+      yaraReport: session.yaraReport,
+    });
+    for (const [key, value] of Object.entries(context)) {
+      if (!(key in session.frameworkContext)) {
+        session.frameworkContext[key] = value;
+      }
+    }
+  },
+};

--- a/src/lib/programs/replay-vision/index.ts
+++ b/src/lib/programs/replay-vision/index.ts
@@ -109,7 +109,12 @@ const DETECT_STEP: ProgramStep = {
 };
 
 const base = createSkillProgram({
-  skillId: 'replay-vision',
+  // The menu ids this skill `<dir>-<variant>`, and context-mill's
+  // `replay-vision/config.yaml` declares a single variant, `setup`. The bare
+  // `replay-vision` id does not exist — the orchestrator never installs this
+  // (it resolves per-task mini-skills instead), but the linear path does, and
+  // aborts `skill-not-found` on a miss.
+  skillId: 'replay-vision-setup',
   command: 'replay-vision',
   id: 'replay-vision',
   description: 'Set up PostHog Replay vision scanners for your product',

--- a/src/lib/programs/replay-vision/test/e2e.json
+++ b/src/lib/programs/replay-vision/test/e2e.json
@@ -1,0 +1,44 @@
+{
+  "program": "replay-vision",
+  "summary": "Happy path: detect framework (platform gate), confirm intro, run the replay-vision orchestrator flow (enable replay + three scanners + report), delete installed skills. On an unsupported platform (pure backend, KMP) the run aborts at detect with the friendly platform explanation before any work.",
+  "profile": {
+    "setup": "first",
+    "healthCheck": "dismiss",
+    "mcp": "skip",
+    "slack": "skip",
+    "skills": "delete",
+    "ask": "first"
+  },
+  "variations": [
+    {
+      "name": "default",
+      "summary": "orchestrator / anthropic / sonnet — the program's pinned binding"
+    },
+    {
+      "name": "linear-fallback",
+      "summary": "linear arm: the command skill drives the same step-skills single-agent",
+      "sequence": "linear"
+    }
+  ],
+  "path": [
+    {
+      "screen": "(headless detect)",
+      "auto": "framework detection; unsupported platforms abort here with the Replay-vision platform message — that abort screen is the snapshot for the negative case"
+    },
+    { "screen": "agent-skill-intro", "auto": "confirm & continue" },
+    {
+      "screen": "health-check",
+      "auto": "dismiss outage — proceed even if the readiness probe flags an issue"
+    },
+    { "screen": "auth", "auto": "(external) — the runner injects credentials" },
+    {
+      "screen": "run",
+      "auto": "(external) — orchestrator: seed plans the graph (install/init only when PostHog is missing), enable-replay, three scanner tasks in parallel, report sink"
+    },
+    { "screen": "outro", "auto": "dismiss" },
+    {
+      "screen": "keep-skills",
+      "auto": "delete — leave nothing behind (terminal: the run's done-signal)"
+    }
+  ]
+}


### PR DESCRIPTION
New `wizard replay-vision` product command, wired to the context-mill replay-vision skill group and pinned to the orchestrator sequence in `PROGRAM_BINDINGS`.

<img width="833" height="734" alt="Screenshot 2026-08-18 at 1 36 03 PM" src="https://github.com/user-attachments/assets/042db3f1-84a4-4844-851f-a7883a47ccb7" />
<img width="833" height="734" alt="Screenshot 2026-08-18 at 1 36 12 PM" src="https://github.com/user-attachments/assets/074679ed-1013-45e8-b1d6-abf231743d46" />

Probably needs carefully testing but it's a start

https://github.com/PostHog/context-mill/pull/343