### PR TITLE
feat: adding deps for runnerSeeded tasks; move dw sources to the end 

### DIFF
--- a/src/lib/agent/__tests__/agent-prompt-loader.test.ts
+++ b/src/lib/agent/__tests__/agent-prompt-loader.test.ts
@@ -59,6 +59,26 @@ Add at least one capture call.
     expect(p.dependsOn).toEqual(['init']);
   });
 
+  it('reads dependsOn past a whole-line comment explaining it', () => {
+    // The shape integration-v2's warehouse agent uses: the ordering is
+    // non-obvious enough to need a note, and the note must not eat the field.
+    const p = parseAgentPrompt(
+      `---
+type: warehouse
+runnerSeeded: true
+# You are the only step that stops for the user, so you go last.
+dependsOn: [review, dashboard]
+---
+
+## Goal
+Connect the sources.
+`,
+      'fallback',
+    );
+    expect(p.runnerSeeded).toBe(true);
+    expect(p.dependsOn).toEqual(['review', 'dashboard']);
+  });
+
   it('resolves the per-harness model + effort, not 1:1 across providers', () => {
     const p = parseAgentPrompt(sample, 'fallback');
     expect(promptModelFor(p, 'pi')).toEqual({
@@ -526,6 +546,24 @@ describe('assembleSeedPrompt', () => {
     ]);
     expect(prompt).toContain('warehouse (id: abc-123)');
     expect(prompt).toContain('Do not queue them again');
+  });
+
+  it('tells the planner the edge is one-way — sink in, nothing else', () => {
+    const ctx = {
+      projectId: 1,
+      projectApiKey: 'k',
+      host: { apiHost: 'https://h' },
+    } as Parameters<typeof assembleSeedPrompt>[0];
+
+    const prompt = assembleSeedPrompt(ctx, 'plan it', [
+      { id: 'abc-123', type: 'warehouse' },
+    ]);
+
+    // A pre-queued task is deferred to the end of the drain and may block on a
+    // person, so a task hung off it would wait on the user — the interruption
+    // deferring it removed.
+    expect(prompt).toContain('hang nothing else off them');
+    expect(prompt).toContain('reporting task depend on each one');
   });
 
   it('says nothing about pre-queued tasks when there are none', () => {

--- a/src/lib/agent/agent-prompt-loader.ts
+++ b/src/lib/agent/agent-prompt-loader.ts
@@ -90,13 +90,20 @@ const SEED_BASICS = `You are the orchestrator. Plan the work and seed the queue 
  * Tasks the wizard queued before the planner ran. It has to see them: they are
  * part of the run it is planning around, and the task that reports last has to
  * depend on them. Their ids are real, so it can wire the edge directly.
+ *
+ * The one-way rule matters as much as the sink edge. These tasks are deferred to
+ * the end of the drain after planning (`seeded-deps.ts`) and may block on a
+ * person, so a task the planner hangs off one would wait on the user too — which
+ * is the interruption deferring them removed. The resolver drops such a task
+ * from the seeded task's own dependencies to stay acyclic, so the damage is
+ * silent; saying so here is what prevents it.
  */
 function preQueuedTasks(
   tasks: readonly { id: string; type: string }[],
 ): string | null {
   if (tasks.length === 0) return null;
   const lines = tasks.map((t) => `- ${t.type} (id: ${t.id})`);
-  return `The queue already holds these tasks, placed by the wizard from what it found in this project. Do not queue them again — plan around them, and make sure the reporting task ends up depending on each one:\n${lines.join(
+  return `The queue already holds these tasks, placed by the wizard from what it found in this project. Do not queue them again. They run late — after every task you queue — and one may stop to ask the user for input, so make the reporting task depend on each one and hang nothing else off them: any other task you made depend on one would end up waiting on a person.\n${lines.join(
     '\n',
   )}`;
 }
@@ -207,6 +214,17 @@ export interface AgentPrompt {
   skills: string[];
   allowedTools: string[];
   disallowedTools: string[];
+  /**
+   * Task types this one runs after. Read differently by the two kinds of task:
+   *
+   * - **Enqueueable types**: advisory. The planner authors the real graph with
+   *   `enqueue_task`, passing ids, and its seed prompt describes the shape it
+   *   should build. Nothing resolves this field for them.
+   * - **`runnerSeeded` types**: authoritative. Such a task is queued before the
+   *   planner runs, so it cannot name ids; the runner resolves these types to
+   *   the ids the planner produced and applies them (see `seeded-deps.ts`).
+   *   Empty means "after everything that is not the sink".
+   */
   dependsOn: string[];
   body: string;
 }

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
@@ -243,3 +243,148 @@ describe('optional task failure', () => {
     expect(store.isDrained()).toBe(true);
   });
 });
+
+/**
+ * The one sanctioned mutation of `dependsOn`: closing the gap for a task queued
+ * before the planner ran. Additive, pending-only, cycle-checked — the three
+ * rules that keep the queue a DAG.
+ */
+describe('addDependencies', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'queue-deps-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('adds edges to a pending task and blocks it behind them', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const install = store.enqueue({ type: 'install' });
+    expect(store.nextRunnable().map((t) => t.id)).toContain(warehouse.id);
+
+    const result = store.addDependencies(warehouse.id, [install.id]);
+
+    expect(result).toEqual({ added: [install.id], refused: [] });
+    expect(store.get(warehouse.id)?.dependsOn).toEqual([install.id]);
+    // The point of the whole change: it is no longer in the first tier.
+    expect(store.nextRunnable().map((t) => t.id)).not.toContain(warehouse.id);
+  });
+
+  it('is additive — it never drops an edge the task already had', () => {
+    const first = store.enqueue({ type: 'install' });
+    const warehouse = store.enqueue({
+      type: 'warehouse',
+      dependsOn: [first.id],
+    });
+    const second = store.enqueue({ type: 'init' });
+
+    store.addDependencies(warehouse.id, [second.id]);
+
+    expect(store.get(warehouse.id)?.dependsOn).toEqual([first.id, second.id]);
+  });
+
+  it('ignores an edge that is already there, without reporting a refusal', () => {
+    const install = store.enqueue({ type: 'install' });
+    const warehouse = store.enqueue({
+      type: 'warehouse',
+      dependsOn: [install.id],
+    });
+
+    expect(store.addDependencies(warehouse.id, [install.id])).toEqual({
+      added: [],
+      refused: [],
+    });
+    expect(store.get(warehouse.id)?.dependsOn).toEqual([install.id]);
+  });
+
+  it('refuses a dependency that would close a cycle', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const report = store.enqueue({
+      type: 'report',
+      dependsOn: [warehouse.id],
+    });
+
+    const result = store.addDependencies(warehouse.id, [report.id]);
+
+    expect(result).toEqual({ added: [], refused: [report.id] });
+    expect(store.get(warehouse.id)?.dependsOn).toEqual([]);
+  });
+
+  it('refuses a cycle through a longer chain', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const mid = store.enqueue({ type: 'capture', dependsOn: [warehouse.id] });
+    const far = store.enqueue({ type: 'review', dependsOn: [mid.id] });
+
+    expect(store.addDependencies(warehouse.id, [far.id]).refused).toEqual([
+      far.id,
+    ]);
+  });
+
+  it('refuses an unknown id', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+
+    expect(store.addDependencies(warehouse.id, ['nope'])).toEqual({
+      added: [],
+      refused: ['nope'],
+    });
+  });
+
+  it('ignores a self-loop', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+
+    expect(store.addDependencies(warehouse.id, [warehouse.id])).toEqual({
+      added: [],
+      refused: [],
+    });
+    expect(store.get(warehouse.id)?.dependsOn).toEqual([]);
+  });
+
+  it('adds the good edges and refuses only the bad ones', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const install = store.enqueue({ type: 'install' });
+    const report = store.enqueue({
+      type: 'report',
+      dependsOn: [warehouse.id],
+    });
+
+    const result = store.addDependencies(warehouse.id, [
+      install.id,
+      report.id,
+      'nope',
+    ]);
+
+    expect(result.added).toEqual([install.id]);
+    expect(result.refused).toEqual([report.id, 'nope']);
+  });
+
+  it('leaves a task that already started alone', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const install = store.enqueue({ type: 'install' });
+    store.start(warehouse.id);
+
+    const result = store.addDependencies(warehouse.id, [install.id]);
+
+    expect(result).toEqual({ added: [], refused: [install.id] });
+    expect(store.get(warehouse.id)?.dependsOn).toEqual([]);
+  });
+
+  it('reflects the new edges to queue.json', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+    const install = store.enqueue({ type: 'install' });
+    store.addDependencies(warehouse.id, [install.id]);
+
+    const file = JSON.parse(
+      fs.readFileSync(store.queuePath, 'utf8'),
+    ) as QueueFile;
+    expect(file.tasks.find((t) => t.id === warehouse.id)?.dependsOn).toEqual([
+      install.id,
+    ]);
+  });
+
+  it('throws for a task that is not in the queue at all', () => {
+    expect(() => store.addDependencies('nope', [])).toThrow('No task nope');
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/run-metrics.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/run-metrics.test.ts
@@ -65,4 +65,28 @@ describe('RunMetrics', () => {
     m.recordStart(2500); // gap 500
     expect(m.summary().max_gap_ms).toBe(2000);
   });
+  it('times the first ask from run start, and only the first', () => {
+    const m = new RunMetrics(0);
+    m.recordStart(0);
+    m.recordAsk(30_000);
+    m.recordAsk(45_000);
+    expect(m.summary().time_to_first_ask_ms).toBe(30_000);
+  });
+
+  it('leaves the first-ask timing unset on a run that asked nothing', () => {
+    const m = new RunMetrics(0);
+    m.recordStart(0);
+    m.recordComplete(1000);
+    expect(m.summary().time_to_first_ask_ms).toBeUndefined();
+  });
+
+  it('does not count waiting on a person as visible progress', () => {
+    const m = new RunMetrics(0);
+    m.recordStart(0);
+    // A long human pause is not a silence the wizard is responsible for, so it
+    // must not land in max_gap_ms.
+    m.recordAsk(60_000);
+    m.recordComplete(2000);
+    expect(m.summary().max_gap_ms).toBe(2000);
+  });
 });

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/seeded-deps.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/seeded-deps.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Where a runner-seeded task lands in the planner's graph.
+ *
+ * The task is queued before the planner runs, so it has no dependencies at
+ * enqueue and would otherwise run in the first drain tier — for the warehouse
+ * step, that means credential prompts arriving while the coding tasks are still
+ * writing files. These cover the resolution that moves it to the end.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('@utils/analytics', () => ({
+  analytics: { wizardCapture: vi.fn(), captureException: vi.fn() },
+}));
+
+import {
+  QueueStore,
+  type QueuedTask,
+} from '@lib/agent/runner/sequence/orchestrator/queue';
+import {
+  deferSeededTasks,
+  seededDependencies,
+} from '@lib/agent/runner/sequence/orchestrator/seeded-deps';
+
+const SINKS = ['report'];
+
+/**
+ * The real integration-v2 graph: the seeded warehouse task first (as the runner
+ * queues it), then the shape the planner builds around it.
+ */
+function plannedQueue(store: QueueStore): {
+  warehouse: QueuedTask;
+  byType: Record<string, QueuedTask>;
+} {
+  const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+  const install = store.enqueue({ type: 'install' });
+  const init = store.enqueue({ type: 'init' });
+  const identify = store.enqueue({
+    type: 'identify',
+    dependsOn: [install.id, init.id],
+  });
+  const errorTracking = store.enqueue({
+    type: 'error-tracking',
+    dependsOn: [install.id, init.id],
+  });
+  const capture = store.enqueue({ type: 'capture', dependsOn: [identify.id] });
+  const review = store.enqueue({
+    type: 'review',
+    dependsOn: [install.id, init.id, identify.id, errorTracking.id, capture.id],
+  });
+  const dashboard = store.enqueue({
+    type: 'dashboard',
+    dependsOn: [capture.id],
+  });
+  // The sink waits for everything, the seeded task included — the planner is
+  // told to, and the sink-closure guard enforces it.
+  const report = store.enqueue({
+    type: 'report',
+    dependsOn: [dashboard.id, review.id, warehouse.id],
+  });
+  return {
+    warehouse,
+    byType: {
+      install,
+      init,
+      identify,
+      'error-tracking': errorTracking,
+      capture,
+      review,
+      dashboard,
+      report,
+    },
+  };
+}
+
+describe('seededDependencies', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seeded-deps-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  describe('with types declared in frontmatter', () => {
+    it('resolves the declared types to the planner’s ids', () => {
+      const { warehouse, byType } = plannedQueue(store);
+
+      const result = seededDependencies(
+        store,
+        warehouse.id,
+        ['review', 'dashboard'],
+        SINKS,
+      );
+
+      expect(result.declared).toBe(true);
+      expect(result.depIds.sort()).toEqual(
+        [byType.review.id, byType.dashboard.id].sort(),
+      );
+      expect(result.unresolvedTypes).toEqual([]);
+    });
+
+    it('waits for every task of a fanned-out type, not just the first', () => {
+      const warehouse = store.enqueue({ type: 'warehouse' });
+      const first = store.enqueue({ type: 'capture' });
+      const second = store.enqueue({ type: 'capture' });
+
+      const result = seededDependencies(
+        store,
+        warehouse.id,
+        ['capture'],
+        SINKS,
+      );
+
+      expect(result.depIds.sort()).toEqual([first.id, second.id].sort());
+    });
+
+    it('drops a declared type the planner never queued, and names it', () => {
+      const { warehouse, byType } = plannedQueue(store);
+
+      const result = seededDependencies(
+        store,
+        warehouse.id,
+        ['review', 'migrate'],
+        SINKS,
+      );
+
+      expect(result.depIds).toEqual([byType.review.id]);
+      expect(result.unresolvedTypes).toEqual(['migrate']);
+    });
+
+    it('never takes a sink as a dependency, even when one is declared', () => {
+      const { warehouse, byType } = plannedQueue(store);
+
+      const result = seededDependencies(store, warehouse.id, ['report'], SINKS);
+
+      expect(result.depIds).toEqual([]);
+      // The sink was queued, so it resolved — it is just not usable as an edge.
+      expect(result.unresolvedTypes).toEqual([]);
+      expect(result.depIds).not.toContain(byType.report.id);
+    });
+  });
+
+  describe('with no types declared', () => {
+    it('waits for every task that is not the sink', () => {
+      const { warehouse, byType } = plannedQueue(store);
+
+      const result = seededDependencies(store, warehouse.id, [], SINKS);
+
+      expect(result.declared).toBe(false);
+      expect(result.depIds.sort()).toEqual(
+        [
+          byType.install.id,
+          byType.init.id,
+          byType.identify.id,
+          byType['error-tracking'].id,
+          byType.capture.id,
+          byType.review.id,
+          byType.dashboard.id,
+        ].sort(),
+      );
+    });
+
+    it('leaves the sink out, so a planner that forgot the edge is still caught', () => {
+      const { warehouse, byType } = plannedQueue(store);
+
+      const result = seededDependencies(store, warehouse.id, [], SINKS);
+
+      expect(result.depIds).not.toContain(byType.report.id);
+    });
+
+    it('never depends on itself', () => {
+      const { warehouse } = plannedQueue(store);
+
+      const result = seededDependencies(store, warehouse.id, [], SINKS);
+
+      expect(result.depIds).not.toContain(warehouse.id);
+    });
+  });
+
+  describe('cycle safety', () => {
+    it('excludes a non-sink task the planner hung off the seeded task', () => {
+      const warehouse = store.enqueue({ type: 'warehouse' });
+      const install = store.enqueue({ type: 'install' });
+      // Downstream of the seeded task: depending on it back would close a loop.
+      const downstream = store.enqueue({
+        type: 'capture',
+        dependsOn: [warehouse.id],
+      });
+
+      const result = seededDependencies(store, warehouse.id, [], SINKS);
+
+      expect(result.depIds).toEqual([install.id]);
+      expect(result.depIds).not.toContain(downstream.id);
+    });
+
+    it('excludes a transitively downstream task', () => {
+      const warehouse = store.enqueue({ type: 'warehouse' });
+      const mid = store.enqueue({ type: 'capture', dependsOn: [warehouse.id] });
+      const far = store.enqueue({ type: 'review', dependsOn: [mid.id] });
+
+      const result = seededDependencies(store, warehouse.id, [], SINKS);
+
+      expect(result.depIds).toEqual([]);
+      expect(result.depIds).not.toContain(far.id);
+    });
+
+    it('refuses a declared type that is downstream rather than inverting it', () => {
+      const warehouse = store.enqueue({ type: 'warehouse' });
+      store.enqueue({ type: 'review', dependsOn: [warehouse.id] });
+
+      const result = seededDependencies(store, warehouse.id, ['review'], SINKS);
+
+      expect(result.depIds).toEqual([]);
+      expect(result.unresolvedTypes).toEqual([]);
+    });
+  });
+
+  it('returns nothing for a queue holding only the seeded task', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+
+    expect(seededDependencies(store, warehouse.id, [], SINKS)).toEqual({
+      depIds: [],
+      unresolvedTypes: [],
+      declared: false,
+    });
+  });
+});
+
+/**
+ * The wiring the runner uses: each seeded task's own prompt supplies its declared
+ * types, and the edges land on the queue.
+ */
+describe('deferSeededTasks', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'defer-seeded-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  /**
+   * A prompt that declares its own position. No shipped flow does today —
+   * integration-v2's warehouse agent leaves `dependsOn` empty and takes the
+   * default — but the mechanism is generic, so it is covered here for the
+   * seeded task that eventually needs a shallower position than "last".
+   */
+  const declaredTypesFor = (type: string) =>
+    type === 'warehouse' ? ['review', 'dashboard'] : [];
+
+  it('applies the prompt’s declared types to the queue', () => {
+    const { warehouse, byType } = plannedQueue(store);
+
+    const [entry] = deferSeededTasks(
+      store,
+      [warehouse],
+      declaredTypesFor,
+      SINKS,
+    );
+
+    expect(entry).toMatchObject({
+      type: 'warehouse',
+      declared: true,
+      declaredTypes: ['review', 'dashboard'],
+      refused: [],
+      unresolvedTypes: [],
+    });
+    expect(store.get(warehouse.id)?.dependsOn.sort()).toEqual(
+      [byType.review.id, byType.dashboard.id].sort(),
+    );
+  });
+
+  it('moves the seeded task out of the first drain tier', () => {
+    const { warehouse } = plannedQueue(store);
+    expect(store.nextRunnable().map((t) => t.type)).toContain('warehouse');
+
+    deferSeededTasks(store, [warehouse], declaredTypesFor, SINKS);
+
+    expect(store.nextRunnable().map((t) => t.type)).not.toContain('warehouse');
+    expect(
+      store
+        .nextRunnable()
+        .map((t) => t.type)
+        .sort(),
+    ).toEqual(['init', 'install']);
+  });
+
+  it('falls back to the default when the prompt declares nothing', () => {
+    const { warehouse, byType } = plannedQueue(store);
+
+    const [entry] = deferSeededTasks(store, [warehouse], () => [], SINKS);
+
+    expect(entry.declared).toBe(false);
+    expect(entry.added).toHaveLength(7);
+    expect(store.get(warehouse.id)?.dependsOn).not.toContain(byType.report.id);
+  });
+
+  it('does nothing when the run seeded no task', () => {
+    plannedQueue(store);
+    expect(deferSeededTasks(store, [], declaredTypesFor, SINKS)).toEqual([]);
+  });
+
+  it('handles several seeded tasks independently', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const other = store.enqueue({ type: 'migrate', optional: true });
+    const install = store.enqueue({ type: 'install' });
+    const review = store.enqueue({ type: 'review', dependsOn: [install.id] });
+    const dashboard = store.enqueue({ type: 'dashboard' });
+
+    const entries = deferSeededTasks(
+      store,
+      [warehouse, other],
+      declaredTypesFor,
+      SINKS,
+    );
+
+    expect(entries.map((e) => e.type)).toEqual(['warehouse', 'migrate']);
+    // warehouse took its declared types; migrate declared none, so it waits for
+    // everything non-sink — the other seeded task included.
+    expect(store.get(warehouse.id)?.dependsOn.sort()).toEqual(
+      [review.id, dashboard.id].sort(),
+    );
+    expect(store.get(other.id)?.dependsOn).toContain(install.id);
+    expect(store.get(other.id)?.dependsOn).toContain(warehouse.id);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/sink-closure.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/sink-closure.test.ts
@@ -328,3 +328,162 @@ describe('a declined seeded task', () => {
     expect(store.isDrained()).toBe(true);
   });
 });
+
+/**
+ * The one-way rule, enforced.
+ *
+ * A runner-seeded task is deferred to the end and stops to ask the user for
+ * input, so anything waiting on it inherits that wait. Prose in the seed prompt
+ * cannot hold this: one planner edge empties the seeded task's resolved
+ * dependencies (the resolver drops anything downstream of it to stay acyclic)
+ * and drops it back to depth 0 — the exact placement deferring it removes.
+ */
+describe('one-way rule for runner-seeded tasks', () => {
+  let dir: string;
+  let store: QueueStore;
+  let ctx: OrchestratorToolsContext;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'one-way-test-'));
+    store = new QueueStore(dir, 'run-1');
+    ctx = {
+      store,
+      validTypes: VALID,
+      sinkTypes: SINKS,
+      runnerSeededTypes: ['warehouse'],
+    };
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('rejects a non-sink task that depends on the seeded task directly', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+
+    const r = checkEnqueueGuards(ctx, {
+      type: 'install',
+      dependsOn: [warehouse.id],
+      reason: 'x',
+    });
+
+    expect(r).toMatchObject({ ok: false, guard: 'seeded-dep' });
+    expect(r.ok === false && r.message).toContain('only the final reporting');
+  });
+
+  it('rejects one that reaches it through an intermediate hop', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    // The intermediate would itself be rejected; construct it directly to prove
+    // the guard walks the closure rather than only direct dependencies.
+    const install = store.enqueue({
+      type: 'install',
+      dependsOn: [warehouse.id],
+    });
+
+    const r = checkEnqueueGuards(ctx, {
+      type: 'capture',
+      dependsOn: [install.id],
+      reason: 'x',
+    });
+
+    expect(r).toMatchObject({ ok: false, guard: 'seeded-dep' });
+  });
+
+  it('still lets the sink depend on it — that edge is required', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+
+    expect(
+      checkEnqueueGuards(ctx, {
+        type: 'report',
+        dependsOn: [install.id, warehouse.id],
+        reason: 'x',
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it('leaves ordinary dependencies between planner tasks alone', () => {
+    store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+
+    expect(
+      checkEnqueueGuards(ctx, {
+        type: 'capture',
+        dependsOn: [install.id],
+        reason: 'x',
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it('is inert for a flow with no runner-seeded types', () => {
+    const warehouse = store.enqueue({ type: 'warehouse' });
+
+    expect(
+      checkEnqueueGuards(
+        { store, validTypes: VALID, sinkTypes: SINKS },
+        { type: 'install', dependsOn: [warehouse.id], reason: 'x' },
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it('points a sink at the only legal placement for a seeded task', () => {
+    store.enqueue({ type: 'warehouse', optional: true });
+
+    const r = checkEnqueueGuards(ctx, { type: 'report', reason: 'x' });
+
+    expect(r).toMatchObject({ ok: false, guard: 'sink-closure' });
+    // The generic advice ("or to a task already in dependsOn") is what invited
+    // the broken shape in the first place.
+    expect(r.ok === false && r.message).not.toContain(
+      'a task already in dependsOn',
+    );
+    expect(r.ok === false && r.message).toContain('only legal spot');
+  });
+
+  it('keeps the generic sink advice when no seeded task is uncovered', () => {
+    const install = store.enqueue({ type: 'install' });
+    store.enqueue({ type: 'capture', dependsOn: [install.id] });
+
+    const r = checkEnqueueGuards(ctx, { type: 'report', reason: 'x' });
+
+    expect(r).toMatchObject({ ok: false, guard: 'sink-closure' });
+    expect(r.ok === false && r.message).toContain(
+      'a task already in dependsOn',
+    );
+  });
+
+  it('the guard is what keeps the seeded task at the end of the drain', () => {
+    // Without it: install depends on warehouse, the resolver drops install and
+    // everything downstream, and warehouse runs alone in the first tier.
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const rejected = checkEnqueueGuards(ctx, {
+      type: 'install',
+      dependsOn: [warehouse.id],
+      reason: 'x',
+    });
+    expect(rejected.ok).toBe(false);
+
+    // With the edge refused, the planner queues install unattached, and the
+    // deferral puts warehouse where it belongs.
+    const install = store.enqueue({ type: 'install' });
+    const capture = store.enqueue({ type: 'capture', dependsOn: [install.id] });
+    store.enqueue({ type: 'report', dependsOn: [capture.id, warehouse.id] });
+    const deferred = seededDependencies(store, warehouse.id, [], SINKS);
+    store.addDependencies(warehouse.id, deferred.depIds);
+
+    const tiers: string[][] = [];
+    for (;;) {
+      const runnable = store.nextRunnable();
+      if (runnable.length === 0) break;
+      tiers.push(runnable.map((t) => t.type).sort());
+      for (const t of runnable) {
+        store.start(t.id);
+        store.complete(t.id);
+      }
+    }
+    expect(tiers).toEqual([
+      ['install'],
+      ['capture'],
+      ['warehouse'],
+      ['report'],
+    ]);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/sink-closure.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/sink-closure.test.ts
@@ -20,6 +20,7 @@ import {
   uncoveredBySink,
   type OrchestratorToolsContext,
 } from '@lib/agent/runner/sequence/orchestrator/queue-tools';
+import { seededDependencies } from '@lib/agent/runner/sequence/orchestrator/seeded-deps';
 
 const VALID = ['warehouse', 'install', 'capture', 'report'];
 const SINKS = ['report'];
@@ -143,7 +144,10 @@ describe('displayOrder', () => {
       'capture',
       'report',
     ]);
-    // The optional task still has nothing to wait for, so it starts at once.
+    // This fixture is the queue as the planner leaves it, before the runner
+    // defers the seeded task — which is why displayOrder needed an
+    // optional-last rule at all. In a real run the deferral has happened by
+    // now and the task genuinely is last; see the deferred suites below.
     expect(store.nextRunnable().map((t) => t.type)).toContain('warehouse');
   });
 
@@ -169,5 +173,158 @@ describe('displayOrder', () => {
       'identify',
       'error-tracking',
     ]);
+  });
+});
+
+/**
+ * Deferring a runner-seeded task rewires the graph between planning and the
+ * drain, so the sink invariant has to survive it — and the guard that catches a
+ * planner which forgot the sink→seeded edge must keep catching it.
+ */
+describe('sink closure with a deferred seeded task', () => {
+  let dir: string;
+  let store: QueueStore;
+  let ctx: OrchestratorToolsContext;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sink-deferred-test-'));
+    store = new QueueStore(dir, 'run-1');
+    ctx = { store, validTypes: VALID, sinkTypes: SINKS };
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('still covers the whole queue once the seeded task runs last', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+    const capture = store.enqueue({ type: 'capture', dependsOn: [install.id] });
+    // The planner wires the sink to everything, seeded task included.
+    const report = store.enqueue({
+      type: 'report',
+      dependsOn: [capture.id, warehouse.id],
+    });
+
+    // Defer: warehouse now waits for the work it used to run alongside.
+    const deferred = seededDependencies(store, warehouse.id, [], SINKS);
+    store.addDependencies(warehouse.id, deferred.depIds);
+
+    const uncovered = uncoveredBySink(ctx, {
+      type: 'report',
+      dependsOn: report.dependsOn,
+    }).filter((t) => t.id !== report.id);
+    expect(uncovered).toEqual([]);
+  });
+
+  it('runs the seeded task after the code work but before the sink', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+    const capture = store.enqueue({ type: 'capture', dependsOn: [install.id] });
+    store.enqueue({ type: 'report', dependsOn: [capture.id, warehouse.id] });
+
+    const deferred = seededDependencies(store, warehouse.id, [], SINKS);
+    store.addDependencies(warehouse.id, deferred.depIds);
+
+    // Nothing runnable but install, so the ask cannot land yet.
+    expect(store.nextRunnable().map((t) => t.type)).toEqual(['install']);
+
+    const drain = (type: string) => {
+      const task = store.nextRunnable().find((t) => t.type === type);
+      if (!task) throw new Error(`${type} was not runnable`);
+      store.start(task.id);
+      store.complete(task.id);
+    };
+    drain('install');
+    drain('capture');
+
+    // Only now, with the code work done, does the human-blocking step open.
+    expect(store.nextRunnable().map((t) => t.type)).toEqual(['warehouse']);
+    drain('warehouse');
+    expect(store.nextRunnable().map((t) => t.type)).toEqual(['report']);
+  });
+
+  it('leaves a planner that forgot the sink edge still failing the invariant', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+    // The planner omits warehouse from the sink's dependencies.
+    const report = store.enqueue({ type: 'report', dependsOn: [install.id] });
+
+    const deferred = seededDependencies(store, warehouse.id, [], SINKS);
+    store.addDependencies(warehouse.id, deferred.depIds);
+
+    // Deferring must not paper this over by inverting the edge.
+    expect(store.get(warehouse.id)?.dependsOn).not.toContain(report.id);
+    const uncovered = uncoveredBySink(ctx, {
+      type: 'report',
+      dependsOn: report.dependsOn,
+    }).filter((t) => t.id !== report.id);
+    expect(uncovered.map((t) => t.type)).toEqual(['warehouse']);
+  });
+
+  it('sorts the deferred task last in the display order it now really runs in', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+    store.enqueue({ type: 'report', dependsOn: [install.id, warehouse.id] });
+
+    const deferred = seededDependencies(store, warehouse.id, [], SINKS);
+    store.addDependencies(warehouse.id, deferred.depIds);
+
+    const order = displayOrder(store.list(), (t) => t.type === 'warehouse').map(
+      (t) => t.type,
+    );
+    expect(order).toEqual(['install', 'warehouse', 'report']);
+  });
+});
+
+/**
+ * Declining the notice at run time. The offer moved from the top of the run to
+ * the moment the step would start, so by then the task is already queued and the
+ * sink already depends on it — declining has to skip it, not remove it.
+ */
+describe('a declined seeded task', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'declined-seeded-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('still lets the sink run, carrying a handoff that says it was declined', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    const install = store.enqueue({ type: 'install' });
+    const report = store.enqueue({
+      type: 'report',
+      dependsOn: [install.id, warehouse.id],
+    });
+    const deferred = seededDependencies(store, warehouse.id, [], SINKS);
+    store.addDependencies(warehouse.id, deferred.depIds);
+
+    store.start(install.id);
+    store.complete(install.id);
+
+    // The step comes up, the notice is shown, the user declines.
+    expect(store.nextRunnable().map((t) => t.type)).toEqual(['warehouse']);
+    store.start(warehouse.id);
+    store.skip(warehouse.id, {
+      goals: 'Connect your data sources',
+      did: 'Nothing — the user chose to skip this step when offered it.',
+      forNextAgent: 'This step was offered and declined, so it did no work.',
+    });
+
+    // The sink is not dammed by the decline, and can say what happened.
+    expect(store.nextRunnable().map((t) => t.id)).toEqual([report.id]);
+    expect(store.readHandoff(warehouse.id)?.did).toContain('chose to skip');
+  });
+
+  it('is not retried — a decline is an answer, not a failure', () => {
+    const warehouse = store.enqueue({ type: 'warehouse', optional: true });
+    store.start(warehouse.id);
+    store.skip(warehouse.id);
+
+    expect(store.get(warehouse.id)?.status).toBe('not needed');
+    expect(store.nextRunnable()).toEqual([]);
+    expect(store.isDrained()).toBe(true);
   });
 });

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/task-notice-timeout.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/task-notice-timeout.test.ts
@@ -97,3 +97,105 @@ describe('task notice timeout', () => {
     }
   });
 });
+
+/**
+ * Two hazards created by offering the notice from inside the drain rather than
+ * from the seed loop. Seeding awaited its notices sequentially, so neither was
+ * reachable before; the executor starts every runnable task at once, so both
+ * are now. Both are pinned here because each fails silently — one as a repeated
+ * modal, the other as a run that never ends.
+ */
+describe('offering a notice from inside the drain', () => {
+  beforeEach(() => {
+    showTaskNotice.mockReset();
+    cancelTaskNotice.mockReset();
+  });
+
+  it('shows a task’s notice at most once, even across a retry', async () => {
+    // The executor requeues a task that ends without reporting, calling runTask
+    // again with the same id. Consent is per task, not per attempt.
+    const notices = new Map<string, TaskNotice>([['task-1', NOTICE]]);
+    showTaskNotice.mockResolvedValue(true);
+
+    const offerOnce = async (taskId: string) => {
+      const notice = notices.get(taskId);
+      if (!notice) return;
+      notices.delete(taskId);
+      await offerSeededTask(notice, 1000);
+    };
+
+    await offerOnce('task-1');
+    await offerOnce('task-1'); // the retry
+
+    expect(showTaskNotice).toHaveBeenCalledTimes(1);
+  });
+
+  it('never puts two notices on screen at once', async () => {
+    // The store holds one pending-notice slot: a second showTaskNotice
+    // overwrites the first's resolver, so the first promise never settles and
+    // its task hangs for the rest of the run.
+    let onScreen = 0;
+    let maxOnScreen = 0;
+    let releaseFirst: ((v: boolean) => void) | undefined;
+
+    showTaskNotice.mockImplementation(() => {
+      onScreen += 1;
+      maxOnScreen = Math.max(maxOnScreen, onScreen);
+      if (!releaseFirst) {
+        return new Promise<boolean>((resolve) => {
+          releaseFirst = (v) => {
+            onScreen -= 1;
+            resolve(v);
+          };
+        });
+      }
+      onScreen -= 1;
+      return Promise.resolve(true);
+    });
+
+    let gate: Promise<unknown> = Promise.resolve();
+    const offer = (): Promise<{ keep: boolean; timedOut: boolean }> => {
+      const p = gate.then(() => offerSeededTask(NOTICE, 60_000));
+      gate = p.catch(() => undefined);
+      return p;
+    };
+
+    const first = offer();
+    const second = offer();
+    await Promise.resolve();
+
+    expect(maxOnScreen).toBe(1);
+    releaseFirst?.(true);
+
+    await expect(first).resolves.toEqual({ keep: true, timedOut: false });
+    await expect(second).resolves.toEqual({ keep: true, timedOut: false });
+    expect(maxOnScreen).toBe(1);
+    expect(showTaskNotice).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Which way consent breaks when the offer itself fails.
+ *
+ * The notice is consumed before it is shown (so a retry cannot re-ask), which
+ * means a thrown offer would otherwise leave the executor's retry path with no
+ * notice to show — and the step would run, and start asking for credentials,
+ * with nobody having agreed to it. It must break towards declining.
+ */
+describe('a notice that fails to show', () => {
+  beforeEach(() => {
+    showTaskNotice.mockReset();
+    cancelTaskNotice.mockReset();
+  });
+
+  it('is treated as a decline, never as consent', async () => {
+    showTaskNotice.mockRejectedValue(new Error('UI blew up'));
+
+    const result = await offerSeededTask(NOTICE, 1000).catch(() => ({
+      keep: false,
+      timedOut: false,
+    }));
+
+    expect(result.keep).toBe(false);
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/task-notice-timeout.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/task-notice-timeout.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The notice's timeout.
+ *
+ * The offer sits in front of the run's last steps, so an unanswered one holds
+ * the report — and with it the notebook and the outro — behind a modal nobody is
+ * looking at. It defaults to declining rather than waiting forever.
+ */
+import type { TaskNotice } from '@lib/wizard-session';
+
+const showTaskNotice = vi.fn<[TaskNotice], Promise<boolean>>();
+const cancelTaskNotice = vi.fn();
+
+vi.mock('@ui', () => ({
+  getUI: () => ({ showTaskNotice, cancelTaskNotice }),
+}));
+vi.mock('@utils/analytics', () => ({
+  analytics: {
+    wizardCapture: vi.fn(),
+    setTag: vi.fn(),
+    capture: vi.fn(),
+    captureException: vi.fn(),
+  },
+}));
+
+import {
+  offerSeededTask,
+  TASK_NOTICE_TIMEOUT_MS,
+} from '@lib/agent/runner/sequence/orchestrator/orchestrator-runner';
+
+const NOTICE: TaskNotice = {
+  title: 'Connect your data sources',
+  body: ['We found some sources.'],
+  items: ['Postgres'],
+  prompt: 'Connect these during setup?',
+  confirmLabel: 'Continue [Enter]',
+  cancelLabel: 'Skip [Esc]',
+};
+
+describe('task notice timeout', () => {
+  beforeEach(() => {
+    showTaskNotice.mockReset();
+    cancelTaskNotice.mockReset();
+  });
+
+  it('waits five minutes before giving up on an answer', () => {
+    expect(TASK_NOTICE_TIMEOUT_MS).toBe(5 * 60 * 1000);
+  });
+
+  it('declines the step when nobody answers, and closes the modal', async () => {
+    vi.useFakeTimers();
+    try {
+      // Nobody presses anything.
+      showTaskNotice.mockReturnValue(new Promise<boolean>(() => undefined));
+
+      const promise = offerSeededTask(NOTICE, 1000);
+      vi.advanceTimersByTime(1000);
+
+      await expect(promise).resolves.toEqual({ keep: false, timedOut: true });
+      // Without this the modal stays on screen over the rest of the run.
+      expect(cancelTaskNotice).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the step when the user accepts in time', async () => {
+    vi.useFakeTimers();
+    try {
+      showTaskNotice.mockResolvedValue(true);
+
+      const result = await offerSeededTask(NOTICE, 1000);
+
+      expect(result).toEqual({ keep: true, timedOut: false });
+      vi.advanceTimersByTime(5000);
+      // The timer must not fire after an answer — it would close a modal that
+      // is no longer there and stamp a second outcome on the step.
+      expect(cancelTaskNotice).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('separates an explicit Skip from a timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      showTaskNotice.mockResolvedValue(false);
+
+      // Both decline, but only one of them means "the user was not there" —
+      // the run reports them differently.
+      await expect(offerSeededTask(NOTICE, 1000)).resolves.toEqual({
+        keep: false,
+        timedOut: false,
+      });
+      expect(cancelTaskNotice).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -60,7 +60,7 @@ import {
 } from './queue';
 import { drainQueue, type RunTask } from './executor';
 import { RunMetrics } from './run-metrics';
-import { uncoveredBySink } from './queue-tools';
+import { dependencyClosure, uncoveredBySink } from './queue-tools';
 import { deferSeededTasks } from './seeded-deps';
 import { createWizardAskBridge } from '@lib/wizard-ask-bridge';
 import { shouldDisableAsk } from '../../shared/bootstrap';
@@ -549,6 +549,11 @@ export async function runOrchestrator(
     // guard instead of duplicating work the wizard already placed.
     validTypes: registry.enqueueableTypes,
     sinkTypes: registry.sinkTypes,
+    // The edge to a runner-seeded task is one-way: the sink may wait for it,
+    // nothing else may. Enforced at enqueue, because prose alone cannot hold it
+    // — a single planner edge is enough to pull the task back to the front of
+    // the drain and put its prompt in front of the code work again.
+    runnerSeededTypes: registry.runnerSeededTypes,
     currentTaskId,
   });
 
@@ -710,6 +715,33 @@ export async function runOrchestrator(
   }
   if (deferred.length > 0) renderQueue();
 
+  // Canary for the one-way rule. The enqueue guard rejects the edge outright, so
+  // this should never fire — but if it ever does, the seeded task has been
+  // pulled back toward the front of the drain and its prompt lands mid-run
+  // again, which is precisely the failure this whole step exists to prevent.
+  // Silent regressions here would look like "the ordering just stopped
+  // working", so make it visible rather than abort a run that is otherwise fine.
+  for (const seeded of seededTasks) {
+    const dependants = store
+      .list()
+      .filter(
+        (t) =>
+          !registry.sinkTypes.includes(t.type) &&
+          t.id !== seeded.id &&
+          dependencyClosure(store, [t.id]).has(seeded.id),
+      );
+    if (dependants.length === 0) continue;
+    logToFile(
+      `[orchestrator] one-way rule broken: ${dependants
+        .map((t) => t.type)
+        .join(', ')} depend on runner-seeded ${seeded.type}`,
+    );
+    analytics.wizardCapture('orchestrator seeded task depended on', {
+      type: seeded.type,
+      dependant_types: dependants.map((t) => t.type),
+    });
+  }
+
   // The enqueue guard rejects a sink that misses part of the queue, so a
   // planner that respected its errors cannot get here with a broken graph.
   // Check it again anyway: a run whose report never sees a task's handoff is
@@ -750,6 +782,16 @@ export async function runOrchestrator(
   const preexistingSkills = new Set(
     existsSync(claudeSkillsDir) ? readdirSync(claudeSkillsDir) : [],
   );
+  // One notice on screen at a time. The store keeps a single pending-notice
+  // slot, so a second `showTaskNotice` overwrites the first's resolver: the
+  // first promise never settles, its task hangs forever, and the overlay stack
+  // is left one deep. Seeding used to await its notices in a loop, which made
+  // that impossible; offering them from inside the drain does not, because the
+  // executor starts every runnable task at once. Today's graphs still serialize
+  // seeded tasks — the default deferral makes each wait for the one before —
+  // but that is a property of the current graph, not a guarantee, so gate it
+  // here where it cannot be undone by a future prompt declaring its own deps.
+  let noticeGate: Promise<unknown> = Promise.resolve();
   const runTask: RunTask = async (task) => {
     renderQueue();
 
@@ -772,7 +814,28 @@ export async function runOrchestrator(
       // outcome with a skip. Later attempts fall through to the executor's
       // normal retry flow instead.
       seededNotices.delete(task.id);
-      const { keep, timedOut } = await offerSeededTask(notice);
+      // Queue behind any notice already on screen. The catch keeps one
+      // offer's failure from poisoning the gate for the next.
+      const offer = noticeGate.then(() => offerSeededTask(notice));
+      noticeGate = offer.catch(() => undefined);
+      // Fail closed. The offer is consumed above, so letting a thrown error
+      // escape would hand the task to the executor's retry path with no notice
+      // left to show — and the second attempt would run the step, and start
+      // asking for credentials, without anyone ever having agreed to it. No UI
+      // implementation throws here today; this is about which way it breaks if
+      // one ever does.
+      const { keep, timedOut } = await offer.catch((err: unknown) => {
+        logToFile(
+          `[orchestrator] notice failed for ${task.type}, declining: ${String(
+            err,
+          )}`,
+        );
+        analytics.captureException(
+          err instanceof Error ? err : new Error(String(err)),
+          { step: 'orchestrator_task_notice' },
+        );
+        return { keep: false, timedOut: false };
+      });
       analytics.wizardCapture('orchestrator task notice answered', {
         type: task.type,
         kept: keep,

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -764,6 +764,14 @@ export async function runOrchestrator(
     // dependency as satisfied, so the report still runs.
     const notice = seededNotices.get(task.id);
     if (notice) {
+      // Consume the offer so it is shown at most once per run. A requeue keeps
+      // the same task id, so without this delete a first attempt that fails or
+      // ends without reporting would re-offer the notice on retry — re-entering
+      // the very timeout stall this screen exists to prevent, double-firing the
+      // notice analytics, and (on a retry decline) overwriting attempt 1's real
+      // outcome with a skip. Later attempts fall through to the executor's
+      // normal retry flow instead.
+      seededNotices.delete(task.id);
       const { keep, timedOut } = await offerSeededTask(notice);
       analytics.wizardCapture('orchestrator task notice answered', {
         type: task.type,

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -20,7 +20,11 @@ import {
   writeFileSync,
 } from 'fs';
 import * as path from 'path';
-import { OutroKind, type WizardSession } from '@lib/wizard-session';
+import {
+  OutroKind,
+  type TaskNotice,
+  type WizardSession,
+} from '@lib/wizard-session';
 import {
   POSTHOG_DOCS_URL,
   WIZARD_CONTACT_EMAIL,
@@ -190,6 +194,48 @@ function resolveReferenceSkillId(
  * — the executor holds the task's promise — so the only real limit is this one.
  */
 const TASK_ASK_TIMEOUT_MS = 20 * 60 * 1000;
+
+/**
+ * How long an optional step's notice waits for an answer.
+ *
+ * Much shorter than the ask timeout above, because it is asking for something
+ * much smaller: one keypress to accept or decline, not "go mint a restricted
+ * Stripe key". The notice is also the only interactive screen sitting in front
+ * of the run's final steps, so an unanswered one holds the report — and with it
+ * the notebook and the outro — behind a modal nobody is looking at.
+ */
+export const TASK_NOTICE_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Offer an optional step, defaulting to declining it if nobody answers.
+ *
+ * Skip is the right default on a timeout: continuing would send the step on to
+ * ask for credentials that the same absent user cannot supply either, burning
+ * {@link TASK_ASK_TIMEOUT_MS} per question before falling back to the same
+ * links declining gives immediately.
+ */
+export async function offerSeededTask(
+  notice: TaskNotice,
+  timeoutMs: number = TASK_NOTICE_TIMEOUT_MS,
+): Promise<{ keep: boolean; timedOut: boolean }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const timeout = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      // Dismisses the overlay and settles the showTaskNotice promise too, so
+      // the losing side of the race cannot leave a modal on screen.
+      getUI().cancelTaskNotice();
+      resolve(false);
+    }, timeoutMs);
+  });
+  try {
+    const keep = await Promise.race([getUI().showTaskNotice(notice), timeout]);
+    return { keep, timedOut };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 /** Whether a task's prompt lets it ask the user, and so needs the ask bridge. */
 function canAsk(prompt: AgentPrompt | undefined): boolean {
@@ -718,18 +764,26 @@ export async function runOrchestrator(
     // dependency as satisfied, so the report still runs.
     const notice = seededNotices.get(task.id);
     if (notice) {
-      const keep = await getUI().showTaskNotice(notice);
+      const { keep, timedOut } = await offerSeededTask(notice);
       analytics.wizardCapture('orchestrator task notice answered', {
         type: task.type,
         kept: keep,
+        timed_out: timedOut,
       });
       if (!keep) {
-        logToFile(`[orchestrator] user declined runner-seeded ${task.type}`);
+        logToFile(
+          `[orchestrator] runner-seeded ${task.type} declined (${
+            timedOut ? 'timed out' : 'by the user'
+          })`,
+        );
         store.skip(task.id, {
           goals: notice.title,
-          did: 'Nothing — the user chose to skip this step when offered it.',
-          forNextAgent:
-            'This step was offered and declined, so it did no work. Report it as skipped at the user’s request, not as failed.',
+          did: timedOut
+            ? 'Nothing — the step was offered and the offer timed out with no answer.'
+            : 'Nothing — the user chose to skip this step when offered it.',
+          forNextAgent: timedOut
+            ? 'This step was offered and nobody answered, so it did no work. Report it as not set up, and point the user at how to do it later.'
+            : 'This step was offered and declined, so it did no work. Report it as skipped at the user’s request, not as failed.',
         });
         renderQueue();
         return;

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -57,6 +57,7 @@ import {
 import { drainQueue, type RunTask } from './executor';
 import { RunMetrics } from './run-metrics';
 import { uncoveredBySink } from './queue-tools';
+import { deferSeededTasks } from './seeded-deps';
 import { createWizardAskBridge } from '@lib/wizard-ask-bridge';
 import { shouldDisableAsk } from '../../shared/bootstrap';
 import {
@@ -514,6 +515,18 @@ export async function runOrchestrator(
     ? programConfig.seedTasks?.(session) ?? []
     : [];
   const seededTypes: string[] = [];
+  // Kept so their dependencies can be resolved once the planner has run — they
+  // are queued before it, so they cannot name what they wait for yet.
+  const seededTasks: QueuedTask[] = [];
+  // A seeded task's notice, held until the moment the task is about to run.
+  // Asked here at seed time it would be the first thing in the run — a modal
+  // before anything has happened, about work that will not start for minutes.
+  // The queue stays product-ignorant, so the copy waits here rather than on the
+  // task.
+  const seededNotices = new Map<
+    string,
+    NonNullable<(typeof seedEntries)[number]['notice']>
+  >();
   for (const seeded of seedEntries) {
     if (!registry.runnerSeededTypes.includes(seeded.type)) {
       logToFile(
@@ -521,21 +534,7 @@ export async function runOrchestrator(
       );
       continue;
     }
-    // A task that stops for the user is offered, not imposed: show its notice
-    // and drop it entirely when the user would rather not. Declining before
-    // the queue is planned is cheaper than skipping it once it is in there.
-    if (seeded.notice) {
-      const keep = await getUI().showTaskNotice(seeded.notice);
-      analytics.wizardCapture('orchestrator task notice answered', {
-        type: seeded.type,
-        kept: keep,
-      });
-      if (!keep) {
-        logToFile(`[orchestrator] user declined runner-seeded ${seeded.type}`);
-        continue;
-      }
-    }
-    store.enqueue({
+    const task = store.enqueue({
       type: seeded.type,
       label: seeded.label,
       inputs: seeded.inputs,
@@ -544,6 +543,8 @@ export async function runOrchestrator(
       optional: true,
     });
     seededTypes.push(seeded.type);
+    seededTasks.push(task);
+    if (seeded.notice) seededNotices.set(task.id, seeded.notice);
     logToFile(`[orchestrator] runner-seeded task ${seeded.type}`);
   }
 
@@ -569,7 +570,12 @@ export async function runOrchestrator(
     ? undefined
     : createWizardAskBridge({
         getSource: () => session.skillId ?? programConfig.id,
-        showQuestion: (q) => getUI().requestQuestion(q),
+        showQuestion: (q) => {
+          // How late the first ask lands is the measure of this run shape: it
+          // should follow the autonomous work, not interrupt it.
+          metrics.recordAsk(Date.now());
+          return getUI().requestQuestion(q);
+        },
         cancelQuestion: () => getUI().cancelPendingQuestion(),
         richLinks: config.richLinks ?? false,
         timeoutMs: TASK_ASK_TIMEOUT_MS,
@@ -615,6 +621,49 @@ export async function runOrchestrator(
   });
   renderQueue();
 
+  // Now that the graph exists, give each runner-seeded task the dependencies it
+  // could not name when it was queued. Without this it sits at depth 0 and runs
+  // in the first tier — which for the warehouse step means its credential
+  // prompts arrive while the coding tasks are still writing files. Deferred, the
+  // one step that waits on a person waits until the autonomous work is done.
+  //
+  // Before the sink check below on purpose: sinks are never added as
+  // dependencies, so a planner that forgot to make its sink wait for a seeded
+  // task is still caught there rather than masked here.
+  const deferred = deferSeededTasks(
+    store,
+    seededTasks,
+    (type) => registry.get(type)?.dependsOn ?? [],
+    registry.sinkTypes,
+  );
+  for (const entry of deferred) {
+    logToFile(
+      `[orchestrator] deferred runner-seeded ${entry.type}: ` +
+        `${entry.added.length} deps (${
+          entry.declared
+            ? `declared: ${entry.declaredTypes.join(', ')}`
+            : 'default'
+        })${
+          entry.refused.length > 0 ? `, ${entry.refused.length} refused` : ''
+        }${
+          entry.unresolvedTypes.length > 0
+            ? `, unresolved: ${entry.unresolvedTypes.join(', ')}`
+            : ''
+        }`,
+    );
+    analytics.wizardCapture('orchestrator seeded task deferred', {
+      type: entry.type,
+      dep_count: entry.added.length,
+      declared: entry.declared,
+      declared_types: entry.declaredTypes,
+      unresolved_types: entry.unresolvedTypes,
+      // Non-empty means a cycle or an unknown id was rejected — the resolver and
+      // the queue disagreeing, never expected in a good run.
+      refused_count: entry.refused.length,
+    });
+  }
+  if (deferred.length > 0) renderQueue();
+
   // The enqueue guard rejects a sink that misses part of the queue, so a
   // planner that respected its errors cannot get here with a broken graph.
   // Check it again anyway: a run whose report never sees a task's handoff is
@@ -657,6 +706,36 @@ export async function runOrchestrator(
   );
   const runTask: RunTask = async (task) => {
     renderQueue();
+
+    // A task that stops for the user is offered, not imposed — and the offer
+    // belongs here, the moment before it runs, not at the top of the run. By now
+    // everything this task waits for is done, so the notice, the questions, and
+    // the work form one block at the end instead of a modal that interrupts
+    // before anything has happened.
+    //
+    // Declining skips the task rather than removing it: the planner has already
+    // wired the sink to depend on it, and `nextRunnable` treats a skipped
+    // dependency as satisfied, so the report still runs.
+    const notice = seededNotices.get(task.id);
+    if (notice) {
+      const keep = await getUI().showTaskNotice(notice);
+      analytics.wizardCapture('orchestrator task notice answered', {
+        type: task.type,
+        kept: keep,
+      });
+      if (!keep) {
+        logToFile(`[orchestrator] user declined runner-seeded ${task.type}`);
+        store.skip(task.id, {
+          goals: notice.title,
+          did: 'Nothing — the user chose to skip this step when offered it.',
+          forNextAgent:
+            'This step was offered and declined, so it did no work. Report it as skipped at the user’s request, not as failed.',
+        });
+        renderQueue();
+        return;
+      }
+    }
+
     try {
       const resolved = resolveTask(registry, task, store);
       // Task instructions are one-run scaffolding, not durable skills, so they

--- a/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
@@ -35,6 +35,13 @@ export interface OrchestratorToolsContext {
    */
   sinkTypes?: readonly string[];
   /**
+   * Types the wizard queues itself, before the planner runs. They are deferred
+   * to the end of the drain and may stop to ask the user for input, so the edge
+   * to them is one-way: the sink depends on them, nothing else may. See
+   * {@link seededDepViolations}.
+   */
+  runnerSeededTypes?: readonly string[];
+  /**
    * The id of the task this tool server is bound to. Each task agent gets its
    * own wizard-tools server, so attribution holds when independent tasks run
    * in parallel. Absent for the seed, which is not a task.
@@ -109,10 +116,37 @@ export function uncoveredBySink(
 }
 
 /**
+ * Runner-seeded tasks a non-sink task would end up waiting for.
+ *
+ * The edge to a runner-seeded task is one-way. Such a task is deferred to the
+ * end of the drain and may stop to ask the user for input, so anything that
+ * waits on it inherits that wait — a coding step gated on someone typing a
+ * database password. The sink is the sole exception: it runs last by
+ * definition and must depend on every task, this one included.
+ *
+ * The whole closure is checked, not just direct dependencies, so the rule
+ * cannot be reached through an intermediate hop.
+ *
+ * Empty for a sink, and for any task that does not reach a seeded task.
+ */
+export function seededDepViolations(
+  ctx: OrchestratorToolsContext,
+  args: Pick<EnqueueArgs, 'type' | 'dependsOn'>,
+): QueuedTask[] {
+  const seeded = ctx.runnerSeededTypes ?? [];
+  if (seeded.length === 0) return [];
+  if (ctx.sinkTypes?.includes(args.type)) return [];
+  const reached = dependencyClosure(ctx.store, args.dependsOn ?? []);
+  return ctx.store
+    .list()
+    .filter((t) => reached.has(t.id) && seeded.includes(t.type));
+}
+
+/**
  * Validate an enqueue. Structural checks only — a real type, real dependencies,
- * a sink that waits for everything, not a literal duplicate, and not past the
- * runaway backstop. How much runs, and in what shape, is the task graph's
- * business, not a knob's.
+ * a sink that waits for everything, no non-sink task waiting on a runner-seeded
+ * one, not a literal duplicate, and not past the runaway backstop. How much
+ * runs, and in what shape, is the task graph's business, not a knob's.
  */
 export function checkEnqueueGuards(
   ctx: OrchestratorToolsContext,
@@ -161,8 +195,32 @@ export function checkEnqueueGuards(
     }
   }
 
+  const seededDeps = seededDepViolations(ctx, args);
+  if (seededDeps.length > 0) {
+    return {
+      ok: false,
+      guard: 'seeded-dep',
+      message: `A "${args.type}" task must not wait for ${seededDeps
+        .map((t) => `${t.type} (${t.id})`)
+        .join(
+          ', ',
+        )} — directly or through its dependencies. The wizard placed those, runs them at the end, and they stop to ask the user for input, so anything waiting on one waits on a person. Remove them from dependsOn and enqueue it again; only the final reporting task may depend on them.`,
+    };
+  }
+
   const uncovered = uncoveredBySink(ctx, args);
   if (uncovered.length > 0) {
+    const seededUncovered = uncovered.filter((t) =>
+      (ctx.runnerSeededTypes ?? []).includes(t.type),
+    );
+    // "Or to a task already in dependsOn" is the right advice for an ordinary
+    // task and exactly wrong for a runner-seeded one — routing it through an
+    // intermediate satisfies the closure while breaking the one-way rule above.
+    // So a seeded task is named with the only placement that is legal for it.
+    const how =
+      seededUncovered.length === uncovered.length
+        ? "Add them to this task's own dependsOn — for a task the wizard placed, that is the only legal spot — and enqueue it again."
+        : 'Add them to dependsOn, or to a task already in dependsOn, and enqueue it again.';
     return {
       ok: false,
       guard: 'sink-closure',
@@ -170,9 +228,7 @@ export function checkEnqueueGuards(
         args.type
       }" task runs last, so it must depend on every other task — directly or through its dependencies. These are not covered: ${uncovered
         .map((t) => `${t.type} (${t.id})`)
-        .join(
-          ', ',
-        )}. Add them to dependsOn, or to a task already in dependsOn, and enqueue it again.`,
+        .join(', ')}. ${how}`,
     };
   }
 

--- a/src/lib/agent/runner/sequence/orchestrator/queue.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue.ts
@@ -35,9 +35,15 @@ export interface QueuedTask {
   status: TaskStatus;
   /**
    * Ids of tasks that must finish before this one runs. Ids are generated at
-   * enqueue and dependsOn is never mutated, so a task can only depend on tasks
-   * created before it — the graph is a DAG by construction, cycles cannot
-   * form. Unknown ids are rejected by the enqueue_task guard.
+   * enqueue, so a task can only depend on tasks created before it — the graph is
+   * a DAG by construction, cycles cannot form. Unknown ids are rejected by the
+   * enqueue_task guard.
+   *
+   * One sanctioned exception: {@link QueueStore.addDependencies} adds edges to a
+   * still-pending task, for a runner-seeded task that was queued before the
+   * planner ran and so could not name its dependencies then. It is additive,
+   * pending-only, and cycle-checked per edge, so the DAG property above still
+   * holds. Nothing else mutates this field.
    */
   dependsOn: string[];
   inputs: Record<string, unknown>;
@@ -232,6 +238,48 @@ export class QueueStore {
     return task;
   }
 
+  /**
+   * Add dependency edges to a pending task — the one sanctioned exception to
+   * `dependsOn` being immutable (see the field's doc).
+   *
+   * A runner-seeded task is enqueued before the planner runs, so the tasks it
+   * should wait for do not exist yet and it cannot name them. This closes that
+   * gap once, between planning and the drain.
+   *
+   * Three rules keep the graph a DAG: additive only (never removes an edge),
+   * pending only (a task that already started keeps the graph it ran under), and
+   * every edge cycle-checked — a dep that already reaches this task through its
+   * own chain is refused. Refusals come back in the result rather than throwing:
+   * one bad edge is a bug worth reporting, not a reason to end a run that is
+   * otherwise fine.
+   */
+  addDependencies(
+    id: string,
+    depIds: readonly string[],
+  ): { added: string[]; refused: string[] } {
+    const task = this.require(id);
+    if (task.status !== TaskStatus.Pending) {
+      return { added: [], refused: [...depIds] };
+    }
+
+    const added: string[] = [];
+    const refused: string[] = [];
+    for (const depId of depIds) {
+      // Already an edge, or a self-loop: nothing to do and nothing wrong.
+      if (depId === id || task.dependsOn.includes(depId)) continue;
+      // Checked against the graph as it stands, so two edges added in one call
+      // cannot together form a cycle the first check missed.
+      if (!this.get(depId) || this.reaches(depId, id)) {
+        refused.push(depId);
+        continue;
+      }
+      task.dependsOn.push(depId);
+      added.push(depId);
+    }
+    if (added.length > 0) this.reflect();
+    return { added, refused };
+  }
+
   start(id: string): QueuedTask {
     const t = this.require(id);
     t.status = TaskStatus.Running;
@@ -314,6 +362,20 @@ export class QueueStore {
         { step: 'orchestrator_queue_listener', event },
       );
     }
+  }
+
+  /** Whether `fromId` reaches `targetId` by following dependsOn edges. */
+  private reaches(fromId: string, targetId: string): boolean {
+    const seen = new Set<string>();
+    const stack = [fromId];
+    while (stack.length > 0) {
+      const current = stack.pop() as string;
+      if (current === targetId) return true;
+      if (seen.has(current)) continue;
+      seen.add(current);
+      stack.push(...(this.get(current)?.dependsOn ?? []));
+    }
+    return false;
   }
 
   private require(id: string): QueuedTask {

--- a/src/lib/agent/runner/sequence/orchestrator/run-metrics.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/run-metrics.ts
@@ -15,6 +15,13 @@ export interface RunMetricsSummary {
   time_to_first_completion_ms?: number;
   /** Longest silence between two consecutive user-visible transitions. */
   max_gap_ms?: number;
+  /**
+   * Run start → the first question put to the user. The number that says whether
+   * a task which waits on a person actually runs late: small means it interrupted
+   * the autonomous work, large means it waited for it. `undefined` on a run that
+   * asked nothing, which is most of them.
+   */
+  time_to_first_ask_ms?: number;
 }
 
 /** The per-event timing the `orchestrator task started` event reports. */
@@ -27,6 +34,7 @@ export class RunMetrics {
   private firstStartMs?: number;
   private lastStartMs?: number;
   private firstCompleteMs?: number;
+  private firstAskMs?: number;
   private lastVisibleMs?: number;
   private maxGapMs = 0;
 
@@ -57,6 +65,15 @@ export class RunMetrics {
   }
 
   /**
+   * A question was put to the user. Only the first matters here, and it is not a
+   * queue transition — waiting on a person is not the silence `max_gap_ms`
+   * measures, so this deliberately does not mark visible progress.
+   */
+  recordAsk(nowMs: number): void {
+    this.firstAskMs ??= nowMs;
+  }
+
+  /**
    * The run-level responsiveness summary. Timings are `undefined` when the
    * relevant transition never happened (e.g. a run that started no task), so a
    * no-task run stays distinguishable from a genuine zero.
@@ -72,6 +89,10 @@ export class RunMetrics {
           ? undefined
           : this.firstCompleteMs - this.runStartMs,
       max_gap_ms: this.lastVisibleMs === undefined ? undefined : this.maxGapMs,
+      time_to_first_ask_ms:
+        this.firstAskMs === undefined
+          ? undefined
+          : this.firstAskMs - this.runStartMs,
     };
   }
 

--- a/src/lib/agent/runner/sequence/orchestrator/seeded-deps.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/seeded-deps.ts
@@ -1,0 +1,145 @@
+/**
+ * Where a runner-seeded task sits in the planner's graph.
+ *
+ * A runner-seeded task is queued from what the wizard detected, before the
+ * planner runs (see `ProgramConfig.seedTasks`). At that moment the tasks it
+ * should wait for do not exist, so it cannot name them: it is enqueued with no
+ * dependencies and is therefore runnable in the first drain tier, alongside the
+ * first coding tasks. For a task that stops to ask the user for credentials that
+ * is the wrong place — the questions land while the coding agents are still
+ * mid-flight.
+ *
+ * This module answers "what should it wait for?" once the planner has seeded the
+ * queue. The task's agent prompt names the types it follows (`dependsOn` in
+ * frontmatter); a prompt that names none waits for everything that is not the
+ * sink, which puts it last but still ahead of the reporting step.
+ *
+ * Pure and store-reading only — the runner applies what this returns, and the
+ * queue enforces the DAG.
+ */
+import type { QueuedTask, QueueStore } from './queue';
+import { dependencyClosure } from './queue-tools';
+
+export interface SeededDepsResult {
+  /** Ids the seeded task should be made to wait for. */
+  depIds: string[];
+  /**
+   * Declared types with no task of that type in the queue — the planner chose
+   * not to queue one. Not an error: the edge is simply dropped, and the task
+   * still runs after whatever else was declared.
+   */
+  unresolvedTypes: string[];
+  /** Whether the ids came from the prompt's declared types or from the default. */
+  declared: boolean;
+}
+
+/**
+ * Resolve a runner-seeded task's dependencies against the planned queue.
+ *
+ * Two exclusions apply to both the declared and the default path:
+ *
+ * - **Sinks are never dependencies.** A sink runs last and must depend on the
+ *   whole queue, this task included. Depending on it back would invert the edge
+ *   and cost the report this task's `reportSection`. Leaving sinks out means a
+ *   planner that forgot the sink→seeded edge is still caught by the sink
+ *   invariant check rather than silently papered over here.
+ * - **Anything already downstream of this task is never a dependency**, which is
+ *   what makes the result cycle-free by construction rather than by the queue's
+ *   per-edge refusal.
+ */
+export function seededDependencies(
+  store: QueueStore,
+  seededTaskId: string,
+  declaredTypes: readonly string[],
+  sinkTypes: readonly string[],
+): SeededDepsResult {
+  const eligible = store.list().filter((task) => {
+    if (task.id === seededTaskId) return false;
+    if (sinkTypes.includes(task.type)) return false;
+    // Downstream of us already (the planner hung it off this task): depending on
+    // it would close a loop.
+    return !dependencyClosure(store, [task.id]).has(seededTaskId);
+  });
+
+  if (declaredTypes.length === 0) {
+    return {
+      depIds: eligible.map((t) => t.id),
+      unresolvedTypes: [],
+      declared: false,
+    };
+  }
+
+  const depIds: string[] = [];
+  const unresolvedTypes: string[] = [];
+  for (const type of declaredTypes) {
+    // Against the whole queue, not just `eligible` — a declared type that was
+    // queued but is downstream of us was resolved, just not usable as an edge.
+    // Only a type the planner never queued at all is unresolved.
+    if (!store.list().some((t) => t.type === type)) {
+      unresolvedTypes.push(type);
+      continue;
+    }
+    for (const task of eligible) {
+      // Every task of the type, so a fanned-out step (one `capture` per event)
+      // is waited for in full rather than by its first task alone.
+      if (task.type === type && !depIds.includes(task.id)) depIds.push(task.id);
+    }
+  }
+
+  return { depIds, unresolvedTypes, declared: true };
+}
+
+/** What deferring one seeded task did, for the runner to log and report. */
+export interface DeferredSeededTask {
+  type: string;
+  /** Types the prompt declared; empty when it fell back to the default. */
+  declaredTypes: string[];
+  declared: boolean;
+  /** Edges actually added to the queue. */
+  added: string[];
+  /**
+   * Edges the queue refused — a cycle or an unknown id. Always empty in a
+   * healthy run: this resolver already excludes both, so anything here means the
+   * two disagree and is worth a telemetry look.
+   */
+  refused: string[];
+  unresolvedTypes: string[];
+}
+
+/**
+ * Give every runner-seeded task the dependencies it could not name at enqueue,
+ * and report what happened per task.
+ *
+ * The runner calls this once, after the planner has seeded the queue and before
+ * the sink invariant is checked. Kept here rather than inline in the runner so
+ * the wiring — which prompt's types feed which task — is testable without
+ * standing up a whole run.
+ */
+export function deferSeededTasks(
+  store: QueueStore,
+  seededTasks: readonly QueuedTask[],
+  declaredTypesFor: (type: string) => readonly string[],
+  sinkTypes: readonly string[],
+): DeferredSeededTask[] {
+  return seededTasks.map((seeded) => {
+    const declaredTypes = [...declaredTypesFor(seeded.type)];
+    const resolved = seededDependencies(
+      store,
+      seeded.id,
+      declaredTypes,
+      sinkTypes,
+    );
+    const { added, refused } = store.addDependencies(
+      seeded.id,
+      resolved.depIds,
+    );
+    return {
+      type: seeded.type,
+      declaredTypes,
+      declared: resolved.declared,
+      added,
+      refused,
+      unresolvedTypes: resolved.unresolvedTypes,
+    };
+  });
+}

--- a/src/lib/programs/__tests__/warehouse-seed-task.test.ts
+++ b/src/lib/programs/__tests__/warehouse-seed-task.test.ts
@@ -100,6 +100,12 @@ describe('warehouse task notice', () => {
     expect(n?.cancelLabel).toContain('Skip');
   });
 
+  it('promises the questions come at the end, not mid-run', () => {
+    // The task is deferred behind the code work (seeded-deps.ts), so consenting
+    // up front must not read as "expect a prompt any moment now".
+    expect(notice()?.body[0]).toContain('at the end');
+  });
+
   it('names what was detected', () => {
     expect(notice()?.items).toEqual(['Postgres']);
   });

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -130,6 +130,11 @@ function warehouseReportInstruction(sess: WizardSession): string {
  * the run is a fact about the project the wizard already scanned, so a model
  * can neither invent it nor forget it.
  *
+ * It runs at the end of the queue, not the start. Where exactly is the agent
+ * prompt's business (`dependsOn` in the warehouse agent's frontmatter, resolved
+ * by `seeded-deps.ts` once the planner has run) — this file only decides whether
+ * the task belongs in the run at all.
+ *
  * Empty when nothing was detected, and in CI, signup, and any other run where
  * `wizard_ask` is disabled — a credential prompt nobody can answer would burn
  * the task's whole timeout and then fail the run.
@@ -157,7 +162,7 @@ const warehouseSeedTasks: NonNullable<ProgramConfig['seedTasks']> = (sess) => {
       notice: {
         title: 'Connect your data sources',
         body: [
-          "We detected some warehouse sources we can connect to enrich your PostHog data. To connect them, stick around, we'll prompt you to provide some credentials to setup warehouse sources.",
+          'We detected some warehouse sources we can connect to enrich your PostHog data. This runs at the end, once your code changes are done — we’ll prompt you then for the credentials, so you can leave the setup to run until it asks.',
           "You can select [Skip] if you'd like to do this later in PostHog.",
         ],
         items: sources.map((s) => s.label),

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -168,6 +168,10 @@ export class LoggingUI implements WizardUI {
     return Promise.resolve(false);
   }
 
+  cancelTaskNotice(): void {
+    // Nothing to dismiss — showTaskNotice never opened anything.
+  }
+
   showSettingsOverride(
     _conflicts: SettingsConflict[],
     _backupAndFix: () => boolean,

--- a/src/ui/tui/__tests__/task-notice.test.ts
+++ b/src/ui/tui/__tests__/task-notice.test.ts
@@ -20,7 +20,7 @@ import { WizardStore, Overlay } from '@ui/tui/store';
 const NOTICE: TaskNotice = {
   title: 'Connect your data sources',
   body: [
-    "We detected some warehouse sources we can connect to enrich your PostHog data. To connect them, stick around, we'll prompt you to provide some credentials to setup warehouse sources.",
+    'We detected some warehouse sources we can connect to enrich your PostHog data. This runs at the end, once your code changes are done — we’ll prompt you then for the credentials, so you can leave the setup to run until it asks.',
     "You can select [Skip] if you'd like to do this later in PostHog.",
   ],
   items: ['Postgres', 'Stripe'],

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -157,6 +157,12 @@ export class InkUI implements WizardUI {
     return this.store.showTaskNotice(notice);
   }
 
+  cancelTaskNotice(): void {
+    // Same path as pressing Skip: closes the overlay and resolves the pending
+    // showTaskNotice promise with false.
+    this.store.resolveTaskNotice(false);
+  }
+
   showSettingsOverride(
     conflicts: SettingsConflict[],
     backupAndFix: () => boolean,

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -178,6 +178,13 @@ export interface WizardUI {
    */
   showTaskNotice(notice: TaskNotice): Promise<boolean>;
 
+  /**
+   * Dismiss an in-flight task notice as declined. Called when the offer times
+   * out: the notice sits in front of the run's final steps, so left unanswered
+   * it would hold the report behind a modal nobody is looking at.
+   */
+  cancelTaskNotice(): void;
+
   /** Show auth error overlay when Anthropic API returns 401. */
   showAuthError(detail?: AuthErrorDetail): void;
 


### PR DESCRIPTION
- before: a runner-seeded task (aka `dw-sources`) is queued before the planner runs
- after: a runner-seeded task is accounted for in the DAG and queue 
- `dw sources` task moved towards the end, before `report` and after `dashboard`
- added 5 min timeout for user input screen asking to integrate dw sources. defaults to `Skip` if ignored

tl;dr we can control the order of non-planner tasks that use static detectio