### PR TITLE
refactor(yara): programs declare their doc paths, L2 reads a registry

### DIFF
--- a/.claude/skills/adding-skill-program/SKILL.md
+++ b/.claude/skills/adding-skill-program/SKILL.md
@@ -61,6 +61,19 @@ The `audit` program (`src/lib/programs/audit/`) is the cleanest example of this 
 
 For more complex post-agent work (env var upload, dashboard creation, anything that needs to run after the agent completes but before the outro), drop the factory and build the `ProgramConfig` directly so you can set `ProgramRun.postRun`. See `posthog-integration` for that pattern.
 
+## Report files and the security scanner
+
+If your program writes documentation files — a report, an event plan, an inventory — declare their basenames on the config's `docPaths` field:
+
+```ts
+export const yourConfig: ProgramConfig = {
+  ...baseConfig,
+  docPaths: ['posthog-your-report.md'],
+};
+```
+
+The security hooks suppress `posthog_pii` matches on these paths only; every other rule still fires on them. Without the declaration, the agent quoting an existing `posthog.capture('event', { email })` call into your report gets blocked as a PII violation. Declarations flow into the shared doc-paths registry when the program registry loads (`src/lib/doc-paths-registry.ts`) — the scanner never learns your program exists, so there is nothing to add on the security side. Entries are exact basenames or RegExps tested against the basename; `events-audit` declares both (its per-part inventory files use a pattern).
+
 ## Dynamic run configuration
 
 If your program needs to inspect the session before building the run config (read framework context, seed state on disk, set per-session prompt fragments), pass an async function as the program's `run`:

--- a/src/lib/__tests__/doc-paths-registry.test.ts
+++ b/src/lib/__tests__/doc-paths-registry.test.ts
@@ -1,0 +1,73 @@
+import {
+  isWizardDocumentationPath,
+  registerWizardDocPaths,
+  resetWizardDocPathsForTests,
+} from '@lib/doc-paths-registry';
+
+describe('doc-paths registry', () => {
+  beforeEach(() => {
+    resetWizardDocPathsForTests();
+  });
+
+  it('matches a registered basename anywhere in the tree', () => {
+    registerWizardDocPaths(['.posthog-events.json']);
+    expect(isWizardDocumentationPath('/tmp/project/.posthog-events.json')).toBe(
+      true,
+    );
+    expect(
+      isWizardDocumentationPath('deep/nested/dir/.posthog-events.json'),
+    ).toBe(true);
+  });
+
+  it('matches a registered pattern against the basename', () => {
+    registerWizardDocPaths([/^\.posthog-events-inventory\.part-\d+\.json$/]);
+    expect(
+      isWizardDocumentationPath('/p/.posthog-events-inventory.part-3.json'),
+    ).toBe(true);
+    expect(isWizardDocumentationPath('/p/.posthog-events-inventory.json')).toBe(
+      false,
+    );
+  });
+
+  it('does not match unregistered paths, and never matches undefined', () => {
+    registerWizardDocPaths(['.posthog-events.json']);
+    expect(isWizardDocumentationPath('/tmp/project/src/index.ts')).toBe(false);
+    expect(isWizardDocumentationPath(undefined)).toBe(false);
+  });
+
+  it('matches on the basename only — a doc filename used as a directory does not qualify its contents', () => {
+    registerWizardDocPaths(['.posthog-events.json']);
+    expect(
+      isWizardDocumentationPath('/tmp/.posthog-events.json/secrets.ts'),
+    ).toBe(false);
+  });
+
+  it('accumulates registrations and tolerates duplicates and undefined', () => {
+    registerWizardDocPaths(['a-report.md']);
+    registerWizardDocPaths(['a-report.md', 'b-report.md']);
+    registerWizardDocPaths(undefined);
+    expect(isWizardDocumentationPath('x/a-report.md')).toBe(true);
+    expect(isWizardDocumentationPath('x/b-report.md')).toBe(true);
+  });
+});
+
+describe('program registry populates the doc-paths registry', () => {
+  // Loading the program registry is the production population path; this
+  // pins that every doc file the security hooks suppressed before the
+  // inversion (wizard#594) is still covered after it.
+  it('registers the doc paths every program declares', async () => {
+    await import('@lib/programs/program-registry');
+
+    const covered = [
+      '.posthog-events.json', // posthog-integration event plan
+      'posthog-audit-report.md', // audit report
+      'posthog-events-audit-report.md', // events-audit report
+      '.posthog-events-inventory.json', // events-audit inventory
+      '.posthog-events-inventory.part-7.json', // events-audit inventory parts
+    ];
+    for (const file of covered) {
+      expect(isWizardDocumentationPath(`/tmp/project/${file}`)).toBe(true);
+    }
+    expect(isWizardDocumentationPath('/tmp/project/src/index.ts')).toBe(false);
+  });
+});

--- a/src/lib/__tests__/yara-hooks.test.ts
+++ b/src/lib/__tests__/yara-hooks.test.ts
@@ -9,6 +9,8 @@ import {
   recordExternalScan,
   resetScanReport,
 } from '@lib/yara-hooks';
+import { registerWizardDocPaths } from '@lib/doc-paths-registry';
+import { EVENT_PLAN_FILE } from '@lib/programs/posthog-integration/constants';
 import { scan, triageMatches } from '@posthog/warlock';
 import fs from 'fs';
 import fg from 'fast-glob';
@@ -38,6 +40,11 @@ const mockScan = scan as Mock;
 const mockTriage = triageMatches as Mock;
 
 const dummySignal = new AbortController().signal;
+
+// In production the program registry populates the doc-paths registry as a
+// module side effect. This file tests the hooks in isolation, so register
+// the one doc path the suppression tests write to.
+registerWizardDocPaths([EVENT_PLAN_FILE]);
 
 // A provider that, when passed, routes matches through triageMatches.
 const dummyProvider = () => Promise.resolve('[]');

--- a/src/lib/agent/runner/harness/pi/__tests__/security.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/security.test.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { scan, triageMatches, type ScanMatch } from '@posthog/warlock';
+import { registerWizardDocPaths } from '@lib/doc-paths-registry';
+import { EVENT_PLAN_FILE } from '@lib/programs/posthog-integration/constants';
 import {
   evaluateToolCall,
   createSecurityExtension,
@@ -21,6 +23,11 @@ vi.mock('@utils/analytics', () => ({
 // load under the CJS test runner). Default: scan matches nothing; tests
 // override per-case with mockResolvedValueOnce.
 const mockedScan = vi.mocked(scan);
+
+// In production the program registry populates the doc-paths registry as a
+// module side effect. This file tests the extension in isolation, so
+// register the one doc path the suppression test writes to.
+registerWizardDocPaths([EVENT_PLAN_FILE]);
 
 const piiMatch: ScanMatch = {
   rule: 'posthog_pii_in_capture_call',

--- a/src/lib/agent/runner/index.ts
+++ b/src/lib/agent/runner/index.ts
@@ -80,6 +80,13 @@ export async function runProgram(
   programConfig: ProgramConfig,
   options: { composed?: boolean } = {},
 ): Promise<void> {
+  // Loading the program registry pushes every program's `docPaths`
+  // declaration into the shared doc-paths registry as a module side effect
+  // (wizard#594). Import it lazily: some entry paths (headless installs
+  // import their config directly) never load the registry otherwise, and a
+  // static import would cycle — program modules import this runner.
+  await import('@lib/programs/program-registry');
+
   const boot = await bootstrapProgram(session, config, programConfig);
 
   // Flush the warlock scan report once, at this single seam, on every

--- a/src/lib/doc-paths-registry.ts
+++ b/src/lib/doc-paths-registry.ts
@@ -1,0 +1,61 @@
+import * as path from 'node:path';
+
+/**
+ * Registry of wizard-documentation paths.
+ *
+ * Files the wizard's own programs write to describe events the user's
+ * codebase already captures, or events a program is proposing to add. When
+ * the agent copies a literal `posthog.capture('event', { email: ... })`
+ * snippet (or a property list including PII-shaped keys) into one of these
+ * files, the `pii_in_capture_call` rule (category: posthog_pii) fires even
+ * though the wizard is documenting / planning, not introducing, the
+ * pattern. The scanning hooks suppress posthog_pii matches on these paths
+ * only; every other rule (secrets, prompt injection, supply chain,
+ * destructive ops) still fires normally so the file cannot be used as a
+ * smuggling vector for actual violations.
+ *
+ * This module is deliberately product-blind (wizard#594): it knows nothing
+ * about which programs exist. Each program declares the doc files it writes
+ * via `ProgramConfig.docPaths`; the program registry pushes every
+ * declaration in here as a module side effect. L2 scanning infra
+ * (yara-hooks, the pi security extension) only ever reads the answer.
+ */
+
+/** Exact basenames (e.g. `.posthog-events.json`). */
+const docBasenames = new Set<string>();
+/** Basename patterns (e.g. per-part inventory files). */
+const docPatterns: RegExp[] = [];
+
+/**
+ * Declare documentation paths. Entries are basenames (matched exactly) or
+ * RegExps (tested against the basename). Duplicate registrations are
+ * harmless; `undefined` is a no-op so call sites can pass
+ * `config.docPaths` straight through.
+ */
+export function registerWizardDocPaths(
+  entries: ReadonlyArray<string | RegExp> | undefined,
+): void {
+  for (const entry of entries ?? []) {
+    if (typeof entry === 'string') {
+      docBasenames.add(entry);
+    } else if (!docPatterns.some((re) => re.source === entry.source)) {
+      docPatterns.push(entry);
+    }
+  }
+}
+
+/** True when `filePath`'s basename was declared as wizard documentation. */
+export function isWizardDocumentationPath(
+  filePath: string | undefined,
+): boolean {
+  if (!filePath) return false;
+  const basename = path.basename(filePath);
+  if (docBasenames.has(basename)) return true;
+  return docPatterns.some((re) => re.test(basename));
+}
+
+/** Test-only: clear all registrations. */
+export function resetWizardDocPathsForTests(): void {
+  docBasenames.clear();
+  docPatterns.length = 0;
+}

--- a/src/lib/programs/audit/index.ts
+++ b/src/lib/programs/audit/index.ts
@@ -97,6 +97,7 @@ export const auditConfig: ProgramConfig = {
   ...baseConfig,
   steps: auditSteps,
   run: auditRun,
+  docPaths: [AUDIT_REPORT_FILE],
   allowedTools: ['Agent'],
   disallowedTools: [WIZARD_TOOL_NAMES.wizardAsk],
   // The experimental headless flag — declared on `audit` (and basic

--- a/src/lib/programs/events-audit/constants.ts
+++ b/src/lib/programs/events-audit/constants.ts
@@ -1,9 +1,12 @@
 /**
  * Leaf-level constants for the events-audit program.
  *
- * Kept separate from `index.ts` so files like `yara-hooks.ts` can import
- * the filename constants without dragging in `index.ts`'s heavier imports
- * (agent-runner, audit/seed, etc.) — which can create import cycles.
+ * Kept separate from `index.ts` so leaf consumers can import the filename
+ * constants without dragging in `index.ts`'s heavier imports (agent-runner,
+ * audit/seed, etc.) — which can create import cycles. The security hooks no
+ * longer import these directly: `index.ts` declares them as
+ * `ProgramConfig.docPaths` and the shared doc-paths registry carries them
+ * to L2 (wizard#594).
  */
 
 export const SETUP_REPORT_FILE = 'posthog-events-audit-report.md';

--- a/src/lib/programs/events-audit/index.ts
+++ b/src/lib/programs/events-audit/index.ts
@@ -14,7 +14,11 @@ import { EVENTS_AUDIT_SEED_CHECKS } from './seed.js';
 // imports from `@lib/programs/events-audit`. EVENT_INVENTORY_FILE and
 // EVENT_INVENTORY_PART_PATTERN are only used by yara-hooks, which imports
 // them directly from `./constants` — no re-export needed.
-import { SETUP_REPORT_FILE } from './constants.js';
+import {
+  SETUP_REPORT_FILE,
+  EVENT_INVENTORY_FILE,
+  EVENT_INVENTORY_PART_PATTERN,
+} from './constants.js';
 export { SETUP_REPORT_FILE };
 
 const DOCS_URL = 'https://posthog.com/docs/product-analytics/best-practices';
@@ -28,6 +32,11 @@ export const eventsAuditConfig: ProgramConfig = {
   // Top-level reportFile so AuditRunScreen can resolve the report path
   // synchronously without unwrapping the deferred `run` function.
   reportFile: SETUP_REPORT_FILE,
+  docPaths: [
+    SETUP_REPORT_FILE,
+    EVENT_INVENTORY_FILE,
+    EVENT_INVENTORY_PART_PATTERN,
+  ],
   allowedTools: ['Agent'],
   disallowedTools: [WIZARD_TOOL_NAMES.wizardAsk],
 

--- a/src/lib/programs/posthog-integration/constants.ts
+++ b/src/lib/programs/posthog-integration/constants.ts
@@ -1,10 +1,12 @@
 /**
  * Leaf-level constants for the posthog-integration program.
  *
- * Kept separate from `index.ts` so files like `yara-hooks.ts` can import
- * the filename constants without dragging in `index.ts`'s heavier imports
- * (agent-interface, framework-config, etc.) — which would create an import
- * cycle through agent-interface → yara-hooks.
+ * Kept separate from `index.ts` so leaf consumers (e.g. task-stream tests)
+ * can import the filename constants without dragging in `index.ts`'s
+ * heavier imports (agent-interface, framework-config, etc.) — which would
+ * create import cycles. The security hooks no longer import these directly:
+ * `index.ts` declares EVENT_PLAN_FILE as `ProgramConfig.docPaths` and the
+ * shared doc-paths registry carries it to L2 (wizard#594).
  */
 
 export const EVENT_PLAN_FILE = '.posthog-events.json';

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -185,6 +185,7 @@ export const posthogIntegrationConfig: ProgramConfig = {
   id: 'posthog-integration',
   agentFlow: 'integration-v2',
   eventPlanFile: EVENT_PLAN_FILE,
+  docPaths: [EVENT_PLAN_FILE],
   steps: POSTHOG_INTEGRATION_PROGRAM,
   getContentBlocks,
   // Basic integration runs without structured user input; drop wizard_ask

--- a/src/lib/programs/program-registry.ts
+++ b/src/lib/programs/program-registry.ts
@@ -12,6 +12,7 @@
 
 import type { ProgramConfig } from './program-step.js';
 import { POSTHOG_DOCS_URL } from '../constants.js';
+import { registerWizardDocPaths } from '../doc-paths-registry.js';
 import { posthogIntegrationConfig } from './posthog-integration/index.js';
 import { revenueAnalyticsConfig } from './revenue-analytics/index.js';
 import { warehouseSourceConfig } from './warehouse-source/index.js';
@@ -82,6 +83,14 @@ export const PROGRAM_REGISTRY = [
   aiObservabilityConfig,
   slackConnectConfig,
 ] as const satisfies readonly ProgramConfig[];
+
+// Push every program's documentation-path declarations into the shared
+// registry so L2 scanning infra (yara-hooks, the pi security extension) can
+// answer "is this a wizard doc file?" without naming any program
+// (wizard#594). Module side effect: runs once, whenever the registry loads.
+for (const config of PROGRAM_REGISTRY) {
+  registerWizardDocPaths(config.docPaths);
+}
 
 /**
  * Typed program names. Values come from each config's `id`, so there's

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -271,6 +271,15 @@ export interface ProgramConfig {
    */
   eventPlanFile?: string;
   /**
+   * Files this program writes that are documentation, not user code —
+   * basenames (matched exactly) or RegExps (tested against the basename).
+   * The security hooks suppress posthog_pii matches on these paths only;
+   * every other rule still fires. Declarations are pushed into the shared
+   * doc-paths registry (`@lib/doc-paths-registry`) when the program
+   * registry loads, so L2 scanning infra never has to name a program.
+   */
+  docPaths?: ReadonlyArray<string | RegExp>;
+  /**
    * LearnCard deck rendered in the shared `RunScreen` while the agent
    * runs. Lives at `<program>/content/index.tsx` by convention.
    * Programs that ship a custom RunScreen variant (audit) or skip the

--- a/src/lib/yara-hooks.ts
+++ b/src/lib/yara-hooks.ts
@@ -41,22 +41,9 @@ import { isSkillInstallCommand } from './skill-install';
 import { highestSeverityMatch, scanVerdict } from './yara-policy';
 import type { ScanAction, ScanContext } from './yara-policy';
 import { WIZARD_YARA_REPORT_FILE } from '@utils/paths';
-// TODO(wizard#594): invert this dependency.
-// L2 infra (yara-hooks) imports product-specific filename constants from
-// individual programs. The leaf `constants.ts` modules break the *import*
-// cycle but don't fix the *layering* concern: this file knowing about
-// `events-audit`, `posthog-integration`, and `audit` violates "product
-// knowledge never enters infrastructure code." Proper fix is inverted —
-// programs declare their own doc paths, the hooks read from a generic
-// registry. For now: every new program emitting a PII-shaped report has
-// to be added here. Land that cleanup before adding a fourth entry.
-import {
-  SETUP_REPORT_FILE as EVENTS_AUDIT_REPORT_FILE,
-  EVENT_INVENTORY_FILE,
-  EVENT_INVENTORY_PART_PATTERN,
-} from '@lib/programs/events-audit/constants';
-import { AUDIT_REPORT_FILE } from '@lib/programs/audit/types';
-import { EVENT_PLAN_FILE } from '@lib/programs/posthog-integration/constants';
+import { isWizardDocumentationPath } from './doc-paths-registry';
+
+export { isWizardDocumentationPath } from './doc-paths-registry';
 
 // ─── Warlock module accessor ─────────────────────────────────────
 // Warlock is ESM-only and lazily inits its WASM engine + compiles rules on the
@@ -441,35 +428,11 @@ export function flushScanReport(
 
 // ─── Wizard-documentation allowlist ───────────────────────────────
 //
-// Files the wizard's own programs write to describe events the user's
-// codebase already captures, or events the integration program is
-// proposing to add. When the agent copies a literal
-// `posthog.capture('event', { email: ... })` snippet (or a property
-// list including PII-shaped keys) into one of these files, the
-// `pii_in_capture_call` rule (category: posthog_pii) fires even though
-// the wizard is documenting / planning, not introducing, the pattern.
-// Suppress posthog_pii matches on these paths only; every other rule
-// (secrets, prompt injection, supply chain, destructive ops) still
-// fires normally so the file cannot be used as a smuggling vector for
-// actual violations.
-
-const WIZARD_DOC_BASENAMES = new Set([
-  EVENT_INVENTORY_FILE,
-  EVENTS_AUDIT_REPORT_FILE,
-  AUDIT_REPORT_FILE,
-  EVENT_PLAN_FILE,
-]);
-
-const WIZARD_DOC_PATTERNS: RegExp[] = [EVENT_INVENTORY_PART_PATTERN];
-
-export function isWizardDocumentationPath(
-  filePath: string | undefined,
-): boolean {
-  if (!filePath) return false;
-  const basename = path.basename(filePath);
-  if (WIZARD_DOC_BASENAMES.has(basename)) return true;
-  return WIZARD_DOC_PATTERNS.some((re) => re.test(basename));
-}
+// Which files count as wizard documentation is product knowledge, so it
+// lives with the programs: each declares its files via
+// `ProgramConfig.docPaths`, and the shared registry in
+// `doc-paths-registry.ts` (re-exported above) answers the question here
+// without this file naming any program (wizard#594).
 
 // ─── Repeat-block tracker ─────────────────────────────────────────
 //
@@ -827,8 +790,8 @@ export function createPostToolUseYaraHooks(
             // discard anyway.
             // TODO(warlock#33): once warlock PR #33 lands with its
             // more-precise PII rules, the wizard-side suppression below
-            // should become unnecessary — remove `WIZARD_DOC_BASENAMES`,
-            // `WIZARD_DOC_PATTERNS`, and `isWizardDocumentationPath` and
+            // should become unnecessary — remove the doc-paths registry
+            // (`doc-paths-registry.ts`, `ProgramConfig.docPaths`) and
             // verify the noisy-PII issue stays fixed.
             const filePath = toolInput?.file_path as string | undefined;
             const activeFlagged = isWizardDocumentationPath(filePath)


### PR DESCRIPTION
Closes #594.

`yara-hooks.ts` (L2 infrastructure) imported product filename constants from three programs to build the wizard-documentation allowlist — the layering violation the file's own TODO flagged. This inverts the dependency along the lines sketched in the issue:

- **`src/lib/doc-paths-registry.ts`** (new) — a product-blind registry: `registerWizardDocPaths()` / `isWizardDocumentationPath()`. Knows nothing about programs.
- **`ProgramConfig.docPaths`** (new field) — each program declares the doc files it writes: posthog-integration declares its event plan, audit its report, events-audit its report + inventory files (incl. the per-part pattern).
- **`program-registry.ts`** pushes every declaration into the registry when it loads. `runProgram` imports the registry lazily so entry paths that never load it otherwise (headless installs import their config directly) are covered too — lazy also because a static import would cycle (program modules import the runner).
- `yara-hooks.ts` drops the TODO block and all three product imports; the pi security extension keeps working via a re-export.

Suppression behavior is unchanged: a parity test locks every previously-covered filename, and the existing suppression tests in `yara-hooks.test.ts` / pi `security.test.ts` still pass (they now register the path they write to, since they test the hooks in isolation). Full suite: 1916 passing.

One placement question for review: the lazy registry import lives at the top of `runProgram` — happy to move it into `bootstrapProgram` if that reads better.

Follow-up commit: documented `docPaths` in the `adding-skill-program` skill, so new-program authors find it where they already look.
