### PR TITLE
feat(mcp-analytics): structured abort telemetry and an actionable no-server-found screen

### DIFF
--- a/src/lib/agent/__tests__/abort-reason.test.ts
+++ b/src/lib/agent/__tests__/abort-reason.test.ts
@@ -1,0 +1,42 @@
+import { normalizeAbortReason } from '@lib/agent/abort-reason';
+
+describe('normalizeAbortReason', () => {
+  it('leaves a clean reason untouched', () => {
+    expect(normalizeAbortReason('no mcp server found')).toBe(
+      'no mcp server found',
+    );
+  });
+
+  // Every string below was observed on a real `wizard: agent aborted` event —
+  // the model wrapped the reason in markdown and the capture regex, which reads
+  // to end-of-line, took the punctuation with it.
+  it.each([
+    ['no mcp server found`', 'no mcp server found'],
+    ['no mcp server found**', 'no mcp server found'],
+    ['**no mcp server found**', 'no mcp server found'],
+    ['`no mcp server found`', 'no mcp server found'],
+    ['no mcp server found.', 'no mcp server found'],
+    ['"no mcp server found"', 'no mcp server found'],
+    ['  no mcp server found  ', 'no mcp server found'],
+  ])('strips wrapper noise from %j', (raw, expected) => {
+    expect(normalizeAbortReason(raw)).toBe(expected);
+  });
+
+  it('collapses internal whitespace', () => {
+    expect(normalizeAbortReason('no  mcp\tserver found')).toBe(
+      'no mcp server found',
+    );
+  });
+
+  it('keeps noise inside the phrase, leaving it to prefix-anchored matching', () => {
+    // Normalization is deliberately conservative — it does not guess where the
+    // intended phrase ended, so a trailing clause survives.
+    expect(normalizeAbortReason('no mcp server found` case.')).toBe(
+      'no mcp server found` case',
+    );
+  });
+
+  it('reduces an all-noise reason to the empty string', () => {
+    expect(normalizeAbortReason('**')).toBe('');
+  });
+});

--- a/src/lib/agent/abort-reason.ts
+++ b/src/lib/agent/abort-reason.ts
@@ -1,0 +1,26 @@
+/**
+ * `[ABORT] <reason>` normalization.
+ *
+ * The reason is a substring of the model's own prose, captured to end-of-line,
+ * so it arrives with whatever markdown the model wrapped it in — a stray
+ * closing backtick, bold markers, a trailing period. Normalizing once at the
+ * capture point means every downstream consumer (the `AbortCase` regexes that
+ * pick the error screen, and the `reason` on `wizard: agent aborted`) sees the
+ * same clean value instead of each having to tolerate the noise.
+ *
+ * Only wrapper punctuation is stripped. Anything the model added *inside* the
+ * phrase stays, so a program's `AbortCase.match` should stay prefix-anchored
+ * rather than assuming an exact end-of-string.
+ */
+
+/** Markdown / quoting noise the model wraps a reason in. */
+const LEADING_NOISE = /^[\s`*_~"'[(]+/;
+const TRAILING_NOISE = /[\s`*_~"'\]).,:;!]+$/;
+
+export function normalizeAbortReason(raw: string): string {
+  return raw
+    .replace(LEADING_NOISE, '')
+    .replace(TRAILING_NOISE, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -42,6 +42,7 @@ import { classifyToolToStage } from './agent-phase';
 import type { PackageManagerDetector } from '@lib/detection/package-manager';
 import { AgentSignals, AgentErrorType, REMARK_INSTRUCTION } from './signals';
 import { AgentOutputSignals } from './output-signals';
+import { normalizeAbortReason } from './abort-reason';
 
 // Signal vocabulary and the output parser live in dedicated modules; re-export
 // so existing importers of these from agent-interface keep working.
@@ -1117,7 +1118,7 @@ export async function runAgent(
             if (block.type === 'text' && typeof block.text === 'string') {
               const match = block.text.match(/\[ABORT\]\s*(.+?)(?:\n|$)/);
               if (match) {
-                abortReason = match[1].trim();
+                abortReason = normalizeAbortReason(match[1]);
                 logToFile(`Agent emitted [ABORT]: ${abortReason}`);
                 abortController.abort();
                 signalDone!();
@@ -1288,10 +1289,14 @@ export async function runAgent(
     throw error;
   } finally {
     // Always capture run duration, even on abort/error, so we can alert on
-    // long runs where the user gave up before completion.
+    // long runs where the user gave up before completion. `abort_kind`
+    // separates this from the skill's own `[ABORT]` signal, which the runner
+    // captures with a reason — without it both land on the same event name and
+    // a funnel can't tell "the skill said stop" from "the run never finished".
     if (!receivedSuccessResult) {
       const durationMs = Date.now() - startTime;
       analytics.wizardCapture('agent aborted', {
+        abort_kind: 'run_incomplete',
         duration_ms: durationMs,
         duration_seconds: Math.round(durationMs / 1000),
         model: agentConfig.model,

--- a/src/lib/agent/runner/harness/pi/index.ts
+++ b/src/lib/agent/runner/harness/pi/index.ts
@@ -216,6 +216,7 @@ export const piBackend: AgentHarness = {
     };
     const captureAborted = () =>
       analytics.wizardCapture('agent aborted', {
+        abort_kind: 'run_incomplete',
         ...runDurations(),
         model: modelId,
       });

--- a/src/lib/agent/runner/harness/pi/task.ts
+++ b/src/lib/agent/runner/harness/pi/task.ts
@@ -189,6 +189,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
   };
   const captureAborted = () =>
     analytics.wizardCapture('agent aborted', {
+      abort_kind: 'run_incomplete',
       ...runDurations(),
       model: modelId,
       ...analyticsProperties,

--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -157,9 +157,13 @@ export async function runLinearProgram(
           docsUrl: config.docsUrl,
         };
     analytics.wizardCapture('agent aborted', {
+      abort_kind: 'skill_signal',
       integration: config.integrationLabel,
       reason,
       matched: matched?.message ?? null,
+      // Group funnels on these two, not on `reason` — see AbortCase.code.
+      reason_code: matched?.code ?? 'unmatched',
+      reason_matched: matched !== undefined,
     });
     await wizardAbort({
       outroData,

--- a/src/lib/agent/runner/sequence/linear.ts
+++ b/src/lib/agent/runner/sequence/linear.ts
@@ -28,6 +28,7 @@ import { createWizardAskBridge } from '../../../wizard-ask-bridge';
 import type { ProgramConfig } from '../../../programs/program-step';
 import { assemblePrompt } from '../../agent-prompt';
 import type { ProgramRun, BootstrapResult } from '../shared/types';
+import { collectAbortFollowUp } from '../shared/abort-follow-up';
 import { abortOnInstallFailure } from '../shared/errors';
 import { shouldDisableAsk, sessionToOptions } from '../shared/bootstrap';
 import { resolveHarness, getHarness } from '../switchboard';
@@ -143,9 +144,10 @@ export async function runLinearProgram(
   if (agentResult.error === AgentErrorType.ABORT) {
     const reason = agentResult.message ?? '';
     const matched = config.abortCases?.find((c) => c.match.test(reason));
+    const notApplicable = matched?.outcome === 'not_applicable';
     const outroData: WizardSession['outroData'] = matched
       ? {
-          kind: OutroKind.Error,
+          kind: notApplicable ? OutroKind.NotApplicable : OutroKind.Error,
           message: matched.message,
           body: matched.body,
           docsUrl: matched.docsUrl,
@@ -156,22 +158,36 @@ export async function runLinearProgram(
           body: reason || 'The agent aborted the program.',
           docsUrl: config.docsUrl,
         };
+
+    // Ask before exiting, not after: this is the last moment the user is still
+    // at the terminal. Never let the exit hinge on an answer — no bridge (CI,
+    // signup), a cancelled prompt, or a timeout all fall through unchanged.
+    const followUp = await collectAbortFollowUp(matched, askBridge);
+
     analytics.wizardCapture('agent aborted', {
       abort_kind: 'skill_signal',
       integration: config.integrationLabel,
       reason,
       matched: matched?.message ?? null,
-      // Group funnels on these two, not on `reason` — see AbortCase.code.
+      // Group funnels on these, not on `reason` — see AbortCase.code.
       reason_code: matched?.code ?? 'unmatched',
       reason_matched: matched !== undefined,
+      outcome: notApplicable ? 'not_applicable' : 'failure',
+      ...followUp,
     });
     await wizardAbort({
       outroData,
-      error: new WizardError(`Agent aborted: ${reason}`, {
-        integration: config.integrationLabel,
-        error_type: AgentErrorType.ABORT,
-        reason,
-      }),
+      // A project this program doesn't serve isn't an exception to capture or
+      // a failed run to report. The exit code stays non-zero either way: a
+      // scripted caller asked for instrumentation and didn't get it.
+      status: notApplicable ? 'not_applicable' : undefined,
+      error: notApplicable
+        ? undefined
+        : new WizardError(`Agent aborted: ${reason}`, {
+            integration: config.integrationLabel,
+            error_type: AgentErrorType.ABORT,
+            reason,
+          }),
     });
   }
 

--- a/src/lib/agent/runner/shared/__tests__/abort-follow-up.test.ts
+++ b/src/lib/agent/runner/shared/__tests__/abort-follow-up.test.ts
@@ -1,0 +1,105 @@
+import { collectAbortFollowUp } from '@lib/agent/runner/shared/abort-follow-up';
+import type { AbortCase } from '@lib/agent/runner/shared/types';
+import {
+  CANCELLED_SENTINEL,
+  type WizardAskBridge,
+} from '@lib/wizard-ask-bridge';
+import type { AskAnswers, AskQuestion } from '@lib/wizard-session';
+
+const PICKER: AskQuestion = {
+  id: 'mcp_server_kind',
+  kind: 'single',
+  prompt: 'What is in this project?',
+  options: [{ label: 'Python', value: 'python' }],
+};
+
+function bridge(answers: AskAnswers | Error): WizardAskBridge {
+  return {
+    request: () =>
+      answers instanceof Error
+        ? Promise.reject(answers)
+        : Promise.resolve(answers),
+  };
+}
+
+function abortCase(followUp?: AskQuestion[]): AbortCase {
+  return { match: /x/, message: 'm', body: 'b', followUp };
+}
+
+describe('collectAbortFollowUp', () => {
+  it('ships a picked value under a follow_up_ key', async () => {
+    await expect(
+      collectAbortFollowUp(
+        abortCase([PICKER]),
+        bridge({ mcp_server_kind: 'python' }),
+      ),
+    ).resolves.toEqual({ follow_up_mcp_server_kind: 'python' });
+  });
+
+  // Every branch below must exit as if no question were configured — asking is
+  // a bonus, and an abort that hangs or throws on it is worse than no data.
+  it('asks nothing when the case declares no follow-up', async () => {
+    const ask = bridge({ mcp_server_kind: 'python' });
+    const spy = vi.spyOn(ask, 'request');
+    await expect(collectAbortFollowUp(abortCase(), ask)).resolves.toEqual({});
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('asks nothing when there is no bridge (CI, signup)', async () => {
+    await expect(
+      collectAbortFollowUp(abortCase([PICKER]), undefined),
+    ).resolves.toEqual({});
+  });
+
+  it('asks nothing when the abort matched no known case', async () => {
+    await expect(
+      collectAbortFollowUp(undefined, bridge({ a: 'b' })),
+    ).resolves.toEqual({});
+  });
+
+  it('swallows a failing request', async () => {
+    await expect(
+      collectAbortFollowUp(abortCase([PICKER]), bridge(new Error('overlay'))),
+    ).resolves.toEqual({});
+  });
+
+  it('drops a cancelled or timed-out answer', async () => {
+    await expect(
+      collectAbortFollowUp(
+        abortCase([PICKER]),
+        bridge({ mcp_server_kind: CANCELLED_SENTINEL }),
+      ),
+    ).resolves.toEqual({});
+  });
+
+  it('records that a free-text question was answered, never what was typed', async () => {
+    // Free text is a path, a repo name, an internal service — none of which
+    // belongs on an analytics event.
+    const text: AskQuestion = {
+      id: 'where',
+      kind: 'text',
+      prompt: 'Where is it?',
+    };
+    await expect(
+      collectAbortFollowUp(
+        abortCase([text, PICKER]),
+        bridge({ where: '/srv/internal/acme-mcp', mcp_server_kind: 'python' }),
+      ),
+    ).resolves.toEqual({
+      follow_up_where: true,
+      follow_up_mcp_server_kind: 'python',
+    });
+  });
+
+  it('keeps multi-select answers as arrays', async () => {
+    const multi: AskQuestion = {
+      id: 'langs',
+      kind: 'multi',
+      prompt: 'Which?',
+      options: [{ label: 'Go', value: 'go' }],
+    };
+    await expect(
+      collectAbortFollowUp(abortCase([multi]), bridge({ langs: ['go', 'rb'] })),
+    ).resolves.toEqual({ follow_up_langs: ['go', 'rb'] });
+  });
+});

--- a/src/lib/agent/runner/shared/abort-follow-up.ts
+++ b/src/lib/agent/runner/shared/abort-follow-up.ts
@@ -1,0 +1,57 @@
+/**
+ * Follow-up questions asked when a program aborts.
+ *
+ * A user the program turns away is the only person who can say what they
+ * actually had, and the abort screen is the last moment they're still at the
+ * terminal. `AbortCase.followUp` lets a program ask before exiting, through the
+ * same overlay the agent's `wizard_ask` uses.
+ *
+ * Two rules hold no matter what the program configures:
+ *
+ * - Asking never changes the exit. No bridge, a thrown request, a cancelled
+ *   prompt, a timeout — all fall through to the same abort.
+ * - Free-text answers never reach analytics. Only `single`/`multi` picks ship
+ *   their values; a `text` question ships a boolean saying it was answered.
+ *   Prefer pickers for anything you intend to aggregate.
+ */
+
+import {
+  CANCELLED_SENTINEL,
+  isFullyCancelled,
+  type WizardAskBridge,
+} from '@lib/wizard-ask-bridge';
+import { logToFile } from '@utils/debug';
+import type { AbortCase } from './types';
+
+/** Analytics properties keyed `follow_up_<question id>`. */
+export type AbortFollowUpProperties = Record<string, string | string[] | true>;
+
+export async function collectAbortFollowUp(
+  matched: AbortCase | undefined,
+  askBridge: WizardAskBridge | undefined,
+): Promise<AbortFollowUpProperties> {
+  const questions = matched?.followUp;
+  if (!questions?.length || !askBridge) return {};
+
+  let answers;
+  try {
+    answers = await askBridge.request({ questions });
+  } catch (error) {
+    logToFile('[abort-follow-up] ask failed, exiting without it:', error);
+    return {};
+  }
+  if (isFullyCancelled(answers)) return {};
+
+  const freeText = new Set(
+    questions.filter((q) => q.kind === 'text').map((q) => q.id),
+  );
+
+  const properties: AbortFollowUpProperties = {};
+  for (const [id, value] of Object.entries(answers)) {
+    if (value === CANCELLED_SENTINEL) continue;
+    // A free-text answer is whatever the user typed — a path, a repo name, an
+    // internal service. Record that they answered, not what they wrote.
+    properties[`follow_up_${id}`] = freeText.has(id) ? true : value;
+  }
+  return properties;
+}

--- a/src/lib/agent/runner/shared/types.ts
+++ b/src/lib/agent/runner/shared/types.ts
@@ -23,6 +23,13 @@ export interface AbortCase {
   message: string;
   body: string;
   docsUrl?: string;
+  /**
+   * Stable snake_case key for this case, shipped as `reason_code` on
+   * `wizard: agent aborted`. The raw `reason` is model prose and drifts with
+   * every skill reword, so a funnel that groups by it silently splits; group
+   * by `reason_code` instead. Omit it and only the raw reason ships.
+   */
+  code?: string;
 }
 
 /**

--- a/src/lib/agent/runner/shared/types.ts
+++ b/src/lib/agent/runner/shared/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  AskQuestion,
   Credentials,
   AdditionalFeature,
   WizardSession,
@@ -30,6 +31,25 @@ export interface AbortCase {
    * by `reason_code` instead. Omit it and only the raw reason ships.
    */
   code?: string;
+  /**
+   * `not_applicable` means the program found nothing it could act on — the
+   * user brought a project this program doesn't serve. It renders a neutral
+   * outro instead of a red error, skips exception capture, and reports
+   * `not_applicable` as the run's terminal status, so these runs stop
+   * depressing the program's success rate. Defaults to `failure`.
+   */
+  outcome?: 'failure' | 'not_applicable';
+  /**
+   * Questions to ask before exiting on this case, through the same overlay the
+   * agent's `wizard_ask` uses. A turned-away user is the only person who can
+   * say what they actually had, and this is the last moment they're still
+   * here. Answers ship on `wizard: agent aborted` as `follow_up_*`.
+   *
+   * Skipped when the ask bridge is unavailable (CI, signup), and a cancelled
+   * or timed-out prompt exits exactly as if none were configured — never make
+   * the exit depend on an answer.
+   */
+  followUp?: AskQuestion[];
 }
 
 /**

--- a/src/lib/programs/__tests__/mcp-analytics.test.ts
+++ b/src/lib/programs/__tests__/mcp-analytics.test.ts
@@ -46,6 +46,43 @@ describe('MCP_ANALYTICS_ABORT_CASES', () => {
     expect(matched).toHaveLength(1);
   });
 
+  it('treats no-server-found as not-applicable, and the rest as failures', () => {
+    // The scan turning a project away is not a broken wizard. The other two
+    // cases are real stopping points, so they stay failures.
+    const byCode = Object.fromEntries(
+      MCP_ANALYTICS_ABORT_CASES.map((c) => [c.code, c]),
+    );
+    expect(byCode.no_mcp_server.outcome).toBe('not_applicable');
+    expect(byCode.unsupported_language.outcome).toBeUndefined();
+    expect(byCode.no_server_entrypoint.outcome).toBeUndefined();
+  });
+
+  it('asks the turned-away user what they had, without requiring an answer', () => {
+    const [noServer] = MCP_ANALYTICS_ABORT_CASES.filter(
+      (c) => c.code === 'no_mcp_server',
+    );
+    const [question] = noServer.followUp ?? [];
+    expect(question).toBeDefined();
+    // A picker, not free text: the answers have to aggregate, and free text on
+    // an analytics event risks carrying paths or internal service names.
+    expect(question.kind).toBe('single');
+    expect(question.required).toBe(false);
+
+    // The options have to separate the outcomes that imply different fixes —
+    // a scan miss, a language gap, a wrong directory, and a user who never
+    // had a server. Collapsing any pair makes the answer unactionable.
+    const values = (question.options ?? []).map((o) => o.value);
+    expect(values).toEqual(
+      expect.arrayContaining([
+        'typescript_javascript',
+        'python',
+        'other_language',
+        'wrong_directory',
+        'no_server',
+      ]),
+    );
+  });
+
   it('gives the no-server abort a way forward instead of a dead end', () => {
     // This is the single most common abort, and it is terminal for the user —
     // the copy has to cover the three things it actually means.

--- a/src/lib/programs/__tests__/mcp-analytics.test.ts
+++ b/src/lib/programs/__tests__/mcp-analytics.test.ts
@@ -1,3 +1,4 @@
+import { AGENT_SKILL_STEPS } from '@lib/programs/agent-skill/index';
 import {
   MCP_ANALYTICS_ABORT_CASES,
   mcpAnalyticsConfig,
@@ -23,6 +24,41 @@ describe('MCP_ANALYTICS_ABORT_CASES', () => {
     expect(matched[0].body).toBeTruthy();
   });
 
+  it('gives every case a stable reason code', () => {
+    // `reason_code` on `wizard: agent aborted` is the funnel's grouping key, so
+    // a case without one is invisible to it.
+    const codes = MCP_ANALYTICS_ABORT_CASES.map((c) => c.code);
+    expect(codes.every(Boolean)).toBe(true);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  // Observed on real aborts: the model appended a trailing clause on the same
+  // line, so the captured reason carries more than the intended phrase. These
+  // used to fall through to the generic "aborted" screen.
+  it.each([
+    'no mcp server found` case.',
+    'no mcp server found — this project only has a client',
+    'unsupported language for mcp analytics (Go)',
+  ])('still matches when the model pads the reason: %j', (reason) => {
+    const matched = MCP_ANALYTICS_ABORT_CASES.filter((c) =>
+      c.match.test(reason),
+    );
+    expect(matched).toHaveLength(1);
+  });
+
+  it('gives the no-server abort a way forward instead of a dead end', () => {
+    // This is the single most common abort, and it is terminal for the user —
+    // the copy has to cover the three things it actually means.
+    const [noServer] = MCP_ANALYTICS_ABORT_CASES.filter(
+      (c) => c.code === 'no_mcp_server',
+    );
+    expect(noServer).toBeDefined();
+    const copy = noServer.body.toLowerCase();
+    expect(copy).toContain('--install-dir');
+    expect(copy).toContain('mcp add');
+    expect(noServer.docsUrl).toBeTruthy();
+  });
+
   it('frames the unsupported-language abort as JS/TS *and* Python supported', () => {
     // Python (`posthog.mcp`) shipped in posthog v7.21.0 — the copy must not
     // claim JS/TS-only or call Python "on the roadmap".
@@ -46,5 +82,15 @@ describe('mcpAnalyticsConfig', () => {
       throw new Error('expected a static run object');
     }
     expect(run.abortCases).toBe(MCP_ANALYTICS_ABORT_CASES);
+  });
+
+  it('attaches the language probe without mutating the shared step list', () => {
+    expect(mcpAnalyticsConfig.steps[0].onReady).toBeTypeOf('function');
+    // AGENT_SKILL_STEPS is shared by every skill program — mutating it here
+    // would fire this probe on `audit`, `revenue-analytics`, and the rest.
+    expect(AGENT_SKILL_STEPS[0].onReady).toBeUndefined();
+    expect(mcpAnalyticsConfig.steps.map((s) => s.id)).toEqual(
+      AGENT_SKILL_STEPS.map((s) => s.id),
+    );
   });
 });

--- a/src/lib/programs/agent-skill/index.ts
+++ b/src/lib/programs/agent-skill/index.ts
@@ -19,7 +19,7 @@
  *   })
  */
 
-import type { ProgramConfig } from '@lib/programs/program-step';
+import type { ProgramConfig, ProgramStep } from '@lib/programs/program-step';
 import type { ProgramRun, AbortCase } from '@lib/agent/agent-runner';
 import { AGENT_SKILL_STEPS } from './steps.js';
 import { getContentBlocks } from './content/index.js';
@@ -48,15 +48,30 @@ export interface SkillProgramOptions {
   buildOutroData?: ProgramRun['buildOutroData'];
   /** Known `[ABORT] <reason>` cases the skill can emit. */
   abortCases?: AbortCase[];
+  /**
+   * Session-dependent pre-program work, run once before any gate is awaited —
+   * e.g. probing the install dir so later events carry what was found. Attached
+   * to the first step; omit it and the shared step list is used as-is.
+   */
+  onReady?: ProgramStep['onReady'];
 }
 
 export function createSkillProgram(opts: SkillProgramOptions): ProgramConfig {
+  // Copy rather than mutate: AGENT_SKILL_STEPS is shared by every skill
+  // program, so an in-place `onReady` would fire for all of them.
+  const steps = opts.onReady
+    ? [
+        { ...AGENT_SKILL_STEPS[0], onReady: opts.onReady },
+        ...AGENT_SKILL_STEPS.slice(1),
+      ]
+    : AGENT_SKILL_STEPS;
+
   return {
     command: opts.command,
     description: opts.description,
     id: opts.id,
     skillId: opts.skillId,
-    steps: AGENT_SKILL_STEPS,
+    steps,
     reportFile: opts.reportFile,
     getContentBlocks,
     run: {

--- a/src/lib/programs/mcp-analytics/__tests__/detect.test.ts
+++ b/src/lib/programs/mcp-analytics/__tests__/detect.test.ts
@@ -1,0 +1,47 @@
+import { languagesFromEntries } from '@lib/programs/mcp-analytics/detect';
+
+describe('languagesFromEntries', () => {
+  it('reads a bare package.json as javascript', () => {
+    expect(languagesFromEntries(['package.json', 'README.md'])).toEqual([
+      'javascript',
+    ]);
+  });
+
+  it('upgrades to typescript when a tsconfig sits alongside', () => {
+    expect(languagesFromEntries(['package.json', 'tsconfig.json'])).toEqual([
+      'typescript',
+    ]);
+  });
+
+  it.each([
+    ['pyproject.toml', 'python'],
+    ['requirements.txt', 'python'],
+    ['go.mod', 'go'],
+    ['Cargo.toml', 'rust'],
+    ['Gemfile', 'ruby'],
+    ['composer.json', 'php'],
+    ['pom.xml', 'java'],
+  ])('maps %s to %s', (entry, language) => {
+    expect(languagesFromEntries([entry])).toEqual([language]);
+  });
+
+  it('matches extension-based ecosystems', () => {
+    expect(languagesFromEntries(['Server.csproj'])).toEqual(['csharp']);
+  });
+
+  it('reports every language in a polyglot repo, sorted and deduped', () => {
+    expect(
+      languagesFromEntries([
+        'package.json',
+        'tsconfig.json',
+        'pyproject.toml',
+        'go.mod',
+        'requirements.txt',
+      ]),
+    ).toEqual(['go', 'python', 'typescript']);
+  });
+
+  it('returns nothing for a project with no recognizable manifest', () => {
+    expect(languagesFromEntries(['README.md', 'LICENSE'])).toEqual([]);
+  });
+});

--- a/src/lib/programs/mcp-analytics/detect.ts
+++ b/src/lib/programs/mcp-analytics/detect.ts
@@ -1,0 +1,99 @@
+/**
+ * MCP analytics language probe.
+ *
+ * The skill decides for itself whether a project can be instrumented, and when
+ * it can't it aborts with `unsupported language for mcp analytics`. That tells
+ * us a project was turned away but not *what* it was written in, so there's no
+ * way to rank which language to support next. This probe answers that from the
+ * manifest files in the install dir and ships the answer as analytics tags, so
+ * every event in the run — including the abort — carries it.
+ *
+ * Manifests only: no source parsing, no recursion. A wrong guess costs a
+ * mislabelled tag, so cheap and predictable beats thorough.
+ */
+
+import { readdirSync } from 'fs';
+import { analytics } from '@utils/analytics';
+import { debug } from '@utils/debug';
+
+/** Languages the `@posthog/mcp` / `posthog.mcp` SDKs cover today. */
+export const MCP_ANALYTICS_SUPPORTED_LANGUAGES = [
+  'typescript',
+  'javascript',
+  'python',
+] as const;
+
+/** Manifest filename → language it implies. */
+const MANIFEST_LANGUAGES: ReadonlyArray<readonly [string, string]> = [
+  ['package.json', 'javascript'],
+  ['pyproject.toml', 'python'],
+  ['requirements.txt', 'python'],
+  ['setup.py', 'python'],
+  ['pipfile', 'python'],
+  ['go.mod', 'go'],
+  ['cargo.toml', 'rust'],
+  ['pom.xml', 'java'],
+  ['build.gradle', 'java'],
+  ['build.gradle.kts', 'kotlin'],
+  ['composer.json', 'php'],
+  ['gemfile', 'ruby'],
+  ['pubspec.yaml', 'dart'],
+  ['package.swift', 'swift'],
+  ['mix.exs', 'elixir'],
+];
+
+/** File extension → language, for ecosystems without a fixed manifest name. */
+const EXTENSION_LANGUAGES: ReadonlyArray<readonly [string, string]> = [
+  ['.csproj', 'csharp'],
+  ['.fsproj', 'fsharp'],
+  ['.sln', 'csharp'],
+];
+
+/**
+ * Map a flat list of directory entry names to the languages they imply,
+ * sorted for a stable tag value. Pure — the fs read is the caller's job.
+ *
+ * `package.json` alone reads as `javascript`; a `tsconfig.json` next to it
+ * upgrades that to `typescript`, since the SDK's install path differs.
+ */
+export function languagesFromEntries(entries: readonly string[]): string[] {
+  const lower = entries.map((e) => e.toLowerCase());
+  const found = new Set<string>();
+
+  for (const [manifest, language] of MANIFEST_LANGUAGES) {
+    if (lower.includes(manifest)) found.add(language);
+  }
+  for (const [extension, language] of EXTENSION_LANGUAGES) {
+    if (lower.some((e) => e.endsWith(extension))) found.add(language);
+  }
+  if (found.has('javascript') && lower.includes('tsconfig.json')) {
+    found.delete('javascript');
+    found.add('typescript');
+  }
+
+  return [...found].sort();
+}
+
+/**
+ * Probe `installDir` and tag the run with the languages found. Best effort:
+ * an unreadable directory tags nothing rather than failing the run, because
+ * the skill — not this probe — decides whether the program can proceed.
+ */
+export function tagMcpAnalyticsLanguages(installDir: string): void {
+  let languages: string[] = [];
+  try {
+    languages = languagesFromEntries(readdirSync(installDir));
+  } catch (error) {
+    debug('mcp-analytics language probe failed:', error);
+  }
+
+  analytics.setTag('mcp_analytics_languages', languages.join(',') || 'unknown');
+  analytics.setTag(
+    'mcp_analytics_language_supported',
+    languages.some((language) =>
+      (MCP_ANALYTICS_SUPPORTED_LANGUAGES as readonly string[]).includes(
+        language,
+      ),
+    ),
+  );
+}

--- a/src/lib/programs/mcp-analytics/index.ts
+++ b/src/lib/programs/mcp-analytics/index.ts
@@ -1,5 +1,6 @@
 import type { AbortCase } from '@lib/agent/agent-runner';
 import { createSkillProgram } from '@lib/programs/agent-skill/index';
+import { tagMcpAnalyticsLanguages } from './detect.js';
 
 const MCP_ANALYTICS_REPORT_FILE = 'posthog-mcp-analytics-report.md';
 
@@ -7,10 +8,17 @@ const MCP_ANALYTICS_REPORT_FILE = 'posthog-mcp-analytics-report.md';
  * `[ABORT]` reasons the mcp-analytics skill emits when the project can't be
  * instrumented. Kept in sync with the stop conditions in the skill's
  * `description.md` (context-mill `context/skills/mcp-analytics`).
+ *
+ * Matches are prefix-anchored, not exact: the reason is a slice of the model's
+ * own prose, so it arrives with trailing clauses the wizard can't predict
+ * ("no mcp server found` case."). `normalizeAbortReason` strips wrapper
+ * punctuation, prefix anchoring absorbs the rest — an exact `$` anchor sends a
+ * known case to the generic "aborted" screen over a stray word.
  */
 export const MCP_ANALYTICS_ABORT_CASES: AbortCase[] = [
   {
-    match: /^unsupported language for mcp analytics$/i,
+    match: /^unsupported language for mcp analytics/i,
+    code: 'unsupported_language',
     message: 'Unsupported language for MCP analytics',
     body:
       'MCP analytics supports TypeScript/JavaScript (`@posthog/mcp`) and Python ' +
@@ -19,15 +27,25 @@ export const MCP_ANALYTICS_ABORT_CASES: AbortCase[] = [
       'See https://posthog.com/docs/mcp-analytics for the supported setups.',
   },
   {
-    match: /^no mcp server found$/i,
+    match: /^no mcp server found/i,
+    code: 'no_mcp_server',
     message: 'No MCP server found',
     body:
-      'This command instruments an existing MCP server with PostHog analytics, ' +
-      'but no MCP server was found in this project. If you just want PostHog ' +
-      'product analytics, run `npx @posthog/wizard` instead.',
+      'This command instruments an MCP server you own, so that it reports on ' +
+      "its own tool calls — and it couldn't find one here. Three things this " +
+      'usually means:\n\n' +
+      '• The server lives in a subdirectory — re-run with `--install-dir` pointed at the package that constructs it.\n' +
+      '• The server is built in a way the scan missed — the SDK can wrap any ' +
+      'server, and https://posthog.com/docs/mcp-analytics/installation has the ' +
+      'manual snippet for both the wrapper and custom-dispatcher shapes.\n' +
+      '• You wanted the PostHog MCP server in your coding agent instead — that ' +
+      'is `npx @posthog/wizard mcp add`, and plain product analytics is ' +
+      '`npx @posthog/wizard`.',
+    docsUrl: 'https://posthog.com/docs/mcp-analytics/installation',
   },
   {
-    match: /^could not locate the server entry point$/i,
+    match: /^could not locate the server entry point/i,
+    code: 'no_server_entrypoint',
     message: 'Could not locate the MCP server entry point',
     body:
       "This project has MCP signals, but the agent couldn't find where the " +
@@ -71,4 +89,7 @@ export const mcpAnalyticsConfig = createSkillProgram({
   spinnerMessage: 'Setting up MCP analytics...',
   estimatedDurationMinutes: 5,
   abortCases: MCP_ANALYTICS_ABORT_CASES,
+  // Tags the run with the project's language before the agent runs, so an
+  // `unsupported_language` abort says which language was turned away.
+  onReady: ({ session }) => tagMcpAnalyticsLanguages(session.installDir),
 });

--- a/src/lib/programs/mcp-analytics/index.ts
+++ b/src/lib/programs/mcp-analytics/index.ts
@@ -29,6 +29,44 @@ export const MCP_ANALYTICS_ABORT_CASES: AbortCase[] = [
   {
     match: /^no mcp server found/i,
     code: 'no_mcp_server',
+    // By far the most common way this program ends, and it's the scan that
+    // decides it. A project the scan can't see through is not a wizard
+    // failure, and counting it as one buries the runs that genuinely broke.
+    outcome: 'not_applicable',
+    // The only person who knows whether the scan was wrong is the user it just
+    // turned away. The options are the four things this outcome can actually
+    // mean, so the answers rank the fix: a JS/TS or Python pick is a scan miss
+    // to reproduce, another language ranks the SDK backlog, a subdirectory is
+    // a discoverability problem, and "no server" is nothing to fix at all.
+    followUp: [
+      {
+        id: 'mcp_server_kind',
+        kind: 'single',
+        required: false,
+        prompt:
+          "Before you go — what's in this project? This tells us whether the " +
+          'scan missed your server or MCP analytics has nothing to offer you yet.',
+        options: [
+          {
+            label: 'A TypeScript/JavaScript MCP server the scan missed',
+            value: 'typescript_javascript',
+          },
+          { label: 'A Python MCP server the scan missed', value: 'python' },
+          {
+            label: 'An MCP server in another language',
+            value: 'other_language',
+          },
+          {
+            label: 'A server in a subdirectory I should have pointed at',
+            value: 'wrong_directory',
+          },
+          {
+            label: 'No MCP server — I was after something else',
+            value: 'no_server',
+          },
+        ],
+      },
+    ],
     message: 'No MCP server found',
     body:
       'This command instruments an MCP server you own, so that it reports on ' +

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -88,6 +88,13 @@ export enum OutroKind {
   Success = 'success',
   Error = 'error',
   Cancel = 'cancel',
+  /**
+   * The program doesn't apply to this project — nothing broke, there was just
+   * nothing to do. Distinct from `Error` so a program that turns a user away
+   * (no MCP server to instrument, no Stripe integration to read) doesn't read
+   * as a broken wizard, on the outro or in the run's terminal event.
+   */
+  NotApplicable = 'not_applicable',
 }
 
 export interface OutroData {

--- a/src/ui/tui/playground/demos/EndScreensDemo.tsx
+++ b/src/ui/tui/playground/demos/EndScreensDemo.tsx
@@ -32,7 +32,12 @@ import { HostResolution } from '@lib/host-resolution';
 const VIEWS = ['slack-connect', 'outro'] as const;
 type View = (typeof VIEWS)[number];
 
-const OUTRO_KINDS = [OutroKind.Success, OutroKind.Error, OutroKind.Cancel];
+const OUTRO_KINDS = [
+  OutroKind.Success,
+  OutroKind.Error,
+  OutroKind.NotApplicable,
+  OutroKind.Cancel,
+];
 
 const OUTRO_FIXTURES: Record<OutroKind, OutroData> = {
   [OutroKind.Success]: {
@@ -53,6 +58,15 @@ const OUTRO_FIXTURES: Record<OutroKind, OutroData> = {
     message: 'The agent hit an error',
     body: 'The integration step failed before any files were changed.\nRe-run the wizard to try again.',
     docsUrl: 'https://posthog.com/docs/ai-engineering/ai-wizard',
+  },
+  [OutroKind.NotApplicable]: {
+    kind: OutroKind.NotApplicable,
+    message: 'No MCP server found',
+    body:
+      "This command instruments an MCP server you own, and it couldn't find " +
+      'one here.\nRe-run with --install-dir pointed at the package that ' +
+      'constructs it, or see the docs for the manual snippet.',
+    docsUrl: 'https://posthog.com/docs/mcp-analytics/installation',
   },
   [OutroKind.Cancel]: {
     kind: OutroKind.Cancel,

--- a/src/ui/tui/screens/OutroScreen.tsx
+++ b/src/ui/tui/screens/OutroScreen.tsx
@@ -190,6 +190,30 @@ export const OutroScreen = ({ store }: OutroScreenProps) => {
         </Box>
       )}
 
+      {outroData.kind === OutroKind.NotApplicable && (
+        <Box flexDirection="column">
+          {/* Neutral, not red: nothing failed, this project just isn't one the
+              program can act on. The body carries the ways forward. */}
+          <Text color="yellow" bold>
+            ◦ {outroData.message || 'Nothing to do here'}
+          </Text>
+
+          {outroData.body && (
+            <Box marginTop={1}>
+              <Text dimColor>{outroData.body}</Text>
+            </Box>
+          )}
+
+          {outroData.docsUrl && (
+            <Box marginTop={1}>
+              <Text>
+                Docs: <Text color="cyan">{outroData.docsUrl}</Text>
+              </Text>
+            </Box>
+          )}
+        </Box>
+      )}
+
       {outroData.kind === OutroKind.Cancel && (
         <Box flexDirection="column">
           <Text color="yellow">■ {outroData.message || 'Cancelled'}</Text>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -343,7 +343,12 @@ export class Analytics {
     return this.activeFlagPayloads;
   }
 
-  async shutdown(status: 'success' | 'error' | 'cancelled') {
+  /**
+   * `not_applicable` is a fourth terminal state, not a flavour of failure: the
+   * run worked and found nothing it could act on. Kept separate so
+   * success-rate metrics can exclude runs that were never eligible.
+   */
+  async shutdown(status: 'success' | 'error' | 'cancelled' | 'not_applicable') {
     if (Object.keys(this.tags).length === 0) {
       return;
     }

--- a/src/utils/wizard-abort.ts
+++ b/src/utils/wizard-abort.ts
@@ -27,6 +27,13 @@ interface WizardAbortOptions {
   outroData?: OutroData;
   error?: Error | WizardError;
   exitCode?: number;
+  /**
+   * Terminal status for `setup wizard finished`. Defaults to `error` when an
+   * `error` is supplied and `cancelled` otherwise. Pass `not_applicable` for a
+   * run that worked but found nothing to act on, so it isn't counted as a
+   * failed run.
+   */
+  status?: 'error' | 'cancelled' | 'not_applicable';
 }
 
 const cleanupFns: Array<() => void> = [];
@@ -59,6 +66,7 @@ export async function wizardAbort(
     outroData,
     error,
     exitCode = 1,
+    status,
   } = options ?? {};
 
   logToFile(`[wizard-abort] exitCode=${exitCode}, message: ${message}`);
@@ -77,7 +85,7 @@ export async function wizardAbort(
   }
 
   // 3. Shutdown analytics
-  await analytics.shutdown(error ? 'error' : 'cancelled');
+  await analytics.shutdown(status ?? (error ? 'error' : 'cancelled'));
 
   // 4. Render the error outro. Synthesize OutroData from `message`
   //    when the caller didn't provide structured data.


### PR DESCRIPTION
## Problem

`wizard mcp-analytics` gives up more often than it finishes, and today an abort is close to invisible in analytics and terminal for the user. Found while diagnosing why MCP analytics activation has never approached its target — users who hit the most common abort essentially never come back.

- **"No MCP server found" is a dead end in three ways at once.** It renders as a red error, it reports the run as *failed*, and it exits without ever asking the one person who knows what the scan missed. That last one is why we can't tell a scan bug from a user who simply doesn't have an MCP server — the two need completely different fixes and are indistinguishable in the data.
- **The abort reason arrives as noisy prose.** `[ABORT] <reason>` is captured to end-of-line, so it comes through wrapped in whatever markdown the model wrote — a stray backtick, bold markers, a trailing clause. The `AbortCase` regexes were exactly anchored, so those variants missed and users got the generic "aborted" screen instead of the case-specific one.
- **`reason` is unusable as a grouping key.** It's model prose, so a funnel grouped on it splits on every reword.
- **`wizard: agent aborted` conflates two different events** — the skill's `[ABORT]` signal and "the run never finished" (user quit, harness hung). Only the former carries a reason, so a large share of these events have no reason at all and can't be separated from real aborts.
- **`unsupported language` never recorded *which* language** was turned away, so there's no way to rank what to support next.

## Changes

Generic, in the runner and session — useful to every program with `abortCases`:

- `OutroKind.NotApplicable`: a neutral outro for "nothing here to act on", distinct from an error.
- `AbortCase.outcome: 'not_applicable'` routes a case there, skips exception capture, and reports `not_applicable` as the run's terminal status on `setup wizard finished`, so ineligible runs stop depressing success rate. The exit code stays non-zero — a scripted caller asked for instrumentation and didn't get it.
- `AbortCase.followUp` asks questions before exiting, reusing the overlay the agent's `wizard_ask` already drives. Two invariants: asking never changes the exit (no bridge in CI/signup, a throw, a cancel, and a timeout all fall through unchanged), and free-text answers never reach analytics — they carry paths and internal service names, so only picker values ship and a text question reports only that it was answered.
- `normalizeAbortReason` strips wrapper punctuation once at the capture point, so the error screen and analytics see the same clean value. Deliberately conservative — it doesn't guess where the intended phrase ended.
- `AbortCase.code` ships as `reason_code` (with `reason_matched` and `outcome`); `abort_kind` (`skill_signal` / `run_incomplete`) at all four `agent aborted` call sites.

Product-specific, in `src/lib/programs/mcp-analytics/`:

- No-server-found is now not-applicable, with a follow-up picker separating the four things that outcome can actually mean — a JS/TS or Python server the scan missed, another language, a subdirectory that should have been the target, or no server at all. Each implies a different fix; collapsing any pair makes the answer unactionable.
- Rewritten body copy covering those same paths (`--install-dir`, the manual snippet, or `mcp add` if they wanted the other thing entirely).
- A manifest-only language probe tags `mcp_analytics_languages` / `mcp_analytics_language_supported` before the run, so an `unsupported_language` abort finally says which language. Wired through a new optional `onReady` on `createSkillProgram` that copies the first step rather than mutating the shared `AGENT_SKILL_STEPS`.
- Abort matches are prefix-anchored, with codes.

## Test plan

`pnpm build && pnpm test && pnpm fix` — full suite green (139 files / 1949 tests). `pnpm typecheck` error count is unchanged from `main` (26, all pre-existing, none in touched files).

New coverage: the observed noisy reason variants; the language mapping including polyglot and no-manifest projects; code uniqueness and outcome routing; padded reasons still matching their case; every follow-up bail-out path (no bridge, no case, throw, cancel, timeout); free-text answers reduced to a boolean; and a regression test that the language probe doesn't leak onto the other skill programs.

`OutroKind.NotApplicable` is added to the end-screens playground demo, so the new outro is visible to whoever builds the next one.

Not covered here: the detection that decides "no mcp server found" lives in the context-mill skill, not this repo — widening it is a separate change. This makes the outcome legible, stops it counting as a failure, and turns the exit into the one question that tells us whether the detection needs widening at all.

<!-- ## LLM context -->
<!-- Authored by the PostHog Slack app from a diagnosis of the MCP analytics activation funnel. -->

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1786720402050809?thread_ts=1786720402.050809&cid=C0B3E1Y576X)*
