### PR TITLE
fix(tui): let users skip a wizard_ask prompt with Esc

### DIFF
--- a/scripts/check-screens.tsx
+++ b/scripts/check-screens.tsx
@@ -14,6 +14,7 @@ import { AuthErrorScreen } from '@ui/tui/screens/AuthErrorScreen';
 import { ProgressList } from '@ui/tui/primitives/ProgressList';
 import { ManagedSettingsScreen } from '@ui/tui/screens/ManagedSettingsScreen';
 import { SettingsOverrideScreen } from '@ui/tui/screens/SettingsOverrideScreen';
+import { WizardAskScreen } from '@ui/tui/screens/WizardAskScreen';
 import type { SettingsConflict } from '@lib/agent/agent-interface';
 
 function fakeStore(session: Record<string, unknown>): any {
@@ -165,6 +166,20 @@ check(
   ],
   // The not-needed task is gone and counts against nothing.
   ['Add user identification', 'not needed', '1/3'],
+);
+
+check(
+  'WizardAskScreen — surfaces the Esc-to-skip affordance',
+  <WizardAskScreen
+    store={fakeStore({
+      pendingQuestion: {
+        id: 'req-1',
+        source: 'postgres',
+        questions: [{ id: 'host', prompt: 'Database host?', kind: 'text' }],
+      },
+    })}
+  />,
+  ['Database host?', 'ESC', 'skip'],
 );
 
 if (failures > 0) {

--- a/src/ui/tui/__tests__/WizardAskScreen.test.ts
+++ b/src/ui/tui/__tests__/WizardAskScreen.test.ts
@@ -1,0 +1,60 @@
+/**
+ * WizardAskScreen — Esc-to-skip wiring.
+ *
+ * The overlay's key handling routes through `handleAskKey`, extracted so the
+ * decision can be tested without a live Ink render (the suite stubs `useInput`
+ * to a no-op). Pressing Esc must decline the whole request so the task can fall
+ * back gracefully — e.g. hand the user a browser setup link.
+ */
+
+import { vi } from 'vitest';
+
+vi.mock('../../../utils/analytics.js', () => ({
+  analytics: {
+    capture: vi.fn(),
+    wizardCapture: vi.fn(),
+    setTag: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  },
+  sessionProperties: vi.fn(() => ({})),
+}));
+
+import { WizardStore } from '@ui/tui/store';
+import { handleAskKey } from '@ui/tui/screens/WizardAskScreen';
+
+const pending = {
+  id: 'req-1',
+  source: 'postgres',
+  questions: [
+    { id: 'host', prompt: 'Database host?', kind: 'text' as const },
+    { id: 'port', prompt: 'Port?', kind: 'text' as const },
+  ],
+};
+
+describe('handleAskKey', () => {
+  it('cancels the pending question on Esc', () => {
+    const store = { cancelPendingQuestion: vi.fn() };
+    handleAskKey({ escape: true }, store);
+    expect(store.cancelPendingQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores every other key', () => {
+    const store = { cancelPendingQuestion: vi.fn() };
+    handleAskKey({ escape: false }, store);
+    handleAskKey({}, store);
+    expect(store.cancelPendingQuestion).not.toHaveBeenCalled();
+  });
+
+  it('declines the whole request end-to-end so the task can fall back', async () => {
+    const store = new WizardStore();
+    const answers = store.requestQuestion(pending);
+
+    handleAskKey({ escape: true }, store);
+
+    await expect(answers).resolves.toEqual({
+      host: '__cancelled__',
+      port: '__cancelled__',
+    });
+    expect(store.session.pendingQuestion).toBeNull();
+  });
+});

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -6,7 +6,7 @@
  * pending request and the overlay pops, returning the agent to its run.
  */
 
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import { TextInput } from '@inkjs/ui';
 import { useEffect, useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
@@ -23,6 +23,18 @@ import type { AskAnswers, AskQuestion } from '@lib/wizard-session';
 
 interface WizardAskScreenProps {
   store: WizardStore;
+}
+
+/**
+ * Key policy for the ask overlay: Esc declines the whole request, everything
+ * else is left to the focused input. Extracted so the wiring is unit-testable
+ * without a live Ink render (the test suite stubs `useInput` to a no-op).
+ */
+export function handleAskKey(
+  key: { escape?: boolean },
+  store: Pick<WizardStore, 'cancelPendingQuestion'>,
+): void {
+  if (key.escape) store.cancelPendingQuestion();
 }
 
 export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
@@ -112,6 +124,13 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
       : [],
   );
 
+  // Esc declines the whole request. Cancellation is a first-class outcome the
+  // ask bridge and the wizard_ask tool already expect (a task treats it as "the
+  // user declined" and falls back — e.g. to a browser setup link), so without
+  // this a user who can't answer has no exit but typing placeholders or waiting
+  // out the multi-minute per-question timeout. Every field comes back cancelled.
+  useInput((_input, key) => handleAskKey(key, store));
+
   if (!pending) return null;
 
   // Reset accumulator state when the agent opens a new request mid-session.
@@ -191,6 +210,11 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
           question={question}
           onSubmit={submit}
         />
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          <Text color={Colors.accent}>ESC</Text> skip
+        </Text>
       </Box>
     </ModalOverlay>
   );


### PR DESCRIPTION
## Problem

When the seeded data-source connection task interviews the user for credentials via the `wizard_ask` overlay, there is no way to decline a prompt. The only exits are typing a placeholder answer or waiting out the multi-minute per-question timeout. A user who can't (or doesn't want to) supply a credential for a detected source is stuck — which shows up in the telemetry as prompts that sit unanswered until they time out, and as accepted tasks that never reach a terminal state.

Cancellation is already a first-class outcome everywhere except the UI: the ask bridge treats a fully-cancelled response as "the user declined" (and refunds the per-run ask cap), and the `wizard_ask` tool contract tells the task to fall back gracefully — e.g. hand the user a pre-filled browser setup link. Nothing in the overlay triggered that path except the timeout.

## Changes

- Wire `Esc` in the `wizard_ask` overlay to cancel the in-flight request. Every field comes back with the cancelled sentinel, exactly matching the timeout path, so the task falls back the same way — just immediately instead of minutes later.
- Surface an `ESC skip` hint so the affordance is discoverable. This mirrors the existing `Esc`-to-cancel affordance on the manual-auth-code screen.
- Extract the key policy into a small `handleAskKey` helper so the wiring is unit-testable without a live Ink render (the test suite stubs `useInput` to a no-op).

## Test plan

- New unit test (`WizardAskScreen.test.ts`) covers `handleAskKey`: `Esc` cancels, other keys are ignored, and an end-to-end pass through a real store resolves the request with cancelled sentinels.
- Added a `WizardAskScreen` case to the real-Ink `screens:check` harness asserting the `ESC skip` hint renders.
- `pnpm build` and the full vitest suite (1913 tests) pass; prettier + eslint clean on the changed files.

## Why

Grounded in telemetry for the seeded data-source connection task: users faced with a credential prompt they can't answer had no clean way to decline, so prompts stalled to timeout instead of falling back to the browser-link path the flow already supports.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*