### PR TITLE
feat(features): offer server-side HTTP log capture on Cloudflare Workers projects

### DIFF
--- a/src/lib/detection/__tests__/features.test.ts
+++ b/src/lib/detection/__tests__/features.test.ts
@@ -47,6 +47,23 @@ describe('discoverFeatures', () => {
     expect(features).toHaveLength(2);
   });
 
+  it.each([
+    [
+      'a wrangler dependency',
+      () => writePackageJson(tmpDir, { wrangler: '3.0.0' }),
+    ],
+    [
+      'a wrangler config file',
+      () => {
+        writePackageJson(tmpDir);
+        writeFile(tmpDir, 'wrangler.toml', 'name = "my-worker"');
+      },
+    ],
+  ])('detects the HttpLog feature from %s', (_name, setup) => {
+    setup();
+    expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.HttpLog]);
+  });
+
   it('returns empty for unrelated dependencies', () => {
     writePackageJson(tmpDir, { react: '18.0.0', express: '4.0.0' });
     expect(discoverFeatures(tmpDir)).toEqual([]);

--- a/src/lib/detection/__tests__/features.test.ts
+++ b/src/lib/detection/__tests__/features.test.ts
@@ -59,6 +59,13 @@ describe('discoverFeatures', () => {
         writeFile(tmpDir, 'wrangler.toml', 'name = "my-worker"');
       },
     ],
+    [
+      'a root middleware file',
+      () => {
+        writePackageJson(tmpDir);
+        writeFile(tmpDir, 'middleware.ts', 'export function middleware() {}');
+      },
+    ],
   ])('detects the HttpLog feature from %s', (_name, setup) => {
     setup();
     expect(discoverFeatures(tmpDir)).toEqual([DiscoveredFeature.HttpLog]);

--- a/src/lib/detection/features.ts
+++ b/src/lib/detection/features.ts
@@ -12,6 +12,22 @@ import { DiscoveredFeature } from '@lib/wizard-session';
 
 const STRIPE_PACKAGES = new Set(['stripe', '@stripe/stripe-js']);
 
+// Cloudflare Workers projects can forward $http_log events for bot analytics.
+const CLOUDFLARE_PACKAGES = new Set([
+  'wrangler',
+  '@cloudflare/workers-types',
+  '@react-router/cloudflare',
+  '@astrojs/cloudflare',
+  '@sveltejs/adapter-cloudflare',
+  '@sveltejs/adapter-cloudflare-workers',
+]);
+
+const WRANGLER_CONFIG_FILES = [
+  'wrangler.toml',
+  'wrangler.jsonc',
+  'wrangler.json',
+];
+
 const LLM_PACKAGES = new Set([
   'openai',
   '@anthropic-ai/sdk',
@@ -83,6 +99,12 @@ function discoverNodeFeatures(
   }
   if (depNames.some((depName) => LLM_PACKAGES.has(depName))) {
     features.push(DiscoveredFeature.LLM);
+  }
+  if (
+    depNames.some((depName) => CLOUDFLARE_PACKAGES.has(depName)) ||
+    WRANGLER_CONFIG_FILES.some((file) => safeRead(installDir, file) !== null)
+  ) {
+    features.push(DiscoveredFeature.HttpLog);
   }
 }
 

--- a/src/lib/detection/features.ts
+++ b/src/lib/detection/features.ts
@@ -28,6 +28,14 @@ const WRANGLER_CONFIG_FILES = [
   'wrangler.json',
 ];
 
+// Root middleware files (Next.js convention) are the one-file place to add $http_log capture.
+const MIDDLEWARE_FILES = [
+  'middleware.ts',
+  'middleware.js',
+  'src/middleware.ts',
+  'src/middleware.js',
+];
+
 const LLM_PACKAGES = new Set([
   'openai',
   '@anthropic-ai/sdk',
@@ -102,7 +110,9 @@ function discoverNodeFeatures(
   }
   if (
     depNames.some((depName) => CLOUDFLARE_PACKAGES.has(depName)) ||
-    WRANGLER_CONFIG_FILES.some((file) => safeRead(installDir, file) !== null)
+    [...WRANGLER_CONFIG_FILES, ...MIDDLEWARE_FILES].some(
+      (file) => safeRead(installDir, file) !== null,
+    )
   ) {
     features.push(DiscoveredFeature.HttpLog);
   }

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -58,21 +58,25 @@ export enum RunPhase {
 export enum DiscoveredFeature {
   Stripe = 'stripe',
   LLM = 'llm',
+  HttpLog = 'http_log',
 }
 
 /** Additional features the agent can integrate after the main setup */
 export enum AdditionalFeature {
   LLM = 'llm',
+  HttpLog = 'http_log',
 }
 
 /** Human-readable labels for additional features (used in TUI progress) */
 export const ADDITIONAL_FEATURE_LABELS: Record<AdditionalFeature, string> = {
   [AdditionalFeature.LLM]: 'AI observability',
+  [AdditionalFeature.HttpLog]: 'Bot analytics (server logs)',
 };
 
 /** Agent prompts for each additional feature, injected via the stop hook */
 export const ADDITIONAL_FEATURE_PROMPTS: Record<AdditionalFeature, string> = {
   [AdditionalFeature.LLM]: `Now integrate AI observability with PostHog. Use the PostHog MCP server to find the appropriate AI observability skill, install it, and follow its workflow. PostHog basics are already installed. Update the setup report markdown file when complete with additions from this task. `,
+  [AdditionalFeature.HttpLog]: `Now integrate server-side HTTP log capture with PostHog so bots, crawlers, and AI agents show up in web analytics. Follow https://posthog.com/docs/web-analytics/sending-http-logs: send one $http_log event per request to the capture API, with $raw_user_agent, $current_url, $ip, and $process_person_profile set to false, using a hashed per-client distinct ID. Prefer the platform's native hook (a Cloudflare Worker on Workers projects, otherwise server middleware), keep it off the request path, and skip static asset requests. PostHog basics are already installed. Update the setup report markdown file when complete with additions from this task. `,
 };
 
 /** Outcome of the MCP server installation step */

--- a/src/ui/tui/components/TipsCard.tsx
+++ b/src/ui/tui/components/TipsCard.tsx
@@ -87,6 +87,23 @@ export const DEFAULT_TIPS: Tip[] = [
       isEnabled: (store) => store.session.llmOptIn,
     },
   },
+  {
+    id: 'http-log',
+    title: 'PostHog can show you bot and AI crawler traffic',
+    description: '',
+    visible: (store) =>
+      store.session.discoveredFeatures.includes(DiscoveredFeature.HttpLog),
+    toggle: {
+      key: 'b',
+      feature: AdditionalFeature.HttpLog,
+      enabledLabel: 'Server log capture queued next',
+      prompt: 'We detected a Cloudflare Workers project.',
+      isEnabled: (store) =>
+        store.session.additionalFeatureQueue.includes(
+          AdditionalFeature.HttpLog,
+        ),
+    },
+  },
 ];
 
 export const TipsCard = ({

--- a/src/ui/tui/components/TipsCard.tsx
+++ b/src/ui/tui/components/TipsCard.tsx
@@ -97,7 +97,7 @@ export const DEFAULT_TIPS: Tip[] = [
       key: 'b',
       feature: AdditionalFeature.HttpLog,
       enabledLabel: 'Server log capture queued next',
-      prompt: 'We detected a Cloudflare Workers project.',
+      prompt: 'Your project can forward server logs with one file.',
       isEnabled: (store) =>
         store.session.additionalFeatureQueue.includes(
           AdditionalFeature.HttpLog,


### PR DESCRIPTION
## Problem

Bots, crawlers, and AI agents rarely run JavaScript, so a wizard-installed JS SDK never sees them. Web analytics bot analytics needs server-side $http_log events, and the wizard has no way to offer that setup even on projects where it is a one-file change.

## Changes

- Feature discovery now detects projects that can forward server logs with one file: a wrangler config, a Cloudflare package (`wrangler`, `@cloudflare/workers-types`, framework adapters), or a root middleware file (Next.js convention).
- On detection, the tips card shows an opt-in toggle (key `b`): "PostHog can show you bot and AI crawler traffic". Opting in queues an additional-feature prompt, exactly like the existing LLM observability opt-in.
- The queued prompt points the agent at the $http_log payload reference ([sending HTTP log events](https://github.com/PostHog/posthog.com/pull/19588)) and states the invariants: one event per request, `$raw_user_agent`/`$current_url`/`$ip`, anonymous person processing, hashed per-client distinct ID, off the request path, skip static assets.

## Test plan

- Three new cases in `features.test.ts`: the HttpLog feature is discovered from a `wrangler` dependency, a `wrangler.toml` config file, and a root `middleware.ts`. Suite passes locally (15/15).
- `pnpm typecheck` fails only on pre-existing errors in `src/utils/bounded-fs.ts`, untouched here; eslint reports 0 errors.
- Not run: an end-to-end wizard session exercising the new toggle.

## LLM context

Authored with Claude Code in a PostHog Desktop cloud task, mirroring the AdditionalFeature.LLM opt-in flow. Part of a wider $http_log adoption effort: source templates in [PostHog/posthog#85969](https://github.com/PostHog/posthog/pull/85969), docs in [PostHog/posthog.com#19588](https://github.com/PostHog/posthog.com/pull/19588).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
