### PR TITLE
fix: adding analytics tags to blindspots and other stuff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,11 @@
 *                                                       @PostHog/team-wizard-docs
 
 # Team-owned programs
+/src/lib/programs/ai-observability/                     @PostHog/team-ai-observability
 /src/lib/programs/error-tracking-upload-source-maps/    @PostHog/team-error-tracking
 /src/lib/programs/mcp-analytics/                        @PostHog/team-mcp-analytics
 /src/lib/programs/posthog-integration/                  @PostHog/team-wizard-docs
+/src/lib/programs/replay-vision/                        @PostHog/team-replay
 /src/lib/programs/revenue-analytics/                    @PostHog/team-web-analytics
 /src/lib/programs/self-driving/                         @PostHog/team-self-driving
 /src/lib/programs/warehouse-source/                     @PostHog/team-warehouse-sources

--- a/src/lib/agent/__tests__/run-tags.test.ts
+++ b/src/lib/agent/__tests__/run-tags.test.ts
@@ -1,4 +1,5 @@
 import { buildRunTags } from '@lib/agent/agent-interface';
+import { CallType } from '@lib/constants';
 
 describe('buildRunTags', () => {
   it('carries the run identifiers as gateway trace tags', () => {
@@ -15,8 +16,23 @@ describe('buildRunTags', () => {
       integration: 'nextjs',
       run_id: 'run-123',
       build: 'ci',
+      call_type: CallType.agent,
       skill_id: 'audit-events',
     });
+  });
+
+  it('marks every run as agent work rather than leaving call_type unset', () => {
+    // Scan triage overrides this to `yara-triage`. Both sides are stamped so a
+    // missing `call_type` means "an old build sent none", not "agent work" —
+    // the two would otherwise be indistinguishable in cost breakdowns.
+    expect(
+      buildRunTags({
+        programId: 'posthog-integration',
+        integration: 'nextjs',
+        runId: 'run-123',
+        build: 'prod',
+      }).call_type,
+    ).toBe('agent');
   });
 
   it("carries a headless run's build type onto gateway traces", () => {
@@ -46,6 +62,7 @@ describe('buildRunTags', () => {
       integration: 'nextjs',
       run_id: 'run-123',
       build: 'prod',
+      call_type: CallType.agent,
     });
   });
 });

--- a/src/lib/agent/__tests__/run-tags.test.ts
+++ b/src/lib/agent/__tests__/run-tags.test.ts
@@ -22,9 +22,8 @@ describe('buildRunTags', () => {
   });
 
   it('marks every run as agent work rather than leaving call_type unset', () => {
-    // Scan triage overrides this to `yara-triage`. Both sides are stamped so a
-    // missing `call_type` means "an old build sent none", not "agent work" —
-    // the two would otherwise be indistinguishable in cost breakdowns.
+    // Triage and detection override this; stamping both sides means a missing
+    // value is an old build, not agent work.
     expect(
       buildRunTags({
         programId: 'posthog-integration',

--- a/src/lib/agent/__tests__/triage-provider.test.ts
+++ b/src/lib/agent/__tests__/triage-provider.test.ts
@@ -91,9 +91,7 @@ describe('createTriageLLMProvider', () => {
   });
 
   it('attributes its spend to the program that triggered the scan', async () => {
-    // Triage fires per tool call. Before it carried run tags, every scan's
-    // gateway spend landed in the unattributed bucket; `call_type` keeps it
-    // separable from the agent work inside the same program.
+    // Triage fires per tool call; untagged it billed to no program at all.
     complete.mockResolvedValue(reply(''));
     const provider = createTriageLLMProvider(
       {

--- a/src/lib/agent/__tests__/triage-provider.test.ts
+++ b/src/lib/agent/__tests__/triage-provider.test.ts
@@ -1,5 +1,8 @@
 import { completeSimple } from '@earendil-works/pi-ai';
-import { createTriageLLMProvider } from '@lib/agent/triage-provider';
+import {
+  createTriageLLMProvider,
+  TRIAGE_CALL_TYPE,
+} from '@lib/agent/triage-provider';
 import { GPT5_6_LUNA_MODEL, HAIKU_TRIAGE_MODEL, Harness } from '@lib/constants';
 import { triageModelFor } from '@lib/agent/runner/switchboard/models';
 
@@ -82,6 +85,31 @@ describe('createTriageLLMProvider', () => {
       'x-posthog-use-bedrock-fallback': 'true',
       'X-POSTHOG-PROPERTY-run_id': 'r1',
       'X-POSTHOG-FLAG-WIZARD-ORCHESTRATOR': 'true',
+    });
+  });
+
+  it('attributes its spend to the program that triggered the scan', async () => {
+    // Triage fires per tool call. Before it carried run tags, every scan's
+    // gateway spend landed in the unattributed bucket; `call_type` keeps it
+    // separable from the agent work inside the same program.
+    complete.mockResolvedValue(reply(''));
+    const provider = createTriageLLMProvider(
+      {
+        ...AUTH,
+        wizardMetadata: {
+          program_id: 'posthog-integration',
+          run_id: 'r1',
+          call_type: TRIAGE_CALL_TYPE,
+        },
+      },
+      Harness.anthropic,
+    );
+
+    await provider('verdict?');
+
+    expect(complete.mock.calls[0][0].headers).toMatchObject({
+      'X-POSTHOG-PROPERTY-program_id': 'posthog-integration',
+      'X-POSTHOG-PROPERTY-call_type': 'yara-triage',
     });
   });
 

--- a/src/lib/agent/__tests__/triage-provider.test.ts
+++ b/src/lib/agent/__tests__/triage-provider.test.ts
@@ -1,9 +1,11 @@
 import { completeSimple } from '@earendil-works/pi-ai';
+import { createTriageLLMProvider } from '@lib/agent/triage-provider';
 import {
-  createTriageLLMProvider,
-  TRIAGE_CALL_TYPE,
-} from '@lib/agent/triage-provider';
-import { GPT5_6_LUNA_MODEL, HAIKU_TRIAGE_MODEL, Harness } from '@lib/constants';
+  CallType,
+  GPT5_6_LUNA_MODEL,
+  HAIKU_TRIAGE_MODEL,
+  Harness,
+} from '@lib/constants';
 import { triageModelFor } from '@lib/agent/runner/switchboard/models';
 
 vi.mock('@earendil-works/pi-ai', () => ({ completeSimple: vi.fn() }));
@@ -99,7 +101,7 @@ describe('createTriageLLMProvider', () => {
         wizardMetadata: {
           program_id: 'posthog-integration',
           run_id: 'r1',
-          call_type: TRIAGE_CALL_TYPE,
+          call_type: CallType.yaraTriage,
         },
       },
       Harness.anthropic,

--- a/src/lib/agent/__tests__/tutorial-run-tags.test.ts
+++ b/src/lib/agent/__tests__/tutorial-run-tags.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Cost-attribution contract for the MCP tutorial.
+ *
+ * The gateway builds each `$ai_generation`'s `program_id` from the
+ * `X-POSTHOG-PROPERTY-*` headers on the request. The tutorial shipped without
+ * them, so every generation it produced landed in the unattributed bucket —
+ * these tests pin the tags so that can't silently return.
+ */
+
+import { buildTutorialRunTags } from '@lib/agent/mcp-prompt-streaming';
+import { buildAgentEnv } from '@lib/agent/agent-interface';
+import { analytics } from '@utils/analytics';
+
+describe('buildTutorialRunTags', () => {
+  it('tags the run with the program its spend belongs to', () => {
+    expect(buildTutorialRunTags({ programId: 'mcp-tutorial' })).toMatchObject({
+      program_id: 'mcp-tutorial',
+      run_id: analytics.runId,
+      build: analytics.build,
+    });
+  });
+
+  it('falls back to the program for integration rather than emitting an empty axis', () => {
+    // The tutorial runs against a PostHog project, not a codebase, so there's
+    // usually no detected framework to report.
+    expect(buildTutorialRunTags({ programId: 'mcp-tutorial' })).toMatchObject({
+      integration: 'mcp-tutorial',
+    });
+  });
+
+  it('keeps a detected integration when the session has one', () => {
+    expect(
+      buildTutorialRunTags({
+        programId: 'mcp-tutorial',
+        integration: 'nextjs',
+      }),
+    ).toMatchObject({ integration: 'nextjs' });
+  });
+
+  it('returns no tags at all when the caller supplies no program', () => {
+    // Explicitly tagless beats a half-populated bag that looks attributed.
+    expect(buildTutorialRunTags({})).toEqual({});
+  });
+
+  it('reaches the gateway as property headers, not just an object', () => {
+    // The object is only useful if buildAgentEnv actually encodes it — that
+    // join is the part that was missing in production.
+    const encoded = buildAgentEnv(
+      buildTutorialRunTags({ programId: 'mcp-tutorial' }),
+      {},
+    );
+
+    expect(encoded).toContain('X-POSTHOG-PROPERTY-program_id: mcp-tutorial');
+    expect(encoded).toContain('x-posthog-use-bedrock-fallback: true');
+  });
+
+  it('sends only the bedrock header when there is no program — the pre-fix shape', () => {
+    const encoded = buildAgentEnv(buildTutorialRunTags({}), {});
+
+    expect(encoded).not.toContain('X-POSTHOG-PROPERTY');
+  });
+});

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -15,6 +15,7 @@ import { runtimeEnv } from '@env';
 import type { AioCapture } from '@lib/agent/aio-capture';
 import {
   Harness,
+  CallType,
   Sequence,
   WIZARD_REMARK_EVENT_NAME,
   POSTHOG_PROPERTY_HEADER_PREFIX,
@@ -35,7 +36,7 @@ import {
   createPostToolUseYaraHooks,
   prewarmYaraScanner,
 } from '@lib/yara-hooks';
-import { createTriageLLMProvider, TRIAGE_CALL_TYPE } from './triage-provider';
+import { createTriageLLMProvider } from './triage-provider';
 import type { LLMProvider } from '@posthog/warlock';
 import { assembleCommandments } from './runner/switchboard/commandments';
 import { classifyToolToStage } from './agent-phase';
@@ -345,6 +346,10 @@ export function buildRunTags(args: {
     integration: args.integration,
     run_id: args.runId,
     build: args.build,
+    // Every caller is agent work; the triage provider spreads these tags and
+    // overrides this one. Sent explicitly so a missing value never has to be
+    // read as "agent" — old builds send none at all.
+    call_type: CallType.agent,
     ...(args.skillId ? { skill_id: args.skillId } : {}),
   };
 }
@@ -537,7 +542,7 @@ export async function initializeAgent(
         authToken: config.posthogApiKey,
         wizardMetadata: {
           ...(config.wizardMetadata ?? {}),
-          call_type: TRIAGE_CALL_TYPE,
+          call_type: CallType.yaraTriage,
         },
         wizardFlags: config.wizardFlags ?? {},
       },

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -346,9 +346,7 @@ export function buildRunTags(args: {
     integration: args.integration,
     run_id: args.runId,
     build: args.build,
-    // Every caller is agent work; the triage provider spreads these tags and
-    // overrides this one. Sent explicitly so a missing value never has to be
-    // read as "agent" — old builds send none at all.
+    // Triage and detection spread these tags and override this one.
     call_type: CallType.agent,
     ...(args.skillId ? { skill_id: args.skillId } : {}),
   };
@@ -530,12 +528,9 @@ export async function initializeAgent(
     process.env.CLAUDE_CODE_OAUTH_TOKEN = config.posthogApiKey;
 
     // Same values the env vars above carry, handed over explicitly so triage
-    // never has to read them back out of the environment.
-    //
-    // The run tags ride along too: triage fires per tool call, so leaving them
-    // off put every scan's gateway spend in the unattributed bucket. Tagged
-    // here it folds into the program that triggered it, and `call_type` keeps
-    // it separable — security scanning is its own cost line, not agent work.
+    // never has to read them back out of the environment. The run tags ride
+    // along so scan spend bills to this program, with `call_type` keeping it
+    // separable from the agent's own calls.
     const triageProvider = createTriageLLMProvider(
       {
         baseURL: gatewayUrl,

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -35,7 +35,7 @@ import {
   createPostToolUseYaraHooks,
   prewarmYaraScanner,
 } from '@lib/yara-hooks';
-import { createTriageLLMProvider } from './triage-provider';
+import { createTriageLLMProvider, TRIAGE_CALL_TYPE } from './triage-provider';
 import type { LLMProvider } from '@posthog/warlock';
 import { assembleCommandments } from './runner/switchboard/commandments';
 import { classifyToolToStage } from './agent-phase';
@@ -526,8 +526,21 @@ export async function initializeAgent(
 
     // Same values the env vars above carry, handed over explicitly so triage
     // never has to read them back out of the environment.
+    //
+    // The run tags ride along too: triage fires per tool call, so leaving them
+    // off put every scan's gateway spend in the unattributed bucket. Tagged
+    // here it folds into the program that triggered it, and `call_type` keeps
+    // it separable — security scanning is its own cost line, not agent work.
     const triageProvider = createTriageLLMProvider(
-      { baseURL: gatewayUrl, authToken: config.posthogApiKey },
+      {
+        baseURL: gatewayUrl,
+        authToken: config.posthogApiKey,
+        wizardMetadata: {
+          ...(config.wizardMetadata ?? {}),
+          call_type: TRIAGE_CALL_TYPE,
+        },
+        wizardFlags: config.wizardFlags ?? {},
+      },
       Harness.anthropic,
     );
 

--- a/src/lib/agent/mcp-prompt-streaming.ts
+++ b/src/lib/agent/mcp-prompt-streaming.ts
@@ -16,8 +16,9 @@ import type { AgentChunk } from '@ui/tui/services/mcp-suggested-prompts-services
 import type { Credentials } from '@lib/wizard-session';
 import { DEFAULT_AGENT_MODEL, WIZARD_USER_AGENT } from '@lib/constants';
 import { logToFile } from '@utils/debug';
-import { buildAgentEnv } from '@lib/agent/agent-interface';
+import { buildAgentEnv, buildRunTags } from '@lib/agent/agent-interface';
 import { sanitizeAgentSubprocessEnv } from '@lib/agent/agent-env-isolation';
+import { analytics } from '@utils/analytics';
 
 // Cached SDK module — first call pays the dynamic-import cost; later
 // calls reuse the same module.
@@ -172,6 +173,34 @@ function buildTerminalFitPrompt(): string {
   ].join('\n');
 }
 
+/**
+ * Gateway trace tags for a tutorial prompt run.
+ *
+ * The gateway attributes each `$ai_generation` it emits from the
+ * `X-POSTHOG-PROPERTY-*` headers on the request, so a run with no tags lands
+ * in the unattributed bucket — which is where every tutorial generation went
+ * before this existed. Exported so that contract is testable without booting
+ * the SDK.
+ *
+ * Returns `{}` when the caller supplies no program, keeping the tagless
+ * behavior explicit rather than silently emitting a half-populated bag.
+ */
+export function buildTutorialRunTags(args: {
+  programId?: string;
+  integration?: string;
+}): Record<string, string> {
+  if (!args.programId) return {};
+  return buildRunTags({
+    programId: args.programId,
+    // The tutorial runs against a project, not a codebase, so there's usually
+    // no detected framework — fall back to the program so the axis is never
+    // an empty string in the gateway's breakdowns.
+    integration: args.integration ?? args.programId,
+    runId: analytics.runId,
+    build: analytics.build,
+  });
+}
+
 export async function* runMcpPromptViaSdk(args: {
   prompt: string;
   credentials: Credentials;
@@ -180,8 +209,19 @@ export async function* runMcpPromptViaSdk(args: {
    *  context so the follow-up prompt can reference what the agent
    *  already showed. */
   resumeSessionId?: string;
+  /** Program this run's gateway spend attributes to. Resolved by the caller
+   *  (`store.analyticsProgramId`) so both tutorial entry points report as
+   *  one program. Omitting it makes the spend unattributable — see the
+   *  `ANTHROPIC_CUSTOM_HEADERS` note below. */
+  programId?: string;
+  /** Integration label for the trace tags; the tutorial usually has none. */
+  integration?: string;
 }): AsyncIterable<AgentChunk> {
   const { prompt, credentials, signal, resumeSessionId } = args;
+
+  // Assembled here rather than passed in so the TUI service layer doesn't
+  // have to import this module's dependencies.
+  const wizardMetadata = buildTutorialRunTags(args);
 
   // Route the SDK's LLM calls through the PostHog LLM gateway, authed
   // with the user's OAuth access token. Set BEFORE loading the SDK in
@@ -338,11 +378,14 @@ export async function* runMcpPromptViaSdk(args: {
           // default; without this the agent may try to call tools
           // before posthog-wizard is connected on turn 1.
           MCP_CONNECTION_NONBLOCKING: '0',
-          // Same Bedrock-fallback + telemetry-friendly headers as the
-          // main runner. No wizard metadata or flags for the tutorial
-          // — runs are distinguished downstream via posthog.capture
-          // calls (program_id + event names), not SDK headers.
-          ANTHROPIC_CUSTOM_HEADERS: buildAgentEnv({}, {}),
+          // Same Bedrock-fallback + telemetry-friendly headers as the main
+          // runner, plus this run's trace tags. The gateway reads
+          // `X-POSTHOG-PROPERTY-*` off the request to attribute each
+          // `$ai_generation` it emits, so sending none put every tutorial
+          // generation in the unattributed bucket — `posthog.capture` events
+          // carry a program id but nothing joins them to gateway spend.
+          // Flags stay empty: the tutorial doesn't fork on any.
+          ANTHROPIC_CUSTOM_HEADERS: buildAgentEnv(wizardMetadata ?? {}, {}),
         },
       },
     });

--- a/src/lib/agent/mcp-prompt-streaming.ts
+++ b/src/lib/agent/mcp-prompt-streaming.ts
@@ -174,16 +174,9 @@ function buildTerminalFitPrompt(): string {
 }
 
 /**
- * Gateway trace tags for a tutorial prompt run.
- *
- * The gateway attributes each `$ai_generation` it emits from the
- * `X-POSTHOG-PROPERTY-*` headers on the request, so a run with no tags lands
- * in the unattributed bucket — which is where every tutorial generation went
- * before this existed. Exported so that contract is testable without booting
- * the SDK.
- *
- * Returns `{}` when the caller supplies no program, keeping the tagless
- * behavior explicit rather than silently emitting a half-populated bag.
+ * Gateway trace tags for a tutorial prompt run — without them the gateway has
+ * nothing to attribute its `$ai_generation` events to. Returns `{}` when no
+ * program is supplied. Exported so the contract is testable without the SDK.
  */
 export function buildTutorialRunTags(args: {
   programId?: string;
@@ -192,9 +185,8 @@ export function buildTutorialRunTags(args: {
   if (!args.programId) return {};
   return buildRunTags({
     programId: args.programId,
-    // The tutorial runs against a project, not a codebase, so there's usually
-    // no detected framework — fall back to the program so the axis is never
-    // an empty string in the gateway's breakdowns.
+    // The tutorial usually has no detected framework; fall back to the
+    // program so the axis is never an empty string.
     integration: args.integration ?? args.programId,
     runId: analytics.runId,
     build: analytics.build,
@@ -209,10 +201,8 @@ export async function* runMcpPromptViaSdk(args: {
    *  context so the follow-up prompt can reference what the agent
    *  already showed. */
   resumeSessionId?: string;
-  /** Program this run's gateway spend attributes to. Resolved by the caller
-   *  (`store.analyticsProgramId`) so both tutorial entry points report as
-   *  one program. Omitting it makes the spend unattributable — see the
-   *  `ANTHROPIC_CUSTOM_HEADERS` note below. */
+  /** Program this run's gateway spend attributes to; omitting it leaves the
+   *  spend unattributed. */
   programId?: string;
   /** Integration label for the trace tags; the tutorial usually has none. */
   integration?: string;
@@ -378,13 +368,9 @@ export async function* runMcpPromptViaSdk(args: {
           // default; without this the agent may try to call tools
           // before posthog-wizard is connected on turn 1.
           MCP_CONNECTION_NONBLOCKING: '0',
-          // Same Bedrock-fallback + telemetry-friendly headers as the main
-          // runner, plus this run's trace tags. The gateway reads
-          // `X-POSTHOG-PROPERTY-*` off the request to attribute each
-          // `$ai_generation` it emits, so sending none put every tutorial
-          // generation in the unattributed bucket — `posthog.capture` events
-          // carry a program id but nothing joins them to gateway spend.
-          // Flags stay empty: the tutorial doesn't fork on any.
+          // Bedrock fallback plus this run's trace tags — the gateway reads
+          // these to attribute its `$ai_generation` events. Flags stay empty:
+          // the tutorial doesn't fork on any.
           ANTHROPIC_CUSTOM_HEADERS: buildAgentEnv(wizardMetadata ?? {}, {}),
         },
       },

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -11,7 +11,10 @@ import type { WizardSession } from '@lib/wizard-session';
 import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
 import { authenticate } from './authenticate';
-import { createTriageLLMProvider } from '@lib/agent/triage-provider';
+import {
+  createTriageLLMProvider,
+  TRIAGE_CALL_TYPE,
+} from '@lib/agent/triage-provider';
 import { resolveHarness } from '../switchboard';
 import { buildRunTags } from '@lib/agent/agent-interface';
 import {
@@ -282,7 +285,9 @@ export async function bootstrapProgram(
       {
         baseURL: credentials.host.gatewayUrl,
         authToken: credentials.accessToken,
-        wizardMetadata,
+        // `call_type` splits scan spend out of the program's agent cost —
+        // same tag the in-run triage provider carries.
+        wizardMetadata: { ...wizardMetadata, call_type: TRIAGE_CALL_TYPE },
         wizardFlags,
       },
       resolveHarness({

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -11,10 +11,7 @@ import type { WizardSession } from '@lib/wizard-session';
 import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
 import { authenticate } from './authenticate';
-import {
-  createTriageLLMProvider,
-  TRIAGE_CALL_TYPE,
-} from '@lib/agent/triage-provider';
+import { createTriageLLMProvider } from '@lib/agent/triage-provider';
 import { resolveHarness } from '../switchboard';
 import { buildRunTags } from '@lib/agent/agent-interface';
 import {
@@ -32,7 +29,7 @@ import {
 import { enableDebugLogs, logToFile, initLogFile } from '@utils/debug';
 import { wizardAbort } from '@utils/wizard-abort';
 import { isNonInteractiveEnvironment } from '@utils/environment';
-import { getSkillsBaseUrl } from '@lib/constants';
+import { CallType, getSkillsBaseUrl } from '@lib/constants';
 import type { WizardRunOptions } from '@utils/types';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun, BootstrapResult } from './types';
@@ -287,7 +284,7 @@ export async function bootstrapProgram(
         authToken: credentials.accessToken,
         // `call_type` splits scan spend out of the program's agent cost —
         // same tag the in-run triage provider carries.
-        wizardMetadata: { ...wizardMetadata, call_type: TRIAGE_CALL_TYPE },
+        wizardMetadata: { ...wizardMetadata, call_type: CallType.yaraTriage },
         wizardFlags,
       },
       resolveHarness({

--- a/src/lib/agent/triage-provider.ts
+++ b/src/lib/agent/triage-provider.ts
@@ -14,6 +14,14 @@ import {
 } from '@lib/agent/runner/switchboard/models';
 import type { LLMProvider } from '@posthog/warlock';
 
+/**
+ * `call_type` tag stamped on triage generations at the gateway, so scan spend
+ * is separable from the agent work inside the same `program_id`. Callers pass
+ * it on `wizardMetadata`; without it triage silently merges into the program's
+ * agent cost and can't be measured on its own.
+ */
+export const TRIAGE_CALL_TYPE = 'yara-triage';
+
 const TRIAGE_MAX_TOKENS = 16_384;
 // Shorter than the hook timeout so a hung triage fails inside the hook's
 // try/catch (→ fail-closed) rather than tripping the SDK hook timeout.

--- a/src/lib/agent/triage-provider.ts
+++ b/src/lib/agent/triage-provider.ts
@@ -24,12 +24,8 @@ export interface TriageGatewayAuth {
   baseURL: string;
   /** The run's OAuth access token. */
   authToken: string;
-  /**
-   * The run's gateway trace tags. Pass the run's own `wizardMetadata` with
-   * `call_type` overridden to `CallType.yaraTriage` — that keeps scan spend
-   * attributed to the program that triggered it while staying separable from
-   * the agent work inside it.
-   */
+  /** The run's trace tags, with `call_type` overridden to
+   *  `CallType.yaraTriage` so scan spend is separable from agent work. */
   wizardMetadata?: Record<string, string>;
   wizardFlags?: Record<string, string>;
 }

--- a/src/lib/agent/triage-provider.ts
+++ b/src/lib/agent/triage-provider.ts
@@ -14,14 +14,6 @@ import {
 } from '@lib/agent/runner/switchboard/models';
 import type { LLMProvider } from '@posthog/warlock';
 
-/**
- * `call_type` tag stamped on triage generations at the gateway, so scan spend
- * is separable from the agent work inside the same `program_id`. Callers pass
- * it on `wizardMetadata`; without it triage silently merges into the program's
- * agent cost and can't be measured on its own.
- */
-export const TRIAGE_CALL_TYPE = 'yara-triage';
-
 const TRIAGE_MAX_TOKENS = 16_384;
 // Shorter than the hook timeout so a hung triage fails inside the hook's
 // try/catch (→ fail-closed) rather than tripping the SDK hook timeout.
@@ -32,6 +24,12 @@ export interface TriageGatewayAuth {
   baseURL: string;
   /** The run's OAuth access token. */
   authToken: string;
+  /**
+   * The run's gateway trace tags. Pass the run's own `wizardMetadata` with
+   * `call_type` overridden to `CallType.yaraTriage` — that keeps scan spend
+   * attributed to the program that triggered it while staying separable from
+   * the agent work inside it.
+   */
   wizardMetadata?: Record<string, string>;
   wizardFlags?: Record<string, string>;
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -59,24 +59,15 @@ export enum Sequence {
 
 /**
  * What kind of call produced a gateway generation — the `call_type` trace tag.
- *
- * Splits a program's LLM spend by workload, so security scanning is separable
- * from the work the user asked for. Both members are sent explicitly rather
- * than treating `agent` as the unset default: old wizard builds in the field
- * send no `call_type` at all, so an absent value can't be read as "agent"
- * without conflating the two.
- *
- * Lives here rather than beside the triage provider because `buildRunTags`
- * (agent-interface) sets the default and the triage provider overrides it —
- * agent-interface already imports the provider, so a shared home avoids a
- * module cycle.
+ * Splits a program's LLM spend by workload. Every member is sent explicitly so
+ * an absent value means "old build", not "agent".
  */
 export enum CallType {
   /** The agent doing the work the user asked for. */
   agent = 'agent',
   /** Warlock's classifier deciding whether a YARA match is a true positive. */
   yaraTriage = 'yara-triage',
-  /** The cheap repo scan that classifies which projects a program should act on. */
+  /** The cheap repo scan that classifies which projects a program acts on. */
   detection = 'detection',
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -57,6 +57,29 @@ export enum Sequence {
   orchestrator = 'orchestrator',
 }
 
+/**
+ * What kind of call produced a gateway generation — the `call_type` trace tag.
+ *
+ * Splits a program's LLM spend by workload, so security scanning is separable
+ * from the work the user asked for. Both members are sent explicitly rather
+ * than treating `agent` as the unset default: old wizard builds in the field
+ * send no `call_type` at all, so an absent value can't be read as "agent"
+ * without conflating the two.
+ *
+ * Lives here rather than beside the triage provider because `buildRunTags`
+ * (agent-interface) sets the default and the triage provider overrides it —
+ * agent-interface already imports the provider, so a shared home avoids a
+ * module cycle.
+ */
+export enum CallType {
+  /** The agent doing the work the user asked for. */
+  agent = 'agent',
+  /** Warlock's classifier deciding whether a YARA match is a true positive. */
+  yaraTriage = 'yara-triage',
+  /** The cheap repo scan that classifies which projects a program should act on. */
+  detection = 'detection',
+}
+
 // ── Integration / CLI ───────────────────────────────────────────────
 
 /**

--- a/src/lib/detection/__tests__/project-scope.test.ts
+++ b/src/lib/detection/__tests__/project-scope.test.ts
@@ -125,6 +125,21 @@ describe('scopeInstallDirToProject', () => {
     expect(scan).not.toHaveBeenCalled();
   });
 
+  it('bills the scan to the program that asked for it', async () => {
+    // The detector drives a real (if cheap) agent through the gateway. It runs
+    // before bootstrap, so nothing upstream supplies run tags — an unattributed
+    // scan is exactly how this spend went missing before.
+    flagsSpy.mockResolvedValue(FLAG_ON);
+    scan.mockResolvedValue({ repoType: 'single', projects: [web] });
+
+    await scopeInstallDirToProject(buildSession({ installDir: '/repo' }));
+
+    expect(scan).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ programId: 'posthog-integration' }),
+    );
+  });
+
   it('re-points installDir at the recommended project and fires recommended with scan facts', async () => {
     flagsSpy.mockResolvedValue(FLAG_ON);
     scan.mockResolvedValue({ repoType: 'monorepo', projects: [web] });

--- a/src/lib/detection/__tests__/project-scope.test.ts
+++ b/src/lib/detection/__tests__/project-scope.test.ts
@@ -126,9 +126,7 @@ describe('scopeInstallDirToProject', () => {
   });
 
   it('bills the scan to the program that asked for it', async () => {
-    // The detector drives a real (if cheap) agent through the gateway. It runs
-    // before bootstrap, so nothing upstream supplies run tags — an unattributed
-    // scan is exactly how this spend went missing before.
+    // Runs before bootstrap, so nothing upstream supplies run tags.
     flagsSpy.mockResolvedValue(FLAG_ON);
     scan.mockResolvedValue({ repoType: 'single', projects: [web] });
 

--- a/src/lib/detection/agentic.ts
+++ b/src/lib/detection/agentic.ts
@@ -16,11 +16,13 @@
 import {
   initializeAgent,
   runAgent as executeAgent,
+  buildRunTags,
   AgentSignals,
 } from '@lib/agent/agent-interface';
 import { isAbsolute, resolve, sep } from 'path';
 import { detectNodePackageManagers } from './package-manager.js';
-import { getSkillsBaseUrl, HAIKU_MODEL } from '@lib/constants';
+import { CallType, getSkillsBaseUrl, HAIKU_MODEL } from '@lib/constants';
+import { analytics } from '@utils/analytics';
 import type { WizardSession } from '@lib/wizard-session';
 import type { WizardRunOptions } from '@utils/types';
 import type { SpinnerHandle } from '@ui';
@@ -108,6 +110,15 @@ export type AgenticDetectOptions = {
    * through ordering (e.g. a bundler target before a generic framework target).
    */
   targets: readonly DetectTarget[];
+  /**
+   * The program this scan runs on behalf of, for gateway cost attribution.
+   *
+   * Required, not optional: this scan drives a real (if cheap) agent through
+   * the LLM gateway, and a caller that forgets to say who it's for sends spend
+   * to the unattributed bucket with no way to trace it back. `call_type`
+   * separates it from the program's own agent work.
+   */
+  programId: string;
   /** One short clause describing what the scan is for (frames the prompt). */
   purpose?: string;
   /** Ask the agent to label exactly one project `recommended` (the main client app). Off by default. */
@@ -328,6 +339,7 @@ export async function detectProjectsWithAgent(
   }
   const {
     targets,
+    programId,
     purpose = 'set up a PostHog integration',
     recommend = false,
     rerankIds,
@@ -336,6 +348,20 @@ export async function detectProjectsWithAgent(
   const { accessToken, host } = session.credentials;
   const cwd = session.installDir;
   const runOptions = sessionToWizardOptions(session);
+
+  // Gateway trace tags. This scan runs before `bootstrapProgram` exists, so
+  // they're built here from the caller's program plus the run's analytics
+  // identity rather than inherited from `boot.wizardMetadata`. Without them
+  // the scan — and the YARA triage it wires up — bill to no program at all.
+  const wizardMetadata = {
+    ...buildRunTags({
+      programId,
+      integration: 'agentic-detect',
+      runId: analytics.runId,
+      build: analytics.build,
+    }),
+    call_type: CallType.detection,
+  };
 
   const agent = await initializeAgent(
     {
@@ -346,6 +372,7 @@ export async function detectProjectsWithAgent(
       detectPackageManager: detectNodePackageManagers,
       skillsBaseUrl: getSkillsBaseUrl(session.localMcp),
       integrationLabel: 'agentic-detect',
+      wizardMetadata,
       allowedTools: ['Read', 'Grep', 'Glob'],
       modelOverride: HAIKU_MODEL,
     },

--- a/src/lib/detection/agentic.ts
+++ b/src/lib/detection/agentic.ts
@@ -110,14 +110,9 @@ export type AgenticDetectOptions = {
    * through ordering (e.g. a bundler target before a generic framework target).
    */
   targets: readonly DetectTarget[];
-  /**
-   * The program this scan runs on behalf of, for gateway cost attribution.
-   *
-   * Required, not optional: this scan drives a real (if cheap) agent through
-   * the LLM gateway, and a caller that forgets to say who it's for sends spend
-   * to the unattributed bucket with no way to trace it back. `call_type`
-   * separates it from the program's own agent work.
-   */
+  /** The program this scan bills to. Required, not optional: the scan drives a
+   *  real agent through the gateway, and a caller that forgets leaves that
+   *  spend unattributed. */
   programId: string;
   /** One short clause describing what the scan is for (frames the prompt). */
   purpose?: string;
@@ -349,10 +344,8 @@ export async function detectProjectsWithAgent(
   const cwd = session.installDir;
   const runOptions = sessionToWizardOptions(session);
 
-  // Gateway trace tags. This scan runs before `bootstrapProgram` exists, so
-  // they're built here from the caller's program plus the run's analytics
-  // identity rather than inherited from `boot.wizardMetadata`. Without them
-  // the scan — and the YARA triage it wires up — bill to no program at all.
+  // Built here rather than inherited: this scan runs before
+  // `bootstrapProgram`, so there's no `boot.wizardMetadata` yet.
   const wizardMetadata = {
     ...buildRunTags({
       programId,

--- a/src/lib/detection/project-scope.ts
+++ b/src/lib/detection/project-scope.ts
@@ -27,7 +27,12 @@ const INTEGRATION_TARGETS: DetectTarget[] = Object.entries(
 /** Run the agentic detector for the wizard's integration frameworks — the single home of targets + purpose. */
 export async function detectIntegrationProjects(
   session: WizardSession,
-  options: { recommend?: boolean; onEvent?: DetectEvent } = {},
+  options: {
+    /** Program the scan bills to. Required so no caller can go unattributed. */
+    programId: string;
+    recommend?: boolean;
+    onEvent?: DetectEvent;
+  },
 ): Promise<AgenticDetectionReport> {
   // Spread first so the targets and purpose this function owns always win.
   return detectProjectsWithAgent(session, {
@@ -85,6 +90,10 @@ export async function scopeInstallDirToProject(
   try {
     report = await Promise.race([
       detectIntegrationProjects(session, {
+        // Same literal the `authenticate` call above uses — importing the
+        // program registry here would cycle back through the programs that
+        // import this module.
+        programId: 'posthog-integration',
         recommend: true,
         onEvent: (line) => logToFile('[agentic detect]', line),
       }),

--- a/src/lib/detection/project-scope.ts
+++ b/src/lib/detection/project-scope.ts
@@ -90,9 +90,8 @@ export async function scopeInstallDirToProject(
   try {
     report = await Promise.race([
       detectIntegrationProjects(session, {
-        // Same literal the `authenticate` call above uses — importing the
-        // program registry here would cycle back through the programs that
-        // import this module.
+        // Literal, like the `authenticate` call above: importing the program
+        // registry here would cycle.
         programId: 'posthog-integration',
         recommend: true,
         onEvent: (line) => logToFile('[agentic detect]', line),

--- a/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
+++ b/src/lib/programs/error-tracking-upload-source-maps/detect-agentic.ts
@@ -406,6 +406,7 @@ export async function detectSourceMapsProjects(
 ): Promise<DetectionReport> {
   const report = await detectProjectsWithAgent(session, {
     targets: SOURCE_MAPS_TARGETS,
+    programId: 'error-tracking-upload-source-maps',
     purpose: 'set up PostHog Error Tracking source-map upload',
     rerankIds: JS_RERANK_VARIANTS,
     onEvent,

--- a/src/lib/programs/mcp/index.ts
+++ b/src/lib/programs/mcp/index.ts
@@ -45,12 +45,9 @@ export const mcpAddConfig: ProgramConfig = {
       // talk to from the tutorial.
       show: (s) => s.mcpOutcome === McpOutcome.Installed,
       isComplete: (s) => s.mcpSuggestedPromptsDismissed,
-      // This step *is* the tutorial, so its events belong to the tutorial's
-      // funnel rather than to `mcp-add` — otherwise the same screen reports
-      // under two program ids depending on how the user arrived, and neither
-      // one measures the tutorial. String literal (not `Program.McpTutorial`)
-      // to avoid a runtime cycle with `program-registry.ts`; the `ProgramId`
-      // type on the field still catches a rename at compile time.
+      // This step *is* the tutorial, so it reports there rather than to
+      // `mcp-add`. Literal avoids a runtime cycle with the program registry;
+      // the `ProgramId` type still catches a rename.
       reportsAsProgramId: 'mcp-tutorial',
     },
   ],

--- a/src/lib/programs/mcp/index.ts
+++ b/src/lib/programs/mcp/index.ts
@@ -45,6 +45,13 @@ export const mcpAddConfig: ProgramConfig = {
       // talk to from the tutorial.
       show: (s) => s.mcpOutcome === McpOutcome.Installed,
       isComplete: (s) => s.mcpSuggestedPromptsDismissed,
+      // This step *is* the tutorial, so its events belong to the tutorial's
+      // funnel rather than to `mcp-add` — otherwise the same screen reports
+      // under two program ids depending on how the user arrived, and neither
+      // one measures the tutorial. String literal (not `Program.McpTutorial`)
+      // to avoid a runtime cycle with `program-registry.ts`; the `ProgramId`
+      // type on the field still catches a rename at compile time.
+      reportsAsProgramId: 'mcp-tutorial',
     },
   ],
 };

--- a/src/lib/programs/posthog-integration/content/index.tsx
+++ b/src/lib/programs/posthog-integration/content/index.tsx
@@ -17,7 +17,12 @@ import { FUNNEL_BLOCK } from './funnel.js';
 
 export const getContentBlocks = (store?: WizardStore): ContentBlock[] => [
   {
-    content: 'Welcome.',
+    // Personalised from the profile we fetch at login — same pattern the
+    // MCP suggested-prompts greeting uses. Falls back to the bare
+    // greeting when the name is missing (CI keys, failed /users/@me).
+    content: store?.session.apiUser?.first_name
+      ? `Welcome, ${store.session.apiUser.first_name}.`
+      : 'Welcome.',
     pause: 3000,
     mode: TextRevealMode.Typewriter,
     animationInterval: 160,

--- a/src/lib/programs/posthog-integration/content/index.tsx
+++ b/src/lib/programs/posthog-integration/content/index.tsx
@@ -17,9 +17,7 @@ import { FUNNEL_BLOCK } from './funnel.js';
 
 export const getContentBlocks = (store?: WizardStore): ContentBlock[] => [
   {
-    // Personalised from the profile we fetch at login — same pattern the
-    // MCP suggested-prompts greeting uses. Falls back to the bare
-    // greeting when the name is missing (CI keys, failed /users/@me).
+    // Name comes from the login profile; falls back when absent (CI keys).
     content: store?.session.apiUser?.first_name
       ? `Welcome, ${store.session.apiUser.first_name}.`
       : 'Welcome.',

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -10,6 +10,9 @@ import type { FrameworkConfig } from '@lib/framework-config';
 import type { ContentBlock } from '@ui/tui/primitives/index';
 import type { WizardStore } from '@ui/tui/store';
 import type { Tip } from '@ui/tui/components/TipsCard';
+// Type-only — erased at compile time, so no runtime cycle with the
+// registry that imports `ProgramConfig` back from this module.
+import type { ProgramId } from './program-registry.js';
 
 /**
  * A program step is the primary unit of the wizard's execution model.
@@ -130,6 +133,27 @@ export interface ProgramStep {
    * scanning the installDir for prerequisites. May be sync or async.
    */
   onReady?: (ctx: ProgramReadyContext) => void | Promise<void>;
+
+  /**
+   * Report this step's analytics under a different program than the one
+   * hosting it. Explicit opt-in — omit for steps that only ever run under
+   * one program, and they report under their host.
+   *
+   * Steps are shared across programs: the MCP tutorial is the whole of
+   * `mcp-tutorial` and also the last step of `mcp-add`. Analytics tag
+   * `program_id` with the program the *run* launched as, so without this
+   * the tutorial's funnel splits across two ids and neither one is the
+   * whole picture. Declaring it here keeps the mapping next to the step
+   * list; the store resolves it (`WizardStore.analyticsProgramId`) and
+   * infrastructure stays ignorant of which surface is which.
+   *
+   * Attribution only — OAuth scopes, switchboard bindings, and screen
+   * sequences all still resolve against the host program.
+   *
+   * Resolved by matching `screenId`, so this has no effect on a headless
+   * step (one with no screen of its own).
+   */
+  reportsAsProgramId?: ProgramId;
 }
 
 /**

--- a/src/lib/programs/program-step.ts
+++ b/src/lib/programs/program-step.ts
@@ -135,23 +135,11 @@ export interface ProgramStep {
   onReady?: (ctx: ProgramReadyContext) => void | Promise<void>;
 
   /**
-   * Report this step's analytics under a different program than the one
-   * hosting it. Explicit opt-in — omit for steps that only ever run under
-   * one program, and they report under their host.
-   *
-   * Steps are shared across programs: the MCP tutorial is the whole of
-   * `mcp-tutorial` and also the last step of `mcp-add`. Analytics tag
-   * `program_id` with the program the *run* launched as, so without this
-   * the tutorial's funnel splits across two ids and neither one is the
-   * whole picture. Declaring it here keeps the mapping next to the step
-   * list; the store resolves it (`WizardStore.analyticsProgramId`) and
-   * infrastructure stays ignorant of which surface is which.
-   *
-   * Attribution only — OAuth scopes, switchboard bindings, and screen
-   * sequences all still resolve against the host program.
-   *
-   * Resolved by matching `screenId`, so this has no effect on a headless
-   * step (one with no screen of its own).
+   * Report this step's analytics under a different program than its host, for
+   * steps shared across programs (the MCP tutorial is all of `mcp-tutorial`
+   * and the last step of `mcp-add`). Attribution only — scopes, bindings, and
+   * sequences still follow the host. Matched by `screenId`, so headless steps
+   * are unaffected.
    */
   reportsAsProgramId?: ProgramId;
 }

--- a/src/lib/programs/self-driving/detect-agentic.ts
+++ b/src/lib/programs/self-driving/detect-agentic.ts
@@ -91,7 +91,10 @@ export async function detectSelfDrivingIntegrationProjects(
   session: WizardSession,
   onEvent?: DetectEvent,
 ): Promise<IntegrationDetectionReport> {
-  const report = await detectIntegrationProjects(session, { onEvent });
+  const report = await detectIntegrationProjects(session, {
+    programId: 'self-driving',
+    onEvent,
+  });
   return toIntegrationReport(report);
 }
 

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -1462,6 +1462,54 @@ describe('WizardStore', () => {
     });
   });
 
+  // ── Program attribution for shared steps ────────────────────────────
+
+  describe('analyticsProgramId', () => {
+    it('reports the running program for a step that claims no override', () => {
+      const store = createStore(Program.McpAdd);
+
+      expect(store.currentScreen).toBe(ScreenId.McpAdd);
+      expect(store.analyticsProgramId).toBe(Program.McpAdd);
+    });
+
+    it('reports mcp-tutorial for the tutorial step hosted inside mcp-add', () => {
+      const store = createStore(Program.McpAdd);
+      const session = store.session;
+      session.mcpOutcome = McpOutcome.Installed;
+      session.mcpComplete = true;
+      session.slackStepDismissed = true;
+      store.session = session;
+
+      expect(store.currentScreen).toBe(ScreenId.McpSuggestedPrompts);
+      expect(store.analyticsProgramId).toBe(Program.McpTutorial);
+    });
+
+    it('reports mcp-tutorial for the same step run standalone', () => {
+      const store = createStore(Program.McpTutorial);
+
+      expect(store.currentScreen).toBe(ScreenId.McpSuggestedPrompts);
+      expect(store.analyticsProgramId).toBe(Program.McpTutorial);
+    });
+
+    it('stamps the tutorial program id on the screen transition event', () => {
+      const store = createStore(Program.McpAdd);
+      // Prime the transition detector: the first emit has no previous
+      // screen, so it records the starting one without firing an event.
+      store.emitChange();
+
+      const session = store.session;
+      session.mcpOutcome = McpOutcome.Installed;
+      session.mcpComplete = true;
+      session.slackStepDismissed = true;
+      store.session = session;
+
+      expect(wizardCaptureMock).toHaveBeenCalledWith(
+        `screen ${ScreenId.McpSuggestedPrompts}`,
+        expect.objectContaining({ program_id: Program.McpTutorial }),
+      );
+    });
+  });
+
   // ── intro gate ──────────────────────────────────────────────────
 
   describe('intro gate', () => {

--- a/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
+++ b/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
@@ -135,6 +135,28 @@ export const McpSuggestedPromptsScreen = ({
 
   const session = store.session;
 
+  // Every event below reports under the tutorial's program id, not the
+  // program that happens to be hosting the screen — `mcp add` runs this
+  // same tutorial as its last step, and splitting the funnel by entry
+  // point means neither half measures the tutorial. The mapping itself is
+  // declared on the step (`programs/mcp/index.ts`), not hardcoded here.
+  //
+  // Sampled once at mount rather than read per call: the screen is only
+  // mounted while it's the active one, and captures that land after
+  // dismissal (the streaming run's terminal chunk) would otherwise resolve
+  // against whatever screen the router moved on to.
+  const programId = useMemo(() => store.analyticsProgramId, [store]);
+  const capture = useMemo(
+    () =>
+      (event: string, properties?: Record<string, unknown>): void => {
+        analytics.wizardCapture(event, {
+          program_id: programId,
+          ...properties,
+        });
+      },
+    [programId],
+  );
+
   // Phase.Choose is the no-commitment entry. Login fires only when the
   // user picks 'Start tutorial' — explicit consent for the OAuth dance.
   const [phase, setPhase] = useState<Phase>(Phase.Choose);
@@ -268,7 +290,7 @@ export const McpSuggestedPromptsScreen = ({
       // misroute or an unwanted write leaves a permanent trail.
       const offerSeed =
         probed.tier === 'empty' && isKnownCloudHost(credentials.host.apiHost);
-      analytics.wizardCapture('mcp suggested prompts scouted', {
+      capture('mcp suggested prompts scouted', {
         tier: probed.tier,
         totalEvents: probed.totalEvents,
         distinctEvents: probed.distinctEventCount,
@@ -306,14 +328,14 @@ export const McpSuggestedPromptsScreen = ({
         });
         if (cancelled) return;
         setProfile(seeded);
-        analytics.wizardCapture('mcp suggested prompts seeded', {
+        capture('mcp suggested prompts seeded', {
           totalEvents: seeded.totalEvents,
         });
       } catch (err) {
         if (cancelled) return;
         const message = err instanceof Error ? err.message : String(err);
         logToFile(`[McpSuggestedPromptsScreen] seeding failed: ${message}`);
-        analytics.wizardCapture('mcp suggested prompts seed failed', {
+        capture('mcp suggested prompts seed failed', {
           error: message,
         });
         // Keep the empty profile; the picker handles the empty case.
@@ -357,12 +379,12 @@ export const McpSuggestedPromptsScreen = ({
       if (controller.signal.aborted) return;
       setRunDurationSecs(Math.round(durationMs / 1000));
       if (kind === 'done') {
-        analytics.wizardCapture('mcp suggested prompts run', {
+        capture('mcp suggested prompts run', {
           prompt: runningPrompt,
           durationMs,
         });
       } else {
-        analytics.wizardCapture('mcp suggested prompts run failed', {
+        capture('mcp suggested prompts run failed', {
           prompt: runningPrompt,
           error: errorText,
         });
@@ -445,7 +467,7 @@ export const McpSuggestedPromptsScreen = ({
     const choice = Array.isArray(value) ? value[0] : value;
     setLoginError(null);
     if (choice === ChoiceValue.Login) {
-      analytics.wizardCapture('mcp suggested prompts choose', {
+      capture('mcp suggested prompts choose', {
         choice: 'login',
       });
       startedTutorialRef.current = true;
@@ -454,7 +476,7 @@ export const McpSuggestedPromptsScreen = ({
       // scout — same landing as post-auth for a started tutorial.
       setPhase(session.credentials ? Phase.Scouting : Phase.Authenticating);
     } else {
-      analytics.wizardCapture('mcp suggested prompts choose', {
+      capture('mcp suggested prompts choose', {
         choice: 'exit',
       });
       enterGoodbye();
@@ -466,12 +488,12 @@ export const McpSuggestedPromptsScreen = ({
   const handleSeedChoice = (value: string | string[]): void => {
     const choice = Array.isArray(value) ? value[0] : value;
     if (choice === SeedChoice.Seed) {
-      analytics.wizardCapture('mcp suggested prompts seed offer', {
+      capture('mcp suggested prompts seed offer', {
         choice: 'seed',
       });
       setPhase(Phase.Seeding);
     } else {
-      analytics.wizardCapture('mcp suggested prompts seed offer', {
+      capture('mcp suggested prompts seed offer', {
         choice: 'skip',
       });
       setPhase(Phase.Greeting);
@@ -495,14 +517,14 @@ export const McpSuggestedPromptsScreen = ({
   const handleFollowUpPick = (value: string | string[]): void => {
     const picked = Array.isArray(value) ? value[0] : value;
     if (picked === FOLLOW_UP_EXIT_SENTINEL) {
-      analytics.wizardCapture('mcp suggested prompts follow-up', {
+      capture('mcp suggested prompts follow-up', {
         choice: 'exit',
         depth: branchHistory.length,
       });
       enterGoodbye();
       return;
     }
-    analytics.wizardCapture('mcp suggested prompts follow-up', {
+    capture('mcp suggested prompts follow-up', {
       choice: 'continue',
       depth: branchHistory.length,
       lastToolName,

--- a/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
+++ b/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
@@ -135,16 +135,8 @@ export const McpSuggestedPromptsScreen = ({
 
   const session = store.session;
 
-  // Every event below reports under the tutorial's program id, not the
-  // program that happens to be hosting the screen — `mcp add` runs this
-  // same tutorial as its last step, and splitting the funnel by entry
-  // point means neither half measures the tutorial. The mapping itself is
-  // declared on the step (`programs/mcp/index.ts`), not hardcoded here.
-  //
-  // Sampled once at mount rather than read per call: the screen is only
-  // mounted while it's the active one, and captures that land after
-  // dismissal (the streaming run's terminal chunk) would otherwise resolve
-  // against whatever screen the router moved on to.
+  // Events report under the tutorial, not whichever program hosts the screen.
+  // Sampled at mount so captures landing after dismissal still resolve here.
   const programId = useMemo(() => store.analyticsProgramId, [store]);
   const capture = useMemo(
     () =>

--- a/src/ui/tui/services/mcp-suggested-prompts-services.ts
+++ b/src/ui/tui/services/mcp-suggested-prompts-services.ts
@@ -138,12 +138,9 @@ export function createMcpSuggestedPromptsServices(
     runPromptStreaming: (args) =>
       runProductionPromptStreaming({
         ...args,
-        // Gateway cost attribution. `analyticsProgramId` resolves to
-        // `mcp-tutorial` from both entry points (standalone and the `mcp add`
-        // step), so the tutorial's spend reports as one program either way.
-        // Only the id crosses here — the rest of the trace tags are assembled
-        // next to the headers they become, keeping the agent module out of the
-        // TUI's startup graph.
+        // Gateway cost attribution. Only the id crosses here; the rest of the
+        // trace tags are built where the headers are, keeping the agent module
+        // out of the TUI's startup graph.
         programId: store.analyticsProgramId,
         integration: store.session.integration ?? undefined,
       }),

--- a/src/ui/tui/services/mcp-suggested-prompts-services.ts
+++ b/src/ui/tui/services/mcp-suggested-prompts-services.ts
@@ -135,7 +135,18 @@ export function createMcpSuggestedPromptsServices(
       };
     },
 
-    runPromptStreaming: (args) => runProductionPromptStreaming(args),
+    runPromptStreaming: (args) =>
+      runProductionPromptStreaming({
+        ...args,
+        // Gateway cost attribution. `analyticsProgramId` resolves to
+        // `mcp-tutorial` from both entry points (standalone and the `mcp add`
+        // step), so the tutorial's spend reports as one program either way.
+        // Only the id crosses here — the rest of the trace tags are assembled
+        // next to the headers they become, keeping the agent module out of the
+        // TUI's startup graph.
+        programId: store.analyticsProgramId,
+        integration: store.session.integration ?? undefined,
+      }),
 
     probeProjectData: (credentials) =>
       runProbe({
@@ -159,6 +170,8 @@ async function* runProductionPromptStreaming(args: {
   credentials: Credentials;
   signal: AbortSignal;
   resumeSessionId?: string;
+  programId?: string;
+  integration?: string;
 }): AsyncIterable<AgentChunk> {
   // Defer the SDK import to call time — the playground never hits
   // this path (it overrides the whole service object), so demo

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -931,6 +931,31 @@ export class WizardStore {
   }
 
   /**
+   * The program id events fired from `screen` should be attributed to.
+   *
+   * Defaults to the running program; a step may claim a different one via
+   * `ProgramStep.reportsAsProgramId` when the same screen is hosted by more
+   * than one program. Overlays and screens with no owning step (the
+   * appended exit screen) fall back to the running program.
+   */
+  private _programIdForScreen(screen: ScreenName): ProgramId {
+    const program = this.router.activeProgram;
+    const step = getProgramConfig(program).steps.find(
+      (s) => s.screenId === screen,
+    );
+    return step?.reportsAsProgramId ?? program;
+  }
+
+  /**
+   * The program id the currently visible screen reports under. Screens
+   * capturing their own events should stamp this rather than assuming the
+   * run-level `program_id` tag — see `_programIdForScreen`.
+   */
+  get analyticsProgramId(): ProgramId {
+    return this._programIdForScreen(this.router.resolve(this.session));
+  }
+
+  /**
    * Detect screen transitions, run enter-screen hooks, and fire analytics.
    * Called at the end of emitChange/pushOverlay/popOverlay.
    */
@@ -949,7 +974,7 @@ export class WizardStore {
       }
       analytics.wizardCapture(`screen ${next}`, {
         from_screen: prev,
-        program_id: this.router.activeProgram,
+        program_id: this._programIdForScreen(next),
         ...sessionProperties(this.session),
       });
     }

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -931,12 +931,9 @@ export class WizardStore {
   }
 
   /**
-   * The program id events fired from `screen` should be attributed to.
-   *
-   * Defaults to the running program; a step may claim a different one via
-   * `ProgramStep.reportsAsProgramId` when the same screen is hosted by more
-   * than one program. Overlays and screens with no owning step (the
-   * appended exit screen) fall back to the running program.
+   * The program `screen` reports under — its step's `reportsAsProgramId` if it
+   * claims one, else the running program (also the fallback for overlays and
+   * screens with no owning step).
    */
   private _programIdForScreen(screen: ScreenName): ProgramId {
     const program = this.router.activeProgram;
@@ -946,11 +943,8 @@ export class WizardStore {
     return step?.reportsAsProgramId ?? program;
   }
 
-  /**
-   * The program id the currently visible screen reports under. Screens
-   * capturing their own events should stamp this rather than assuming the
-   * run-level `program_id` tag — see `_programIdForScreen`.
-   */
+  /** The program the visible screen reports under; screens stamp this on their
+   *  own events rather than relying on the run-level `program_id` tag. */
   get analyticsProgramId(): ProgramId {
     return this._programIdForScreen(this.router.resolve(this.session));
   }


### PR DESCRIPTION
## Changes

mixed salad of stuff
- shedding light on our analytic blind spots like YARA and mcp tutorial
- added a `reportAsProgramId` analytics override for certain screens
- adding "Welcome, {first name of user}" to Learn Card
- codeowners update

