### PR TITLE
fix(mcp): auth once in the client, no wizard feature menus — scope choice lives on the OAuth consent screen

### DIFF
--- a/src/__tests__/mcp-cli.test.ts
+++ b/src/__tests__/mcp-cli.test.ts
@@ -73,21 +73,17 @@ describe('mcp add handler', () => {
     );
   });
 
-  test('passes --api-key through to buildSession', async () => {
+  test('never puts credentials in the session — auth belongs to the MCP client', async () => {
+    // Even with a key on argv and one sitting in .env, the install flow must
+    // stay credential-free: a wizard-injected key overrides the editor's OAuth
+    // tokens forever and locks it into a rejected-reconnect loop.
+    mockReadApiKeyFromEnvMcp.mockReturnValueOnce('phx_from_env');
     mcpAddCommand.handler!(makeArgv({ apiKey: 'phx_from_flag' }));
     await flush();
-    expect(mockBuildSessionMcp).toHaveBeenCalledWith(
-      expect.objectContaining({ apiKey: 'phx_from_flag' }),
+    expect(mockBuildSessionMcp).not.toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: expect.anything() }),
     );
-  });
-
-  test('falls back to readApiKeyFromEnv when --api-key is omitted', async () => {
-    mockReadApiKeyFromEnvMcp.mockReturnValueOnce('phx_from_env');
-    mcpAddCommand.handler!(makeArgv());
-    await flush();
-    expect(mockBuildSessionMcp).toHaveBeenCalledWith(
-      expect.objectContaining({ apiKey: 'phx_from_env' }),
-    );
+    expect(mockReadApiKeyFromEnvMcp).not.toHaveBeenCalled();
   });
 
   test('parses --features into a trimmed array', async () => {
@@ -100,12 +96,11 @@ describe('mcp add handler', () => {
 });
 
 describe('mcp parsing (end-to-end yargs)', () => {
-  test('mcp add camelCases --api-key and parses its flags', async () => {
+  test('mcp add parses its flags', async () => {
     const argv = await parseCommand(
       mcpCommand,
-      'mcp add --api-key phx_x --local --features flags,errors',
+      'mcp add --local --features flags,errors',
     );
-    expect(argv.apiKey).toBe('phx_x');
     expect(argv.local).toBe(true);
     expect(argv.features).toBe('flags,errors');
   });

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -19,10 +19,6 @@ export const mcpAddCommand: Command = {
       describe: 'Comma-separated list of features to enable (default: all)',
       type: 'string',
     },
-    'api-key': {
-      describe: 'PostHog personal API key (phx_xxx) for MCP authentication',
-      type: 'string',
-    },
   },
   handler: runMcpAdd,
 };
@@ -30,8 +26,6 @@ export const mcpAddCommand: Command = {
 function runMcpAdd(argv: Arguments): void {
   const features = parseFeatures(argv.features);
   void (async () => {
-    const { readApiKeyFromEnv } = await import('@utils/env-api-key');
-    const apiKey = (argv.apiKey as string | undefined) || readApiKeyFromEnv();
     const debug = argv.debug as boolean | undefined;
     const localMcp = argv.local as boolean | undefined;
 
@@ -43,7 +37,6 @@ function runMcpAdd(argv: Arguments): void {
         debug,
         localMcp,
         mcpFeatures: features,
-        apiKey,
         baseUrl: argv.baseUrl as string | undefined,
       });
     } catch (error) {
@@ -52,7 +45,7 @@ function runMcpAdd(argv: Arguments): void {
       const { addMCPServerToClientsStep } = await import(
         '@steps/add-mcp-server-to-clients/index'
       );
-      await addMCPServerToClientsStep({ local: localMcp, features, apiKey });
+      await addMCPServerToClientsStep({ local: localMcp, features });
     }
   })();
 }

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -306,6 +306,8 @@ export interface WizardSession {
   mcpComplete: boolean;
   mcpOutcome: McpOutcome | null;
   mcpInstalledClients: string[];
+  /** Editor-owned login commands still to run (e.g. `claude mcp login posthog`), echoed at exit. */
+  mcpLoginCommands: string[];
   mcpSuggestedPromptsDismissed: boolean;
   /** True once the user has acted on (opened or skipped) the Connect-Slack step. */
   slackStepDismissed: boolean;
@@ -443,6 +445,7 @@ export function buildSession(args: {
     mcpComplete: false,
     mcpOutcome: null,
     mcpInstalledClients: [],
+    mcpLoginCommands: [],
     mcpSuggestedPromptsDismissed: false,
     slackStepDismissed: false,
     slackConnected: null,

--- a/src/steps/add-mcp-server-to-clients/MCPClient.ts
+++ b/src/steps/add-mcp-server-to-clients/MCPClient.ts
@@ -12,7 +12,6 @@ export abstract class MCPClient {
   abstract getServerPropertyName(): string;
   abstract isServerInstalled(local?: boolean): Promise<boolean>;
   abstract addServer(
-    apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult>;
@@ -32,11 +31,10 @@ export abstract class DefaultMCPClient extends MCPClient {
   }
 
   getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
-    return getDefaultServerConfig(apiKey, selectedFeatures, local);
+    return getDefaultServerConfig(selectedFeatures, local);
   }
 
   async isServerInstalled(local?: boolean): Promise<boolean> {
@@ -61,7 +59,6 @@ export abstract class DefaultMCPClient extends MCPClient {
   }
 
   async addServer(
-    apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult> {
@@ -80,11 +77,7 @@ export abstract class DefaultMCPClient extends MCPClient {
         existingConfig = jsonc.parse(configContent) || {};
       }
 
-      const newServerConfig = this.getServerConfig(
-        apiKey,
-        selectedFeatures,
-        local,
-      );
+      const newServerConfig = this.getServerConfig(selectedFeatures, local);
       const typedConfig = existingConfig as Record<string, any>;
       if (!typedConfig[serverPropertyName]) {
         typedConfig[serverPropertyName] = {};

--- a/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
@@ -22,6 +22,12 @@ describe('defaults', () => {
         'https://mcp.posthog.com/mcp?features=dashboards,insights',
       );
     });
+
+    it('builds the same URL for the same features in any order', () => {
+      expect(buildMCPUrl(['insights', 'dashboards'])).toBe(
+        buildMCPUrl(['dashboards', 'insights']),
+      );
+    });
   });
 
   describe('getDefaultServerConfig', () => {

--- a/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
@@ -25,50 +25,35 @@ describe('defaults', () => {
   });
 
   describe('getDefaultServerConfig', () => {
-    it('should return config with auth header when API key provided', () => {
-      const config = getDefaultServerConfig('phx_test123');
-      expect(config).toEqual({
-        command: 'npx',
-        args: [
-          '-y',
-          'mcp-remote@latest',
-          'https://mcp.posthog.com/mcp',
-          '--header',
-          'Authorization:${POSTHOG_AUTH_HEADER}',
-        ],
-        env: {
-          POSTHOG_AUTH_HEADER: 'Bearer phx_test123',
-        },
-      });
-    });
-
-    it('should return config without auth header for OAuth mode (no API key)', () => {
-      const config = getDefaultServerConfig(undefined);
+    it("should return a credential-free mcp-remote config (auth is the client's job)", () => {
+      const config = getDefaultServerConfig();
       expect(config).toEqual({
         command: 'npx',
         args: ['-y', 'mcp-remote@latest', 'https://mcp.posthog.com/mcp'],
       });
       expect(config).not.toHaveProperty('env');
     });
+
+    it('should encode the feature selection in the URL', () => {
+      const config = getDefaultServerConfig(['workflows']);
+      expect(config.args).toContain(
+        'https://mcp.posthog.com/mcp?features=workflows',
+      );
+    });
   });
 
   describe('getNativeHTTPServerConfig', () => {
-    it('should return config with headers when API key provided', () => {
-      const config = getNativeHTTPServerConfig('phx_test123');
-      expect(config).toEqual({
-        url: 'https://mcp.posthog.com/mcp',
-        headers: {
-          Authorization: 'Bearer phx_test123',
-        },
-      });
-    });
-
-    it('should return config without headers for OAuth mode (no API key)', () => {
-      const config = getNativeHTTPServerConfig(undefined);
+    it("should return a URL-only config with no headers (auth is the client's job)", () => {
+      const config = getNativeHTTPServerConfig();
       expect(config).toEqual({
         url: 'https://mcp.posthog.com/mcp',
       });
       expect(config).not.toHaveProperty('headers');
+    });
+
+    it('should encode the feature selection in the URL', () => {
+      const config = getNativeHTTPServerConfig(['workflows']);
+      expect(config.url).toBe('https://mcp.posthog.com/mcp?features=workflows');
     });
   });
 });

--- a/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/defaults.test.ts
@@ -22,12 +22,6 @@ describe('defaults', () => {
         'https://mcp.posthog.com/mcp?features=dashboards,insights',
       );
     });
-
-    it('builds the same URL for the same features in any order', () => {
-      expect(buildMCPUrl(['insights', 'dashboards'])).toBe(
-        buildMCPUrl(['dashboards', 'insights']),
-      );
-    });
   });
 
   describe('getDefaultServerConfig', () => {

--- a/src/steps/add-mcp-server-to-clients/__tests__/mcp-client.test.ts
+++ b/src/steps/add-mcp-server-to-clients/__tests__/mcp-client.test.ts
@@ -28,7 +28,7 @@ describe('DefaultMCPClient — addServer', () => {
   const writeFileMock = fs.promises.writeFile as Mock;
 
   const serverConfigFor = () =>
-    new TestClient().getServerConfig(undefined, ['flags'], false);
+    new TestClient().getServerConfig(['flags'], false);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -37,9 +37,9 @@ describe('DefaultMCPClient — addServer', () => {
   it('installs into a config that has no posthog entry yet', async () => {
     existsSyncMock.mockReturnValue(false);
 
-    await expect(
-      new TestClient().addServer(undefined, ['flags']),
-    ).resolves.toEqual({ success: true });
+    await expect(new TestClient().addServer(['flags'])).resolves.toEqual({
+      success: true,
+    });
     expect(writeFileMock).toHaveBeenCalled();
   });
 
@@ -49,9 +49,9 @@ describe('DefaultMCPClient — addServer', () => {
       JSON.stringify({ mcpServers: { posthog: serverConfigFor() } }),
     );
 
-    await expect(
-      new TestClient().addServer(undefined, ['flags'], false),
-    ).resolves.toEqual({ success: true, alreadyInstalled: true });
+    await expect(new TestClient().addServer(['flags'], false)).resolves.toEqual(
+      { success: true, alreadyInstalled: true },
+    );
     expect(writeFileMock).not.toHaveBeenCalled();
   });
 
@@ -61,9 +61,9 @@ describe('DefaultMCPClient — addServer', () => {
       JSON.stringify({ mcpServers: { posthog: { command: 'stale' } } }),
     );
 
-    await expect(
-      new TestClient().addServer(undefined, ['flags'], false),
-    ).resolves.toEqual({ success: true });
+    await expect(new TestClient().addServer(['flags'], false)).resolves.toEqual(
+      { success: true },
+    );
     expect(writeFileMock).toHaveBeenCalled();
   });
 
@@ -71,8 +71,9 @@ describe('DefaultMCPClient — addServer', () => {
     existsSyncMock.mockReturnValue(true);
     readFileMock.mockRejectedValue(new Error('EACCES: permission denied'));
 
-    await expect(
-      new TestClient().addServer(undefined, ['flags']),
-    ).resolves.toEqual({ success: false, reason: 'EACCES: permission denied' });
+    await expect(new TestClient().addServer(['flags'])).resolves.toEqual({
+      success: false,
+      reason: 'EACCES: permission denied',
+    });
   });
 });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -98,6 +98,46 @@ describe('ClaudeCodeMCPClient — addServer', () => {
     expect(callsMatching('mcp remove')).toHaveLength(1);
   });
 
+  it('treats a same-set, different-order selection as identical (no remove)', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) throw new Error('already exists');
+      if (c.includes('mcp get'))
+        return Buffer.from(`  URL: ${BASE_URL}?features=dashboards,insights\n`);
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['insights', 'dashboards'])).resolves.toEqual(
+      { success: true, alreadyInstalled: true },
+    );
+    expect(callsMatching('mcp remove')).toHaveLength(0);
+  });
+
+  it('restores the previous entry when the replacement re-add fails', async () => {
+    let adds = 0;
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) {
+        adds += 1;
+        if (adds === 1) throw new Error('already exists');
+        if (c.includes('features=workflows')) throw new Error('add blew up');
+        return Buffer.from('');
+      }
+      if (c.includes('mcp get'))
+        return Buffer.from(`  URL: ${BASE_URL}?features=flags\n`);
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: false,
+      reason: 'add blew up',
+    });
+    const restore = callsMatching('mcp" "add').filter((c) =>
+      String(c[0]).includes('features=flags'),
+    );
+    expect(restore).toHaveLength(1);
+  });
+
   it('reports a failed replacement with its reason', async () => {
     execSyncMock.mockImplementation((cmd: string) => {
       const c = String(cmd);

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -18,6 +18,117 @@ vi.mock('../../../../utils/debug', () => ({
   debug: vi.fn(),
 }));
 
+describe('ClaudeCodeMCPClient — addServer', () => {
+  const execSyncMock = execSync as Mock;
+  const BASE_URL = 'https://mcp.posthog.com/mcp';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (cmd === 'command -v claude') return Buffer.from('');
+      return Buffer.from('');
+    });
+  });
+
+  const callsMatching = (fragment: string) =>
+    execSyncMock.mock.calls.filter((c) => String(c[0]).includes(fragment));
+
+  it('adds the server without any credentials in the command', async () => {
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: true,
+    });
+    const addCall = callsMatching('mcp" "add')[0]!;
+    expect(String(addCall[0])).toContain(`${BASE_URL}?features=workflows`);
+    expect(String(addCall[0])).not.toContain('Authorization');
+  });
+
+  it('leaves an existing entry alone when it already points at the same URL', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) throw new Error('already exists');
+      if (c.includes('mcp get')) return Buffer.from(`  URL: ${BASE_URL}\n`);
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer()).resolves.toEqual({
+      success: true,
+      alreadyInstalled: true,
+    });
+    expect(callsMatching('mcp remove')).toHaveLength(0);
+  });
+
+  it('replaces the entry when it exists with a different URL', async () => {
+    let adds = 0;
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) {
+        adds += 1;
+        if (adds === 1) throw new Error('already exists');
+        return Buffer.from('');
+      }
+      if (c.includes('mcp get'))
+        return Buffer.from(`  URL: ${BASE_URL}?features=flags\n`);
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: true,
+    });
+    expect(callsMatching('mcp remove')).toHaveLength(1);
+    expect(adds).toBe(2);
+  });
+
+  it('replaces the entry when the existing URL cannot be determined', async () => {
+    let adds = 0;
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) {
+        adds += 1;
+        if (adds === 1) throw new Error('already exists');
+        return Buffer.from('');
+      }
+      if (c.includes('mcp get')) throw new Error('unknown command');
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: true,
+    });
+    expect(callsMatching('mcp remove')).toHaveLength(1);
+  });
+
+  it('reports a failed replacement with its reason', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp" "add')) throw new Error('already exists');
+      if (c.includes('mcp get'))
+        return Buffer.from(`  URL: ${BASE_URL}?features=flags\n`);
+      if (c.includes('mcp remove')) throw new Error('remove blew up');
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer(['workflows'])).resolves.toEqual({
+      success: false,
+      reason: 'remove blew up',
+    });
+    expect(analytics.captureException).toHaveBeenCalled();
+  });
+
+  it('returns failure with the reason on an unexpected add error', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (String(cmd).includes('mcp" "add')) throw new Error('spawn EPERM');
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.addServer()).resolves.toEqual({
+      success: false,
+      reason: 'spawn EPERM',
+    });
+    expect(analytics.captureException).toHaveBeenCalled();
+  });
+});
+
 describe('ClaudeCodeMCPClient — plugin methods', () => {
   const execSyncMock = execSync as Mock;
 

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -54,6 +54,16 @@ describe('ClaudeCodeMCPClient — addServer', () => {
     await expect(client.isServerInstalled()).resolves.toBe(true);
   });
 
+  it('surfaces the editor-owned login commands without ever running them', () => {
+    const client = new ClaudeCodeMCPClient();
+    expect(client.loginCommand()).toBe('claude mcp login posthog');
+    expect(client.loginCommand(true)).toBe('claude mcp login posthog-local');
+    expect(client.pluginLoginCommand()).toBe(
+      'claude mcp login plugin:posthog:posthog',
+    );
+    expect(callsMatching('mcp login')).toHaveLength(0);
+  });
+
   it('adds the server without any credentials in the command', async () => {
     const client = new ClaudeCodeMCPClient();
     await expect(client.addServer(['workflows'])).resolves.toEqual({

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -33,37 +33,6 @@ describe('ClaudeCodeMCPClient — addServer', () => {
   const callsMatching = (fragment: string) =>
     execSyncMock.mock.calls.filter((c) => String(c[0]).includes(fragment));
 
-  it('detects the entry with an exact mcp get, not a substring of mcp list', async () => {
-    execSyncMock.mockImplementation((cmd: string) => {
-      const c = String(cmd);
-      if (c.includes('mcp get posthog')) throw new Error('No MCP server named');
-      if (c.includes('mcp list'))
-        return Buffer.from(
-          'claude.ai PostHog: ... Connected\nplugin:posthog:posthog\n',
-        );
-      return Buffer.from('');
-    });
-    const client = new ClaudeCodeMCPClient();
-    await expect(client.isServerInstalled()).resolves.toBe(false);
-
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (String(cmd).includes('mcp get posthog'))
-        return Buffer.from('posthog:\n  URL: https://mcp.posthog.com/mcp\n');
-      return Buffer.from('');
-    });
-    await expect(client.isServerInstalled()).resolves.toBe(true);
-  });
-
-  it('surfaces the editor-owned login commands without ever running them', () => {
-    const client = new ClaudeCodeMCPClient();
-    expect(client.loginCommand()).toBe('claude mcp login posthog');
-    expect(client.loginCommand(true)).toBe('claude mcp login posthog-local');
-    expect(client.pluginLoginCommand()).toBe(
-      'claude mcp login plugin:posthog:posthog',
-    );
-    expect(callsMatching('mcp login')).toHaveLength(0);
-  });
-
   it('adds the server without any credentials in the command', async () => {
     const client = new ClaudeCodeMCPClient();
     await expect(client.addServer(['workflows'])).resolves.toEqual({
@@ -127,46 +96,6 @@ describe('ClaudeCodeMCPClient — addServer', () => {
       success: true,
     });
     expect(callsMatching('mcp remove')).toHaveLength(1);
-  });
-
-  it('treats a same-set, different-order selection as identical (no remove)', async () => {
-    execSyncMock.mockImplementation((cmd: string) => {
-      const c = String(cmd);
-      if (c.includes('mcp" "add')) throw new Error('already exists');
-      if (c.includes('mcp get'))
-        return Buffer.from(`  URL: ${BASE_URL}?features=dashboards,insights\n`);
-      return Buffer.from('');
-    });
-    const client = new ClaudeCodeMCPClient();
-    await expect(client.addServer(['insights', 'dashboards'])).resolves.toEqual(
-      { success: true, alreadyInstalled: true },
-    );
-    expect(callsMatching('mcp remove')).toHaveLength(0);
-  });
-
-  it('restores the previous entry when the replacement re-add fails', async () => {
-    let adds = 0;
-    execSyncMock.mockImplementation((cmd: string) => {
-      const c = String(cmd);
-      if (c.includes('mcp" "add')) {
-        adds += 1;
-        if (adds === 1) throw new Error('already exists');
-        if (c.includes('features=workflows')) throw new Error('add blew up');
-        return Buffer.from('');
-      }
-      if (c.includes('mcp get'))
-        return Buffer.from(`  URL: ${BASE_URL}?features=flags\n`);
-      return Buffer.from('');
-    });
-    const client = new ClaudeCodeMCPClient();
-    await expect(client.addServer(['workflows'])).resolves.toEqual({
-      success: false,
-      reason: 'add blew up',
-    });
-    const restore = callsMatching('mcp" "add').filter((c) =>
-      String(c[0]).includes('features=flags'),
-    );
-    expect(restore).toHaveLength(1);
   });
 
   it('reports a failed replacement with its reason', async () => {
@@ -342,43 +271,5 @@ describe('ClaudeCodeMCPClient — plugin methods', () => {
         reason: expect.stringContaining('PATH'),
       });
     });
-  });
-});
-
-describe('ClaudeCodeMCPClient — removePlugin', () => {
-  const execSyncMock = execSync as Mock;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('uninstalls the plugin when it is installed', async () => {
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (String(cmd).includes('plugin list'))
-        return Buffer.from('posthog@claude-plugins-official 1.1.58\n');
-      return Buffer.from('');
-    });
-    const client = new ClaudeCodeMCPClient();
-    await expect(client.removePlugin()).resolves.toEqual({ success: true });
-    const uninstalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes('plugin uninstall posthog'),
-    );
-    expect(uninstalls).toHaveLength(1);
-  });
-
-  it('reports nothing-to-do when the plugin is absent', async () => {
-    execSyncMock.mockImplementation((cmd: string) => {
-      if (String(cmd).includes('plugin list')) return Buffer.from('other\n');
-      return Buffer.from('');
-    });
-    const client = new ClaudeCodeMCPClient();
-    await expect(client.removePlugin()).resolves.toEqual({
-      success: true,
-      alreadyInstalled: true,
-    });
-    const uninstalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes('plugin uninstall'),
-    );
-    expect(uninstalls).toHaveLength(0);
   });
 });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -33,6 +33,27 @@ describe('ClaudeCodeMCPClient — addServer', () => {
   const callsMatching = (fragment: string) =>
     execSyncMock.mock.calls.filter((c) => String(c[0]).includes(fragment));
 
+  it('detects the entry with an exact mcp get, not a substring of mcp list', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      if (c.includes('mcp get posthog')) throw new Error('No MCP server named');
+      if (c.includes('mcp list'))
+        return Buffer.from(
+          'claude.ai PostHog: ... Connected\nplugin:posthog:posthog\n',
+        );
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.isServerInstalled()).resolves.toBe(false);
+
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (String(cmd).includes('mcp get posthog'))
+        return Buffer.from('posthog:\n  URL: https://mcp.posthog.com/mcp\n');
+      return Buffer.from('');
+    });
+    await expect(client.isServerInstalled()).resolves.toBe(true);
+  });
+
   it('adds the server without any credentials in the command', async () => {
     const client = new ClaudeCodeMCPClient();
     await expect(client.addServer(['workflows'])).resolves.toEqual({

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude-code.test.ts
@@ -334,3 +334,41 @@ describe('ClaudeCodeMCPClient — plugin methods', () => {
     });
   });
 });
+
+describe('ClaudeCodeMCPClient — removePlugin', () => {
+  const execSyncMock = execSync as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uninstalls the plugin when it is installed', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (String(cmd).includes('plugin list'))
+        return Buffer.from('posthog@claude-plugins-official 1.1.58\n');
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.removePlugin()).resolves.toEqual({ success: true });
+    const uninstalls = execSyncMock.mock.calls.filter((c) =>
+      String(c[0]).includes('plugin uninstall posthog'),
+    );
+    expect(uninstalls).toHaveLength(1);
+  });
+
+  it('reports nothing-to-do when the plugin is absent', async () => {
+    execSyncMock.mockImplementation((cmd: string) => {
+      if (String(cmd).includes('plugin list')) return Buffer.from('other\n');
+      return Buffer.from('');
+    });
+    const client = new ClaudeCodeMCPClient();
+    await expect(client.removePlugin()).resolves.toEqual({
+      success: true,
+      alreadyInstalled: true,
+    });
+    const uninstalls = execSyncMock.mock.calls.filter((c) =>
+      String(c[0]).includes('plugin uninstall'),
+    );
+    expect(uninstalls).toHaveLength(0);
+  });
+});

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/claude.test.ts
@@ -31,11 +31,9 @@ vi.mock('../../defaults', () => ({
 describe('ClaudeMCPClient', () => {
   let client: ClaudeMCPClient;
   const mockHomeDir = '/mock/home';
-  const mockApiKey = 'test-api-key';
   const mockServerConfig = {
     command: 'npx',
-    args: ['-y', 'mcp-remote@latest'],
-    env: { POSTHOG_AUTH_HEADER: `Bearer ${mockApiKey}` },
+    args: ['-y', 'mcp-remote@latest', 'https://mcp.posthog.com/mcp'],
   };
 
   const mkdirMock = fs.promises.mkdir as Mock;
@@ -222,7 +220,7 @@ describe('ClaudeMCPClient', () => {
     it('should create config directory and add server when config file does not exist', async () => {
       existsSyncMock.mockReturnValue(false);
 
-      await client.addServer(mockApiKey);
+      await client.addServer();
 
       const expectedConfigPath = path.join(
         mockHomeDir,
@@ -265,7 +263,7 @@ describe('ClaudeMCPClient', () => {
       };
       readFileMock.mockResolvedValue(JSON.stringify(existingConfig));
 
-      await client.addServer(mockApiKey);
+      await client.addServer();
 
       expect(writeFileMock).toHaveBeenCalledWith(
         expect.any(String),
@@ -298,7 +296,7 @@ describe('ClaudeMCPClient', () => {
         }),
       );
 
-      await client.addServer(mockApiKey);
+      await client.addServer();
 
       expect(writeFileMock).toHaveBeenCalledWith(
         expect.any(String),
@@ -323,27 +321,14 @@ describe('ClaudeMCPClient', () => {
       );
     });
 
-    it('should call getDefaultServerConfig with the provided API key', async () => {
+    it('should forward the feature selection and local flag to getDefaultServerConfig', async () => {
       existsSyncMock.mockReturnValue(false);
 
-      await client.addServer(mockApiKey);
+      await client.addServer(['workflows'], false);
 
       expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
-        mockApiKey,
-        undefined,
-        undefined,
-      );
-    });
-
-    it('should call getDefaultServerConfig with undefined API key for OAuth mode', async () => {
-      existsSyncMock.mockReturnValue(false);
-
-      await client.addServer(undefined);
-
-      expect(getDefaultServerConfigMock).toHaveBeenCalledWith(
-        undefined,
-        undefined,
-        undefined,
+        ['workflows'],
+        false,
       );
     });
   });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -79,15 +79,6 @@ describe('CodexMCPClient', () => {
     });
   });
 
-  describe('loginCommand', () => {
-    it('surfaces the editor-owned login command without ever running it', () => {
-      const client = new CodexMCPClient();
-      expect(client.loginCommand()).toBe('codex mcp login posthog');
-      expect(client.loginCommand(true)).toBe('codex mcp login posthog-local');
-      expect(spawnSyncMock).not.toHaveBeenCalled();
-    });
-  });
-
   describe('isServerInstalled', () => {
     it('returns true when config.toml has an exact [mcp_servers.posthog] section', async () => {
       readFileSyncMock.mockReturnValue(
@@ -192,32 +183,6 @@ describe('CodexMCPClient', () => {
       const client = new CodexMCPClient();
       await expect(client.addServer()).resolves.toEqual({ success: true });
       expect(spawnSyncMock).toHaveBeenCalledTimes(3);
-    });
-
-    it('restores the previous entry when the replacement re-add fails', async () => {
-      spawnSyncMock
-        .mockReturnValueOnce({
-          status: 1,
-          stderr: "Server 'posthog' already exists",
-        })
-        .mockReturnValueOnce({ status: 0, stderr: '' }) // mcp remove
-        .mockReturnValueOnce({ status: 1, stderr: 'add blew up' }) // mcp add retry
-        .mockReturnValueOnce({ status: 0, stderr: '' }); // restore previous
-      readFileSyncMock.mockReturnValue(
-        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp?features=flags"\n',
-      );
-      const client = new CodexMCPClient();
-      await expect(client.addServer(['workflows'])).resolves.toEqual({
-        success: false,
-        reason: 'add blew up',
-      });
-      expect(spawnSyncMock.mock.calls[3]![1]).toEqual([
-        'mcp',
-        'add',
-        'posthog',
-        '--url',
-        'https://mcp.posthog.com/mcp?features=flags',
-      ]);
     });
 
     it('returns failure when the replacement remove fails', async () => {

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -79,6 +79,15 @@ describe('CodexMCPClient', () => {
     });
   });
 
+  describe('loginCommand', () => {
+    it('surfaces the editor-owned login command without ever running it', () => {
+      const client = new CodexMCPClient();
+      expect(client.loginCommand()).toBe('codex mcp login posthog');
+      expect(client.loginCommand(true)).toBe('codex mcp login posthog-local');
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe('isServerInstalled', () => {
     it('returns true when config.toml has an exact [mcp_servers.posthog] section', async () => {
       readFileSyncMock.mockReturnValue(

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -80,28 +80,26 @@ describe('CodexMCPClient', () => {
   });
 
   describe('isServerInstalled', () => {
-    it('returns true when posthog appears in mcp list output', async () => {
-      spawnSyncMock.mockReturnValue({
-        status: 0,
-        stdout: 'posthog\n',
-        stderr: '',
-      });
+    it('returns true when config.toml has an exact [mcp_servers.posthog] section', async () => {
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp"\n',
+      );
       const client = new CodexMCPClient();
       await expect(client.isServerInstalled()).resolves.toBe(true);
     });
 
-    it('returns false when posthog is absent from mcp list output', async () => {
-      spawnSyncMock.mockReturnValue({
-        status: 0,
-        stdout: 'other-server\n',
-        stderr: '',
-      });
+    it('ignores unrelated posthog-ish sections instead of substring-matching', async () => {
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog-analytics]\nurl = "https://example.com"\n',
+      );
       const client = new CodexMCPClient();
       await expect(client.isServerInstalled()).resolves.toBe(false);
     });
 
-    it('returns false when mcp list exits non-zero', async () => {
-      spawnSyncMock.mockReturnValue({ status: 1, stdout: '', stderr: 'err' });
+    it('returns false when config.toml is unreadable', async () => {
+      readFileSyncMock.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
       const client = new CodexMCPClient();
       await expect(client.isServerInstalled()).resolves.toBe(false);
     });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -108,10 +108,10 @@ describe('CodexMCPClient', () => {
   });
 
   describe('addServer', () => {
-    it('runs codex mcp add with the resolved URL and returns success on exit 0', async () => {
+    it('runs codex mcp add with the resolved URL and no credentials, and returns success on exit 0', async () => {
       spawnSyncMock.mockReturnValue({ status: 0, stderr: '' });
       const client = new CodexMCPClient();
-      await expect(client.addServer('phx_test')).resolves.toEqual({
+      await expect(client.addServer()).resolves.toEqual({
         success: true,
       });
       const call = spawnSyncMock.mock.calls[0]!;
@@ -122,28 +122,93 @@ describe('CodexMCPClient', () => {
         'posthog',
         '--url',
         'https://mcp.posthog.com/mcp',
-        '--bearer-token-env-var',
-        'POSTHOG_AUTH_HEADER',
       ]);
-      expect(call[2].env.POSTHOG_AUTH_HEADER).toBe('Bearer phx_test');
     });
 
-    it('reports "already" stderr as an already-installed success', async () => {
+    it('reports "already" stderr as already-installed when the entry has the same URL', async () => {
       spawnSyncMock.mockReturnValue({
         status: 1,
         stderr: "Server 'posthog' already exists",
       });
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp"\n',
+      );
       const client = new CodexMCPClient();
-      await expect(client.addServer('phx_test')).resolves.toEqual({
+      await expect(client.addServer()).resolves.toEqual({
         success: true,
         alreadyInstalled: true,
       });
+      // Only the add ran — the matching entry is left untouched.
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('replaces the entry when it exists with a different URL', async () => {
+      spawnSyncMock
+        .mockReturnValueOnce({
+          status: 1,
+          stderr: "Server 'posthog' already exists",
+        })
+        .mockReturnValueOnce({ status: 0, stderr: '' }) // mcp remove
+        .mockReturnValueOnce({ status: 0, stderr: '' }); // mcp add retry
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp?features=flags"\n',
+      );
+      const client = new CodexMCPClient();
+      await expect(client.addServer(['workflows'])).resolves.toEqual({
+        success: true,
+      });
+      expect(spawnSyncMock.mock.calls[1]![1]).toEqual([
+        'mcp',
+        'remove',
+        'posthog',
+      ]);
+      expect(spawnSyncMock.mock.calls[2]![1]).toEqual([
+        'mcp',
+        'add',
+        'posthog',
+        '--url',
+        'https://mcp.posthog.com/mcp?features=workflows',
+      ]);
+    });
+
+    it('replaces the entry when the existing URL cannot be determined', async () => {
+      spawnSyncMock
+        .mockReturnValueOnce({
+          status: 1,
+          stderr: "Server 'posthog' already exists",
+        })
+        .mockReturnValueOnce({ status: 0, stderr: '' })
+        .mockReturnValueOnce({ status: 0, stderr: '' });
+      readFileSyncMock.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      const client = new CodexMCPClient();
+      await expect(client.addServer()).resolves.toEqual({ success: true });
+      expect(spawnSyncMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns failure when the replacement remove fails', async () => {
+      spawnSyncMock
+        .mockReturnValueOnce({
+          status: 1,
+          stderr: "Server 'posthog' already exists",
+        })
+        .mockReturnValueOnce({ status: 1, stderr: 'remove failed' });
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp?features=flags"\n',
+      );
+      const client = new CodexMCPClient();
+      await expect(client.addServer()).resolves.toEqual({
+        success: false,
+        reason: 'remove failed',
+      });
+      expect(analytics.captureException).toHaveBeenCalled();
     });
 
     it('returns failure with the reason and captures exception on unexpected error', async () => {
       spawnSyncMock.mockReturnValue({ status: 1, stderr: 'network timeout' });
       const client = new CodexMCPClient();
-      await expect(client.addServer('phx_test')).resolves.toEqual({
+      await expect(client.addServer()).resolves.toEqual({
         success: false,
         reason: 'network timeout',
       });

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/codex.test.ts
@@ -187,6 +187,32 @@ describe('CodexMCPClient', () => {
       expect(spawnSyncMock).toHaveBeenCalledTimes(3);
     });
 
+    it('restores the previous entry when the replacement re-add fails', async () => {
+      spawnSyncMock
+        .mockReturnValueOnce({
+          status: 1,
+          stderr: "Server 'posthog' already exists",
+        })
+        .mockReturnValueOnce({ status: 0, stderr: '' }) // mcp remove
+        .mockReturnValueOnce({ status: 1, stderr: 'add blew up' }) // mcp add retry
+        .mockReturnValueOnce({ status: 0, stderr: '' }); // restore previous
+      readFileSyncMock.mockReturnValue(
+        '[mcp_servers.posthog]\nurl = "https://mcp.posthog.com/mcp?features=flags"\n',
+      );
+      const client = new CodexMCPClient();
+      await expect(client.addServer(['workflows'])).resolves.toEqual({
+        success: false,
+        reason: 'add blew up',
+      });
+      expect(spawnSyncMock.mock.calls[3]![1]).toEqual([
+        'mcp',
+        'add',
+        'posthog',
+        '--url',
+        'https://mcp.posthog.com/mcp?features=flags',
+      ]);
+    });
+
     it('returns failure when the replacement remove fails', async () => {
       spawnSyncMock
         .mockReturnValueOnce({

--- a/src/steps/add-mcp-server-to-clients/clients/__tests__/opencode.test.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/__tests__/opencode.test.ts
@@ -127,34 +127,9 @@ describe('OpenCodeMCPClient', () => {
   });
 
   describe('addServer (inherited from DefaultMCPClient)', () => {
-    it('writes server config with type:remote to the config file', async () => {
+    it('writes a credential-free type:remote server config', async () => {
       existsSyncMock.mockReturnValue(false);
       readFileMock.mockRejectedValue(new Error('should not be called'));
-      writeFileMock.mockResolvedValue(undefined);
-      mkdirMock.mockResolvedValue(undefined);
-
-      const client = new OpenCodeMCPClient();
-      await expect(client.addServer('phx_test123')).resolves.toEqual({
-        success: true,
-      });
-
-      const writtenContent = writeFileMock.mock.calls[0][1];
-      const parsed = JSON.parse(writtenContent);
-      expect(parsed).toEqual({
-        mcp: {
-          posthog: {
-            type: 'remote',
-            url: 'https://mcp.posthog.com/mcp',
-            headers: {
-              Authorization: 'Bearer phx_test123',
-            },
-          },
-        },
-      });
-    });
-
-    it('writes without headers when no apiKey provided', async () => {
-      existsSyncMock.mockReturnValue(false);
       writeFileMock.mockResolvedValue(undefined);
       mkdirMock.mockResolvedValue(undefined);
 
@@ -163,9 +138,15 @@ describe('OpenCodeMCPClient', () => {
 
       const writtenContent = writeFileMock.mock.calls[0][1];
       const parsed = JSON.parse(writtenContent);
-      expect(parsed.mcp.posthog.type).toBe('remote');
-      expect(parsed.mcp.posthog.url).toBe('https://mcp.posthog.com/mcp');
-      expect(parsed.mcp.posthog.headers).toBeUndefined();
+      // Auth lives in the client (OAuth), never in the config we write.
+      expect(parsed).toEqual({
+        mcp: {
+          posthog: {
+            type: 'remote',
+            url: 'https://mcp.posthog.com/mcp',
+          },
+        },
+      });
     });
 
     it('uses posthog-local for local server', async () => {
@@ -174,9 +155,9 @@ describe('OpenCodeMCPClient', () => {
       mkdirMock.mockResolvedValue(undefined);
 
       const client = new OpenCodeMCPClient();
-      await expect(
-        client.addServer(undefined, undefined, true),
-      ).resolves.toEqual({ success: true });
+      await expect(client.addServer(undefined, true)).resolves.toEqual({
+        success: true,
+      });
 
       const writtenContent = writeFileMock.mock.calls[0][1];
       const parsed = JSON.parse(writtenContent);

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -126,19 +126,7 @@ export class ClaudeCodeMCPClient
 
     const serverName = local ? 'posthog-local' : 'posthog';
     const url = buildMCPUrl(selectedFeatures, local);
-    const addCommand = [
-      binary,
-      'mcp',
-      'add',
-      '--transport',
-      'http',
-      '--scope',
-      'user',
-      serverName,
-      url,
-    ]
-      .map((a) => JSON.stringify(a))
-      .join(' ');
+    const addCommand = this.buildAddCommand(binary, serverName, url);
 
     try {
       execSync(addCommand, { stdio: 'pipe' });
@@ -157,11 +145,12 @@ export class ClaudeCodeMCPClient
         // points at this exact URL is left untouched: removing it would throw
         // away the OAuth credentials Claude Code holds for it and force a
         // needless re-auth.
-        if (this.installedServerUrl(binary, serverName) === url) {
+        const previousUrl = this.installedServerUrl(binary, serverName);
+        if (previousUrl === url) {
           return Promise.resolve({ success: true, alreadyInstalled: true });
         }
         return Promise.resolve(
-          this.replaceServer(binary, serverName, addCommand),
+          this.replaceServer(binary, serverName, addCommand, previousUrl),
         );
       }
       analytics.captureException(
@@ -187,21 +176,55 @@ export class ClaudeCodeMCPClient
     }
   }
 
+  private buildAddCommand(
+    binary: string,
+    serverName: string,
+    url: string,
+  ): string {
+    return [
+      binary,
+      'mcp',
+      'add',
+      '--transport',
+      'http',
+      '--scope',
+      'user',
+      serverName,
+      url,
+    ]
+      .map((a) => JSON.stringify(a))
+      .join(' ');
+  }
+
   private replaceServer(
     binary: string,
     serverName: string,
     addCommand: string,
+    previousUrl: string | null,
   ): InstallResult {
+    let removed = false;
     try {
       execSync(`${binary} mcp remove --scope user ${serverName}`, {
         stdio: 'pipe',
       });
+      removed = true;
       execSync(addCommand, { stdio: 'pipe' });
       return { success: true };
     } catch (error) {
       const msg = redactSecrets(
         error instanceof Error ? error.message : String(error),
       );
+      // Re-add fails after a successful remove: put the previous entry back so a
+      // failed update never leaves the user with no server at all.
+      if (removed && previousUrl) {
+        try {
+          execSync(this.buildAddCommand(binary, serverName, previousUrl), {
+            stdio: 'pipe',
+          });
+        } catch {
+          // The failure report below already tells the user to re-run.
+        }
+      }
       analytics.captureException(
         new Error(`Claude Code MCP update failed: ${msg}`),
       );

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -311,4 +311,28 @@ export class ClaudeCodeMCPClient
       return { success: false, reason: msg };
     }
   }
+
+  async removePlugin(): Promise<PluginInstallResult> {
+    const binary = this.findClaudeBinary();
+    if (!binary)
+      return {
+        success: false,
+        reason: 'The claude CLI is no longer on your PATH.',
+      };
+
+    if (!(await this.isPluginInstalled())) {
+      return { success: true, alreadyInstalled: true };
+    }
+
+    try {
+      execSync(`${binary} plugin uninstall posthog`, { stdio: 'pipe' });
+      return { success: true };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      analytics.captureException(
+        new Error(`Claude Code plugin uninstall failed: ${msg}`),
+      );
+      return { success: false, reason: msg };
+    }
+  }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -7,6 +7,7 @@ import {
   PluginCapable,
   PluginInstallResult,
 } from '@steps/add-mcp-server-to-clients/plugin-client';
+import { LoginCapable } from '@steps/add-mcp-server-to-clients/login-client';
 import {
   redactSecrets,
   type InstallResult,
@@ -25,7 +26,7 @@ export type ClaudeCodeMCPConfig = z.infer<typeof DefaultMCPClientConfig>;
 
 export class ClaudeCodeMCPClient
   extends DefaultMCPClient
-  implements PluginCapable
+  implements PluginCapable, LoginCapable
 {
   name = 'Claude Code';
   private claudeBinaryPath: string | null = null;
@@ -160,6 +161,16 @@ export class ClaudeCodeMCPClient
       );
       return Promise.resolve({ success: false, reason: msg });
     }
+  }
+
+  /** Claude Code's own login runs its OAuth and owns the token; the wizard only surfaces the command. */
+  loginCommand(local?: boolean): string {
+    return `claude mcp login ${local ? 'posthog-local' : 'posthog'}`;
+  }
+
+  /** The plugin bundles its own `posthog` server, addressed as `plugin:<plugin>:<server>`. */
+  pluginLoginCommand(): string {
+    return 'claude mcp login plugin:posthog:posthog';
   }
 
   /** URL the existing entry points at, or null when it can't be determined. */

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -99,11 +99,13 @@ export class ClaudeCodeMCPClient
     const binary = this.findClaudeBinary();
     if (!binary) return Promise.resolve(false);
     const serverName = local ? 'posthog-local' : 'posthog';
+    // `mcp get <name>` exits non-zero when the entry doesn't exist. A substring
+    // scan of `mcp list` reports anyone's posthog-ish server — the claude.ai
+    // "PostHog" connector and the plugin's `plugin:posthog:posthog` both match,
+    // making install/remove look like no-ops forever.
     try {
-      const output = execSync(`${binary} mcp list`, { stdio: 'pipe' })
-        .toString()
-        .toLowerCase();
-      return Promise.resolve(output.includes(serverName));
+      execSync(`${binary} mcp get ${serverName}`, { stdio: 'pipe' });
+      return Promise.resolve(true);
     } catch {
       return Promise.resolve(false);
     }

--- a/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/claude-code.ts
@@ -114,7 +114,6 @@ export class ClaudeCodeMCPClient
   }
 
   addServer(
-    apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult> {
@@ -127,7 +126,8 @@ export class ClaudeCodeMCPClient
 
     const serverName = local ? 'posthog-local' : 'posthog';
     const url = buildMCPUrl(selectedFeatures, local);
-    const args = [
+    const addCommand = [
+      binary,
       'mcp',
       'add',
       '--transport',
@@ -136,29 +136,76 @@ export class ClaudeCodeMCPClient
       'user',
       serverName,
       url,
-    ];
-    if (apiKey) {
-      args.push('--header', `Authorization: Bearer ${apiKey}`);
-    }
+    ]
+      .map((a) => JSON.stringify(a))
+      .join(' ');
 
     try {
-      execSync(`${binary} ${args.map((a) => JSON.stringify(a)).join(' ')}`, {
-        stdio: 'pipe',
-      });
+      execSync(addCommand, { stdio: 'pipe' });
       return Promise.resolve({ success: true });
     } catch (error) {
-      // The failing command echoes back the Authorization header we passed, so
-      // redact before this reaches a log, the screen, or an exception report.
+      // Redact before this reaches a log, the screen, or an exception report —
+      // the failing command echoes its arguments back in the error output.
       const msg = redactSecrets(
         error instanceof Error ? error.message : String(error),
       );
       if (msg.includes('already exists')) {
-        return Promise.resolve({ success: true, alreadyInstalled: true });
+        // The URL encodes the feature selection, so an existing entry with a
+        // different URL must be replaced — leaving it "as is" means the user's
+        // new selection silently never takes effect, and their next OAuth in
+        // Claude Code authorizes the wrong toolset. An entry that already
+        // points at this exact URL is left untouched: removing it would throw
+        // away the OAuth credentials Claude Code holds for it and force a
+        // needless re-auth.
+        if (this.installedServerUrl(binary, serverName) === url) {
+          return Promise.resolve({ success: true, alreadyInstalled: true });
+        }
+        return Promise.resolve(
+          this.replaceServer(binary, serverName, addCommand),
+        );
       }
       analytics.captureException(
         new Error(`Claude Code MCP add failed: ${msg}`),
       );
       return Promise.resolve({ success: false, reason: msg });
+    }
+  }
+
+  /** URL the existing entry points at, or null when it can't be determined. */
+  private installedServerUrl(
+    binary: string,
+    serverName: string,
+  ): string | null {
+    try {
+      const output = execSync(`${binary} mcp get ${serverName}`, {
+        stdio: 'pipe',
+      }).toString();
+      const match = output.match(/URL:\s*(\S+)/i);
+      return match ? match[1]! : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private replaceServer(
+    binary: string,
+    serverName: string,
+    addCommand: string,
+  ): InstallResult {
+    try {
+      execSync(`${binary} mcp remove --scope user ${serverName}`, {
+        stdio: 'pipe',
+      });
+      execSync(addCommand, { stdio: 'pipe' });
+      return { success: true };
+    } catch (error) {
+      const msg = redactSecrets(
+        error instanceof Error ? error.message : String(error),
+      );
+      analytics.captureException(
+        new Error(`Claude Code MCP update failed: ${msg}`),
+      );
+      return { success: false, reason: msg };
     }
   }
 

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -96,10 +96,13 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
         // elsewhere must be replaced or the new selection never takes effect.
         // An identical entry is left untouched so codex keeps whatever auth
         // state it holds for the server.
-        if (this.installedServerUrl(serverName) === url) {
+        const previousUrl = this.installedServerUrl(serverName);
+        if (previousUrl === url) {
           return Promise.resolve({ success: true, alreadyInstalled: true });
         }
-        return Promise.resolve(this.replaceServer(binary, serverName, args));
+        return Promise.resolve(
+          this.replaceServer(binary, serverName, args, previousUrl),
+        );
       }
       const reason = redactSecrets(stderr);
       analytics.captureException(new Error(`Codex MCP add failed: ${reason}`));
@@ -134,6 +137,7 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     binary: string,
     serverName: string,
     addArgs: string[],
+    previousUrl: string | null,
   ): InstallResult {
     const removed = spawnSync(binary, ['mcp', 'remove', serverName], {
       encoding: 'utf-8',
@@ -143,6 +147,13 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
         ? spawnSync(binary, addArgs, { encoding: 'utf-8' })
         : removed;
     if (retried.status !== 0) {
+      // Re-add fails after a successful remove: put the previous entry back so a
+      // failed update never leaves the user with no server at all.
+      if (removed.status === 0 && previousUrl) {
+        spawnSync(binary, ['mcp', 'add', serverName, '--url', previousUrl], {
+          encoding: 'utf-8',
+        });
+      }
       const reason = redactSecrets(retried.stderr ?? 'codex mcp update failed');
       analytics.captureException(
         new Error(`Codex MCP update failed: ${reason}`),

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -9,6 +9,7 @@ import {
   DefaultMCPClientConfig,
   buildMCPUrl,
 } from '@steps/add-mcp-server-to-clients/defaults';
+import { LoginCapable } from '@steps/add-mcp-server-to-clients/login-client';
 import {
   PluginCapable,
   PluginInstallResult,
@@ -30,7 +31,10 @@ export const CodexMCPConfig = DefaultMCPClientConfig;
 
 export type CodexMCPConfig = z.infer<typeof DefaultMCPClientConfig>;
 
-export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
+export class CodexMCPClient
+  extends DefaultMCPClient
+  implements PluginCapable, LoginCapable
+{
   name = 'Codex';
   private codexBinaryPath: string | null = null;
 
@@ -107,6 +111,11 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
       return Promise.resolve({ success: false, reason });
     }
     return Promise.resolve({ success: true });
+  }
+
+  /** Codex's own login runs its OAuth and owns the token; the wizard only surfaces the command. */
+  loginCommand(local?: boolean): string {
+    return `codex mcp login ${local ? 'posthog-local' : 'posthog'}`;
   }
 
   /**

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -74,7 +74,6 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
   }
 
   addServer(
-    apiKey?: string,
     selectedFeatures?: string[],
     local?: boolean,
   ): Promise<InstallResult> {
@@ -88,24 +87,69 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     const serverName = local ? 'posthog-local' : 'posthog';
     const url = buildMCPUrl(selectedFeatures, local);
     const args = ['mcp', 'add', serverName, '--url', url];
-    const env = { ...process.env };
-    if (apiKey) {
-      const tokenVar = 'POSTHOG_AUTH_HEADER';
-      env[tokenVar] = `Bearer ${apiKey}`;
-      args.push('--bearer-token-env-var', tokenVar);
-    }
 
-    const result = spawnSync(binary, args, { encoding: 'utf-8', env });
+    const result = spawnSync(binary, args, { encoding: 'utf-8' });
     if (result.status !== 0) {
       const stderr = result.stderr ?? '';
       if (ALREADY_INSTALLED_PATTERN.test(stderr)) {
-        return Promise.resolve({ success: true, alreadyInstalled: true });
+        // The URL encodes the feature selection — an existing entry pointing
+        // elsewhere must be replaced or the new selection never takes effect.
+        // An identical entry is left untouched so codex keeps whatever auth
+        // state it holds for the server.
+        if (this.installedServerUrl(serverName) === url) {
+          return Promise.resolve({ success: true, alreadyInstalled: true });
+        }
+        return Promise.resolve(this.replaceServer(binary, serverName, args));
       }
       const reason = redactSecrets(stderr);
       analytics.captureException(new Error(`Codex MCP add failed: ${reason}`));
       return Promise.resolve({ success: false, reason });
     }
     return Promise.resolve({ success: true });
+  }
+
+  /**
+   * URL the existing entry points at, read from `~/.codex/config.toml` (where
+   * `codex mcp add` writes `[mcp_servers.<name>]` sections). Null when it
+   * can't be determined — the caller then replaces the entry, which converges
+   * on the right state either way.
+   */
+  private installedServerUrl(serverName: string): string | null {
+    try {
+      const contents = fs.readFileSync(
+        path.join(os.homedir(), '.codex', 'config.toml'),
+        'utf-8',
+      );
+      const section = contents
+        .split(/^\[/m)
+        .find((s) => s.startsWith(`mcp_servers.${serverName}]`));
+      const match = section?.match(/^\s*url\s*=\s*"([^"]+)"/m);
+      return match ? match[1]! : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private replaceServer(
+    binary: string,
+    serverName: string,
+    addArgs: string[],
+  ): InstallResult {
+    const removed = spawnSync(binary, ['mcp', 'remove', serverName], {
+      encoding: 'utf-8',
+    });
+    const retried =
+      removed.status === 0
+        ? spawnSync(binary, addArgs, { encoding: 'utf-8' })
+        : removed;
+    if (retried.status !== 0) {
+      const reason = redactSecrets(retried.stderr ?? 'codex mcp update failed');
+      analytics.captureException(
+        new Error(`Codex MCP update failed: ${reason}`),
+      );
+      return { success: false, reason };
+    }
+    return { success: true };
   }
 
   removeServer(local?: boolean): Promise<InstallResult> {

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -66,11 +66,9 @@ export class CodexMCPClient extends DefaultMCPClient implements PluginCapable {
     const binary = this.findCodexBinary();
     if (!binary) return Promise.resolve(false);
     const serverName = local ? 'posthog-local' : 'posthog';
-    const result = spawnSync(binary, ['mcp', 'list'], { encoding: 'utf-8' });
-    if (result.status !== 0) return Promise.resolve(false);
-    return Promise.resolve(
-      (result.stdout ?? '').toLowerCase().includes(serverName),
-    );
+    // Exact `[mcp_servers.<name>]` section in config.toml — a substring scan of
+    // `mcp list` output matches unrelated posthog-ish servers.
+    return Promise.resolve(this.installedServerUrl(serverName) !== null);
   }
 
   addServer(

--- a/src/steps/add-mcp-server-to-clients/clients/cursor.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/cursor.ts
@@ -32,10 +32,9 @@ export class CursorMCPClient extends DefaultMCPClient {
   }
 
   getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
-    return getNativeHTTPServerConfig(apiKey, selectedFeatures, local);
+    return getNativeHTTPServerConfig(selectedFeatures, local);
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/opencode.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/opencode.ts
@@ -72,13 +72,12 @@ export class OpenCodeMCPClient extends DefaultMCPClient {
   }
 
   override getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       type: 'remote',
-      ...getNativeHTTPServerConfig(apiKey, selectedFeatures, local),
+      ...getNativeHTTPServerConfig(selectedFeatures, local),
     };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/visual-studio-code.ts
@@ -82,13 +82,12 @@ export class VisualStudioCodeClient extends DefaultMCPClient {
   }
 
   getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       type: 'http',
-      ...getNativeHTTPServerConfig(apiKey, selectedFeatures, local),
+      ...getNativeHTTPServerConfig(selectedFeatures, local),
     };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/clients/zed.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/zed.ts
@@ -73,13 +73,12 @@ export class ZedClient extends DefaultMCPClient {
   }
 
   getServerConfig(
-    apiKey: string | undefined,
     selectedFeatures?: string[],
     local?: boolean,
   ): MCPServerConfig {
     return {
       enabled: true,
-      ...getNativeHTTPServerConfig(apiKey, selectedFeatures, local),
+      ...getNativeHTTPServerConfig(selectedFeatures, local),
     };
   }
 }

--- a/src/steps/add-mcp-server-to-clients/defaults.ts
+++ b/src/steps/add-mcp-server-to-clients/defaults.ts
@@ -260,52 +260,26 @@ export const buildMCPUrl = (selectedFeatures?: string[], local?: boolean) => {
   return params.length > 0 ? `${baseUrl}?${params.join('&')}` : baseUrl;
 };
 
+/**
+ * The wizard never writes credentials into MCP client configs. The client owns
+ * auth: it runs the OAuth flow against mcp.posthog.com the first time it
+ * connects (e.g. `/mcp` in Claude Code), which is the only place that knows
+ * which scopes each feature needs. A wizard-injected Authorization header
+ * would be sent forever — even after the client obtains fresh OAuth tokens —
+ * so a stale or under-scoped key locks the server into a rejected-reconnect
+ * loop the user can't escape without editing the config by hand.
+ */
 export const getNativeHTTPServerConfig = (
-  apiKey: string | undefined,
   selectedFeatures?: string[],
   local?: boolean,
-) => {
-  const config: Record<string, unknown> = {
-    url: buildMCPUrl(selectedFeatures, local),
-  };
-
-  // Only add auth header if API key is provided (not OAuth mode)
-  if (apiKey) {
-    config.headers = {
-      Authorization: `Bearer ${apiKey}`,
-    };
-  }
-
-  return config;
-};
+) => ({
+  url: buildMCPUrl(selectedFeatures, local),
+});
 
 export const getDefaultServerConfig = (
-  apiKey: string | undefined,
   selectedFeatures?: string[],
   local?: boolean,
-) => {
-  const urlWithFeatures = buildMCPUrl(selectedFeatures, local);
-
-  // OAuth mode: no auth header, let MCP handle OAuth
-  if (!apiKey) {
-    return {
-      command: 'npx',
-      args: ['-y', 'mcp-remote@latest', urlWithFeatures],
-    };
-  }
-
-  // API key mode: include auth header
-  return {
-    command: 'npx',
-    args: [
-      '-y',
-      'mcp-remote@latest',
-      urlWithFeatures,
-      '--header',
-      `Authorization:\${POSTHOG_AUTH_HEADER}`,
-    ],
-    env: {
-      POSTHOG_AUTH_HEADER: `Bearer ${apiKey}`,
-    },
-  };
-};
+) => ({
+  command: 'npx',
+  args: ['-y', 'mcp-remote@latest', buildMCPUrl(selectedFeatures, local)],
+});

--- a/src/steps/add-mcp-server-to-clients/defaults.ts
+++ b/src/steps/add-mcp-server-to-clients/defaults.ts
@@ -254,7 +254,8 @@ export const buildMCPUrl = (selectedFeatures?: string[], local?: boolean) => {
     selectedFeatures.length > 0 &&
     !isAllFeaturesSelected(selectedFeatures)
   ) {
-    params.push(`features=${selectedFeatures.join(',')}`);
+    // Sorted so the same selection always yields the same URL, whatever the input order.
+    params.push(`features=${[...selectedFeatures].sort().join(',')}`);
   }
 
   return params.length > 0 ? `${baseUrl}?${params.join('&')}` : baseUrl;

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -60,14 +60,12 @@ export const addMCPServerToClientsStep = async ({
   ci = false,
   cloudRegion: _cloudRegion,
   features,
-  apiKey,
 }: {
   integration?: Integration;
   local?: boolean;
   ci?: boolean;
   cloudRegion?: CloudRegion;
   features?: string[];
-  apiKey?: string;
 }): Promise<string[]> => {
   const ui = getUI();
 
@@ -88,12 +86,7 @@ export const addMCPServerToClientsStep = async ({
 
   // Auto-install to all supported clients
   const results = await withProgress('adding mcp servers', () =>
-    addMCPServer(
-      supportedClients,
-      apiKey,
-      features ?? [...ALL_FEATURE_VALUES],
-      local,
-    ),
+    addMCPServer(supportedClients, features ?? [...ALL_FEATURE_VALUES], local),
   );
 
   const installed = namesWithStatus(results, McpClientStatus.Changed);
@@ -104,6 +97,9 @@ export const addMCPServerToClientsStep = async ({
   // hid both the no-op re-runs and the outright failures.
   if (installed.length > 0) {
     ui.log.success(`Added the MCP server to:\n${bulletList(installed)}`);
+    ui.log.info(
+      'Your editor handles authentication — approve the PostHog connection when it prompts (in Claude Code, run /mcp).',
+    );
   }
   if (already.length > 0) {
     ui.log.info(
@@ -212,18 +208,13 @@ export const getInstalledClients = async (
 
 export const addMCPServer = async (
   clients: MCPClient[],
-  personalApiKey?: string,
   selectedFeatures?: string[],
   local?: boolean,
 ): Promise<McpClientResult[]> => {
   const results: McpClientResult[] = [];
   for (const client of clients) {
     try {
-      const result = await client.addServer(
-        personalApiKey,
-        selectedFeatures,
-        local,
-      );
+      const result = await client.addServer(selectedFeatures, local);
       results.push(toClientResult(client.name, result));
     } catch (err) {
       debug(`[addMCPServer] addServer threw for ${client.name}: ${err}`);

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -14,6 +14,7 @@ import { OpenCodeMCPClient } from './clients/opencode';
 import { ALL_FEATURE_VALUES } from './defaults';
 import { debug } from '@utils/debug';
 import { isPluginCapable, PluginCapable } from './plugin-client';
+import { isLoginCapable } from './login-client';
 import {
   McpClientStatus,
   namesWithStatus,
@@ -98,8 +99,13 @@ export const addMCPServerToClientsStep = async ({
   // hid both the no-op re-runs and the outright failures.
   if (installed.length > 0) {
     ui.log.success(`Added the MCP server to:\n${bulletList(installed)}`);
+  }
+  const logins = loginCommands(supportedClients, results, local);
+  if (logins.length > 0) {
     ui.log.info(
-      'Your editor handles authentication — approve the PostHog connection when it prompts (in Claude Code, run /mcp).',
+      `One step left — authenticate in your editor (nothing prompts you automatically):\n${bulletList(
+        logins,
+      )}`,
     );
   }
   if (already.length > 0) {
@@ -280,6 +286,23 @@ const mergeRemovals = (
       ? { alreadyInstalled: true }
       : {}),
   };
+};
+
+/**
+ * The exact editor-owned login command for every login-capable client that
+ * just got a fresh entry. The editor CLI runs its own OAuth and owns the token
+ * and its refresh; its login command requires a real terminal, so the wizard
+ * surfaces it instead of running it.
+ */
+export const loginCommands = (
+  clients: MCPClient[],
+  results: McpClientResult[],
+  local?: boolean,
+): string[] => {
+  const changed = new Set(namesWithStatus(results, McpClientStatus.Changed));
+  return clients
+    .filter((c) => changed.has(c.name) && isLoginCapable(c))
+    .map((c) => c.loginCommand(local));
 };
 
 export const removeMCPServer = async (

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -18,6 +18,7 @@ import {
   McpClientStatus,
   namesWithStatus,
   toClientResult,
+  type InstallResult,
   type McpClientResult,
 } from './results';
 
@@ -198,7 +199,12 @@ export const getInstalledClients = async (
   const installedClients: MCPClient[] = [];
 
   for (const client of clients) {
-    if (await client.isServerInstalled(local)) {
+    // The plugin bundles its own posthog MCP server, so for removal purposes a
+    // plugin install counts as installed even with no config entry (`--local`
+    // targets only the local-dev entry and leaves the plugin alone).
+    const pluginInstalled =
+      !local && isPluginCapable(client) && (await client.isPluginInstalled());
+    if ((await client.isServerInstalled(local)) || pluginInstalled) {
       installedClients.push(client);
     }
   }
@@ -255,6 +261,27 @@ export const installPlugins = async (
   return results;
 };
 
+// One report per client: a failure on either half wins, a change on either
+// half counts as removed, and "nothing to do" only when both halves had
+// nothing to do.
+const mergeRemovals = (
+  entry: InstallResult,
+  plugin: InstallResult,
+): InstallResult => {
+  if (!entry.success || !plugin.success) {
+    return {
+      success: false,
+      reason: [entry.reason, plugin.reason].filter(Boolean).join('; '),
+    };
+  }
+  return {
+    success: true,
+    ...(entry.alreadyInstalled && plugin.alreadyInstalled
+      ? { alreadyInstalled: true }
+      : {}),
+  };
+};
+
 export const removeMCPServer = async (
   clients: MCPClient[],
   local?: boolean,
@@ -262,9 +289,13 @@ export const removeMCPServer = async (
   const results: McpClientResult[] = [];
   for (const client of clients) {
     try {
-      results.push(
-        toClientResult(client.name, await client.removeServer(local)),
-      );
+      let result = await client.removeServer(local);
+      // The plugin bundles its own posthog server — leaving it installed makes
+      // the removal a lie (`--local` never touches the plugin).
+      if (!local && isPluginCapable(client) && client.removePlugin) {
+        result = mergeRemovals(result, await client.removePlugin());
+      }
+      results.push(toClientResult(client.name, result));
     } catch (err) {
       debug(`[removeMCPServer] removeServer threw for ${client.name}: ${err}`);
       results.push(

--- a/src/steps/add-mcp-server-to-clients/login-client.ts
+++ b/src/steps/add-mcp-server-to-clients/login-client.ts
@@ -1,0 +1,26 @@
+/**
+ * Capability for MCP clients whose editor CLI has its own login command
+ * (`claude mcp login`, `codex mcp login`). The editor owns the OAuth token and
+ * its refresh, and its login command requires a real terminal — so the wizard
+ * never runs it, it surfaces the exact command for the user to run.
+ *
+ * Mirrors the PluginCapable pattern in plugin-client.ts: the client carries the
+ * product knowledge (its command), the TUI renders whatever the capability
+ * surfaces.
+ */
+export interface LoginCapable {
+  /** The editor's own login command for the installed server, e.g. `claude mcp login posthog`. */
+  loginCommand(local?: boolean): string;
+  /**
+   * The login command when the server comes from the editor's plugin instead
+   * of a config entry (plugin-provided servers have their own name, e.g.
+   * `plugin:posthog:posthog`). Absent when the client has no plugin server.
+   */
+  pluginLoginCommand?(): string;
+}
+
+export function isLoginCapable<T>(client: T): client is T & LoginCapable {
+  return (
+    typeof client === 'object' && client !== null && 'loginCommand' in client
+  );
+}

--- a/src/steps/add-mcp-server-to-clients/plugin-client.ts
+++ b/src/steps/add-mcp-server-to-clients/plugin-client.ts
@@ -6,6 +6,8 @@ export interface PluginCapable {
   supportsPlugin(): boolean;
   isPluginInstalled(): Promise<boolean>;
   installPlugin(): Promise<PluginInstallResult>;
+  /** Uninstall the plugin. Absent when the client CLI has no uninstall surface. */
+  removePlugin?(): Promise<PluginInstallResult>;
 }
 
 export function isPluginCapable<T>(client: T): client is T & PluginCapable {

--- a/src/ui/tui/__tests__/exit-line.test.ts
+++ b/src/ui/tui/__tests__/exit-line.test.ts
@@ -1,6 +1,6 @@
 import { getExitLine } from '@ui/tui/exit-line';
 import { WizardStore, Program } from '@ui/tui/store';
-import { McpOutcome, OutroKind } from '@lib/wizard-session';
+import { OutroKind } from '@lib/wizard-session';
 
 vi.mock('../../../utils/analytics.js', () => ({
   analytics: {
@@ -121,43 +121,6 @@ describe('getExitLine', () => {
     );
     expect(line).toMatch(/exited\.$/);
     expect(line).not.toContain('coding agent');
-  });
-
-  describe('MCP login commands (the one manual auth step survives into scrollback)', () => {
-    it('echoes each login command on its own line instead of a bare exit line', () => {
-      const store = new WizardStore(Program.PostHogIntegration);
-      store.setMcpComplete(McpOutcome.Installed, ['Claude Code'], 'all', [
-        'claude mcp login posthog',
-      ]);
-      const line = stripAnsi(getExitLine(store));
-      expect(line).toContain('Authenticate to finish');
-      expect(line).toContain('claude mcp login posthog');
-      expect(line).not.toMatch(/exited\.$/);
-    });
-
-    it('appends the login commands to a success outro too', () => {
-      const store = storeWithOutro({
-        kind: OutroKind.Success,
-        message: 'Done!',
-      });
-      store.setMcpComplete(
-        McpOutcome.Installed,
-        ['Claude Code', 'Codex'],
-        'all',
-        ['claude mcp login posthog', 'codex mcp login posthog'],
-      );
-      const line = stripAnsi(getExitLine(store));
-      expect(line).toContain('Done!');
-      expect(line).toContain('claude mcp login posthog');
-      expect(line).toContain('codex mcp login posthog');
-    });
-
-    it('keeps the plain exit line when no login command is pending', () => {
-      const line = stripAnsi(
-        getExitLine(storeWithOutro({ kind: OutroKind.Error, message: 'boom' })),
-      );
-      expect(line).not.toContain('Authenticate to finish');
-    });
   });
 
   describe('token/cost tally (hidden Ctrl+T HUD survives into scrollback)', () => {

--- a/src/ui/tui/__tests__/exit-line.test.ts
+++ b/src/ui/tui/__tests__/exit-line.test.ts
@@ -1,6 +1,6 @@
 import { getExitLine } from '@ui/tui/exit-line';
 import { WizardStore, Program } from '@ui/tui/store';
-import { OutroKind } from '@lib/wizard-session';
+import { McpOutcome, OutroKind } from '@lib/wizard-session';
 
 vi.mock('../../../utils/analytics.js', () => ({
   analytics: {
@@ -121,6 +121,43 @@ describe('getExitLine', () => {
     );
     expect(line).toMatch(/exited\.$/);
     expect(line).not.toContain('coding agent');
+  });
+
+  describe('MCP login commands (the one manual auth step survives into scrollback)', () => {
+    it('echoes each login command on its own line instead of a bare exit line', () => {
+      const store = new WizardStore(Program.PostHogIntegration);
+      store.setMcpComplete(McpOutcome.Installed, ['Claude Code'], 'all', [
+        'claude mcp login posthog',
+      ]);
+      const line = stripAnsi(getExitLine(store));
+      expect(line).toContain('Authenticate to finish');
+      expect(line).toContain('claude mcp login posthog');
+      expect(line).not.toMatch(/exited\.$/);
+    });
+
+    it('appends the login commands to a success outro too', () => {
+      const store = storeWithOutro({
+        kind: OutroKind.Success,
+        message: 'Done!',
+      });
+      store.setMcpComplete(
+        McpOutcome.Installed,
+        ['Claude Code', 'Codex'],
+        'all',
+        ['claude mcp login posthog', 'codex mcp login posthog'],
+      );
+      const line = stripAnsi(getExitLine(store));
+      expect(line).toContain('Done!');
+      expect(line).toContain('claude mcp login posthog');
+      expect(line).toContain('codex mcp login posthog');
+    });
+
+    it('keeps the plain exit line when no login command is pending', () => {
+      const line = stripAnsi(
+        getExitLine(storeWithOutro({ kind: OutroKind.Error, message: 'boom' })),
+      );
+      expect(line).not.toContain('Authenticate to finish');
+    });
   });
 
   describe('token/cost tally (hidden Ctrl+T HUD survives into scrollback)', () => {

--- a/src/ui/tui/exit-line.ts
+++ b/src/ui/tui/exit-line.ts
@@ -49,10 +49,25 @@ function tokenCostLine(store: WizardStore): string | null {
   );
 }
 
+/**
+ * The one manual step the wizard can't do itself: the editor's own MCP login.
+ * Echoed into scrollback like the handoff prompt — command on its own plain
+ * line so a terminal can triple-click-select it.
+ */
+function mcpLoginBlock(store: WizardStore): string | null {
+  const commands = store.session.mcpLoginCommands;
+  if (!commands || commands.length === 0) return null;
+  return (
+    `${DIM}Authenticate to finish (opens your browser):${RESET_ATTRS}\n` +
+    commands.join('\n')
+  );
+}
+
 export function getExitLine(store: WizardStore): string {
   const outro = store.session.outroData;
   const label = store.session.programLabel ?? 'Wizard';
   const costLine = tokenCostLine(store);
+  const loginBlock = mcpLoginBlock(store);
 
   if (outro?.kind === OutroKind.Success) {
     const message = outro.message ?? `${label} completed successfully.`;
@@ -87,12 +102,15 @@ export function getExitLine(store: WizardStore): string {
       );
     }
 
+    if (loginBlock) parts.push(loginBlock);
     if (costLine) parts.push(costLine);
 
     return parts.join('\n\n');
   }
 
-  return costLine
-    ? `${DIM}${label} exited.${RESET_ATTRS}\n\n${costLine}`
-    : `${DIM}${label} exited.${RESET_ATTRS}`;
+  const parts = loginBlock
+    ? [loginBlock]
+    : [`${DIM}${label} exited.${RESET_ATTRS}`];
+  if (costLine) parts.push(costLine);
+  return parts.join('\n\n');
 }

--- a/src/ui/tui/exit-line.ts
+++ b/src/ui/tui/exit-line.ts
@@ -58,7 +58,7 @@ function mcpLoginBlock(store: WizardStore): string | null {
   const commands = store.session.mcpLoginCommands;
   if (!commands || commands.length === 0) return null;
   return (
-    `${DIM}Authenticate to finish (opens your browser):${RESET_ATTRS}\n` +
+    `${GREEN}${BOLD}\u2714 Authenticate to finish (opens your browser):${RESET_ATTRS}\n` +
     commands.join('\n')
   );
 }

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -282,11 +282,7 @@ export const McpScreen = ({
       // Plugin-capable clients get the plugin (which bundles MCP).
       // Non-plugin-capable clients get a direct MCP config write.
       try {
-        mcpResult = await installer.install(
-          directNames,
-          features,
-          store.session.apiKey,
-        );
+        mcpResult = await installer.install(directNames, features);
       } catch (err) {
         setFlowError(errorText(err));
       }
@@ -300,11 +296,7 @@ export const McpScreen = ({
       // 'custom' — MCP-only for every selected client. Plugin install is
       // skipped so the user's feature selection is actually respected.
       try {
-        mcpResult = await installer.install(
-          names,
-          features,
-          store.session.apiKey,
-        );
+        mcpResult = await installer.install(names, features);
       } catch (err) {
         setFlowError(errorText(err));
       }
@@ -587,7 +579,7 @@ export const McpScreen = ({
                   note={
                     isRemove
                       ? 'It was already gone, so nothing was changed.'
-                      : 'Left as-is. To change which PostHog areas it can reach, run `wizard mcp remove` first, then `wizard mcp add`.'
+                      : 'It already matched this exact setup, so nothing changed — including any login your editor already holds.'
                   }
                 />
                 <ResultGroup
@@ -599,6 +591,17 @@ export const McpScreen = ({
                   icon={'\u2716'}
                   note="Run with --debug for the full output, or report it at github.com/PostHog/wizard/issues."
                 />
+                {!isRemove &&
+                  installedNow.length + alreadyInstalled.length > 0 && (
+                    <Box marginBottom={1}>
+                      <Text dimColor>
+                        Your editor handles authentication — approve the
+                        PostHog connection when it prompts (in Claude Code, run
+                        /mcp). Changing the enabled areas later means
+                        authenticating once more.
+                      </Text>
+                    </Box>
+                  )}
                 {finishNotes.map((note) => (
                   <Box key={note.name} flexDirection="column" marginTop={1}>
                     <Text color="green" bold>

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -628,14 +628,16 @@ export const McpScreen = ({
                 />
                 {!isRemove && loginCommands.length > 0 && (
                   <Box flexDirection="column" marginBottom={1}>
-                    <Text dimColor>
-                      One step left — authenticate in your editor (nothing
-                      prompts you automatically):
+                    <Text color="green" bold>
+                      {'\u2714'} Authenticate to finish (opens your browser):
                     </Text>
                     {loginCommands.map((c) => (
-                      <Text key={c.name} dimColor>
+                      <Text key={c.name}>
                         {'  '}
-                        {c.name}: <Text bold>{c.command}</Text>
+                        {c.name}:{' '}
+                        <Text bold color="green">
+                          {c.command}
+                        </Text>
                       </Text>
                     ))}
                   </Box>

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -15,11 +15,7 @@ import { Box, Text, useInput } from 'ink';
 import { useState, useEffect, useRef } from 'react';
 import { useSyncExternalStore } from 'react';
 import { type WizardStore, McpOutcome } from '@ui/tui/store';
-import {
-  ConfirmationInput,
-  PickerMenu,
-  GroupedPickerMenu,
-} from '@ui/tui/primitives/index';
+import { ConfirmationInput, PickerMenu } from '@ui/tui/primitives/index';
 import { Colors, Icons } from '@ui/tui/styles';
 import type {
   McpInstaller,
@@ -33,7 +29,6 @@ import {
   summarizeFailure,
 } from '@steps/add-mcp-server-to-clients/results';
 import {
-  AVAILABLE_FEATURES,
   ALL_FEATURE_VALUES,
   isAllFeaturesSelected,
 } from '@steps/add-mcp-server-to-clients/defaults';
@@ -50,7 +45,6 @@ enum Phase {
   Detecting = 'detecting',
   Ask = 'ask',
   Pick = 'pick',
-  FeatureSelect = 'feature-select',
   Connector = 'connector',
   Working = 'working',
   Done = 'done',
@@ -191,7 +185,6 @@ export const McpScreen = ({
   const [selectedClientNames, setSelectedClientNames] = useState<string[]>([]);
   const [mcpResults, setMcpResults] = useState<McpClientResult[]>([]);
   const [pluginResults, setPluginResults] = useState<McpClientResult[]>([]);
-  const [installMode, setInstallMode] = useState<'all' | 'custom'>('custom');
   // Detection and the install/remove call can both blow up. Keep the reason so
   // a crash reads as a crash instead of as "you have nothing installed" or
   // "you selected nothing".
@@ -223,28 +216,12 @@ export const McpScreen = ({
     })();
   }, [installer]); // eslint-disable-line
 
-  const proceedAfterClientPick = (
-    clientNames: string[],
-    chosenMode: 'all' | 'custom',
-  ) => {
+  const proceedAfterClientPick = (clientNames: string[]) => {
     setSelectedClientNames(clientNames);
 
-    // Recommended flow: install everything straight away. Browser connectors
-    // (e.g. Claude Desktop/Web) just open their connector page here, same as
-    // before — no extra screen.
-    if (chosenMode === 'all') {
-      void doInstall(clientNames, [...ALL_FEATURE_VALUES], chosenMode);
-      return;
-    }
-    if (store.session.mcpFeatures) {
-      void doInstall(clientNames, store.session.mcpFeatures, chosenMode);
-      return;
-    }
-
-    // Customize flow: a browser connector configures its tools and features in
-    // Claude's UI, not through the wizard's feature picker. The picker keeps it
-    // mutually exclusive from local editors, so a connector selection is
-    // connector-only — show its own screen instead of the feature picker.
+    // Browser connectors just open their connector page — no extra screen.
+    // Which PostHog areas the agent can reach is decided at the OAuth consent
+    // screen, not in the wizard, so there is nothing else to ask here.
     const isConnector = clientNames.some(
       (name) => clients.find((c) => c.name === name)?.finish,
     );
@@ -252,27 +229,17 @@ export const McpScreen = ({
       setPhase(Phase.Connector);
       return;
     }
-    setPhase(Phase.FeatureSelect);
+    void doInstall(
+      clientNames,
+      store.session.mcpFeatures ?? [...ALL_FEATURE_VALUES],
+    );
   };
 
   const handleConfirm = () => {
     if (isRemove) {
       void doRemove();
     } else if (clients.length === 1) {
-      proceedAfterClientPick([clients[0]!.name], 'custom');
-    } else {
-      setPhase(Phase.Pick);
-    }
-  };
-
-  const handleTriStateChoice = (choice: 'all' | 'custom' | 'skip') => {
-    if (choice === 'skip') {
-      handleSkip();
-      return;
-    }
-    setInstallMode(choice);
-    if (clients.length === 1) {
-      proceedAfterClientPick([clients[0]!.name], choice);
+      proceedAfterClientPick([clients[0]!.name]);
     } else {
       setPhase(Phase.Pick);
     }
@@ -282,17 +249,7 @@ export const McpScreen = ({
     markDone(store, McpOutcome.Skipped);
   };
 
-  /**
-   * `chosenMode` is passed in rather than read from `installMode`: the tri-state
-   * picker sets that state and installs in the same tick when a single client
-   * is detected, so the closure would still hold the previous value and a
-   * one-editor machine would silently get the MCP-only path.
-   */
-  const doInstall = async (
-    names: string[],
-    features?: string[],
-    chosenMode: 'all' | 'custom' = installMode,
-  ) => {
+  const doInstall = async (names: string[], features?: string[]) => {
     setPhase(Phase.Working);
     let mcpResult: McpClientResult[] = [];
     let pluginResult: McpClientResult[] = [];
@@ -303,26 +260,23 @@ export const McpScreen = ({
     const pluginCapableNames = names.filter((n) => pluginCapableSet.has(n));
     const directNames = names.filter((n) => !pluginCapableSet.has(n));
 
-    if (chosenMode === 'all') {
-      // Plugin-capable clients get the plugin (which bundles MCP).
-      // Non-plugin-capable clients get a direct MCP config write.
-      try {
-        mcpResult = await installer.install(directNames, features);
-      } catch (err) {
-        setFlowError(errorText(err));
-      }
+    // Plugin-capable clients get the plugin (which bundles MCP); the rest get
+    // a direct MCP config write. A `--features` flag narrows the toolset, so
+    // those runs write a direct entry everywhere instead of the plugin.
+    const narrowed = Boolean(store.session.mcpFeatures);
+    try {
+      mcpResult = await installer.install(
+        narrowed ? names : directNames,
+        features,
+      );
+    } catch (err) {
+      setFlowError(errorText(err));
+    }
+    if (!narrowed) {
       try {
         pluginResult = await installer.installPlugins(pluginCapableNames);
       } catch (err) {
         // Best-effort, but still say so rather than showing an empty screen.
-        setFlowError(errorText(err));
-      }
-    } else {
-      // 'custom' — MCP-only for every selected client. Plugin install is
-      // skipped so the user's feature selection is actually respected.
-      try {
-        mcpResult = await installer.install(names, features);
-      } catch (err) {
         setFlowError(errorText(err));
       }
     }
@@ -395,14 +349,6 @@ export const McpScreen = ({
     mcpResults,
     McpClientStatus.Unchanged,
   ).filter((name) => !isConnectorName(name));
-  // Fresh entries and plugin-provided servers need the editor's own login
-  // command — the one manual step left. Untouched direct entries keep
-  // whatever login they have.
-  const loginCommands = pendingLoginCommands(
-    clients,
-    mcpResults,
-    pluginResults,
-  );
   const pluginInstalled = namesWithStatus(
     pluginResults,
     McpClientStatus.Changed,
@@ -475,84 +421,40 @@ export const McpScreen = ({
               Detected: {clients.map((c) => c.name).join(', ')}
             </Text>
             <Box marginTop={1}>
-              {!isRemove && !store.session.mcpFeatures ? (
-                <PickerMenu
-                  message={`Install the PostHog MCP server${
-                    clients.some((c) => c.supportsPlugin) ? ' and plugin' : ''
-                  }?`}
-                  options={[
-                    {
-                      label: 'Install with all features',
-                      value: 'all',
-                      hint: 'recommended',
-                    },
-                    {
-                      label: 'Customize features',
-                      value: 'custom',
-                    },
-                    { label: 'No thanks', value: 'skip' },
-                  ]}
-                  mode="single"
-                  onSelect={(choice) =>
-                    handleTriStateChoice(choice as 'all' | 'custom' | 'skip')
-                  }
-                />
-              ) : (
-                <ConfirmationInput
-                  message={`${
-                    isRemove ? 'Remove' : 'Install'
-                  } the PostHog MCP server${
-                    clients.some((c) => c.supportsPlugin) ? ' and plugin' : ''
-                  }?`}
-                  confirmLabel={isRemove ? 'Remove' : 'Install'}
-                  cancelLabel="No thanks"
-                  onConfirm={handleConfirm}
-                  onCancel={handleSkip}
-                />
-              )}
+              <ConfirmationInput
+                message={`${
+                  isRemove ? 'Remove' : 'Install'
+                } the PostHog MCP server${
+                  clients.some((c) => c.supportsPlugin) ? ' and plugin' : ''
+                }?`}
+                confirmLabel={isRemove ? 'Remove' : 'Install'}
+                cancelLabel="No thanks"
+                onConfirm={handleConfirm}
+                onCancel={handleSkip}
+              />
             </Box>
           </>
         )}
 
         {phase === Phase.Pick && (
           <PickerMenu
-            message={
-              installMode === 'all'
-                ? 'Select editor to install'
-                : 'Select editor to install MCP server'
-            }
+            message="Select editor to install"
             options={clients.map((c) => ({
               label: c.name,
               value: c.name,
               // Browser connectors can't be installed alongside local editors
-              // and are configured on their own screen, not the feature picker.
+              // and are configured on their own screen.
               exclusive: Boolean(c.finish),
-              // Hints only show in the recommended flow; the customize flow
-              // keeps the list clean.
-              hint:
-                installMode === 'all'
-                  ? c.finish
-                    ? 'connector'
-                    : c.supportsPlugin
-                    ? 'plugin'
-                    : 'MCP'
-                  : undefined,
+              hint: c.finish
+                ? 'connector'
+                : c.supportsPlugin
+                ? 'plugin'
+                : 'MCP',
             }))}
             mode="multi"
             onSelect={(selected) => {
               const names = Array.isArray(selected) ? selected : [selected];
-              proceedAfterClientPick(names, installMode);
-            }}
-          />
-        )}
-
-        {phase === Phase.FeatureSelect && (
-          <GroupedPickerMenu
-            message="Select the PostHog areas your agent can reach"
-            groups={AVAILABLE_FEATURES}
-            initialSelected={[]}
-            onSelect={(features) => {
-              void doInstall(selectedClientNames, features);
+              proceedAfterClientPick(names);
             }}
           />
         )}
@@ -626,22 +528,6 @@ export const McpScreen = ({
                   icon={'\u2716'}
                   note="Run with --debug for the full output, or report it at github.com/PostHog/wizard/issues."
                 />
-                {!isRemove && loginCommands.length > 0 && (
-                  <Box flexDirection="column" marginBottom={1}>
-                    <Text color="green" bold>
-                      {'\u2714'} Authenticate to finish (opens your browser):
-                    </Text>
-                    {loginCommands.map((c) => (
-                      <Text key={c.name}>
-                        {'  '}
-                        {c.name}:{' '}
-                        <Text bold color="green">
-                          {c.command}
-                        </Text>
-                      </Text>
-                    ))}
-                  </Box>
-                )}
                 {finishNotes.map((note) => (
                   <Box key={note.name} flexDirection="column" marginTop={1}>
                     <Text color="green" bold>

--- a/src/ui/tui/screens/McpScreen.tsx
+++ b/src/ui/tui/screens/McpScreen.tsx
@@ -62,8 +62,33 @@ const markDone = (
   outcome: McpOutcome,
   clients: string[] = [],
   featuresSelected?: 'all' | string[],
+  loginCommands: string[] = [],
 ) => {
-  store.setMcpComplete(outcome, clients, featuresSelected);
+  store.setMcpComplete(outcome, clients, featuresSelected, loginCommands);
+};
+
+/**
+ * The editor-owned login commands still to run after this install: fresh
+ * config entries use the client's own server name, plugin-provided servers
+ * their `plugin:` name. One entry per client — a client that just got a direct
+ * entry doesn't also list its plugin command.
+ */
+const pendingLoginCommands = (
+  clients: McpClientInfo[],
+  mcpResult: McpClientResult[],
+  pluginResult: McpClientResult[],
+): Array<{ name: string; command: string }> => {
+  const commands = new Map<string, string>();
+  for (const r of pluginResult) {
+    const command = clients.find((c) => c.name === r.name)?.pluginLoginCommand;
+    if (isOk(r) && command) commands.set(r.name, command);
+  }
+  for (const r of mcpResult) {
+    const command = clients.find((c) => c.name === r.name)?.loginCommand;
+    if (r.status === McpClientStatus.Changed && command)
+      commands.set(r.name, command);
+  }
+  return [...commands.entries()].map(([name, command]) => ({ name, command }));
 };
 
 const reportFeatures = (features: string[]): 'all' | string[] =>
@@ -309,12 +334,14 @@ export const McpScreen = ({
     const ready = [...mcpResult, ...pluginResult].filter(isOk);
     const outcome = ready.length > 0 ? McpOutcome.Installed : McpOutcome.Failed;
     const featuresReport = reportFeatures(features ?? [...ALL_FEATURE_VALUES]);
+    const logins = pendingLoginCommands(clients, mcpResult, pluginResult);
     finishFlow.current = () =>
       markDone(
         store,
         outcome,
         ready.map((r) => r.name),
         featuresReport,
+        logins.map((l) => l.command),
       );
     setPhase(Phase.Done);
   };
@@ -368,6 +395,14 @@ export const McpScreen = ({
     mcpResults,
     McpClientStatus.Unchanged,
   ).filter((name) => !isConnectorName(name));
+  // Fresh entries and plugin-provided servers need the editor's own login
+  // command — the one manual step left. Untouched direct entries keep
+  // whatever login they have.
+  const loginCommands = pendingLoginCommands(
+    clients,
+    mcpResults,
+    pluginResults,
+  );
   const pluginInstalled = namesWithStatus(
     pluginResults,
     McpClientStatus.Changed,
@@ -557,7 +592,7 @@ export const McpScreen = ({
                   items={pluginAlreadyInstalled}
                   color="green"
                   icon={'\u2714'}
-                  note="It was already set up, so nothing changed. You are good to go."
+                  note="It was already set up, so nothing changed. The plugin bundles the PostHog MCP server."
                 />
                 <ResultGroup
                   title={`MCP server ${
@@ -591,17 +626,20 @@ export const McpScreen = ({
                   icon={'\u2716'}
                   note="Run with --debug for the full output, or report it at github.com/PostHog/wizard/issues."
                 />
-                {!isRemove &&
-                  installedNow.length + alreadyInstalled.length > 0 && (
-                    <Box marginBottom={1}>
-                      <Text dimColor>
-                        Your editor handles authentication — approve the
-                        PostHog connection when it prompts (in Claude Code, run
-                        /mcp). Changing the enabled areas later means
-                        authenticating once more.
+                {!isRemove && loginCommands.length > 0 && (
+                  <Box flexDirection="column" marginBottom={1}>
+                    <Text dimColor>
+                      One step left — authenticate in your editor (nothing
+                      prompts you automatically):
+                    </Text>
+                    {loginCommands.map((c) => (
+                      <Text key={c.name} dimColor>
+                        {'  '}
+                        {c.name}: <Text bold>{c.command}</Text>
                       </Text>
-                    </Box>
-                  )}
+                    ))}
+                  </Box>
+                )}
                 {finishNotes.map((note) => (
                   <Box key={note.name} flexDirection="column" marginTop={1}>
                     <Text color="green" bold>

--- a/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
+++ b/src/ui/tui/screens/McpSuggestedPromptsScreen.tsx
@@ -670,6 +670,7 @@ export const McpSuggestedPromptsScreen = ({
             integration={session.integration}
             profile={profile}
             engaged={branchHistory.length > 0}
+            loginCommands={session.mcpLoginCommands}
             onClose={closeWizard}
           />
         )}
@@ -1232,6 +1233,8 @@ interface GoodbyePhaseProps {
   profile: ProjectDataProfile | null;
   /** True if the user actually ran at least one prompt this session. */
   engaged: boolean;
+  /** Editor-owned login commands still to run (e.g. `claude mcp login posthog`). */
+  loginCommands: string[];
   onClose: () => void;
 }
 
@@ -1241,6 +1244,7 @@ const GoodbyePhase = ({
   integration,
   profile,
   engaged,
+  loginCommands,
   onClose,
 }: GoodbyePhaseProps) => {
   // Three "next time you open your IDE, try this" reminders. Prefer quests
@@ -1280,6 +1284,22 @@ const GoodbyePhase = ({
       </Box>
 
       <Box marginBottom={1}>{introLine}</Box>
+
+      {loginCommands.length > 0 && (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text color="green" bold>
+            {'\u2714'} Authenticate to finish (opens your browser):
+          </Text>
+          {loginCommands.map((command) => (
+            <Text key={command}>
+              {'  '}
+              <Text bold color="green">
+                {command}
+              </Text>
+            </Text>
+          ))}
+        </Box>
+      )}
 
       <Box marginBottom={1} flexDirection="column">
         {samples.map((p, i) => (

--- a/src/ui/tui/services/mcp-installer.ts
+++ b/src/ui/tui/services/mcp-installer.ts
@@ -50,7 +50,6 @@ export interface McpInstaller {
   install(
     clientNames: string[],
     features?: string[],
-    apiKey?: string,
   ): Promise<McpClientResult[]>;
 
   /**
@@ -86,7 +85,6 @@ export function createMcpInstaller(): McpInstaller {
     async install(
       clientNames: string[],
       features?: string[],
-      apiKey?: string,
     ): Promise<McpClientResult[]> {
       const resolvedFeatures = features ?? [...ALL_FEATURE_VALUES];
       const toInstall = cachedClients
@@ -107,11 +105,7 @@ export function createMcpInstaller(): McpInstaller {
       for (const client of toInstall) {
         const name = client.name as string;
         try {
-          const result = await client.addServer(
-            apiKey,
-            resolvedFeatures,
-            false,
-          );
+          const result = await client.addServer(resolvedFeatures, false);
           results.push(toClientResult(name, result));
           if (!result?.success) {
             // redactSecrets, not the raw reason: the CLIs we shell out to echo

--- a/src/ui/tui/services/mcp-installer.ts
+++ b/src/ui/tui/services/mcp-installer.ts
@@ -21,6 +21,7 @@ import {
   type McpClientResult,
 } from '@steps/add-mcp-server-to-clients/results';
 import { isPluginCapable } from '@steps/add-mcp-server-to-clients/plugin-client';
+import { isLoginCapable } from '@steps/add-mcp-server-to-clients/login-client';
 import { isBrowserFinishable } from '@steps/add-mcp-server-to-clients/browser-client';
 import { logToFile } from '@utils/debug';
 import { analytics } from '@utils/analytics';
@@ -33,6 +34,15 @@ export interface McpClientInfo {
    * Done screen renders this so the user knows to finish setup in the browser.
    */
   finish?: { url: string; instruction: string };
+  /**
+   * The editor's own login command (e.g. `claude mcp login posthog`) for
+   * clients whose CLI runs its own OAuth. The Done screen renders it as the
+   * one manual step left — the command needs a real terminal, so the wizard
+   * never runs it itself.
+   */
+  loginCommand?: string;
+  /** Same, for the plugin-provided server (e.g. `claude mcp login plugin:posthog:posthog`). */
+  pluginLoginCommand?: string;
 }
 
 export { McpClientStatus };
@@ -78,6 +88,10 @@ export function createMcpInstaller(): McpInstaller {
         supportsPlugin: isPluginCapable(c) && c.supportsPlugin(),
         finish: isBrowserFinishable(c)
           ? { url: c.connectorUrl, instruction: c.finishInstruction }
+          : undefined,
+        loginCommand: isLoginCapable(c) ? c.loginCommand(false) : undefined,
+        pluginLoginCommand: isLoginCapable(c)
+          ? c.pluginLoginCommand?.()
           : undefined,
       }));
     },

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -735,10 +735,12 @@ export class WizardStore {
     outcome: McpOutcome = McpOutcome.Skipped,
     installedClients: string[] = [],
     featuresSelected?: 'all' | string[],
+    loginCommands: string[] = [],
   ): void {
     this.$session.setKey('mcpComplete', true);
     this.$session.setKey('mcpOutcome', outcome);
     this.$session.setKey('mcpInstalledClients', installedClients);
+    this.$session.setKey('mcpLoginCommands', loginCommands);
     const featuresPayload =
       outcome === McpOutcome.Installed && featuresSelected !== undefined
         ? { mcp_features_selected: featuresSelected }


### PR DESCRIPTION
Redo of #1100 with the re-run/removal bugs fixed (exact entry detection, plugin uninstall on remove, restore on failed replace, sorted URLs) and the wizard's feature-selection menus removed so the OAuth consent screen is the single place access is chosen, with the editor's own login command surfaced on the end screen and at exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)