### PR TITLE
fix(e2e): read dependencies from every ecosystem manifest

### DIFF
--- a/scripts/tui-host.no-jest.ts
+++ b/scripts/tui-host.no-jest.ts
@@ -256,7 +256,6 @@ async function main() {
       // One dependency-name pattern per ecosystem manifest. A run only needs
       // the names, so a line-level scan beats per-format parsers.
       const MANIFESTS: Array<[string, RegExp]> = [
-        ['package.json', /"([^"]+)"\s*:\s*"[^"]*"/g],
         ['pubspec.yaml', /^ {2}([A-Za-z_][A-Za-z0-9_]*)\s*:/gm],
         ['go.mod', /^\s*([\w.\/-]+)\s+v[\w.-]+/gm],
         ['Cargo.toml', /^([A-Za-z0-9_-]+)\s*=/gm],
@@ -265,6 +264,18 @@ async function main() {
         ['mix.exs', /\{:([a-z_]+)\s*,/g],
       ];
       const deps: string[] = [];
+      try {
+        // package.json needs a real parse: a line scan would also match script
+        // names, and only the dependency blocks carry dependencies.
+        const pkg = JSON.parse(
+          fs.readFileSync(`${appDir}/package.json`, 'utf8'),
+        );
+        deps.push(
+          ...Object.keys({ ...pkg.dependencies, ...pkg.devDependencies }),
+        );
+      } catch {
+        /* not a JS project */
+      }
       for (const [file, pattern] of MANIFESTS) {
         try {
           const text = fs.readFileSync(`${appDir}/${file}`, 'utf8');

--- a/scripts/tui-host.no-jest.ts
+++ b/scripts/tui-host.no-jest.ts
@@ -253,34 +253,36 @@ async function main() {
     // env file, and the screens walked.
     if (process.env.E2E_RESULT_JSON) {
       const appDir = process.env.APP_DIR!;
-      let deps: string[] = [];
-      try {
-        const pkg = JSON.parse(
-          fs.readFileSync(`${appDir}/package.json`, 'utf8'),
-        );
-        deps = Object.keys({ ...pkg.dependencies, ...pkg.devDependencies });
-      } catch {
-        /* some frameworks have no package.json */
-      }
-      try {
-        // Dart/Flutter declares dependencies in pubspec.yaml, so a Flutter run
-        // reports no dependency at all when only package.json is read.
-        const pubspec = fs.readFileSync(`${appDir}/pubspec.yaml`, 'utf8');
-        for (const line of pubspec.split('\n')) {
-          const dep = /^\s{2}([A-Za-z_][A-Za-z0-9_]*)\s*:/.exec(line);
-          if (dep) deps.push(dep[1]);
+      // One dependency-name pattern per ecosystem manifest. A run only needs
+      // the names, so a line-level scan beats per-format parsers.
+      const MANIFESTS: Array<[string, RegExp]> = [
+        ['package.json', /"([^"]+)"\s*:\s*"[^"]*"/g],
+        ['pubspec.yaml', /^ {2}([A-Za-z_][A-Za-z0-9_]*)\s*:/gm],
+        ['go.mod', /^\s*([\w.\/-]+)\s+v[\w.-]+/gm],
+        ['Cargo.toml', /^([A-Za-z0-9_-]+)\s*=/gm],
+        ['pom.xml', /<artifactId>([^<]+)<\/artifactId>/g],
+        ['build.gradle', /['"]([\w.-]+:[\w.-]+)[:'"]/g],
+        ['mix.exs', /\{:([a-z_]+)\s*,/g],
+      ];
+      const deps: string[] = [];
+      for (const [file, pattern] of MANIFESTS) {
+        try {
+          const text = fs.readFileSync(`${appDir}/${file}`, 'utf8');
+          for (const match of text.matchAll(pattern)) deps.push(match[1]);
+        } catch {
+          /* app doesn't use this ecosystem */
         }
-      } catch {
-        /* not a Dart project */
       }
-      const posthogDeps = deps.filter((d) => d.includes('posthog'));
+      const posthogDeps = [
+        ...new Set(deps.filter((d) => d.toLowerCase().includes('posthog'))),
+      ];
       let envFile: string | null = null;
       try {
         const hit = fs
           .readdirSync(appDir)
           .find(
             (f) =>
-              f.startsWith('.env') &&
+              (f.startsWith('.env') || f.endsWith('.env')) &&
               /posthog/i.test(fs.readFileSync(`${appDir}/${f}`, 'utf8')),
           );
         envFile = hit ? `${appDir}/${hit}` : null;


### PR DESCRIPTION
The result JSON parsed package.json and pubspec.yaml only, so Go, Rust, Java, and Elixir runs reported hasPosthogDep false and gotify's `gotify-server.env` failed the `.env` prefix check — verified against the four real e2e outputs (gotify, miniserve, petclinic, teslamate), each now resolving its posthog dependency.