### PR TITLE
feat(metrics): bind the metrics program to sol at medium effort

### DIFF
--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -61,6 +61,7 @@ describe('switchboard PROGRAM_BINDINGS', () => {
   it('resolves every program, unflagged, to the same default binding', () => {
     for (const program of PROGRAM_IDS) {
       if (program === 'ai-observability') continue; // pinned below
+      if (program === 'metrics') continue; // pinned below
       expect(resolveBinding({ program, flags: {} })).toEqual(DEFAULT_RESOLVED);
     }
   });
@@ -74,6 +75,17 @@ describe('switchboard PROGRAM_BINDINGS', () => {
         harness: Harness.anthropic,
         model: SONNET_5_MODEL,
         thinkingLevel: undefined,
+      },
+      trace: { harness: 'binding', model: 'binding', sequence: 'binding' },
+    },
+    {
+      name: 'binds metrics to pi + sol at medium effort',
+      ctx: { program: 'metrics', flags: {} },
+      binding: {
+        sequence: Sequence.linear,
+        harness: Harness.pi,
+        model: GPT5_6_SOL_MODEL,
+        thinkingLevel: 'medium',
       },
       trace: { harness: 'binding', model: 'binding', sequence: 'binding' },
     },
@@ -183,12 +195,20 @@ describe('switchboard composed clamp', () => {
       };
       // The flag routes posthog-integration's harness to pi; the composed
       // clamp holds every sequence at linear; other programs keep their
-      // bindings (sonnet 5 for ai-observability, the default elsewhere).
+      // bindings (sonnet 5 for ai-observability, sol on pi for metrics,
+      // the default elsewhere).
       expect(resolveBinding(ctx)).toEqual(
         program === 'posthog-integration'
           ? { ...DEFAULT_RESOLVED, harness: Harness.pi }
           : program === 'ai-observability'
           ? { ...DEFAULT_RESOLVED, model: SONNET_5_MODEL }
+          : program === 'metrics'
+          ? {
+              ...DEFAULT_RESOLVED,
+              harness: Harness.pi,
+              model: GPT5_6_SOL_MODEL,
+              thinkingLevel: 'medium',
+            }
           : DEFAULT_RESOLVED,
       );
       expect(ctx.trace?.sequence).toBe('composed');

--- a/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
@@ -7,6 +7,7 @@ import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
 import * as constants from '@lib/constants';
 import {
   DEFAULT_AGENT_MODEL,
+  GPT5_6_SOL_MODEL,
   GPT5_6_TERRA_MODEL,
   Harness,
   Sequence,
@@ -276,6 +277,13 @@ describe('isolation — everything on at once', () => {
         expect(resolved).toEqual({
           ...LINEAR_ANTHROPIC_DEFAULT,
           model: SONNET_5_MODEL,
+        });
+      } else if (program === 'metrics') {
+        expect(resolved).toEqual({
+          sequence: Sequence.linear,
+          harness: Harness.pi,
+          model: GPT5_6_SOL_MODEL,
+          thinkingLevel: 'medium',
         });
       } else {
         expect(resolved).toEqual(LINEAR_ANTHROPIC_DEFAULT);

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -9,6 +9,7 @@
 
 import {
   DEFAULT_AGENT_MODEL,
+  GPT5_6_SOL_MODEL,
   SONNET_5_MODEL,
   Harness,
   Sequence,
@@ -135,7 +136,12 @@ export const PROGRAM_BINDINGS: Partial<Record<ProgramId, ProgramBinding>> = {
   'mcp-remove': DEFAULT_BINDING,
   'mcp-tutorial': DEFAULT_BINDING,
   'mcp-analytics': DEFAULT_BINDING,
-  metrics: DEFAULT_BINDING,
+  metrics: {
+    sequence: Sequence.linear,
+    harness: Harness.pi,
+    model: GPT5_6_SOL_MODEL,
+    thinkingLevel: 'medium',
+  },
   'ai-observability': {
     sequence: Sequence.linear,
     harness: Harness.anthropic,


### PR DESCRIPTION
Stacked on #1102: routes `wizard metrics` to gpt-5.6-sol on the pi harness at medium effort instead of the default anthropic binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)