### PR TITLE
fix(orchestrator): pause Write/Edit while a task's wizard_ask is open

### DIFF
--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -148,6 +148,10 @@ export const anthropicBackend: AgentHarness = {
         // Only a task allowed to ask carries a bridge, so the Write/Edit pause
         // that rides on a pending question stays inside that task's agent.
         askBridge,
+        // Enforce that pause: without this, canUseTool never sees the open
+        // question and the task could write files while a credential prompt
+        // waits (up to TASK_ASK_TIMEOUT_MS). Same wiring as the linear run.
+        getPendingQuestion: () => session.pendingQuestion,
         orchestrator,
         capture,
       },

--- a/src/lib/agent/runner/harness/anthropic/index.ts
+++ b/src/lib/agent/runner/harness/anthropic/index.ts
@@ -148,10 +148,6 @@ export const anthropicBackend: AgentHarness = {
         // Only a task allowed to ask carries a bridge, so the Write/Edit pause
         // that rides on a pending question stays inside that task's agent.
         askBridge,
-        // Enforce that pause: without this, canUseTool never sees the open
-        // question and the task could write files while a credential prompt
-        // waits (up to TASK_ASK_TIMEOUT_MS). Same wiring as the linear run.
-        getPendingQuestion: () => session.pendingQuestion,
         orchestrator,
         capture,
       },

--- a/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
@@ -13,6 +13,7 @@ import {
   type WizardAskBridge,
 } from '@lib/wizard-ask-bridge';
 import { createWizardPiTools } from '../tools';
+import { evaluateToolCall } from '../security';
 import { allowedPiCodingTools, allowedOrchestratorTools } from '../task';
 
 const SECRET = 'phx_live_zendesk_token_123';
@@ -176,6 +177,56 @@ describe('pi set_env_values — resolves vault refs host-side', () => {
       values: { ZENDESK_TOKEN: answers.token },
     });
     expect(textOf(result)).toMatch(/not known to the vault/);
+  });
+});
+
+describe('pi task wiring — wizard_ask pauses Write/Edit', () => {
+  it('blocks write/edit while an ask is in flight, then reallows once answered', async () => {
+    // Mirrors runPiTask: one askState shared between the ask tool
+    // (onAskPendingChange) and the security fence (getWizardAskPending). The
+    // regression this pins is the task path forgetting to connect them, which
+    // let a task mutate files while its credential prompt sat open.
+    const askState = { pending: false };
+    let release!: (answers: Record<string, string>) => void;
+    const request = vi.fn(
+      () =>
+        new Promise<Record<string, string>>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const [wizardAsk] = createWizardPiTools({
+      workingDirectory: mkdtempSync(join(tmpdir(), 'pi-ask-pause-')),
+      skillsBaseUrl: 'http://localhost:0',
+      askBridge: { request } as unknown as WizardAskBridge,
+      triageProvider: undefined,
+      onAskPendingChange: (pending) => {
+        askState.pending = pending;
+      },
+    }).filter((t) => t.name === 'wizard_ask');
+
+    const gate = { getWizardAskPending: () => askState.pending };
+    const write = { path: 'src/app.ts', content: 'x' };
+    const edit = { path: 'src/app.ts', edits: [] };
+
+    // Before asking, writes flow.
+    expect((await evaluateToolCall('write', write, gate)).block).toBe(false);
+
+    // Open the overlay but do not answer — the credential prompt is on screen.
+    const inFlight = call(wizardAsk, {
+      questions: [
+        { id: 'pw', prompt: 'DB password', kind: 'text', sensitive: true },
+      ],
+    });
+    await Promise.resolve();
+    expect(askState.pending).toBe(true);
+    expect((await evaluateToolCall('write', write, gate)).block).toBe(true);
+    expect((await evaluateToolCall('edit', edit, gate)).block).toBe(true);
+
+    // Answer — the overlay closes and writes flow again.
+    release({ pw: CANCELLED_SENTINEL });
+    await inFlight;
+    expect(askState.pending).toBe(false);
+    expect((await evaluateToolCall('write', write, gate)).block).toBe(false);
   });
 });
 

--- a/src/lib/agent/runner/harness/pi/task.ts
+++ b/src/lib/agent/runner/harness/pi/task.ts
@@ -234,12 +234,20 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
       };
     }
 
+    // Shared flag: true while a wizard_ask overlay is open. The ask tool sets
+    // it (onAskPendingChange, below); the security fence reads it to pause
+    // Write/Edit until the answer comes back. Wired the same way as the linear
+    // pi run — without it the warehouse task could mutate files while its
+    // credential prompt sits open (up to TASK_ASK_TIMEOUT_MS).
+    const askState = { pending: false };
+
     // The same fail-closed fence as the linear run, with the task's disallow
     // list layered in (both the wizard-vocabulary and pi-short names).
     const { createSecurityExtension } = await import('./security');
     const security = createSecurityExtension({
       disallowedTools: fenceDisallowList(disallowedTools),
       triageProvider: boot.triageProvider,
+      getWizardAskPending: () => askState.pending,
     });
     const { prewarmYaraScanner } = await import('@lib/yara-hooks');
     void prewarmYaraScanner();
@@ -330,6 +338,10 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
       // Present only for a task allowed to ask; without it wizard_ask errors
       // instead of hanging on a prompt nobody will ever see.
       askBridge,
+      // Pause Write/Edit while the ask overlay is open (see askState above).
+      onAskPendingChange: (pending) => {
+        askState.pending = pending;
+      },
     }).filter((t) => wizardToolNames.has(t.name));
 
     const { createPiOrchestratorTools } = await import('./orchestrator-tools');


### PR DESCRIPTION
## Problem

The `wizard_ask` overlay is meant to pause `Write`/`Edit` until the user answers, as a defense-in-depth guard on top of the SDK's own turn pause (see the guard in `wizardCanUseTool`). The pi harness wires it in its **linear** run path, but not in its **per-task** path — the ask tool's `onAskPendingChange` signal and the security fence's `getWizardAskPending` reader were never connected there.

This is exactly the path the seeded warehouse task runs on: the one step that stops to collect plaintext database passwords and API keys, holding the prompt open for up to the 20-minute task ask timeout. During that window the guard was silently absent, so the agent could mutate files while the credential prompt waited on the user.

## Changes

- pi task path (`runPiTask`): share one `askState` object between the ask tool (`onAskPendingChange`) and the security fence (`getWizardAskPending`), matching the linear pi run. Mutating a property on a shared object (rather than a captured nanostore snapshot) keeps the signal live.

Scope note: the anthropic `runTask` path has the same missing guard, but its only available signal — `session.pendingQuestion` — is read from a nanostore snapshot that `requestQuestion` replaces via `setKey`, so a captured accessor goes stale (the anthropic *linear* path is affected by this too). Wiring it there would ship a no-op; that pre-existing staleness is left out of scope. The pi path is where the orchestrator's warehouse task actually runs.

## Why

Surfaced while reviewing telemetry for the warehouse source-connection task, which collects credentials over a long-lived `wizard_ask` prompt. The safety pause that flow relies on was only present in the linear run, not the task run the flow actually uses.

## Test plan

- New regression test in `pi/__tests__/tools.test.ts` mirrors the `runPiTask` wiring: a write is allowed, blocked while an ask is in flight, and allowed again once answered.
- `pnpm build && pnpm test` — 141 files / 2016 tests pass; `pnpm fix` clean.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
