### PR TITLE
fix(wizard-tools): share wizard_ask sensitive-field guidance across harnesses

### DIFF
--- a/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@lib/wizard-ask-bridge';
 import { createWizardPiTools } from '../tools';
 import { allowedPiCodingTools, allowedOrchestratorTools } from '../task';
+import { WIZARD_ASK_SENSITIVE_DESCRIPTION } from '@lib/wizard-tools/tools';
 
 const SECRET = 'phx_live_zendesk_token_123';
 
@@ -95,6 +96,31 @@ describe('pi wizard_ask — sensitive answers are vaulted', () => {
     });
     expect(textOf(result)).toMatch(/Only kind="text" answers can be sensitive/);
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it('carries the shared secretRef guidance (parity with the MCP server)', () => {
+    // The pi harness runs the orchestrator's warehouse credential task, so its
+    // `sensitive` guidance must warn — like the MCP server's — that a vaulted
+    // { secretRef } is rejected by the PostHog data-warehouse tools. Without it
+    // the agent vaults a credential it must hand to source creation, the create
+    // tool rejects the ref, and the task dead-ends into the browser fallback.
+    const { wizardAsk } = makeTools({});
+    const desc = (
+      wizardAsk as unknown as {
+        parameters: {
+          properties: {
+            questions: {
+              items: {
+                properties: { sensitive: { description?: string } };
+              };
+            };
+          };
+        };
+      }
+    ).parameters.properties.questions.items.properties.sensitive.description;
+    expect(desc).toBe(WIZARD_ASK_SENSITIVE_DESCRIPTION);
+    expect(desc).toMatch(/data-warehouse tools/);
+    expect(desc).toMatch(/reject it/);
   });
 });
 

--- a/src/lib/agent/runner/harness/pi/tools.ts
+++ b/src/lib/agent/runner/harness/pi/tools.ts
@@ -30,6 +30,7 @@ import {
   resolveEnvPath,
   resolveEnvSecretRefs,
   vaultSensitiveAnswers,
+  WIZARD_ASK_SENSITIVE_DESCRIPTION,
 } from '@lib/wizard-tools/tools';
 import type { LLMProvider } from '@posthog/warlock';
 import { isFullyCancelled, type WizardAskBridge } from '@lib/wizard-ask-bridge';
@@ -300,8 +301,7 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
           ),
           sensitive: Type.Optional(
             Type.Boolean({
-              description:
-                "Only valid for kind='text'. The answer is stored in the wizard's secret vault and returned as { secretRef: 'secret:...' } instead of the raw string. Use for API keys and tokens; the ref is resolved only by tools that accept it (e.g. set_env_values).",
+              description: WIZARD_ASK_SENSITIVE_DESCRIPTION,
             }),
           ),
         }),

--- a/src/lib/wizard-tools/mcp.ts
+++ b/src/lib/wizard-tools/mcp.ts
@@ -52,6 +52,7 @@ import {
   writeLedgerAtomic,
   type SkillEntry,
   AUDIT_STATUSES,
+  WIZARD_ASK_SENSITIVE_DESCRIPTION,
 } from './tools';
 
 const auditCheckSchema = z.object({
@@ -622,9 +623,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
     sensitive: z
       .boolean()
       .optional()
-      .describe(
-        "Only valid for kind='text'. When true, the user's answer is stored in the wizard's secret vault and returned to you as { secretRef: 'secret:...' } instead of the raw string. Use for API keys, tokens, and any other secret the user types in. The secretRef is only resolved by wizard-tools that accept it (e.g. set_env_values) — it is NOT resolved when passed to other MCP tools (e.g. PostHog data-warehouse tools), which will reject it. For a secret that must reach another tool, write it to the env with set_env_values first, or use that tool's own credential-reference flow.",
-      ),
+      .describe(WIZARD_ASK_SENSITIVE_DESCRIPTION),
   });
 
   const wizardAsk = tool(

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -301,6 +301,29 @@ export const DEFAULT_ASK_MAX_QUESTIONS = 10;
 /** The call after this many returns a one-time batch-your-questions nudge. */
 export const ASK_BATCH_THRESHOLD = 3;
 
+/**
+ * The `wizard_ask` `sensitive` field description, shared by both harness facades
+ * (the zod schema in `./mcp` and the typebox mirror in `harness/pi/tools.ts`) so
+ * the secret-handling guidance cannot drift between them — the same discipline
+ * `HANDOFF_FIELDS` applies to the handoff schema.
+ *
+ * The load-bearing part is the last two sentences: a vaulted `{secretRef}` is
+ * resolved only by wizard-tools that accept it, and the PostHog data-warehouse
+ * tools reject it. Without that, a pi agent collecting a credential it must hand
+ * to `external-data-sources-create` vaults it, gets a ref the create tool
+ * rejects, and dead-ends into the browser fallback — the exact loss the wizard's
+ * in-cli source setup is meant to avoid.
+ */
+export const WIZARD_ASK_SENSITIVE_DESCRIPTION =
+  "Only valid for kind='text'. When true, the user's answer is stored in the " +
+  "wizard's secret vault and returned to you as { secretRef: 'secret:...' } " +
+  'instead of the raw string. Use for API keys, tokens, and any other secret ' +
+  'the user types in. The secretRef is only resolved by wizard-tools that ' +
+  'accept it (e.g. set_env_values) — it is NOT resolved when passed to other ' +
+  'MCP tools (e.g. PostHog data-warehouse tools), which will reject it. For a ' +
+  'secret that must reach another tool, write it to the env with set_env_values ' +
+  "first, or use that tool's own credential-reference flow.";
+
 export type AskCapDecision =
   | { kind: 'ok' }
   | {


### PR DESCRIPTION
## Problem

The `wizard_ask` `sensitive`-field description had drifted between the two harness facades. The MCP server's copy warns that a vaulted `{ secretRef }` is resolved only by wizard-tools that accept it and is **rejected** by the PostHog data-warehouse tools. The pi mirror carried an older, shorter copy without that warning.

The orchestrator — and with it the interactive warehouse credential-collection task — runs on **pi**, so pi's copy is the one actually in effect during source setup. Without the warning, an agent can vault a credential it then has to hand to `external-data-sources-create`, get back a ref the create tool rejects, and dead-end into the browser-link fallback instead of connecting the source in-CLI. This flow's telemetry is dominated by runs that end in that fallback, so the guidance the pi agent sees matters.

## Changes

- Extract the `sensitive`-field description into a single `WIZARD_ASK_SENSITIVE_DESCRIPTION` constant in `wizard-tools/tools.ts` — the same shared-source discipline `HANDOFF_FIELDS` already applies to the handoff schema.
- Reference it from both the zod schema (`mcp.ts`) and the typebox schema (`harness/pi/tools.ts`) so the two can't drift again.
- Add a pi tools test asserting the pi schema carries the shared guidance (including the data-warehouse-rejection warning).

No behaviour change on the MCP side (its wording was already the complete one); this brings the pi harness up to it.

## Test plan

- `pnpm build && pnpm lint` — clean (0 errors).
- `pnpm test` — full unit suite passes (2016 tests), including the new pi `wizard_ask` parity assertion.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
