### PR TITLE
chore: mcp install smoke test using headless flag

### DIFF
--- a/.github/workflows/mcp-install.yml
+++ b/.github/workflows/mcp-install.yml
@@ -1,0 +1,80 @@
+name: MCP Install
+
+# Installs the PostHog MCP server into a real editor CLI on a fresh runner and
+# asserts the config that comes out. The unit suite mocks `child_process` and
+# `fs`, so every assertion there is about the call we meant to make, not the
+# file the editor ends up reading.
+#
+# The fresh runner is the point: "no ~/.codex, no ~/.claude.json, never logged
+# in" is the state a first-time user is in and a dev machine never is.
+#
+# Needs no secrets — the OAuth path writes a tokenless entry and defers auth to
+# the editor, so this all happens pre-auth and works on fork PRs.
+
+on:
+  pull_request:
+    paths:
+      - 'src/steps/add-mcp-server-to-clients/**'
+      - 'scripts/mcp-install-smoke-test.ts'
+      - '.github/workflows/mcp-install.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/steps/add-mcp-server-to-clients/**'
+      - 'scripts/mcp-install-smoke-test.ts'
+      - '.github/workflows/mcp-install.yml'
+  # A renamed editor subcommand breaks the wizard with no wizard change to
+  # trigger a run, so poll for it.
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mcp-install:
+    name: ${{ matrix.provider }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      # One provider failing must not hide the other's result.
+      fail-fast: false
+      matrix:
+        include:
+          - provider: claude-code
+            cli_package: '@anthropic-ai/claude-code'
+          - provider: codex
+            cli_package: '@openai/codex'
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: 10.23.0
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The test drives dist/bin.js, the same entry point users run.
+      - name: Build
+        run: pnpm build
+
+      # Unpinned on purpose: pinning would hide new editor releases changing the
+      # surface we shell out to. The version is logged, so breaks stay attributable.
+      - name: Install ${{ matrix.cli_package }}
+        run: |
+          npm install -g ${{ matrix.cli_package }}
+          echo "::notice::$(npm view ${{ matrix.cli_package }} version) installed for ${{ matrix.provider }}"
+
+      - name: Run the MCP install smoke test
+        run: pnpm test:mcp-install --provider=${{ matrix.provider }}

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "postbuild": "chmod +x ./dist/bin.js && cp -r scripts/** dist && rm -f dist/*.no-jest.* && pnpm test:smoke && pnpm test:warlock",
     "test:smoke": "bash ./scripts/smoke-test.sh",
     "test:warlock": "tsx scripts/warlock-smoke-test.ts",
+    "test:mcp-install": "tsx scripts/mcp-install-smoke-test.ts",
     "lint": "pnpm lint:prettier && pnpm lint:eslint",
     "lint:prettier": "prettier --check \"{lib,src,test}/**/*.ts\"",
     "lint:eslint": "eslint . --cache --format stylish",

--- a/scripts/mcp-install-smoke-test.ts
+++ b/scripts/mcp-install-smoke-test.ts
@@ -182,9 +182,11 @@ async function scenarioFreshInstall(spec: ProviderSpec): Promise<void> {
     if (spec.configPath) {
       const contents = readIfPresent(path.join(home, spec.configPath));
       if (!check(contents !== null, `wrote ${spec.configPath}`)) return;
+      // Match the whole configured value, not a URL substring — `includes`
+      // on a bare URL also accepts hosts that merely embed it.
       check(
-        contents!.includes(MCP_URL),
-        'the written config carries the MCP url',
+        contents!.includes(`"${MCP_URL}"`),
+        'the written config carries exactly the MCP url',
       );
       check(
         /startup_timeout_sec\s*=/.test(contents!),

--- a/scripts/mcp-install-smoke-test.ts
+++ b/scripts/mcp-install-smoke-test.ts
@@ -1,0 +1,475 @@
+/**
+ * Runs a headless `wizard mcp add` against a real editor CLI in a throwaway HOME
+ * and asserts the config that comes out. Drives the built binary rather than
+ * importing client classes, so arg parsing and command wiring are covered too.
+ *
+ * Needs no credentials: the OAuth path writes a tokenless entry and defers auth
+ * to the editor's own login command.
+ *
+ * Usage: tsx scripts/mcp-install-smoke-test.ts --provider=claude-code|codex
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { HEADLESS_FLAG } from '../src/lib/headless-mode';
+
+const PROVIDERS = ['claude-code', 'codex'] as const;
+type Provider = (typeof PROVIDERS)[number];
+
+const MCP_URL = 'https://mcp.posthog.com/mcp';
+const WIZARD = path.resolve(
+  fileURLToPath(import.meta.url),
+  '..',
+  '..',
+  'dist',
+  'bin.js',
+);
+
+interface ProviderSpec {
+  /** Editor CLI binary, looked up on PATH. */
+  binary: string;
+  /** The login subcommand the wizard tells the user to run, minus the server name. */
+  loginProbe: string[];
+  /** Config file relative to HOME, set only when the file is the contract. */
+  configPath?: string;
+  /** Exit code of a "is posthog installed" probe against the editor itself. */
+  isInstalled: () => boolean;
+}
+
+const SPECS: Record<Provider, ProviderSpec> = {
+  'claude-code': {
+    binary: 'claude',
+    loginProbe: ['mcp', 'login', '--help'],
+    isInstalled: () => run('claude', ['mcp', 'get', 'posthog']).status === 0,
+  },
+  codex: {
+    binary: 'codex',
+    loginProbe: ['mcp', 'login', '--help'],
+    configPath: '.codex/config.toml',
+    isInstalled: () =>
+      (
+        readIfPresent(path.join(process.env.HOME!, '.codex', 'config.toml')) ??
+        ''
+      ).includes('[mcp_servers.posthog]'),
+  },
+};
+
+// ── harness ───────────────────────────────────────────────────────────────
+
+const failures: string[] = [];
+let currentScenario = '';
+
+function fail(message: string): void {
+  failures.push(`${currentScenario}: ${message}`);
+  console.log(`  ✗ ${message}`);
+}
+
+function pass(message: string): void {
+  console.log(`  ✔ ${message}`);
+}
+
+function check(condition: boolean, message: string): boolean {
+  if (condition) pass(message);
+  else fail(message);
+  return condition;
+}
+
+interface Run {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(binary: string, args: string[]): Run {
+  const r = spawnSync(binary, args, { encoding: 'utf-8' });
+  return {
+    status: r.error ? -1 : r.status ?? -1,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  };
+}
+
+/** `wizard <args>` against the built binary, inheriting the sandbox HOME. */
+function wizard(...args: string[]): Run {
+  return run(process.execPath, [WIZARD, ...args]);
+}
+
+/**
+ * The non-interactive install. Reuses the run pipeline's headless flag, so the
+ * name is imported rather than spelled out — see @lib/headless-mode.
+ */
+function mcpAdd(...extra: string[]): Run {
+  return wizard('mcp', 'add', `--${HEADLESS_FLAG}`, ...extra);
+}
+
+function mcpRemove(): Run {
+  return wizard('mcp', 'remove', `--${HEADLESS_FLAG}`);
+}
+
+/**
+ * `os.homedir()` reads $HOME on POSIX and both editor CLIs store config under
+ * it, so one env var isolates the wizard and the CLI it shells out to. A
+ * pristine dir per scenario is what a first-time user actually has.
+ */
+async function withSandboxHome(
+  spec: ProviderSpec,
+  fn: (home: string) => Promise<void>,
+): Promise<void> {
+  const realHome = process.env.HOME;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'wizard-mcp-'));
+  const before = failures.length;
+  process.env.HOME = home;
+  try {
+    await fn(home);
+  } finally {
+    // The sandbox is about to go and CI has nothing else to look at.
+    if (failures.length > before && spec.configPath) {
+      const contents = readIfPresent(path.join(home, spec.configPath));
+      console.log(
+        contents === null
+          ? `  ── ${spec.configPath} was never written ──`
+          : `  ── ${spec.configPath} ──\n${contents.replace(/^/gm, '  │ ')}`,
+      );
+    }
+    process.env.HOME = realHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function seed(home: string, relative: string, contents: string): void {
+  const target = path.join(home, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, contents);
+}
+
+function readIfPresent(file: string): string | null {
+  try {
+    return fs.readFileSync(file, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/** Asserts a clean exit, quoting the reason only when it failed. */
+function checkRun(r: Run, label: string): boolean {
+  if (r.status === 0) return check(true, label);
+  const lines = (r.stderr + r.stdout)
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  // The step prints failures as `- <client> — <detail>` under a success header,
+  // so the first line is usually the wrong one to quote.
+  const reason =
+    lines.find((l) => l.includes('—')) ?? lines[0] ?? `exit ${r.status}`;
+  return check(false, `${label} — ${reason}`);
+}
+
+// ── scenarios ─────────────────────────────────────────────────────────────
+
+/** A fresh box has no editor config directory at all — the write must create it. */
+async function scenarioFreshInstall(spec: ProviderSpec): Promise<void> {
+  await withSandboxHome(spec, async (home) => {
+    check(!spec.isInstalled(), 'reports not-installed on a fresh HOME');
+
+    const r = mcpAdd();
+    if (!checkRun(r, 'mcp add exits 0')) return;
+    check(spec.isInstalled(), 'the editor reports the server installed');
+
+    if (spec.configPath) {
+      const contents = readIfPresent(path.join(home, spec.configPath));
+      if (!check(contents !== null, `wrote ${spec.configPath}`)) return;
+      check(
+        contents!.includes(MCP_URL),
+        'the written config carries the MCP url',
+      );
+      check(
+        /startup_timeout_sec\s*=/.test(contents!),
+        'the written config carries a startup timeout',
+      );
+    }
+  });
+}
+
+/**
+ * A config the wizard is happy with and the editor rejects is the worst case:
+ * we report "installed" and the user loses every server in the file.
+ */
+async function scenarioEditorAcceptsConfig(spec: ProviderSpec): Promise<void> {
+  await withSandboxHome(spec, async () => {
+    const r = mcpAdd();
+    if (!checkRun(r, 'mcp add exits 0')) return;
+
+    check(
+      run(spec.binary, ['mcp', 'list']).status === 0,
+      `${spec.binary} mcp list parses the config (exit 0)`,
+    );
+  });
+}
+
+/** Re-running the wizard is the common case, not the edge case. */
+async function scenarioIdempotent(spec: ProviderSpec): Promise<void> {
+  await withSandboxHome(spec, async (home) => {
+    const first = mcpAdd();
+    if (!checkRun(first, 'first add exits 0')) return;
+
+    const second = mcpAdd();
+    checkRun(second, 'second add exits 0');
+    check(
+      /already installed|nothing changed/i.test(second.stdout + second.stderr),
+      'second add reports it changed nothing',
+    );
+
+    if (spec.configPath) {
+      const contents = readIfPresent(path.join(home, spec.configPath)) ?? '';
+      const sections = contents.match(/^\s*\[mcp_servers\.posthog\]/gm) ?? [];
+      // Two definitions of one TOML table is a parse error on the whole file.
+      check(
+        sections.length === 1,
+        `exactly one [mcp_servers.posthog] section (found ${sections.length})`,
+      );
+      check(
+        run(spec.binary, ['mcp', 'list']).status === 0,
+        'the editor still parses the config after a re-run',
+      );
+    }
+  });
+}
+
+/**
+ * `--features` is a documented flag. Honouring it or rejecting it are both
+ * defensible; accepting it and installing full scope anyway is not.
+ */
+async function scenarioFeaturesFlag(spec: ProviderSpec): Promise<void> {
+  await withSandboxHome(spec, async (home) => {
+    const r = mcpAdd('--features', 'flags,insights');
+    if (!checkRun(r, 'mcp add --features exits 0')) return;
+
+    // Claude Code owns its own store, so read the URL back through its CLI.
+    const url = spec.configPath
+      ? readIfPresent(path.join(home, spec.configPath)) ?? ''
+      : run(spec.binary, ['mcp', 'get', 'posthog']).stdout;
+
+    check(
+      url.includes('features=flags,insights'),
+      'the installed URL carries the requested features',
+    );
+  });
+}
+
+/** The update path is separate code from the create path, and can no-op silently. */
+async function scenarioUpdatesExistingEntry(spec: ProviderSpec): Promise<void> {
+  if (!spec.configPath) return;
+
+  await withSandboxHome(spec, async (home) => {
+    seed(
+      home,
+      spec.configPath!,
+      [
+        '[mcp_servers.unrelated]',
+        'command = "some-other-server"',
+        '',
+        '[mcp_servers.posthog]',
+        'url = "https://mcp.posthog.com/mcp?features=flags"',
+        'startup_timeout_sec = 30',
+        '',
+      ].join('\n'),
+    );
+
+    const r = mcpAdd();
+    if (!checkRun(r, 'mcp add exits 0')) return;
+
+    const contents = readIfPresent(path.join(home, spec.configPath!)) ?? '';
+    check(
+      contents.includes(`url = "${MCP_URL}"`),
+      'the stale features URL was replaced',
+    );
+    check(
+      contents.includes('[mcp_servers.unrelated]'),
+      "an unrelated user's server survived the write",
+    );
+    check(
+      run(spec.binary, ['mcp', 'list']).status === 0,
+      'the editor still parses the config after an update',
+    );
+  });
+}
+
+/**
+ * TOML does not care about key order, so anything assuming `url` sits on the
+ * line after the header reads this as "no match".
+ */
+async function scenarioUpdatesReorderedEntry(
+  spec: ProviderSpec,
+): Promise<void> {
+  if (!spec.configPath) return;
+
+  await withSandboxHome(spec, async (home) => {
+    seed(
+      home,
+      spec.configPath!,
+      [
+        '[mcp_servers.posthog]',
+        'startup_timeout_sec = 30',
+        'url = "https://mcp.posthog.com/mcp?features=flags"',
+        '',
+      ].join('\n'),
+    );
+
+    const r = mcpAdd();
+    const contents = readIfPresent(path.join(home, spec.configPath!)) ?? '';
+
+    // Rewrite it or refuse and say so; claiming success without writing is the
+    // only outcome that isn't defensible.
+    if (r.status !== 0) {
+      pass("declined to edit a key order it can't handle");
+    } else {
+      check(
+        contents.includes(`url = "${MCP_URL}"`),
+        'a reported success actually replaced the stale URL',
+      );
+    }
+  });
+}
+
+/**
+ * TOML permits a quoted table key. A substring scan for the bare form misses it
+ * and appends a second definition of the same table.
+ */
+async function scenarioQuotedTableKey(spec: ProviderSpec): Promise<void> {
+  if (!spec.configPath) return;
+
+  await withSandboxHome(spec, async (home) => {
+    seed(
+      home,
+      spec.configPath!,
+      ['[mcp_servers."posthog"]', `url = "${MCP_URL}"`, ''].join('\n'),
+    );
+
+    mcpAdd();
+
+    check(
+      run(spec.binary, ['mcp', 'list']).status === 0,
+      'the editor still parses a config that used a quoted table key',
+    );
+  });
+}
+
+/** `mcp remove` reporting success while leaving the server in place is the bug. */
+async function scenarioRemove(spec: ProviderSpec): Promise<void> {
+  await withSandboxHome(spec, async () => {
+    const added = mcpAdd();
+    if (!checkRun(added, 'mcp add exits 0')) return;
+
+    const removed = mcpRemove();
+    if (!checkRun(removed, 'mcp remove exits 0')) return;
+
+    check(!spec.isInstalled(), 'the editor reports the server gone');
+  });
+}
+
+/**
+ * The wizard prints a login command for the user to run by hand. If the editor
+ * renames that subcommand, nothing else in the build notices.
+ */
+async function scenarioLoginCommandExists(spec: ProviderSpec): Promise<void> {
+  const probe = run(spec.binary, spec.loginProbe);
+  check(
+    probe.status === 0,
+    `${spec.binary} ${spec.loginProbe.join(' ')} exists (exit 0)`,
+  );
+}
+
+// ── runner ────────────────────────────────────────────────────────────────
+
+const SCENARIOS: Array<{
+  name: string;
+  run: (spec: ProviderSpec) => Promise<void>;
+}> = [
+  { name: 'fresh install on an empty HOME', run: scenarioFreshInstall },
+  {
+    name: 'the editor can parse what we wrote',
+    run: scenarioEditorAcceptsConfig,
+  },
+  { name: 're-running the install is a no-op', run: scenarioIdempotent },
+  { name: '--features reaches the installed URL', run: scenarioFeaturesFlag },
+  { name: 'updates an existing entry', run: scenarioUpdatesExistingEntry },
+  {
+    name: 'updates an entry with reordered keys',
+    run: scenarioUpdatesReorderedEntry,
+  },
+  { name: 'survives a quoted TOML table key', run: scenarioQuotedTableKey },
+  { name: 'remove actually removes', run: scenarioRemove },
+  {
+    name: 'the login command it prints exists',
+    run: scenarioLoginCommandExists,
+  },
+];
+
+function parseProvider(): Provider {
+  const arg = process.argv
+    .find((a) => a.startsWith('--provider='))
+    ?.split('=')[1];
+  if (!arg || !(PROVIDERS as readonly string[]).includes(arg)) {
+    console.error(`Pass --provider=<${PROVIDERS.join('|')}>.`);
+    process.exit(2);
+  }
+  return arg as Provider;
+}
+
+async function main(): Promise<void> {
+  const provider = parseProvider();
+  const spec = SPECS[provider];
+
+  if (!fs.existsSync(WIZARD)) {
+    console.error(`✗ ${WIZARD} not found — run \`pnpm build\` first.`);
+    process.exit(1);
+  }
+
+  // Hard failure, not a skip — a skipped matrix leg looks green on the PR page.
+  let version: string;
+  try {
+    version = execFileSync(spec.binary, ['--version'], { encoding: 'utf-8' })
+      .trim()
+      .split('\n')[0]!;
+  } catch (err) {
+    console.error(
+      `✗ ${spec.binary} is not runnable on this machine — ${
+        (err as Error).message
+      }`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`\nMCP install smoke test — ${provider} (${version})\n`);
+
+  for (const scenario of SCENARIOS) {
+    currentScenario = scenario.name;
+    console.log(`▸ ${scenario.name}`);
+    try {
+      await scenario.run(spec);
+    } catch (err) {
+      fail(`threw — ${(err as Error).message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(
+      `\n✗ MCP install smoke test FAILED for ${provider} (${failures.length}):`,
+    );
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `\n✔ MCP install smoke test passed for ${provider} (${SCENARIOS.length} scenarios)`,
+  );
+}
+
+main().catch((err) => {
+  console.error('MCP install smoke test crashed:', err);
+  process.exit(1);
+});

--- a/src/commands/mcp/add.ts
+++ b/src/commands/mcp/add.ts
@@ -1,6 +1,7 @@
 import type { Arguments } from 'yargs';
 import { setUI } from '@ui';
 import { LoggingUI } from '@ui/logging-ui';
+import { headlessOption, isHeadless } from '@lib/headless-mode';
 import { Program } from '@lib/programs/program-registry';
 import { VERSION } from '@lib/version';
 import type { Command } from '../command';
@@ -23,6 +24,9 @@ export const mcpAddCommand: Command = {
       describe: 'PostHog personal API key (phx_xxx) for MCP authentication',
       type: 'string',
     },
+    // Reuses the run pipeline's headless flag rather than minting a public one:
+    // this stays reversible, and today the only caller is our own CI.
+    ...headlessOption,
   },
   handler: runMcpAdd,
 };
@@ -34,6 +38,16 @@ function runMcpAdd(argv: Arguments): void {
     const apiKey = (argv.apiKey as string | undefined) || readApiKeyFromEnv();
     const debug = argv.debug as boolean | undefined;
     const localMcp = argv.local as boolean | undefined;
+    const args = { local: localMcp, features, apiKey };
+
+    // Ink renders into a pipe happily and only throws on raw-mode input, so a
+    // non-TTY run reaches the confirm prompt and stalls there rather than
+    // hitting the isTUIUnavailable fallback below. The headless flag is the
+    // only reliable way to install from a script.
+    if (isHeadless(argv)) {
+      await runHeadlessAdd(args);
+      return;
+    }
 
     try {
       const { startTUI } = await import('@ui/tui/start-tui');
@@ -48,13 +62,27 @@ function runMcpAdd(argv: Arguments): void {
       });
     } catch (error) {
       if (!isTUIUnavailable(error)) throw error;
-      setUI(new LoggingUI());
-      const { addMCPServerToClientsStep } = await import(
-        '@steps/add-mcp-server-to-clients/index'
-      );
-      await addMCPServerToClientsStep({ local: localMcp, features, apiKey });
+      await runHeadlessAdd(args);
     }
   })();
+}
+
+async function runHeadlessAdd(args: {
+  local?: boolean;
+  features?: string[];
+  apiKey?: string;
+}): Promise<void> {
+  setUI(new LoggingUI());
+  const { addMCPServerToClientsStep } = await import(
+    '@steps/add-mcp-server-to-clients/index'
+  );
+  // Never forwards `ci`: headless implies session.ci elsewhere, and the step
+  // reads that as "skip MCP entirely" — the opposite of what we're here to do.
+  const { installed, failed } = await addMCPServerToClientsStep(args);
+  // A scripted caller has no screen to read, so this has to be an exit code.
+  // Any failure counts, not just a total wipeout: the step installs to every
+  // detected client, so one succeeding would otherwise mask the rest.
+  if (failed.length > 0 || installed.length === 0) process.exitCode = 1;
 }
 
 function parseFeatures(raw: unknown): string[] | undefined {

--- a/src/commands/mcp/remove.ts
+++ b/src/commands/mcp/remove.ts
@@ -1,6 +1,7 @@
 import type { Arguments } from 'yargs';
 import { setUI } from '@ui';
 import { LoggingUI } from '@ui/logging-ui';
+import { headlessOption, isHeadless } from '@lib/headless-mode';
 import { Program } from '@lib/programs/program-registry';
 import { VERSION } from '@lib/version';
 import type { Command } from '../command';
@@ -15,6 +16,8 @@ export const mcpRemoveCommand: Command = {
       describe: 'Remove local development MCP server (http://localhost:8787)',
       type: 'boolean',
     },
+    // Mirrors `mcp add` — see the note there on reusing the run pipeline's flag.
+    ...headlessOption,
   },
   handler: runMcpRemove,
 };
@@ -23,6 +26,13 @@ function runMcpRemove(argv: Arguments): void {
   void (async () => {
     const debug = argv.debug as boolean | undefined;
     const localMcp = argv.local as boolean | undefined;
+
+    // See the note in add.ts: a non-TTY run stalls on the confirm prompt
+    // instead of falling back, so scripts need an explicit flag.
+    if (isHeadless(argv)) {
+      await runHeadlessRemove(localMcp);
+      return;
+    }
 
     try {
       const { startTUI } = await import('@ui/tui/start-tui');
@@ -37,11 +47,16 @@ function runMcpRemove(argv: Arguments): void {
       // Same guard as `mcp add`: only a missing TTY falls back to LoggingUI,
       // so a genuine TUI bug surfaces instead of looking like a plain shell.
       if (!isTUIUnavailable(error)) throw error;
-      setUI(new LoggingUI());
-      const { removeMCPServerFromClientsStep } = await import(
-        '@steps/add-mcp-server-to-clients/index'
-      );
-      await removeMCPServerFromClientsStep({ local: localMcp });
+      await runHeadlessRemove(localMcp);
     }
   })();
+}
+
+/** No exit code on an empty result: nothing to remove is the requested end state. */
+async function runHeadlessRemove(local?: boolean): Promise<void> {
+  setUI(new LoggingUI());
+  const { removeMCPServerFromClientsStep } = await import(
+    '@steps/add-mcp-server-to-clients/index'
+  );
+  await removeMCPServerFromClientsStep({ local });
 }

--- a/src/steps/add-mcp-server-to-clients/clients/codex.ts
+++ b/src/steps/add-mcp-server-to-clients/clients/codex.ts
@@ -27,6 +27,37 @@ const ALREADY_INSTALLED_PATTERN =
 /** Wording that means the opposite: a cache entry exists but the plugin doesn't. */
 const STALE_MARKETPLACE_CACHE = /already added from a different source/i;
 
+/**
+ * Codex allows servers 10s to finish the MCP initialize handshake, and a remote
+ * OAuth handshake can exceed that on a cold start — the "servers were not
+ * initialized" warning.
+ */
+const STARTUP_TIMEOUT_SEC = 30;
+
+/**
+ * The server's table header. TOML accepts a bare or quoted key for the same
+ * table, and matching only the bare form means we append a second definition of
+ * a table that already exists — a duplicate-key error that takes the user's
+ * whole config down, not just PostHog's entry.
+ */
+const sectionHeader = (serverName: string): RegExp =>
+  new RegExp(
+    `^\\[mcp_servers\\.(?:${serverName}|"${serverName}")\\][ \\t]*$`,
+    'm',
+  );
+
+/**
+ * Set `key = value` inside a section body, inserting it when absent. Scans the
+ * whole body rather than the line after the header: TOML does not care about
+ * key order, and assuming it does means silently matching nothing.
+ */
+const setKey = (body: string, key: string, value: string): string => {
+  const existing = new RegExp(`^[ \\t]*${key}[ \\t]*=.*$`, 'm');
+  return existing.test(body)
+    ? body.replace(existing, `${key} = ${value}`)
+    : `\n${key} = ${value}${body}`;
+};
+
 export const CodexMCPConfig = DefaultMCPClientConfig;
 
 export type CodexMCPConfig = z.infer<typeof DefaultMCPClientConfig>;
@@ -72,12 +103,12 @@ export class CodexMCPClient
 
   isServerInstalled(local?: boolean): Promise<boolean> {
     const serverName = local ? 'posthog-local' : 'posthog';
-    // Exact `[mcp_servers.<name>]` section in config.toml — both the CLI and
-    // the desktop app read (and `codex mcp add` writes) this file, and a
-    // substring scan of `mcp list` matches unrelated posthog-ish servers.
+    // The `[mcp_servers.<name>]` section in config.toml — both the CLI and the
+    // desktop app read (and `codex mcp add` writes) this file, and a substring
+    // scan of `mcp list` matches unrelated posthog-ish servers.
     try {
       const contents = fs.readFileSync(this.configPath(), 'utf-8');
-      return Promise.resolve(contents.includes(`[mcp_servers.${serverName}]`));
+      return Promise.resolve(sectionHeader(serverName).test(contents));
     } catch {
       return Promise.resolve(false);
     }
@@ -131,41 +162,49 @@ export class CodexMCPClient
     return Promise.resolve(this.writeServerSection(serverName, url));
   }
 
-  private hasServerSection(serverName: string): boolean {
-    try {
-      return fs
-        .readFileSync(this.configPath(), 'utf-8')
-        .includes(`[mcp_servers.${serverName}]`);
-    } catch {
-      return false;
-    }
-  }
-
-  /** Append or update the `[mcp_servers.<name>]` section in config.toml. */
+  /**
+   * Create or update the `[mcp_servers.<name>]` section in config.toml, editing
+   * in place so the user's other servers, key order, and comments survive.
+   */
   private writeServerSection(serverName: string, url: string): InstallResult {
-    const header = `[mcp_servers.${serverName}]`;
+    const configPath = this.configPath();
     try {
-      const contents = fs.readFileSync(this.configPath(), 'utf-8');
-      if (contents.includes(header)) {
-        if (contents.includes(`${header}\nurl = "${url}"`)) {
-          return { success: true, alreadyInstalled: true };
-        }
-        const section = new RegExp(
-          `(\\[mcp_servers\\.${serverName}\\]\\n)url = "[^"]*"`,
-        );
-        fs.writeFileSync(
-          this.configPath(),
-          contents.replace(section, `$1url = "${url}"`),
+      // A machine that has codex installed but has never run it has no
+      // ~/.codex at all — `codex mcp add` used to create it for us.
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      const contents = fs.existsSync(configPath)
+        ? fs.readFileSync(configPath, 'utf-8')
+        : '';
+
+      const header = sectionHeader(serverName).exec(contents);
+      if (!header) {
+        const gap = contents === '' || contents.endsWith('\n\n') ? '' : '\n';
+        const pad = contents === '' || contents.endsWith('\n') ? '' : '\n';
+        this.write(
+          configPath,
+          `${contents}${pad}${gap}[mcp_servers.${serverName}]\n` +
+            `url = "${url}"\nstartup_timeout_sec = ${STARTUP_TIMEOUT_SEC}\n`,
         );
         return { success: true };
       }
-      const suffix = contents.endsWith('\n') ? '' : '\n';
-      // 30s startup budget: codex gives servers 10s to finish the MCP
-      // initialize handshake, and the remote OAuth handshake can exceed that
-      // on cold start — the "servers were not initialized" warning.
-      fs.appendFileSync(
-        this.configPath(),
-        `${suffix}\n${header}\nurl = "${url}"\nstartup_timeout_sec = 30\n`,
+
+      // Everything up to the next table header belongs to this server.
+      const start = header.index + header[0].length;
+      const rest = contents.slice(start);
+      const next = /^\[/m.exec(rest);
+      const end = next ? start + next.index : contents.length;
+
+      const body = contents.slice(start, end);
+      const updated = setKey(
+        setKey(body, 'url', `"${url}"`),
+        'startup_timeout_sec',
+        String(STARTUP_TIMEOUT_SEC),
+      );
+      if (updated === body) return { success: true, alreadyInstalled: true };
+
+      this.write(
+        configPath,
+        contents.slice(0, start) + updated + contents.slice(end),
       );
       return { success: true };
     } catch (error) {
@@ -175,6 +214,13 @@ export class CodexMCPClient
       );
       return { success: false, reason };
     }
+  }
+
+  /** Write via a sibling temp file: a crash mid-write must not truncate the config. */
+  private write(configPath: string, contents: string): void {
+    const tmp = `${configPath}.wizard-tmp`;
+    fs.writeFileSync(tmp, contents);
+    fs.renameSync(tmp, configPath);
   }
 
   /** Codex's own login runs its OAuth and owns the token; the wizard only surfaces the command. */

--- a/src/steps/add-mcp-server-to-clients/index.ts
+++ b/src/steps/add-mcp-server-to-clients/index.ts
@@ -50,6 +50,13 @@ export const getSupportedClients = async (): Promise<MCPClient[]> => {
   return supportedClients;
 };
 
+/** Per-client outcome, so a scripted caller can turn a failure into an exit code. */
+export interface McpStepOutcome {
+  /** Clients that ended up with the server, whether we wrote it or it was already there. */
+  installed: string[];
+  failed: string[];
+}
+
 /**
  * Add MCP server to clients. No prompts — pure orchestration.
  * Prompts are handled by McpScreen (TUI) or auto-accepted (CI).
@@ -68,13 +75,13 @@ export const addMCPServerToClientsStep = async ({
   cloudRegion?: CloudRegion;
   features?: string[];
   apiKey?: string;
-}): Promise<string[]> => {
+}): Promise<McpStepOutcome> => {
   const ui = getUI();
 
   // CI mode: skip MCP installation entirely
   if (ci) {
     ui.log.info('Skipping MCP installation (CI mode)');
-    return [];
+    return { installed: [], failed: [] };
   }
 
   const supportedClients = await getSupportedClients();
@@ -83,7 +90,7 @@ export const addMCPServerToClientsStep = async ({
     ui.log.info(
       'No supported MCP clients detected. Skipping MCP installation.',
     );
-    return [];
+    return { installed: [], failed: [] };
   }
 
   // Auto-install to all supported clients
@@ -132,7 +139,7 @@ export const addMCPServerToClientsStep = async ({
     integration,
   });
 
-  return withServer;
+  return { installed: withServer, failed: failed.map((r) => r.name) };
 };
 
 const bulletList = (items: string[]): string =>


### PR DESCRIPTION
piggyback off of #1122

- added test script 
- created a CI runner to test `mcp add|remove` against Codex and Claude Code
- reuses the experimental `--headless` flag to skip UI
