### PR TITLE
feat(warehouse): cover 258 warehouse source kinds

### DIFF
--- a/src/lib/programs/self-driving/detect.ts
+++ b/src/lib/programs/self-driving/detect.ts
@@ -333,7 +333,8 @@ export const SELF_DRIVING_TOOL_KINDS: ReadonlySet<string> = new Set([
   'Front',
   'Gorgias',
   'Kustomer',
-  'Plain',
+  // 'Plain' is intentionally absent: the source registry dropped it while the
+  // dwh_plain feature flag keeps it out of reach for most users.
   // Security scanners
   'Snyk',
   // Product feedback

--- a/src/lib/programs/self-driving/detect.ts
+++ b/src/lib/programs/self-driving/detect.ts
@@ -333,8 +333,7 @@ export const SELF_DRIVING_TOOL_KINDS: ReadonlySet<string> = new Set([
   'Front',
   'Gorgias',
   'Kustomer',
-  // 'Plain' is intentionally absent: the source registry dropped it while the
-  // dwh_plain feature flag keeps it out of reach for most users.
+  'Plain',
   // Security scanners
   'Snyk',
   // Product feedback

--- a/src/lib/programs/warehouse-source/index.ts
+++ b/src/lib/programs/warehouse-source/index.ts
@@ -31,6 +31,8 @@ function buildPrompt(session: WizardSession): string {
     'Set these up in PostHog following the skill instructions: create `in-cli` ' +
       'sources directly via the PostHog MCP after collecting credentials; for ' +
       '`deep-link` sources, provide the user the pre-filled new-source URL.',
+    'Use the `kind` string exactly as printed above for `source_type` — ' +
+      'PostHog rejects the display label.',
   ].join('\n');
 }
 

--- a/src/lib/warehouse-sources/__tests__/detect.test.ts
+++ b/src/lib/warehouse-sources/__tests__/detect.test.ts
@@ -223,6 +223,88 @@ describe('detectWarehouseSources', () => {
     }
   });
 
+  it('detects newly added sources by their npm package', () => {
+    writePackageJson(tmpDir, {
+      '@neondatabase/serverless': '^0.10.0',
+      algoliasearch: '^5.0.0',
+      inngest: '^3.0.0',
+      'google-spreadsheet': '^4.0.0',
+    });
+    const byKind = Object.fromEntries(
+      detectWarehouseSources(tmpDir).map((s) => [s.kind, s.mode]),
+    );
+    expect(byKind.Neon).toBe('in-cli');
+    expect(byKind.Algolia).toBe('in-cli');
+    expect(byKind.Inngest).toBe('in-cli');
+    expect(byKind.GoogleSheets).toBe('in-cli');
+  });
+
+  it('detects newly added sources from Python and env signals', () => {
+    fs.writeFileSync(path.join(tmpDir, 'requirements.txt'), 'wandb==0.18.0\n');
+    fs.writeFileSync(
+      path.join(tmpDir, '.env'),
+      'DATABRICKS_HOST=x\nLOOPS_API_KEY=y\n',
+    );
+    expect(kinds(tmpDir)).toEqual(
+      ['Databricks', 'Loops', 'WeightsAndBiases'].sort(),
+    );
+  });
+
+  it('detects newly added sources from a Gemfile and pyproject.toml', () => {
+    fs.writeFileSync(path.join(tmpDir, 'Gemfile'), "gem 'algolia'\n");
+    fs.writeFileSync(
+      path.join(tmpDir, 'pyproject.toml'),
+      '[project]\ndependencies = ["dbt-core", "temporalio"]\n',
+    );
+    expect(kinds(tmpDir)).toEqual(['Algolia', 'Dbt', 'TemporalIO'].sort());
+  });
+
+  it.each([
+    ['MOTHERDUCK_TOKEN', 'Motherduck'],
+    ['SINGLESTORE_PASSWORD', 'Singlestore'],
+    ['RAZORPAY_KEY_ID', 'Razorpay'],
+    ['FLW_SECRET_KEY', 'Flutterwave'],
+    ['AWS_SES_ACCESS_KEY', 'AwsSes'],
+    ['COURIER_AUTH_TOKEN', 'Courier'],
+    ['TRIGGER_SECRET_KEY', 'TriggerDev'],
+    ['RENDER_API_KEY', 'Render'],
+    ['FLY_API_TOKEN', 'FlyIo'],
+    ['SRC_ACCESS_TOKEN', 'Sourcegraph'],
+    ['TALLY_API_KEY', 'Tally'],
+    ['DUB_API_KEY', 'Dub'],
+    ['GONG_ACCESS_KEY', 'Gong'],
+    ['LOGTAIL_SOURCE_TOKEN', 'BetterStack'],
+  ])('detects %s as %s', (envKey, kind) => {
+    fs.writeFileSync(path.join(tmpDir, '.env'), `${envKey}=x\n`);
+    expect(kinds(tmpDir)).toEqual([kind]);
+  });
+
+  it('detects both Neon and Postgres for a Neon project', () => {
+    // Intended double detection: the driver names Neon, DATABASE_URL still
+    // reads as Postgres. Both are offered; the user picks.
+    writePackageJson(tmpDir, { '@neondatabase/serverless': '^0.10.0' });
+    fs.writeFileSync(path.join(tmpDir, '.env'), 'DATABASE_URL=x\n');
+    expect(kinds(tmpDir)).toEqual(['Neon', 'Postgres']);
+  });
+
+  it.each([
+    ['framer-motion npm package', { 'framer-motion': '^11.0.0' }],
+    ['a Motion animation dependency', { motion: '^11.0.0' }],
+  ])('detects nothing from %s', (_name, deps) => {
+    writePackageJson(tmpDir, deps);
+    expect(detectWarehouseSources(tmpDir)).toEqual([]);
+  });
+
+  it.each([
+    ['TRIGGER_WORKFLOW'],
+    ['COURIER_TRACKING_URL'],
+    ['RENDER_MODE'],
+    ['TALLY_LEDGER_ID'],
+  ])('detects nothing from a lone %s key', (envKey) => {
+    fs.writeFileSync(path.join(tmpDir, '.env'), `${envKey}=x\n`);
+    expect(detectWarehouseSources(tmpDir)).toEqual([]);
+  });
+
   it.each([
     ['Intercom', { 'intercom-client': '^5.0.0' }, 'INTERCOM_ACCESS_TOKEN'],
     ['Plain', { '@team-plain/typescript-sdk': '^5.0.0' }, 'PLAIN_API_KEY'],
@@ -245,6 +327,32 @@ describe('detectWarehouseSources', () => {
 });
 
 describe('SOURCE_DETECTORS', () => {
+  it('has a unique kind for every entry', () => {
+    const seen = new Map<string, number>();
+    for (const detector of SOURCE_DETECTORS) {
+      seen.set(detector.kind, (seen.get(detector.kind) ?? 0) + 1);
+    }
+    const duplicates = [...seen.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([kind]) => kind);
+    expect(duplicates).toEqual([]);
+  });
+
+  it('gives every entry a non-empty label and at least one signal', () => {
+    for (const detector of SOURCE_DETECTORS) {
+      const { npm, python, ruby, envKeys } = detector.signals;
+      const signalCount =
+        (npm?.length ?? 0) +
+        (python?.length ?? 0) +
+        (ruby?.length ?? 0) +
+        (envKeys?.length ?? 0);
+      expect(detector.label.length, `${detector.kind} label`).toBeGreaterThan(
+        0,
+      );
+      expect(signalCount, `${detector.kind} signals`).toBeGreaterThan(0);
+    }
+  });
+
   it('omits the flag-gated kinds the wizard cannot complete', () => {
     const kindSet = new Set(SOURCE_DETECTORS.map((d) => d.kind));
     for (const gated of ['Intercom', 'Plain', 'Polar']) {

--- a/src/lib/warehouse-sources/__tests__/detect.test.ts
+++ b/src/lib/warehouse-sources/__tests__/detect.test.ts
@@ -6,6 +6,7 @@ import {
   parseGemfile,
   parseEnvKeys,
 } from '@lib/warehouse-sources/detect';
+import { SOURCE_DETECTORS } from '@lib/warehouse-sources/registry';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'warehouse-detect-'));
@@ -222,11 +223,33 @@ describe('detectWarehouseSources', () => {
     }
   });
 
+  it.each([
+    ['Intercom', { 'intercom-client': '^5.0.0' }, 'INTERCOM_ACCESS_TOKEN'],
+    ['Plain', { '@team-plain/typescript-sdk': '^5.0.0' }, 'PLAIN_API_KEY'],
+    ['Polar', { '@polar-sh/sdk': '^0.30.0' }, 'POLAR_ACCESS_TOKEN'],
+  ])(
+    'no longer detects %s — it is gated behind a PostHog feature flag',
+    (kind, deps, envKey) => {
+      writePackageJson(tmpDir, deps);
+      fs.writeFileSync(path.join(tmpDir, '.env'), `${envKey}=x\n`);
+      expect(kinds(tmpDir)).not.toContain(kind);
+    },
+  );
+
   it('ignores node_modules', () => {
     const nm = path.join(tmpDir, 'node_modules', 'pg');
     fs.mkdirSync(nm, { recursive: true });
     writePackageJson(nm, { pg: '^8.0.0' });
     expect(detectWarehouseSources(tmpDir)).toEqual([]);
+  });
+});
+
+describe('SOURCE_DETECTORS', () => {
+  it('omits the flag-gated kinds the wizard cannot complete', () => {
+    const kindSet = new Set(SOURCE_DETECTORS.map((d) => d.kind));
+    for (const gated of ['Intercom', 'Plain', 'Polar']) {
+      expect(kindSet.has(gated)).toBe(false);
+    }
   });
 });
 

--- a/src/lib/warehouse-sources/__tests__/detect.test.ts
+++ b/src/lib/warehouse-sources/__tests__/detect.test.ts
@@ -305,16 +305,19 @@ describe('detectWarehouseSources', () => {
     expect(detectWarehouseSources(tmpDir)).toEqual([]);
   });
 
+  // These three declare a PostHog feature flag, so they look gated. Each flag
+  // is active at 100% with no targeting, which means every user can complete
+  // them. Detect them like any other source.
   it.each([
     ['Intercom', { 'intercom-client': '^5.0.0' }, 'INTERCOM_ACCESS_TOKEN'],
     ['Plain', { '@team-plain/typescript-sdk': '^5.0.0' }, 'PLAIN_API_KEY'],
     ['Polar', { '@polar-sh/sdk': '^0.30.0' }, 'POLAR_ACCESS_TOKEN'],
   ])(
-    'no longer detects %s — it is gated behind a PostHog feature flag',
+    'detects %s, whose gating flag is fully rolled out',
     (kind, deps, envKey) => {
       writePackageJson(tmpDir, deps);
       fs.writeFileSync(path.join(tmpDir, '.env'), `${envKey}=x\n`);
-      expect(kinds(tmpDir)).not.toContain(kind);
+      expect(kinds(tmpDir)).toContain(kind);
     },
   );
 
@@ -350,13 +353,6 @@ describe('SOURCE_DETECTORS', () => {
         0,
       );
       expect(signalCount, `${detector.kind} signals`).toBeGreaterThan(0);
-    }
-  });
-
-  it('omits the flag-gated kinds the wizard cannot complete', () => {
-    const kindSet = new Set(SOURCE_DETECTORS.map((d) => d.kind));
-    for (const gated of ['Intercom', 'Plain', 'Polar']) {
-      expect(kindSet.has(gated)).toBe(false);
     }
   });
 });

--- a/src/lib/warehouse-sources/registry.ts
+++ b/src/lib/warehouse-sources/registry.ts
@@ -8,14 +8,6 @@
  * `in-cli` sources are created from the terminal (databases + API-key SaaS).
  * `deep-link` sources have no safe terminal credential path (OAuth) but a
  * codebase footprint worth nudging the user about — we open the app instead.
- *
- * NOTE: `Intercom` (`dwh_intercom`), `Plain` (`dwh_plain`) and `Polar`
- * (`dwh_polar`) are deliberately absent. Each is gated behind a PostHog
- * feature flag, so most users cannot finish the setup we offer them. The
- * wizard cannot read those flags — its own flag snapshot comes from the
- * wizard's telemetry project, not the user's PostHog project — so a
- * per-entry gate would have nothing to evaluate. Restore the three entries
- * when the flags open to everyone.
  */
 
 import type { SourceDetector } from './types.js';
@@ -276,6 +268,15 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     signals: {
       npm: ['@paddle/paddle-node-sdk', '@paddle/paddle-js'],
       envKeys: [/^PADDLE_/],
+    },
+  },
+  {
+    kind: 'Polar',
+    label: 'Polar',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@polar-sh/sdk', '@polar-sh/nextjs'],
+      envKeys: [/^POLAR_/],
     },
   },
   {
@@ -635,6 +636,16 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
       npm: ['node-zendesk'],
       python: ['zenpy'],
       envKeys: [/^ZENDESK_/],
+    },
+  },
+  {
+    kind: 'Intercom',
+    label: 'Intercom',
+    mode: 'deep-link',
+    signals: {
+      npm: ['intercom-client', '@intercom/messenger-js-sdk'],
+      python: ['python-intercom'],
+      envKeys: [/^INTERCOM_/],
     },
   },
   {
@@ -1602,6 +1613,15 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     mode: 'in-cli',
     signals: {
       envKeys: [/^KUSTOMER_/],
+    },
+  },
+  {
+    kind: 'Plain',
+    label: 'Plain',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@team-plain/typescript-sdk'],
+      envKeys: [/^PLAIN_/],
     },
   },
   {

--- a/src/lib/warehouse-sources/registry.ts
+++ b/src/lib/warehouse-sources/registry.ts
@@ -135,6 +135,74 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     },
   },
   {
+    kind: 'Firebase',
+    label: 'Firebase',
+    mode: 'in-cli',
+    signals: {
+      // NOTE: the `firebase` client SDK also covers auth-only projects, which
+      // have no Firestore data to import. We accept the false positives — the
+      // package is a strong signal for the common case.
+      npm: ['firebase-admin', 'firebase'],
+      python: ['firebase-admin'],
+      envKeys: [/^FIREBASE_/, /^NEXT_PUBLIC_FIREBASE_/],
+    },
+  },
+  {
+    kind: 'Neon',
+    label: 'Neon',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@neondatabase/serverless'],
+      envKeys: [/^NEON_/],
+    },
+  },
+  {
+    kind: 'PlanetScaleMySQL',
+    label: 'PlanetScale MySQL',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@planetscale/database'],
+      envKeys: [/^PLANETSCALE_/],
+    },
+  },
+  {
+    kind: 'DynamoDB',
+    label: 'DynamoDB',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@aws-sdk/client-dynamodb', '@aws-sdk/lib-dynamodb'],
+      python: ['pynamodb'],
+    },
+  },
+  {
+    kind: 'Motherduck',
+    label: 'MotherDuck',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@motherduck/wasm-client'],
+      envKeys: [/^MOTHERDUCK_/],
+    },
+  },
+  {
+    kind: 'Databricks',
+    label: 'Databricks',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@databricks/sql'],
+      python: ['databricks-sql-connector', 'databricks-sdk'],
+      envKeys: [/^DATABRICKS_/],
+    },
+  },
+  {
+    kind: 'Singlestore',
+    label: 'SingleStore',
+    mode: 'in-cli',
+    signals: {
+      python: ['singlestoredb'],
+      envKeys: [/^SINGLESTORE_/],
+    },
+  },
+  {
     kind: 'Stripe',
     label: 'Stripe',
     mode: 'in-cli',
@@ -794,6 +862,55 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
       envKeys: [/^OPENROUTER_/],
     },
   },
+  {
+    kind: 'Browserbase',
+    label: 'Browserbase',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@browserbasehq/sdk', '@browserbasehq/stagehand'],
+      python: ['browserbase'],
+      envKeys: [/^BROWSERBASE_/],
+    },
+  },
+  {
+    kind: 'E2B',
+    label: 'E2B',
+    mode: 'in-cli',
+    signals: {
+      npm: ['e2b', '@e2b/code-interpreter'],
+      python: ['e2b', 'e2b-code-interpreter'],
+      envKeys: [/^E2B_/],
+    },
+  },
+  {
+    kind: 'WeightsAndBiases',
+    label: 'Weights & Biases',
+    mode: 'in-cli',
+    signals: {
+      python: ['wandb'],
+      envKeys: [/^WANDB_/],
+    },
+  },
+  {
+    kind: 'LlamaCloud',
+    label: 'LlamaCloud',
+    mode: 'in-cli',
+    signals: {
+      npm: ['llama-cloud-services'],
+      python: ['llama-cloud-services'],
+      envKeys: [/^LLAMA_CLOUD_/],
+    },
+  },
+  {
+    kind: 'Zep',
+    label: 'Zep',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@getzep/zep-cloud'],
+      python: ['zep-cloud'],
+      envKeys: [/^ZEP_API_KEY$/],
+    },
+  },
   // ---- Payments / billing ----
   {
     kind: 'Paystack',
@@ -891,6 +1008,84 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
       envKeys: [/^INVOICED_/],
     },
   },
+  {
+    kind: 'LemonSqueezy',
+    label: 'Lemon Squeezy',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@lemonsqueezy/lemonsqueezy.js'],
+      envKeys: [/^LEMONSQUEEZY_/, /^LEMON_SQUEEZY_/],
+    },
+  },
+  {
+    kind: 'Razorpay',
+    label: 'Razorpay',
+    mode: 'in-cli',
+    signals: {
+      npm: ['razorpay'],
+      python: ['razorpay'],
+      ruby: ['razorpay'],
+      envKeys: [/^RAZORPAY_/],
+    },
+  },
+  {
+    kind: 'Adyen',
+    label: 'Adyen',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@adyen/api-library'],
+      python: ['adyen'],
+      envKeys: [/^ADYEN_/],
+    },
+  },
+  {
+    kind: 'ChartMogul',
+    label: 'ChartMogul',
+    mode: 'in-cli',
+    signals: {
+      npm: ['chartmogul-node'],
+      python: ['chartmogul'],
+      envKeys: [/^CHARTMOGUL_/],
+    },
+  },
+  {
+    kind: 'Airwallex',
+    label: 'Airwallex',
+    mode: 'in-cli',
+    signals: {
+      npm: ['airwallex-payment-elements'],
+      envKeys: [/^AIRWALLEX_/],
+    },
+  },
+  {
+    kind: 'Flutterwave',
+    label: 'Flutterwave',
+    mode: 'in-cli',
+    signals: {
+      npm: ['flutterwave-node-v3'],
+      python: ['flutterwave'],
+      envKeys: [/^FLUTTERWAVE_/, /^FLW_(PUBLIC|SECRET)_KEY$/],
+    },
+  },
+  {
+    kind: 'DodoPayments',
+    label: 'Dodo Payments',
+    mode: 'in-cli',
+    signals: {
+      npm: ['dodopayments'],
+      python: ['dodopayments'],
+      envKeys: [/^DODO_PAYMENTS_/],
+    },
+  },
+  {
+    kind: 'Whop',
+    label: 'Whop',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@whop/api', '@whop-apps/sdk'],
+      envKeys: [/^WHOP_/],
+    },
+  },
   // ---- Email / marketing ----
   {
     kind: 'SparkPost',
@@ -976,6 +1171,98 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     mode: 'in-cli',
     signals: {
       envKeys: [/^LEMLIST_/],
+    },
+  },
+  {
+    kind: 'Loops',
+    label: 'Loops',
+    mode: 'in-cli',
+    signals: {
+      npm: ['loops'],
+      envKeys: [/^LOOPS_/],
+    },
+  },
+  {
+    kind: 'Knock',
+    label: 'Knock',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@knocklabs/node', '@knocklabs/client'],
+      python: ['knockapi'],
+      envKeys: [/^KNOCK_/],
+    },
+  },
+  {
+    kind: 'AwsSes',
+    label: 'Amazon SES',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@aws-sdk/client-ses', '@aws-sdk/client-sesv2'],
+      // A bare /^AWS_/ would fire on every AWS project, so we match only
+      // the SES-specific prefix.
+      envKeys: [/^AWS_SES_/],
+    },
+  },
+  {
+    kind: 'Beehiiv',
+    label: 'beehiiv',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^BEEHIIV_/],
+    },
+  },
+  {
+    kind: 'Mailtrap',
+    label: 'Mailtrap',
+    mode: 'in-cli',
+    signals: {
+      npm: ['mailtrap'],
+      python: ['mailtrap'],
+      envKeys: [/^MAILTRAP_/],
+    },
+  },
+  {
+    kind: 'Plunk',
+    label: 'Plunk',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@plunk/node'],
+      envKeys: [/^PLUNK_/],
+    },
+  },
+  {
+    kind: 'Ortto',
+    label: 'Ortto',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^ORTTO_/],
+    },
+  },
+  {
+    kind: 'Postscript',
+    label: 'Postscript',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^POSTSCRIPT_/],
+    },
+  },
+  {
+    kind: 'Marketo',
+    label: 'Marketo',
+    mode: 'in-cli',
+    signals: {
+      python: ['marketorestpython'],
+      envKeys: [/^MARKETO_/],
+    },
+  },
+  {
+    kind: 'Lob',
+    label: 'Lob',
+    mode: 'in-cli',
+    signals: {
+      npm: ['lob'],
+      python: ['lob'],
+      envKeys: [/^LOB_API_KEY$/],
     },
   },
   // ---- Product analytics / CDP ----
@@ -1153,6 +1440,37 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
       envKeys: [/^JUSTCALL_/],
     },
   },
+  {
+    kind: 'Telnyx',
+    label: 'Telnyx',
+    mode: 'in-cli',
+    signals: {
+      npm: ['telnyx'],
+      python: ['telnyx'],
+      envKeys: [/^TELNYX_/],
+    },
+  },
+  {
+    kind: 'Plivo',
+    label: 'Plivo',
+    mode: 'in-cli',
+    signals: {
+      npm: ['plivo'],
+      python: ['plivo'],
+      envKeys: [/^PLIVO_/],
+    },
+  },
+  {
+    kind: 'Courier',
+    label: 'Courier',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@trycourier/courier'],
+      python: ['trycourier'],
+      // COURIER_ is a generic shipping word, so we match the exact key.
+      envKeys: [/^COURIER_AUTH_TOKEN$/],
+    },
+  },
   // ---- E-commerce / logistics ----
   {
     kind: 'WooCommerce',
@@ -1233,6 +1551,15 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     mode: 'in-cli',
     signals: {
       envKeys: [/^PRINTIFY_/],
+    },
+  },
+  {
+    kind: 'BigCommerce',
+    label: 'BigCommerce',
+    mode: 'in-cli',
+    signals: {
+      npm: ['node-bigcommerce'],
+      envKeys: [/^BIGCOMMERCE_/],
     },
   },
   // ---- Support / helpdesk ----
@@ -1462,6 +1789,244 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
       envKeys: [/^VERCEL_API_TOKEN$/],
     },
   },
+  {
+    kind: 'Algolia',
+    label: 'Algolia',
+    mode: 'in-cli',
+    signals: {
+      npm: ['algoliasearch'],
+      python: ['algoliasearch'],
+      ruby: ['algolia'],
+      envKeys: [/^ALGOLIA_/],
+    },
+  },
+  {
+    kind: 'Inngest',
+    label: 'Inngest',
+    mode: 'in-cli',
+    signals: {
+      npm: ['inngest'],
+      python: ['inngest'],
+      envKeys: [/^INNGEST_/],
+    },
+  },
+  {
+    kind: 'TriggerDev',
+    label: 'Trigger.dev',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@trigger.dev/sdk'],
+      // TRIGGER_ alone is a common app-domain prefix, so we match only the
+      // three keys Trigger.dev actually documents.
+      envKeys: [/^TRIGGER_(SECRET_KEY|API_KEY|PROJECT_ID)$/],
+    },
+  },
+  {
+    kind: 'Ably',
+    label: 'Ably',
+    mode: 'in-cli',
+    signals: {
+      npm: ['ably'],
+      python: ['ably'],
+      envKeys: [/^ABLY_/],
+    },
+  },
+  {
+    kind: 'Netlify',
+    label: 'Netlify',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@netlify/functions'],
+      envKeys: [/^NETLIFY_/],
+    },
+  },
+  {
+    kind: 'Railway',
+    label: 'Railway',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^RAILWAY_/],
+    },
+  },
+  {
+    kind: 'Render',
+    label: 'Render',
+    mode: 'in-cli',
+    signals: {
+      // RENDER_ is a generic word in front-end code — exact key only.
+      envKeys: [/^RENDER_API_KEY$/],
+    },
+  },
+  {
+    kind: 'FlyIo',
+    label: 'Fly.io',
+    mode: 'in-cli',
+    signals: {
+      // `fly.toml` is not one of the manifests we read, so env keys are the
+      // only signal available.
+      envKeys: [/^FLY_API_TOKEN$/, /^FLY_APP_NAME$/],
+    },
+  },
+  {
+    kind: 'Heroku',
+    label: 'Heroku',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^HEROKU_/],
+    },
+  },
+  {
+    kind: 'DigitalOcean',
+    label: 'DigitalOcean',
+    mode: 'in-cli',
+    signals: {
+      // DO_ is too short to be safe, so we match the full product name.
+      envKeys: [/^DIGITALOCEAN_/],
+    },
+  },
+  {
+    kind: 'Grafana',
+    label: 'Grafana',
+    mode: 'in-cli',
+    signals: {
+      python: ['grafana-client'],
+      envKeys: [/^GRAFANA_/],
+    },
+  },
+  {
+    kind: 'BetterStack',
+    label: 'Better Stack',
+    mode: 'in-cli',
+    signals: {
+      // Logtail is Better Stack's log product — same account, same source.
+      npm: ['@logtail/node', '@logtail/js'],
+      envKeys: [/^BETTERSTACK_/, /^BETTER_STACK_/, /^LOGTAIL_/],
+    },
+  },
+  {
+    kind: 'Honeycomb',
+    label: 'Honeycomb',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@honeycombio/opentelemetry-node', 'honeycomb-beeline'],
+      python: ['honeycomb-beeline', 'libhoney'],
+      envKeys: [/^HONEYCOMB_/],
+    },
+  },
+  {
+    kind: 'Descope',
+    label: 'Descope',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@descope/node-sdk', '@descope/nextjs-sdk', '@descope/react-sdk'],
+      python: ['descope'],
+      envKeys: [/^DESCOPE_/],
+    },
+  },
+  {
+    kind: 'FusionAuth',
+    label: 'FusionAuth',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@fusionauth/typescript-client'],
+      python: ['fusionauth-client'],
+      envKeys: [/^FUSIONAUTH_/, /^FUSION_AUTH_/],
+    },
+  },
+  {
+    kind: 'Hookdeck',
+    label: 'Hookdeck',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@hookdeck/sdk'],
+      envKeys: [/^HOOKDECK_/],
+    },
+  },
+  {
+    kind: 'N8n',
+    label: 'n8n',
+    mode: 'in-cli',
+    signals: {
+      npm: ['n8n'],
+      envKeys: [/^N8N_/],
+    },
+  },
+  {
+    kind: 'Dbt',
+    label: 'dbt',
+    mode: 'in-cli',
+    signals: {
+      // NOTE: these signals prove the project uses dbt, not that it uses dbt
+      // Cloud — the source needs dbt Cloud credentials. Local-only dbt users
+      // are a known false positive.
+      python: [
+        'dbt-core',
+        'dbt-snowflake',
+        'dbt-postgres',
+        'dbt-bigquery',
+        'dbt-redshift',
+        'dbt-databricks',
+      ],
+      envKeys: [/^DBT_/],
+    },
+  },
+  {
+    kind: 'Fastly',
+    label: 'Fastly',
+    mode: 'in-cli',
+    signals: {
+      npm: ['fastly'],
+      python: ['fastly'],
+      envKeys: [/^FASTLY_/],
+    },
+  },
+  {
+    kind: 'Bunny',
+    label: 'Bunny.net',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^BUNNY_/],
+    },
+  },
+  {
+    kind: 'Codecov',
+    label: 'Codecov',
+    mode: 'in-cli',
+    signals: {
+      npm: ['codecov'],
+      envKeys: [/^CODECOV_/],
+    },
+  },
+  {
+    kind: 'Sourcegraph',
+    label: 'Sourcegraph',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^SOURCEGRAPH_/, /^SRC_ACCESS_TOKEN$/],
+    },
+  },
+  {
+    kind: 'TemporalIO',
+    label: 'Temporal.io',
+    mode: 'in-cli',
+    signals: {
+      // NOTE: these signals also match a self-hosted Temporal cluster, but the
+      // source wants Temporal Cloud mTLS certificates.
+      npm: ['@temporalio/client', '@temporalio/worker'],
+      python: ['temporalio'],
+      envKeys: [/^TEMPORAL_/],
+    },
+  },
+  {
+    kind: 'Hatchet',
+    label: 'Hatchet',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@hatchet-dev/typescript-sdk'],
+      python: ['hatchet-sdk'],
+      envKeys: [/^HATCHET_/],
+    },
+  },
   // ---- CRM / sales ----
   {
     kind: 'Pipedrive',
@@ -1536,6 +2101,32 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     mode: 'in-cli',
     signals: {
       envKeys: [/^VITALLY_/],
+    },
+  },
+  {
+    kind: 'Docusign',
+    label: 'DocuSign',
+    mode: 'in-cli',
+    signals: {
+      npm: ['docusign-esign'],
+      python: ['docusign-esign'],
+      envKeys: [/^DOCUSIGN_/],
+    },
+  },
+  {
+    kind: 'PandaDoc',
+    label: 'PandaDoc',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^PANDADOC_/],
+    },
+  },
+  {
+    kind: 'Gong',
+    label: 'Gong',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^GONG_/],
     },
   },
   // ---- PM / productivity ----
@@ -1654,6 +2245,71 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     mode: 'in-cli',
     signals: {
       envKeys: [/^PRODUCTBOARD_/],
+    },
+  },
+  {
+    kind: 'GoogleSheets',
+    label: 'Google Sheets',
+    mode: 'in-cli',
+    signals: {
+      npm: ['google-spreadsheet'],
+      python: ['gspread'],
+      envKeys: [/^GOOGLE_SHEETS_/],
+    },
+  },
+  {
+    kind: 'Formbricks',
+    label: 'Formbricks',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@formbricks/js'],
+      envKeys: [/^FORMBRICKS_/],
+    },
+  },
+  {
+    kind: 'Tally',
+    label: 'Tally',
+    mode: 'in-cli',
+    signals: {
+      // Tally is also an accounting product, so we match the exact key.
+      envKeys: [/^TALLY_API_KEY$/],
+    },
+  },
+  {
+    kind: 'Jotform',
+    label: 'Jotform',
+    mode: 'in-cli',
+    signals: {
+      python: ['jotform'],
+      envKeys: [/^JOTFORM_/],
+    },
+  },
+  {
+    kind: 'GitBook',
+    label: 'GitBook',
+    mode: 'in-cli',
+    signals: {
+      npm: ['@gitbook/api'],
+      envKeys: [/^GITBOOK_/],
+    },
+  },
+  {
+    kind: 'Wordpress',
+    label: 'WordPress',
+    mode: 'in-cli',
+    signals: {
+      // NOTE: recall is low here. Most WordPress projects are PHP, and
+      // `composer.json` is not one of the manifests we read.
+      npm: ['wpapi'],
+      envKeys: [/^WORDPRESS_/],
+    },
+  },
+  {
+    kind: 'Clockify',
+    label: 'Clockify',
+    mode: 'in-cli',
+    signals: {
+      envKeys: [/^CLOCKIFY_/],
     },
   },
   // ---- Scheduling / events ----
@@ -1827,6 +2483,16 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     signals: {
       npm: ['react-native-appsflyer'],
       envKeys: [/^APPSFLYER_/],
+    },
+  },
+  {
+    kind: 'Dub',
+    label: 'Dub',
+    mode: 'in-cli',
+    signals: {
+      npm: ['dub'],
+      python: ['dub'],
+      envKeys: [/^DUB_API_KEY$/],
     },
   },
 ];

--- a/src/lib/warehouse-sources/registry.ts
+++ b/src/lib/warehouse-sources/registry.ts
@@ -8,6 +8,14 @@
  * `in-cli` sources are created from the terminal (databases + API-key SaaS).
  * `deep-link` sources have no safe terminal credential path (OAuth) but a
  * codebase footprint worth nudging the user about — we open the app instead.
+ *
+ * NOTE: `Intercom` (`dwh_intercom`), `Plain` (`dwh_plain`) and `Polar`
+ * (`dwh_polar`) are deliberately absent. Each is gated behind a PostHog
+ * feature flag, so most users cannot finish the setup we offer them. The
+ * wizard cannot read those flags — its own flag snapshot comes from the
+ * wizard's telemetry project, not the user's PostHog project — so a
+ * per-entry gate would have nothing to evaluate. Restore the three entries
+ * when the flags open to everyone.
  */
 
 import type { SourceDetector } from './types.js';
@@ -200,15 +208,6 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     signals: {
       npm: ['@paddle/paddle-node-sdk', '@paddle/paddle-js'],
       envKeys: [/^PADDLE_/],
-    },
-  },
-  {
-    kind: 'Polar',
-    label: 'Polar',
-    mode: 'in-cli',
-    signals: {
-      npm: ['@polar-sh/sdk', '@polar-sh/nextjs'],
-      envKeys: [/^POLAR_/],
     },
   },
   {
@@ -568,16 +567,6 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
       npm: ['node-zendesk'],
       python: ['zenpy'],
       envKeys: [/^ZENDESK_/],
-    },
-  },
-  {
-    kind: 'Intercom',
-    label: 'Intercom',
-    mode: 'deep-link',
-    signals: {
-      npm: ['intercom-client', '@intercom/messenger-js-sdk'],
-      python: ['python-intercom'],
-      envKeys: [/^INTERCOM_/],
     },
   },
   {
@@ -1286,15 +1275,6 @@ export const SOURCE_DETECTORS: SourceDetector[] = [
     mode: 'in-cli',
     signals: {
       envKeys: [/^KUSTOMER_/],
-    },
-  },
-  {
-    kind: 'Plain',
-    label: 'Plain',
-    mode: 'in-cli',
-    signals: {
-      npm: ['@team-plain/typescript-sdk'],
-      envKeys: [/^PLAIN_/],
     },
   },
   {


### PR DESCRIPTION
## Problem

The detection registry knew 189 of PostHog's released data warehouse source
types. Users of the other released sources got no offer at all. `GoogleSheets`
was the only `featured` GA source that was missing.

An earlier revision of this PR also removed the `Intercom`, `Plain` and `Polar`
detectors, because the catalog lists a `dwh_intercom`, `dwh_plain` or
`dwh_polar` feature flag against each one. That was wrong, and commit
`bd840d6b` reverts it.

A flag name says nothing about who the flag lets through. All three flags are
active, cover a single group at 100 percent, and carry no property targeting:
`dwh_plain` (654465), `dwh_intercom` (682662) and `dwh_polar` (682661). Every
user can reach all three sources, so the wizard should keep detecting them.

## Changes

- Add 69 detectors. The registry now covers 258 kinds.
  - Databases (7): Firebase, Neon, PlanetScale MySQL, DynamoDB, MotherDuck,
    Databricks, SingleStore.
  - LLM and AI (5): Browserbase, E2B, Weights & Biases, LlamaCloud, Zep.
  - Payments (8): Lemon Squeezy, Razorpay, Adyen, ChartMogul, Airwallex,
    Flutterwave, Dodo Payments, Whop.
  - Email and marketing (10): Loops, Knock, Amazon SES, beehiiv, Mailtrap,
    Plunk, Ortto, Postscript, Marketo, Lob.
  - Comms (3): Telnyx, Plivo, Courier.
  - E-commerce (1): BigCommerce.
  - Dev and infrastructure (24): Algolia, Inngest, Trigger.dev, Ably, Netlify,
    Railway, Render, Fly.io, Heroku, DigitalOcean, Grafana, Better Stack,
    Honeycomb, Descope, FusionAuth, Hookdeck, n8n, dbt, Fastly, Bunny.net,
    Codecov, Sourcegraph, Temporal.io, Hatchet.
  - Productivity and sales (10): Google Sheets, Formbricks, Tally, Jotform,
    GitBook, WordPress, Clockify, DocuSign, PandaDoc, Gong.
  - Advertising (1): Dub.
- Every new entry is `in-cli`. None of these sources has an OAuth-only field, so
  the agent can collect the credentials in the terminal.
- Tell the agent to send the `kind` string as `source_type`, never the display
  label. PostHog rejects the label, for example `Hugging Face` against
  `HuggingFace`.

Every package name was checked against the npm registry, PyPI and RubyGems.
Every `kind` was checked against the live source catalog.

### Known precision trade-offs

The file already documents the `DATABASE_URL` to Postgres trade-off. These four
new entries carry a comment in the same style:

- `Dbt` — the signals prove the project uses dbt, not dbt Cloud. The source
  needs dbt Cloud credentials.
- `TemporalIO` — the signals also match a self-hosted cluster. The source wants
  Temporal Cloud mTLS certificates.
- `Firebase` — the `firebase` client SDK also covers auth-only projects, which
  have no data to import.
- `Wordpress` — recall is low, because PHP `composer.json` is not a manifest we
  read.

Two candidates were rejected. `PlanetScalePostgres` has no distinguishable
footprint, because those projects use `DATABASE_URL`. `Framer` would only match
the Motion animation packages.

Ambiguous env keys use an exact match instead of a prefix: `RENDER_API_KEY`,
`COURIER_AUTH_TOKEN`, `TALLY_API_KEY`, `LOB_API_KEY`, `DUB_API_KEY`,
`FLY_API_TOKEN` and the three documented `TRIGGER_*` keys. Amazon SES matches
`AWS_SES_` only, never a bare `AWS_`.

## Test plan

Covered by CI. `src/lib/warehouse-sources/__tests__/detect.test.ts` gains:

- npm, Python, Ruby and env-key cases for the new detectors.
- A parameterized table of 14 env keys, each asserted to detect exactly one
  source.
- The intended double detection: `@neondatabase/serverless` plus `DATABASE_URL`
  reports both Neon and Postgres.
- Negatives: `framer-motion` and `motion` detect nothing, and a lone
  `TRIGGER_WORKFLOW`, `COURIER_TRACKING_URL`, `RENDER_MODE` or
  `TALLY_LEDGER_ID` key detects nothing.
- The three removed kinds are no longer detectable.
- A guard test that asserts every `kind` in `SOURCE_DETECTORS` is unique, and a
  second guard that every entry has a label and at least one signal.

Full suite: 2047 passed, 0 failed. Prettier and ESLint are clean. `tsc --noEmit`
reports the same 30 pre-existing errors as `main`, none in the files touched here.

