### PR TITLE
fix(wizard-ask): count the batching nudge per subject, not per run

### DIFF
--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -4,13 +4,18 @@ import * as path from 'path';
 import { zipSync } from 'fflate';
 import {
   ASK_BATCH_THRESHOLD,
+  ASK_SUBJECT_UNSPECIFIED,
   DEFAULT_ASK_MAX_QUESTIONS,
+  WIZARD_ASK_SUBJECT_DESCRIPTION,
+  WIZARD_ASK_TOOL_DESCRIPTION,
   WIZARD_TOOL_NAMES,
   __test,
+  createAskAccounting,
   ensureGitignoreCoverage,
   evaluateAskCap,
   fetchSkillMenu,
   mergeEnvValues,
+  normaliseAskSubject,
   parseEnvKeys,
   resolveEnvPath,
 } from '@lib/wizard-tools';
@@ -311,61 +316,309 @@ describe('WIZARD_TOOL_NAMES', () => {
   });
 });
 
-describe('evaluateAskCap', () => {
-  const MAX = DEFAULT_ASK_MAX_QUESTIONS;
-
-  it('allows calls under both the adjacency threshold and the max cap', () => {
-    for (let i = 0; i < ASK_BATCH_THRESHOLD; i++) {
-      expect(evaluateAskCap(i, MAX)).toEqual({ kind: 'ok' });
+describe('normaliseAskSubject', () => {
+  it('collapses an absent, blank or whitespace subject to one shared key', () => {
+    for (const raw of [undefined, '', '   ', '\n\t']) {
+      expect(normaliseAskSubject(raw)).toBe(ASK_SUBJECT_UNSPECIFIED);
     }
   });
 
-  it('returns the adjacency nudge once the threshold is hit', () => {
-    expect(evaluateAskCap(ASK_BATCH_THRESHOLD, MAX)).toEqual({
+  it('folds case and surrounding whitespace so one source is one subject', () => {
+    expect(normaliseAskSubject('Postgres')).toBe('postgres');
+    expect(normaliseAskSubject('  POSTGRES  ')).toBe('postgres');
+    expect(normaliseAskSubject('postgres')).toBe('postgres');
+  });
+
+  it('truncates instead of rejecting an over-long subject', () => {
+    // A rejected subject would fail the whole ask; the agent must never lose a
+    // credential prompt because it wrote a verbose tag.
+    const long = 'x'.repeat(200);
+    expect(normaliseAskSubject(long)).toHaveLength(60);
+  });
+});
+
+describe('evaluateAskCap', () => {
+  const MAX = DEFAULT_ASK_MAX_QUESTIONS;
+  const at = (over: Partial<Parameters<typeof evaluateAskCap>[0]>) =>
+    evaluateAskCap({
+      callCount: 0,
+      maxQuestions: MAX,
+      subject: 'postgres',
+      subjectRunLength: 0,
+      ...over,
+    });
+
+  it('allows calls under both the adjacency threshold and the max cap', () => {
+    for (let i = 0; i < ASK_BATCH_THRESHOLD; i++) {
+      expect(at({ callCount: i, subjectRunLength: i })).toEqual({ kind: 'ok' });
+    }
+  });
+
+  it('returns the adjacency nudge once one subject repeats to the threshold', () => {
+    expect(
+      at({
+        callCount: ASK_BATCH_THRESHOLD,
+        subjectRunLength: ASK_BATCH_THRESHOLD,
+      }),
+    ).toEqual({
       kind: 'capped',
       reason: 'adjacency',
+      subject: 'postgres',
+      subjectRunLength: ASK_BATCH_THRESHOLD,
       message: expect.stringMatching(/batch/i),
     });
+  });
+
+  it('never nudges a call whose subject run is still short, however many calls ran', () => {
+    // The warehouse task asks once per detected source: many calls, run
+    // length 0 every time. It must never be interrupted.
+    for (let i = 0; i < MAX; i++) {
+      expect(at({ callCount: i, subjectRunLength: 0 })).toEqual({ kind: 'ok' });
+    }
   });
 
   it('frames the adjacency nudge as retryable, not a refusal', () => {
     // Agents abandon the source to browser fallback when this reads as a hard
     // error — it must not start with "Error" and must say the ask can be re-sent.
-    const decision = evaluateAskCap(ASK_BATCH_THRESHOLD, MAX);
+    const decision = at({ subjectRunLength: ASK_BATCH_THRESHOLD });
     if (decision.kind !== 'capped') throw new Error('expected capped');
     expect(decision.message).not.toMatch(/^Error/);
     expect(decision.message).toMatch(/not an error/i);
     expect(decision.message).toMatch(/not sent|again/i);
+    expect(decision.message).toMatch(/do not abandon the task/i);
+  });
+
+  it('tells the agent to re-tag rather than to squeeze sources into one call', () => {
+    // The old message told the agent to fit every remaining question into a
+    // single 8-question call. With 5 sources left that is arithmetically
+    // impossible, so the agent fell back to browser links instead.
+    const decision = at({ subjectRunLength: ASK_BATCH_THRESHOLD });
+    if (decision.kind !== 'capped') throw new Error('expected capped');
+    expect(decision.message).toMatch(/different `subject`/);
+    expect(decision.message).toMatch(/per subject/i);
+    expect(decision.message).toMatch(/one call per source is never blocked/i);
+  });
+
+  it('names the repeated subject so the agent knows which one to batch', () => {
+    const decision = at({ subject: 'stripe', subjectRunLength: 4 });
+    if (decision.kind !== 'capped') throw new Error('expected capped');
+    expect(decision.message).toContain('"stripe"');
+    expect(decision.message).toContain('4 wizard_ask calls in a row');
+  });
+
+  it('explains the missing-subject case instead of quoting a placeholder', () => {
+    const decision = at({
+      subject: ASK_SUBJECT_UNSPECIFIED,
+      subjectRunLength: ASK_BATCH_THRESHOLD,
+    });
+    if (decision.kind !== 'capped') throw new Error('expected capped');
+    expect(decision.message).toMatch(/declared no `subject`/);
+    expect(decision.message).not.toContain(`"${ASK_SUBJECT_UNSPECIFIED}"`);
   });
 
   it('fires the adjacency nudge only once — later calls proceed up to the cap', () => {
     // After the nudge is recorded, calls between the threshold and the cap
     // go through; otherwise caps above the threshold would be unreachable.
     for (let i = ASK_BATCH_THRESHOLD; i < MAX; i++) {
-      expect(evaluateAskCap(i, MAX, true)).toEqual({ kind: 'ok' });
+      expect(
+        at({ callCount: i, subjectRunLength: i, adjacencyNudged: true }),
+      ).toEqual({ kind: 'ok' });
     }
-    expect(evaluateAskCap(MAX, MAX, true)).toEqual({
+    expect(
+      at({ callCount: MAX, subjectRunLength: MAX, adjacencyNudged: true }),
+    ).toMatchObject({ kind: 'capped', reason: 'max_questions' });
+  });
+
+  it('escalates to the max_questions reason once the cap is reached', () => {
+    expect(at({ callCount: MAX })).toEqual({
       kind: 'capped',
       reason: 'max_questions',
+      subject: 'postgres',
+      subjectRunLength: 0,
       message: expect.stringMatching(/cap reached/i),
     });
   });
 
-  it('escalates to the max_questions reason once the cap is reached', () => {
-    expect(evaluateAskCap(MAX, MAX)).toEqual({
+  it('keeps the per-run cap hard even when every call has a fresh subject', () => {
+    // Subjects relax adjacency only. They must never widen the run budget.
+    expect(at({ callCount: MAX, subjectRunLength: 0 })).toMatchObject({
       kind: 'capped',
       reason: 'max_questions',
-      message: expect.stringMatching(/cap reached/i),
     });
   });
 
   it('honors a custom maxQuestions override smaller than the adjacency threshold', () => {
     // With maxQuestions=2 (below ASK_BATCH_THRESHOLD), the per-run cap wins.
-    expect(evaluateAskCap(2, 2)).toEqual({
+    expect(
+      at({ callCount: 2, maxQuestions: 2, subjectRunLength: 2 }),
+    ).toMatchObject({ kind: 'capped', reason: 'max_questions' });
+  });
+});
+
+describe('createAskAccounting', () => {
+  const MAX = DEFAULT_ASK_MAX_QUESTIONS;
+
+  /** Send `n` calls for `subject`, asserting each was allowed through. */
+  const sendAllowed = (
+    acc: ReturnType<typeof createAskAccounting>,
+    subject: string | undefined,
+    n: number,
+  ) => {
+    for (let i = 0; i < n; i++) {
+      expect(acc.evaluate(subject)).toEqual({ kind: 'ok' });
+      acc.record(subject);
+    }
+  };
+
+  it('lets a five-source warehouse run ask once per source without a nudge', () => {
+    // The exact shape the telemetry showed failing: 5 in-cli sources, one
+    // batched credential call each. Every call must go through.
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, 'Postgres', 1);
+    sendAllowed(acc, 'Stripe', 1);
+    sendAllowed(acc, 'MySQL', 1);
+    sendAllowed(acc, 'Hubspot', 1);
+    sendAllowed(acc, 'Snowflake', 1);
+    expect(acc.snapshot()).toMatchObject({
+      callCount: 5,
+      subjectRunLength: 1,
+      adjacencyNudged: false,
+    });
+  });
+
+  it('still nudges an agent that machine-guns one subject', () => {
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, 'Postgres', ASK_BATCH_THRESHOLD);
+    const decision = acc.evaluate('Postgres');
+    expect(decision).toMatchObject({ kind: 'capped', reason: 'adjacency' });
+  });
+
+  it('still nudges an agent that declares no subject at all', () => {
+    // The guard's original run-wide behaviour is the default, so an agent that
+    // opts out of subjects gains nothing.
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, undefined, ASK_BATCH_THRESHOLD);
+    expect(acc.evaluate(undefined)).toMatchObject({
+      kind: 'capped',
+      reason: 'adjacency',
+      subject: ASK_SUBJECT_UNSPECIFIED,
+    });
+  });
+
+  it('treats differently-cased spellings of one subject as the same run', () => {
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, 'Postgres', 1);
+    sendAllowed(acc, ' postgres ', 1);
+    sendAllowed(acc, 'POSTGRES', 1);
+    expect(acc.evaluate('postgres')).toMatchObject({
+      kind: 'capped',
+      reason: 'adjacency',
+    });
+  });
+
+  it('resets the run when a different subject interleaves', () => {
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, 'Postgres', 2);
+    sendAllowed(acc, 'Stripe', 1);
+    sendAllowed(acc, 'Postgres', 2);
+    expect(acc.snapshot()).toMatchObject({
+      subject: 'postgres',
+      subjectRunLength: 2,
+      adjacencyNudged: false,
+    });
+  });
+
+  it('does not advance the run for a call the nudge blocked', () => {
+    // The blocked call never reached the user, so it must not count.
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, 'Postgres', ASK_BATCH_THRESHOLD);
+    expect(acc.evaluate('Postgres')).toMatchObject({ reason: 'adjacency' });
+    expect(acc.snapshot()).toMatchObject({
+      callCount: ASK_BATCH_THRESHOLD,
+      subjectRunLength: ASK_BATCH_THRESHOLD,
+      adjacencyNudged: true,
+    });
+  });
+
+  it('fires the nudge once per run, then lets the same subject through', () => {
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, 'Postgres', ASK_BATCH_THRESHOLD);
+    expect(acc.evaluate('Postgres')).toMatchObject({ reason: 'adjacency' });
+    sendAllowed(acc, 'Postgres', 1);
+    expect(acc.evaluate('Postgres')).toEqual({ kind: 'ok' });
+  });
+
+  it('refunds a cancelled ask on both the run total and the subject run', () => {
+    // The skill promises a declined ask is free. A refund that only rolled back
+    // the total would still push the subject towards the nudge.
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, 'Postgres', 1);
+    acc.record('Postgres');
+    acc.refund('Postgres');
+    expect(acc.snapshot()).toMatchObject({
+      callCount: 1,
+      subjectRunLength: 1,
+    });
+  });
+
+  it('never lets repeated cancellations exhaust the per-run cap', () => {
+    const acc = createAskAccounting(2);
+    for (let i = 0; i < 20; i++) {
+      expect(acc.evaluate('Postgres')).toEqual({ kind: 'ok' });
+      acc.record('Postgres');
+      acc.refund('Postgres');
+    }
+    expect(acc.snapshot()).toMatchObject({ callCount: 0, subjectRunLength: 0 });
+  });
+
+  it('clamps a refund that has nothing left to refund', () => {
+    const acc = createAskAccounting(MAX);
+    acc.refund('Postgres');
+    acc.refund('Postgres');
+    expect(acc.snapshot()).toMatchObject({ callCount: 0, subjectRunLength: 0 });
+  });
+
+  it('refunds only the subject it was given', () => {
+    const acc = createAskAccounting(MAX);
+    sendAllowed(acc, 'Postgres', 2);
+    acc.refund('Stripe');
+    expect(acc.snapshot()).toMatchObject({
+      callCount: 1,
+      subject: 'postgres',
+      subjectRunLength: 2,
+    });
+  });
+
+  it('stops the run at maxQuestions however many subjects were used', () => {
+    const acc = createAskAccounting(4);
+    sendAllowed(acc, 'Postgres', 1);
+    sendAllowed(acc, 'Stripe', 1);
+    sendAllowed(acc, 'MySQL', 1);
+    sendAllowed(acc, 'Hubspot', 1);
+    expect(acc.evaluate('Snowflake')).toMatchObject({
       kind: 'capped',
       reason: 'max_questions',
-      message: expect.any(String),
     });
+  });
+});
+
+describe('wizard_ask shared descriptions', () => {
+  it('tells the agent that walking a list is expected, not capped', () => {
+    expect(WIZARD_ASK_TOOL_DESCRIPTION).toMatch(/`subject`/);
+    expect(WIZARD_ASK_TOOL_DESCRIPTION).toMatch(/per subject/i);
+    expect(WIZARD_ASK_TOOL_DESCRIPTION).toMatch(/never blocked/i);
+  });
+
+  it('keeps the cancellation promise the warehouse skill relies on', () => {
+    expect(WIZARD_ASK_TOOL_DESCRIPTION).toMatch(
+      /cancelled or timed-out response does NOT count/,
+    );
+  });
+
+  it('explains what a subject is and what omitting it costs', () => {
+    expect(WIZARD_ASK_SUBJECT_DESCRIPTION).toMatch(/Postgres/);
+    expect(WIZARD_ASK_SUBJECT_DESCRIPTION).toMatch(/consecutive calls/i);
+    expect(WIZARD_ASK_SUBJECT_DESCRIPTION).toMatch(/Omit it/);
   });
 });
 

--- a/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/tools.test.ts
@@ -15,11 +15,19 @@ import {
 import { createWizardPiTools } from '../tools';
 import { evaluateToolCall } from '../security';
 import { allowedPiCodingTools, allowedOrchestratorTools } from '../task';
-import { WIZARD_ASK_SENSITIVE_DESCRIPTION } from '@lib/wizard-tools/tools';
+import {
+  ASK_BATCH_THRESHOLD,
+  WIZARD_ASK_SENSITIVE_DESCRIPTION,
+  WIZARD_ASK_SUBJECT_DESCRIPTION,
+  WIZARD_ASK_TOOL_DESCRIPTION,
+} from '@lib/wizard-tools/tools';
 
 const SECRET = 'phx_live_zendesk_token_123';
 
-const makeTools = (answers: Record<string, string | string[]>) => {
+const makeTools = (
+  answers: Record<string, string | string[]>,
+  maxQuestions?: number,
+) => {
   const request = vi.fn().mockResolvedValue(answers);
   const workingDirectory = mkdtempSync(join(tmpdir(), 'pi-tools-vault-'));
   const tools = createWizardPiTools({
@@ -27,6 +35,7 @@ const makeTools = (answers: Record<string, string | string[]>) => {
     skillsBaseUrl: 'http://localhost:0',
     askBridge: { request } as unknown as WizardAskBridge,
     triageProvider: undefined,
+    maxQuestions,
   });
   const byName = (name: string) => {
     const tool = tools.find((t) => t.name === name);
@@ -122,6 +131,107 @@ describe('pi wizard_ask — sensitive answers are vaulted', () => {
     expect(desc).toBe(WIZARD_ASK_SENSITIVE_DESCRIPTION);
     expect(desc).toMatch(/data-warehouse tools/);
     expect(desc).toMatch(/reject it/);
+  });
+});
+
+describe('pi wizard_ask — the batching guard counts per subject', () => {
+  /** One credential-style question, so each call is a realistic source ask. */
+  const ask = (wizardAsk: { execute: unknown }, subject?: string) =>
+    call(wizardAsk, {
+      questions: [{ id: 'host', prompt: 'Database host?', kind: 'text' }],
+      ...(subject === undefined ? {} : { subject }),
+    });
+
+  it('lets a five-source run ask once per source, all reaching the user', async () => {
+    // The failure this fixes: with a run-wide count the third source tripped
+    // the nudge, and agents read the nudge as a stop and fell back to links.
+    const { wizardAsk, request } = makeTools({ host: 'db.example.com' });
+    for (const kind of [
+      'Postgres',
+      'Stripe',
+      'MySQL',
+      'Hubspot',
+      'Snowflake',
+    ]) {
+      const result = await ask(wizardAsk, kind);
+      expect(textOf(result)).not.toMatch(/not sent/);
+    }
+    expect(request).toHaveBeenCalledTimes(5);
+  });
+
+  it('nudges the fourth rapid call about one source and does not send it', async () => {
+    const { wizardAsk, request } = makeTools({ host: 'db.example.com' });
+    for (let i = 0; i < ASK_BATCH_THRESHOLD; i++) {
+      await ask(wizardAsk, 'Postgres');
+    }
+    const nudged = await ask(wizardAsk, 'Postgres');
+    expect(textOf(nudged)).toMatch(/Not an error/);
+    expect(request).toHaveBeenCalledTimes(ASK_BATCH_THRESHOLD);
+
+    // The nudge fires once; the retry goes straight through.
+    const retried = await ask(wizardAsk, 'Postgres');
+    expect(textOf(retried)).not.toMatch(/Not an error/);
+    expect(request).toHaveBeenCalledTimes(ASK_BATCH_THRESHOLD + 1);
+  });
+
+  it('keeps the run-wide guard for an agent that declares no subject', async () => {
+    const { wizardAsk, request } = makeTools({ host: 'db.example.com' });
+    for (let i = 0; i < ASK_BATCH_THRESHOLD; i++) {
+      await ask(wizardAsk);
+    }
+    expect(textOf(await ask(wizardAsk))).toMatch(/Not an error/);
+    expect(request).toHaveBeenCalledTimes(ASK_BATCH_THRESHOLD);
+  });
+
+  it('still stops at the per-run cap however many subjects were used', async () => {
+    const { wizardAsk, request } = makeTools({ host: 'db.example.com' }, 3);
+    for (const kind of ['Postgres', 'Stripe', 'MySQL']) {
+      await ask(wizardAsk, kind);
+    }
+    const capped = await ask(wizardAsk, 'Snowflake');
+    expect(textOf(capped)).toMatch(/cap reached/i);
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not charge a cancelled ask against the per-run cap', async () => {
+    // The skill promises a declined ask is free. With maxQuestions=1, a run of
+    // cancellations must never exhaust the budget.
+    const { wizardAsk, request } = makeTools({ host: CANCELLED_SENTINEL }, 1);
+    for (let i = 0; i < 5; i++) {
+      const result = await ask(wizardAsk, `Source${i}`);
+      expect(textOf(result)).not.toMatch(/cap reached/i);
+    }
+    expect(request).toHaveBeenCalledTimes(5);
+  });
+
+  it('does not charge a bridge failure against the per-run cap', async () => {
+    const { wizardAsk, request } = makeTools({}, 1);
+    (
+      request as unknown as { mockRejectedValue: (e: Error) => void }
+    ).mockRejectedValue(new Error('overlay closed'));
+    for (let i = 0; i < 3; i++) {
+      expect(textOf(await ask(wizardAsk, `Source${i}`))).toMatch(
+        /wizard_ask failed/,
+      );
+    }
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it('exposes subject on the schema with the shared guidance', () => {
+    const { wizardAsk } = makeTools({});
+    const params = (
+      wizardAsk as unknown as {
+        parameters: { properties: { subject?: { description?: string } } };
+      }
+    ).parameters.properties;
+    expect(params.subject?.description).toBe(WIZARD_ASK_SUBJECT_DESCRIPTION);
+  });
+
+  it('shares one tool description with the MCP server', () => {
+    const { wizardAsk } = makeTools({});
+    expect((wizardAsk as unknown as { description: string }).description).toBe(
+      WIZARD_ASK_TOOL_DESCRIPTION,
+    );
   });
 });
 

--- a/src/lib/agent/runner/harness/pi/tools.ts
+++ b/src/lib/agent/runner/harness/pi/tools.ts
@@ -22,7 +22,7 @@ import {
   DEFAULT_ASK_MAX_QUESTIONS,
   ENV_FILE_PATH_DESCRIPTION,
   WIZARD_TOOL_NAMES,
-  evaluateAskCap,
+  createAskAccounting,
   fetchSkillMenu,
   installSkillById,
   mergeEnvValues,
@@ -31,6 +31,8 @@ import {
   resolveEnvSecretRefs,
   vaultSensitiveAnswers,
   WIZARD_ASK_SENSITIVE_DESCRIPTION,
+  WIZARD_ASK_SUBJECT_DESCRIPTION,
+  WIZARD_ASK_TOOL_DESCRIPTION,
 } from '@lib/wizard-tools/tools';
 import type { LLMProvider } from '@posthog/warlock';
 import { isFullyCancelled, type WizardAskBridge } from '@lib/wizard-ask-bridge';
@@ -82,10 +84,10 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
   const detectPackageManager =
     ctx.detectPackageManager ?? detectNodePackageManagers;
   const askMaxQuestions = ctx.maxQuestions ?? DEFAULT_ASK_MAX_QUESTIONS;
-  // Per-run wizard_ask accounting (total cap + one-time adjacency nudge),
-  // mirroring the MCP server's counters.
-  let askCallCount = 0;
-  let askAdjacencyNudged = false;
+  // Per-run wizard_ask accounting (total cap + one-time per-subject adjacency
+  // nudge). Same shared implementation the MCP server drives, so the two
+  // facades cannot diverge on the cap, the nudge or the refund.
+  const askAccounting = createAskAccounting(askMaxQuestions);
   // Session-scoped secret vault, same contract as the MCP server: wizard_ask
   // mints `{secretRef}` for sensitive answers, set_env_values resolves them.
   const secretVault = createSecretVault();
@@ -254,15 +256,9 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
   const wizardAsk = defineTool({
     name: 'wizard_ask',
     label: 'Ask the user',
-    description:
-      'Ask the user one or more structured questions and wait for their answers. ' +
-      'Use this whenever you would otherwise inline a question in your text output. ' +
-      'Batch related questions into a single call (up to 8) rather than asking one at ' +
-      'a time; sequential calls are fine when later questions genuinely depend on ' +
-      'earlier answers. A fully cancelled or timed-out response does NOT count against ' +
-      'the per-run cap — treat it as "the user declined" and fall back gracefully.',
+    description: WIZARD_ASK_TOOL_DESCRIPTION,
     promptSnippet:
-      'wizard_ask(questions) — ask the user structured questions and wait for answers',
+      'wizard_ask(questions, subject) — ask the user structured questions and wait for answers; tag each call with the subject it collects for',
     parameters: Type.Object({
       questions: Type.Array(
         Type.Object({
@@ -307,6 +303,9 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
         }),
         { minItems: 1, maxItems: 8 },
       ),
+      subject: Type.Optional(
+        Type.String({ description: WIZARD_ASK_SUBJECT_DESCRIPTION }),
+      ),
     }),
     async execute(_id, args) {
       if (!askBridge) {
@@ -315,20 +314,18 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
         );
       }
 
-      const cap = evaluateAskCap(
-        askCallCount,
-        askMaxQuestions,
-        askAdjacencyNudged,
-      );
+      const cap = askAccounting.evaluate(args.subject);
       if (cap.kind === 'capped') {
-        if (cap.reason === 'adjacency') askAdjacencyNudged = true;
+        const { callCount } = askAccounting.snapshot();
         logToFile(
-          `[pi] wizard_ask capped: reason=${cap.reason} count=${askCallCount}`,
+          `[pi] wizard_ask capped: reason=${cap.reason} count=${callCount} subject=${cap.subject} run=${cap.subjectRunLength}`,
         );
         analytics.wizardCapture('wizard_ask capped', {
           reason: cap.reason,
-          call_count: askCallCount,
+          call_count: callCount,
           max_questions: askMaxQuestions,
+          subject: cap.subject,
+          subject_run_length: cap.subjectRunLength,
         });
         return text(cap.message);
       }
@@ -356,13 +353,13 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
 
       // Optimistically take the slot; refund it on a cancellation or a bridge
       // error so a declined/failed ask doesn't burn the budget for later ones.
-      askCallCount += 1;
+      askAccounting.record(args.subject);
       // Block Write/Edit for as long as the overlay is open, so the agent can't
       // mutate files while it's waiting on the user's answer.
       onAskPendingChange?.(true);
       try {
         const answers = await askBridge.request({ questions: args.questions });
-        if (isFullyCancelled(answers)) askCallCount -= 1;
+        if (isFullyCancelled(answers)) askAccounting.refund(args.subject);
         // Sensitive answers go to the vault; the agent sees an opaque ref
         // (same contract as the MCP wizard_ask).
         const sanitised = vaultSensitiveAnswers(
@@ -377,7 +374,7 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
         );
         return text(JSON.stringify({ answers: sanitised }, null, 2));
       } catch (err) {
-        askCallCount -= 1;
+        askAccounting.refund(args.subject);
         const message = err instanceof Error ? err.message : String(err);
         logToFile(`[pi] wizard_ask: error: ${message}`);
         return text(`Error: wizard_ask failed: ${message}`);

--- a/src/lib/programs/self-driving/ARCHITECTURE.md
+++ b/src/lib/programs/self-driving/ARCHITECTURE.md
@@ -184,7 +184,11 @@ against `config.abortCases`. `PromptContext` (project/host + AI-consent
 `check_env_keys` / `set_env_values` are the only sanctioned `.env` access
 (value-safe, `.gitignore`-guarded, secret-vault aware). `wizard_ask` is the
 **only** way to ask the user anything — 1–8 questions, capped at `maxQuestions`
-(13), batched. Each `single`/`multi` option is `{ label, value, description? }`.
+(13), batched. Each call carries an optional `subject` tag; the one-time
+batch-your-questions nudge counts consecutive calls **per subject**, so a step
+that walks a list (one call per detected source) is never interrupted, while
+repeated prompting about one thing still gets nudged. Each `single`/`multi`
+option is `{ label, value, description? }`.
 `description` is **optional and additive** (added for STEP 7): rendered dimmed
 and wrapped beneath the label, and **only in the multi-select render path**
 (`PickerMenu` `MultiPickerMenu` + `WizardAskScreen`); when a question omits it,

--- a/src/lib/wizard-tools/mcp.ts
+++ b/src/lib/wizard-tools/mcp.ts
@@ -41,7 +41,7 @@ import {
   applyAuditUpdates,
   downloadSkill,
   ensureGitignoreCoverage,
-  evaluateAskCap,
+  createAskAccounting,
   fetchSkillMenu,
   mergeEnvValues,
   parseEnvKeys,
@@ -53,6 +53,8 @@ import {
   type SkillEntry,
   AUDIT_STATUSES,
   WIZARD_ASK_SENSITIVE_DESCRIPTION,
+  WIZARD_ASK_SUBJECT_DESCRIPTION,
+  WIZARD_ASK_TOOL_DESCRIPTION,
 } from './tools';
 
 const auditCheckSchema = z.object({
@@ -107,8 +109,9 @@ export interface WizardToolsOptions {
 
   /**
    * Per-run cap on `wizard_ask` invocations. Defaults to {@link DEFAULT_ASK_MAX_QUESTIONS}.
-   * The 4th call always returns a "batch your questions" error regardless
-   * of this cap — see {@link ASK_BATCH_THRESHOLD}.
+   * A separate one-time "batch your questions" nudge fires when several calls
+   * in a row share a `subject` — see {@link ASK_BATCH_THRESHOLD}. That nudge is
+   * per subject, so a flow that asks once per detected source never trips it.
    */
   askMaxQuestions?: number;
 
@@ -156,10 +159,9 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
   const sdk = await getSDKModule();
   const { tool, createSdkMcpServer } = sdk;
 
-  // Per-server counter for wizard_ask call accounting (adjacency + total cap).
-  let askCallCount = 0;
-  // The adjacency nudge fires once per run; after that only the total cap applies.
-  let askAdjacencyNudged = false;
+  // Per-server wizard_ask accounting: the total cap plus the per-subject
+  // adjacency run. Shared with the pi facade so neither can drift.
+  const askAccounting = createAskAccounting(askMaxQuestions);
 
   // Pre-fetch skill menu so category names are available in the tool schema
   let cachedSkillMenu: Record<string, SkillEntry[]> = {};
@@ -628,15 +630,10 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
 
   const wizardAsk = tool(
     'wizard_ask',
-    'Ask the user one or more structured questions and wait for their answers. ' +
-      'Use this whenever you would otherwise inline a question in your text output. ' +
-      'Batch related questions into a single call (up to 8) rather than asking one at a ' +
-      'time; sequential calls are fine when later questions genuinely depend on earlier ' +
-      'answers. A fully cancelled or timed-out response does NOT count against the per-run ' +
-      'cap — treat it as "the user declined" and fall back gracefully (e.g. hand over a ' +
-      'deep link) without worrying about a wasted call.',
+    WIZARD_ASK_TOOL_DESCRIPTION,
     {
       questions: z.array(askQuestionSchema).min(1).max(8),
+      subject: z.string().optional().describe(WIZARD_ASK_SUBJECT_DESCRIPTION),
     },
     async (args: {
       questions: Array<{
@@ -647,6 +644,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         required?: boolean;
         sensitive?: boolean;
       }>;
+      subject?: string;
     }) => {
       if (!askBridge) {
         return {
@@ -660,19 +658,14 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         };
       }
 
-      const capDecision = evaluateAskCap(
-        askCallCount,
-        askMaxQuestions,
-        askAdjacencyNudged,
-      );
+      const capDecision = askAccounting.evaluate(args.subject);
       if (capDecision.kind === 'capped') {
-        if (capDecision.reason === 'adjacency') {
-          askAdjacencyNudged = true;
-        }
         analytics.wizardCapture('wizard_ask capped', {
           reason: capDecision.reason,
-          call_count: askCallCount,
+          call_count: askAccounting.snapshot().callCount,
           max_questions: askMaxQuestions,
+          subject: capDecision.subject,
+          subject_run_length: capDecision.subjectRunLength,
         });
         return {
           content: [{ type: 'text' as const, text: capDecision.message }],
@@ -730,7 +723,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         ids.add(q.id);
       }
 
-      askCallCount += 1;
+      askAccounting.record(args.subject);
 
       try {
         const answers = await askBridge.request({ questions: args.questions });
@@ -741,7 +734,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         // fallback even when the user was willing to answer. Refund the slot we
         // optimistically took so cancellation is free.
         if (isFullyCancelled(answers)) {
-          askCallCount -= 1;
+          askAccounting.refund(args.subject);
         }
 
         // Sensitive answers go to the vault; the agent sees an opaque ref.
@@ -768,7 +761,7 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
         // A failed ask never reached the user, so it shouldn't burn the
         // per-run cap either — otherwise a transient bridge error eats the
         // budget for every remaining source.
-        askCallCount -= 1;
+        askAccounting.refund(args.subject);
         logToFile(`wizard_ask: error: ${err?.message ?? err}`);
         return {
           content: [

--- a/src/lib/wizard-tools/tools.ts
+++ b/src/lib/wizard-tools/tools.ts
@@ -298,8 +298,33 @@ export async function installSkillById(
 }
 
 export const DEFAULT_ASK_MAX_QUESTIONS = 10;
-/** The call after this many returns a one-time batch-your-questions nudge. */
+/**
+ * Consecutive calls about the *same subject* before the one-time
+ * batch-your-questions nudge fires. Adjacency is per subject, not per run:
+ * the guard exists to stop an agent firing many small prompts about one
+ * thing, not to stop a flow that legitimately walks a list — the warehouse
+ * task asks one call per detected source, and 5–8 sources need 15–25 fields,
+ * far more than the 8-question schema limit allows in a single call.
+ */
 export const ASK_BATCH_THRESHOLD = 3;
+
+/** Subject recorded for a `wizard_ask` call that declares none. */
+export const ASK_SUBJECT_UNSPECIFIED = '(unspecified)';
+
+/** Longest subject we keep; anything longer is truncated, never rejected. */
+const ASK_SUBJECT_MAX_LENGTH = 60;
+
+/**
+ * Fold a caller-supplied subject into the key adjacency is counted by.
+ * Case- and whitespace-insensitive so `Postgres`, `postgres ` and ` POSTGRES`
+ * are one subject. An absent or blank subject collapses to a single shared
+ * key, so an agent that declares nothing keeps the original run-wide guard.
+ */
+export function normaliseAskSubject(subject?: string): string {
+  const trimmed = (subject ?? '').trim().toLowerCase();
+  if (trimmed.length === 0) return ASK_SUBJECT_UNSPECIFIED;
+  return trimmed.slice(0, ASK_SUBJECT_MAX_LENGTH);
+}
 
 /**
  * The `wizard_ask` `sensitive` field description, shared by both harness facades
@@ -324,13 +349,65 @@ export const WIZARD_ASK_SENSITIVE_DESCRIPTION =
   'secret that must reach another tool, write it to the env with set_env_values ' +
   "first, or use that tool's own credential-reference flow.";
 
+/**
+ * The `wizard_ask` `subject` field description, shared by both harness facades
+ * so the batching contract cannot drift between them.
+ *
+ * `subject` is what lets the runtime tell "three rapid prompts about one thing"
+ * (which the guard should stop) from "one prompt per item in a list" (which it
+ * must not). Without it the runtime saw only a call count, so a warehouse run
+ * with five detected sources tripped the nudge on its third source.
+ */
+export const WIZARD_ASK_SUBJECT_DESCRIPTION =
+  'Short, stable tag naming what this call collects — the data-warehouse ' +
+  'source kind (e.g. "Postgres", "Stripe"), the integration step, or the ' +
+  'decision at hand. The batching guard counts consecutive calls per subject, ' +
+  'so walking a list one call per item is never interrupted as long as each ' +
+  'call carries its own subject. Reuse the same subject only when you are ' +
+  'still collecting for the same thing (e.g. re-asking after a validation ' +
+  'failure). Omit it and every call counts as one shared subject.';
+
+/**
+ * The `wizard_ask` tool description, shared by both harness facades (the MCP
+ * server in `./mcp` and the pi-native mirror in `harness/pi/tools.ts`) so the
+ * batching and cancellation contract reads identically in both harnesses.
+ */
+export const WIZARD_ASK_TOOL_DESCRIPTION =
+  'Ask the user one or more structured questions and wait for their answers. ' +
+  'Use this whenever you would otherwise inline a question in your text output. ' +
+  'Batch every question about one subject into a single call (up to 8) rather ' +
+  'than asking one at a time, and tag the call with `subject`. Walking a list — ' +
+  'one call per data-warehouse source, one call per integration step — is ' +
+  'expected and is never blocked, because the batching guard counts consecutive ' +
+  'calls per subject. A fully cancelled or timed-out response does NOT count ' +
+  'against the per-run cap — treat it as "the user declined" and fall back ' +
+  'gracefully (e.g. hand over a deep link) without worrying about a wasted call.';
+
 export type AskCapDecision =
   | { kind: 'ok' }
   | {
       kind: 'capped';
       reason: 'max_questions' | 'adjacency';
       message: string;
+      /** Normalised subject of the call that was capped — analytics dimension. */
+      subject: string;
+      /** Consecutive calls already sent for that subject. */
+      subjectRunLength: number;
     };
+
+/** Everything the cap policy needs about the upcoming `wizard_ask` call. */
+export type AskCapInput = {
+  /** Calls already sent to the user in this run (cancelled ones are refunded). */
+  callCount: number;
+  /** Hard per-run ceiling on sent calls. */
+  maxQuestions: number;
+  /** Normalised subject of the upcoming call. */
+  subject: string;
+  /** Consecutive calls already sent for that same subject. */
+  subjectRunLength: number;
+  /** Whether the one-time adjacency nudge already fired in this run. */
+  adjacencyNudged?: boolean;
+};
 
 /**
  * Pure decision function for the wizard_ask caps. Returns whether the
@@ -343,33 +420,133 @@ export type AskCapDecision =
  * failure — an agent that reads it as a refusal abandons the source instead
  * of re-asking with batched questions.
  *
+ * Adjacency counts consecutive calls that share a `subject`, not calls in the
+ * run. A flow that walks a list — the warehouse task's one call per detected
+ * source — changes subject on every call, so its run length never grows and
+ * the nudge never fires. Only repeated prompting about the same thing trips
+ * it, which is what the guard was always for. An agent that declares no
+ * subject falls back to one shared key, so the original run-wide guard still
+ * applies to it.
+ *
  * The adjacency nudge fires exactly once per run (the caller records it
  * via `adjacencyNudged`) — flows that legitimately need several
- * sequential, answer-dependent asks then proceed up to `maxQuestions`.
- * Without the flag the rejected call would never advance the counter and
- * every later call would be rejected, making caps above the threshold
- * unreachable.
+ * sequential, answer-dependent asks about one subject then proceed up to
+ * `maxQuestions`. Without the flag the rejected call would never advance the
+ * counter and every later call would be rejected, making caps above the
+ * threshold unreachable.
+ *
+ * `maxQuestions` is checked first and is never per-subject, so subjects can
+ * never widen the per-run budget.
  */
-export function evaluateAskCap(
-  callCount: number,
-  maxQuestions: number,
+export function evaluateAskCap({
+  callCount,
+  maxQuestions,
+  subject,
+  subjectRunLength,
   adjacencyNudged = false,
-): AskCapDecision {
+}: AskCapInput): AskCapDecision {
   if (callCount >= maxQuestions) {
     return {
       kind: 'capped',
       reason: 'max_questions',
+      subject,
+      subjectRunLength,
       message: `Error: wizard_ask cap reached (${maxQuestions} calls in this run). Proceed with sensible defaults using the answers you already have, or emit [ABORT] requirements-incomplete.`,
     };
   }
-  if (!adjacencyNudged && callCount >= ASK_BATCH_THRESHOLD) {
+  if (!adjacencyNudged && subjectRunLength >= ASK_BATCH_THRESHOLD) {
+    const subjectNote =
+      subject === ASK_SUBJECT_UNSPECIFIED
+        ? 'they all declared no `subject`, so they count as one subject'
+        : `they all used subject "${subject}"`;
     return {
       kind: 'capped',
       reason: 'adjacency',
-      message: `Not an error — this ask was not sent (a one-time nudge). You've made ${callCount} wizard_ask calls in a row. Batch the questions you still need into a single call (the schema accepts up to 8 questions per invocation) and call wizard_ask again now; or, if they genuinely depend on earlier answers, just ask again as-is. Either way the next call goes through. Do not abandon the task or fall back to browser setup because of this message.`,
+      subject,
+      subjectRunLength,
+      message:
+        `Not an error — this ask was not sent (a one-time nudge). ` +
+        `You have sent ${subjectRunLength} wizard_ask calls in a row about the same subject (${subjectNote}). ` +
+        `Batch every question you still need for that subject into one call (up to 8 questions) and send wizard_ask again now. ` +
+        `If your next questions are about something else — another data-warehouse source, another integration step — ` +
+        `set a different \`subject\` on the call. Adjacency is counted per subject, so one call per source is never blocked, ` +
+        `and you must not try to squeeze several sources into one 8-question call. ` +
+        `Either way the next call is sent. Do not abandon the task, and do not fall back to browser setup because of this message.`,
     };
   }
   return { kind: 'ok' };
+}
+
+/**
+ * Per-run `wizard_ask` call accounting: the total cap plus the per-subject
+ * adjacency run. Both harness facades drive one of these instead of holding
+ * their own counters, so the cap, the nudge and the cancellation refund
+ * cannot drift between the MCP server and the pi-native tools.
+ */
+export type AskAccounting = {
+  /**
+   * Decide whether the upcoming call may go through. Records the one-time
+   * adjacency nudge as a side effect, so a nudged call is never nudged twice.
+   */
+  evaluate(subject?: string): AskCapDecision;
+  /** Record a call that was sent to the user. */
+  record(subject?: string): void;
+  /**
+   * Refund a call that never produced an answer — cancelled, timed out, or
+   * failed in the bridge. Rolls back the total *and* the subject run, so a
+   * declined ask costs the agent nothing on either cap.
+   */
+  refund(subject?: string): void;
+  /** Current state, for analytics and tests. */
+  snapshot(): {
+    callCount: number;
+    subject: string;
+    subjectRunLength: number;
+    adjacencyNudged: boolean;
+  };
+};
+
+export function createAskAccounting(maxQuestions: number): AskAccounting {
+  let callCount = 0;
+  let currentSubject = ASK_SUBJECT_UNSPECIFIED;
+  let subjectRunLength = 0;
+  let adjacencyNudged = false;
+
+  return {
+    evaluate(subject) {
+      const key = normaliseAskSubject(subject);
+      const decision = evaluateAskCap({
+        callCount,
+        maxQuestions,
+        subject: key,
+        subjectRunLength: key === currentSubject ? subjectRunLength : 0,
+        adjacencyNudged,
+      });
+      if (decision.kind === 'capped' && decision.reason === 'adjacency') {
+        adjacencyNudged = true;
+      }
+      return decision;
+    },
+    record(subject) {
+      const key = normaliseAskSubject(subject);
+      callCount += 1;
+      subjectRunLength = key === currentSubject ? subjectRunLength + 1 : 1;
+      currentSubject = key;
+    },
+    refund(subject) {
+      const key = normaliseAskSubject(subject);
+      callCount = Math.max(0, callCount - 1);
+      if (key === currentSubject) {
+        subjectRunLength = Math.max(0, subjectRunLength - 1);
+      }
+    },
+    snapshot: () => ({
+      callCount,
+      subject: currentSubject,
+      subjectRunLength,
+      adjacencyNudged,
+    }),
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The install flow seeds a `warehouse` task. That task asks the user for each detected source's credentials, then creates the source in PostHog.

The `wizard_ask` batching guard counted **every** call in a run. After 3 calls in a row it returned a nudge and did not send the ask. Runs routinely carry 5–8 in-cli sources, and Postgres alone needs 5 fields. So the third source tripped the nudge.

The nudge then gave impossible advice. It told the agent to put the remaining questions into a single call of at most 8 questions. Five remaining sources need 15–25 fields.

Measured on project 2, for the seeded warehouse task since 2026-08-12, prod builds, internal users excluded:

- `wizard_ask capped` with `reason = adjacency`: **62** events across **62** distinct runs.
- `wizard_ask cancelled`: **143**, plus **111** more that timed out.
- Of 697 warehouse tasks that reported *completed*, only **247** produced a `data warehouse source created` event. That is a ~65% silent no-op rate.

Agents named the cause themselves. One example: *"The credential workflow has at most eight questions per ask, but the large source set requires multiple batches. The runtime's three-consecutive-ask nudge interrupted the third batch."*

#1096 softened the nudge's wording. Agents still read it as a stop signal and fell back to browser links, so the rate did not move.

## Changes

`wizard_ask` now takes an optional `subject` tag, and adjacency counts **consecutive calls that share a subject**. This is exactly what the skill always meant by "don't fire several rapid calls for the *same* source" — the runtime just could not tell before.

- **One call per source is never interrupted.** Each call carries a different subject, so its run length never grows.
- **The original guard survives.** Three rapid calls about one subject still earn the one-time nudge. An agent that declares no subject falls back to one shared key, so it keeps the run-wide behaviour.
- **The per-run cap is unchanged.** `maxQuestions` is checked first and is never per-subject, so subjects cannot widen the budget.
- **The nudge message no longer gives impossible advice.** It names the repeated subject, says the ask was not sent, and tells the agent to re-tag rather than to squeeze several sources into one call.
- **Both facades share one implementation.** The MCP server and the pi-native tools now drive a single `createAskAccounting` helper instead of holding their own counters, so the cap, the nudge and the refund cannot drift. They also share one tool description.
- **The refund is stronger.** A cancelled, timed-out or failed ask now rolls back the subject run as well as the total. A refund that only cleared the total would still push a subject towards the nudge.
- **Analytics stay accurate.** `wizard_ask capped` still fires with its `reason`, plus new `subject` and `subject_run_length` dimensions.

Why not the alternatives:

- **Raise the threshold or the cap.** This hides the problem instead of describing it. A 9-source run would trip a raised threshold too, and a raised cap lets a genuinely chatty agent prompt the user more.
- **Make the budget task-type aware.** The runtime would need product knowledge of the warehouse task, which this repo's design discipline keeps out of infrastructure code. It also does not help any other flow that walks a list.
- **Rewrite the message only.** #1096 already tried that. The message was still an interruption, and the advice inside it was still impossible.

The skill side lands in PostHog/context-mill#360. The two changes are one change: the runtime reads `subject`, and the skill sets it.

## Test plan

`pnpm build && pnpm test && pnpm lint` — 2048 tests pass, lint reports 0 errors.

New and updated tests:

- `evaluateAskCap`: threshold boundary, a long run that never repeats a subject, the max-questions cap with fresh subjects on every call, subject normalisation, and the nudge's wording.
- `createAskAccounting`: the five-source warehouse shape, same-subject machine-gunning, the no-subject fallback, run resets on an interleaved subject, the nudge firing once, refund on cancel, refund clamping, and refunds scoped to their own subject.
- `pi wizard_ask` end to end: five sources all reach the bridge, the fourth same-subject call is nudged and never sent, the retry goes through, the per-run cap still stops the run, and neither a cancellation nor a bridge failure charges the cap.