### PR TITLE
fix(orchestrator): take warehouse consent at seed time, and name every skip

### DIFF
--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/queue-tools.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/queue-tools.test.ts
@@ -160,6 +160,31 @@ describe('apply functions', () => {
     expect(r.ok).toBe(true);
     expect(store.get(t.id)?.status).toBe('not needed');
     expect(store.nextRunnable().map((task) => task.id)).toContain(dependent.id);
+    // An agent deciding a step does not apply is a different fact from a user
+    // declining one; the skipped-task event has to be able to tell them apart.
+    expect(store.get(t.id)?.skipReason).toBe('agent-not-needed');
+  });
+
+  it("keeps the agent's own words out of the skip reason", () => {
+    // The handoff is free text an LLM wrote, on a flow that reaches live
+    // database and API credentials. It stays in the run's queue.json, where the
+    // report reads it, and out of telemetry, which has no redaction pass.
+    const t = store.enqueue({ type: 'warehouse' });
+    ctx.currentTaskId = t.id;
+    store.start(t.id);
+    applyComplete(ctx, {
+      status: 'not needed',
+      handoff: {
+        goals: 'g',
+        did: 'nothing — postgres://user:hunter2@db.internal was unreachable',
+        forNextAgent: 'n',
+      },
+    });
+
+    expect(store.get(t.id)?.skipReason).toBe('agent-not-needed');
+    expect(JSON.stringify(store.get(t.id)?.skipReason)).not.toContain(
+      'hunter2',
+    );
   });
 
   it('a remark is captured against its task type, never left in the handoff', () => {

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/queue.test.ts
@@ -4,8 +4,11 @@ import * as path from 'path';
 import {
   QueueStore,
   QUEUE_DIR_NAME,
+  SkipReason,
   type QueueFile,
+  type QueuedTask,
   type TaskHandoff,
+  type TransitionEvent,
 } from '@lib/agent/runner/sequence/orchestrator/queue';
 
 vi.mock('@utils/analytics', () => ({
@@ -82,7 +85,7 @@ describe('QueueStore', () => {
     const b = q.enqueue({ type: 'init', dependsOn: [a.id] });
 
     q.start(a.id);
-    q.skip(a.id);
+    q.skip(a.id, SkipReason.AgentNotNeeded);
     expect(q.nextRunnable().map((t) => t.id)).toEqual([b.id]);
   });
 
@@ -386,5 +389,86 @@ describe('addDependencies', () => {
 
   it('throws for a task that is not in the queue at all', () => {
     expect(() => store.addDependencies('nope', [])).toThrow('No task nope');
+  });
+});
+
+/**
+ * Why a skip happened, recorded where the skip happens.
+ *
+ * A skip has causes that mean opposite things: an agent finding a step does not
+ * apply is a no-op, a user declining it is a decision, and an unanswered offer
+ * is neither. For a week they were one indistinguishable number on
+ * `orchestrator task skipped`, which is how a regression that halved the
+ * warehouse completion rate stayed invisible. The reason has to be on the task
+ * itself, so the transition listener can read it and the run's queue.json keeps
+ * it.
+ */
+describe('skip reasons', () => {
+  let dir: string;
+  let q: QueueStore;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    q = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it.each([
+    ['user-declined', SkipReason.UserDeclined],
+    ['notice-timeout', SkipReason.NoticeTimeout],
+    ['notice-error', SkipReason.NoticeError],
+    ['agent-not-needed', SkipReason.AgentNotNeeded],
+  ] as const)('records %s on the task', (expected, reason) => {
+    const t = q.enqueue({ type: 'warehouse' });
+    q.start(t.id);
+    q.skip(t.id, reason);
+
+    expect(q.get(t.id)?.status).toBe('not needed');
+    expect(q.get(t.id)?.skipReason).toBe(expected);
+  });
+
+  it('hands the reason to the transition listener', () => {
+    const seen: { event: TransitionEvent; reason?: string }[] = [];
+    const listened = new QueueStore(dir, 'run-1', {
+      onTransition: (event: TransitionEvent, task: QueuedTask) =>
+        seen.push({ event, reason: task.skipReason }),
+    });
+
+    const t = listened.enqueue({ type: 'warehouse' });
+    listened.start(t.id);
+    listened.skip(t.id, SkipReason.NoticeTimeout);
+
+    expect(seen.at(-1)).toEqual({
+      event: 'skip',
+      reason: 'notice-timeout',
+    });
+  });
+
+  it('leaves the reason unset on every other terminal transition', () => {
+    const done = q.enqueue({ type: 'install' });
+    q.start(done.id);
+    q.complete(done.id);
+    const failed = q.enqueue({ type: 'capture', maxAttempts: 1 });
+    q.start(failed.id);
+    q.fail(failed.id, { type: 'API_ERROR', message: 'boom' });
+
+    expect(q.get(done.id)?.skipReason).toBeUndefined();
+    expect(q.get(failed.id)?.skipReason).toBeUndefined();
+  });
+
+  it('reflects the reason to queue.json, so a finished run still explains itself', () => {
+    const t = q.enqueue({ type: 'warehouse' });
+    q.start(t.id);
+    q.skip(t.id, SkipReason.UserDeclined, {
+      goals: 'Connect your data sources',
+      did: 'Nothing — the user chose to skip this step when offered it.',
+      forNextAgent: 'Report it as skipped at the user’s request.',
+    });
+
+    const file = JSON.parse(fs.readFileSync(q.queuePath, 'utf8')) as QueueFile;
+    expect(file.tasks.find((t2) => t2.id === t.id)?.skipReason).toBe(
+      'user-declined',
+    );
   });
 });

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/seeded-deps.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/seeded-deps.test.ts
@@ -330,3 +330,84 @@ describe('deferSeededTasks', () => {
     expect(store.get(other.id)?.dependsOn).toContain(warehouse.id);
   });
 });
+
+/**
+ * The half of #1103 this change keeps.
+ *
+ * Consent moved back to seed time; execution did not. The warehouse step still
+ * runs last, after every coding task, because that is where its credential
+ * questions belong. These drain the whole planned graph and assert the order the
+ * user actually experiences, so a future change that answers the notice early
+ * cannot quietly drag the work forward with it.
+ */
+describe('execution still happens last', () => {
+  let dir: string;
+  let store: QueueStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seeded-order-test-'));
+    store = new QueueStore(dir, 'run-1');
+  });
+
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  /** Run the graph to completion, tier by tier, recording the order. */
+  const drain = (): string[][] => {
+    const tiers: string[][] = [];
+    for (let guard = 0; guard < 20; guard += 1) {
+      const runnable = store.nextRunnable();
+      if (runnable.length === 0) break;
+      tiers.push(runnable.map((t) => t.type).sort());
+      for (const task of runnable) {
+        store.start(task.id);
+        store.complete(task.id);
+      }
+    }
+    return tiers;
+  };
+
+  it('leaves the seeded task in the last tier before the sink', () => {
+    const { warehouse } = plannedQueue(store);
+    deferSeededTasks(store, [warehouse], () => [], SINKS);
+
+    const tiers = drain();
+
+    expect(tiers.at(-1)).toEqual(['report']);
+    expect(tiers.at(-2)).toEqual(['warehouse']);
+    expect(tiers[0]).toEqual(['init', 'install']);
+  });
+
+  it('runs every coding task before the seeded one, whatever order they finish in', () => {
+    const { warehouse } = plannedQueue(store);
+    deferSeededTasks(store, [warehouse], () => [], SINKS);
+
+    const order = drain().flat();
+    const warehouseAt = order.indexOf('warehouse');
+
+    for (const type of [
+      'install',
+      'init',
+      'identify',
+      'error-tracking',
+      'capture',
+      'review',
+      'dashboard',
+    ]) {
+      expect(order.indexOf(type)).toBeLessThan(warehouseAt);
+    }
+    expect(order.indexOf('report')).toBeGreaterThan(warehouseAt);
+  });
+
+  it('is not pulled forward by a task that was answered but not yet run', () => {
+    // Consent is taken at seed time, before the planner runs. The task is still
+    // an ordinary pending task at that point, so the deferral applies to it
+    // exactly as it did before the answer existed.
+    const { warehouse } = plannedQueue(store);
+    expect(store.get(warehouse.id)?.status).toBe('pending');
+
+    deferSeededTasks(store, [warehouse], () => [], SINKS);
+
+    expect(store.get(warehouse.id)?.dependsOn).toHaveLength(7);
+    expect(store.nextRunnable().map((t) => t.type)).not.toContain('warehouse');
+  });
+});

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/sink-closure.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/sink-closure.test.ts
@@ -11,7 +11,10 @@ vi.mock('@utils/analytics', () => ({
   analytics: { wizardCapture: vi.fn() },
 }));
 
-import { QueueStore } from '@lib/agent/runner/sequence/orchestrator/queue';
+import {
+  QueueStore,
+  SkipReason,
+} from '@lib/agent/runner/sequence/orchestrator/queue';
 import { displayOrder } from '@lib/agent/runner/sequence/orchestrator/orchestrator-runner';
 import {
   applyEnqueue,
@@ -276,9 +279,13 @@ describe('sink closure with a deferred seeded task', () => {
 });
 
 /**
- * Declining the notice at run time. The offer moved from the top of the run to
- * the moment the step would start, so by then the task is already queued and the
- * sink already depends on it — declining has to skip it, not remove it.
+ * Applying a decline that was given at the top of the run.
+ *
+ * The offer is made at seed time, but the answer cannot be acted on there: the
+ * task must still enter the queue as an ordinary pending task so the planner
+ * plans around it and the sink is made to depend on it. By the time the drain
+ * reaches the task the sink already waits for it, so declining has to skip it,
+ * not remove it — and the skip has to carry why.
  */
 describe('a declined seeded task', () => {
   let dir: string;
@@ -304,10 +311,10 @@ describe('a declined seeded task', () => {
     store.start(install.id);
     store.complete(install.id);
 
-    // The step comes up, the notice is shown, the user declines.
+    // The step comes up, and the answer taken at seed time is applied.
     expect(store.nextRunnable().map((t) => t.type)).toEqual(['warehouse']);
     store.start(warehouse.id);
-    store.skip(warehouse.id, {
+    store.skip(warehouse.id, SkipReason.UserDeclined, {
       goals: 'Connect your data sources',
       did: 'Nothing — the user chose to skip this step when offered it.',
       forNextAgent: 'This step was offered and declined, so it did no work.',
@@ -316,12 +323,13 @@ describe('a declined seeded task', () => {
     // The sink is not dammed by the decline, and can say what happened.
     expect(store.nextRunnable().map((t) => t.id)).toEqual([report.id]);
     expect(store.readHandoff(warehouse.id)?.did).toContain('chose to skip');
+    expect(store.get(warehouse.id)?.skipReason).toBe('user-declined');
   });
 
   it('is not retried — a decline is an answer, not a failure', () => {
     const warehouse = store.enqueue({ type: 'warehouse', optional: true });
     store.start(warehouse.id);
-    store.skip(warehouse.id);
+    store.skip(warehouse.id, SkipReason.UserDeclined);
 
     expect(store.get(warehouse.id)?.status).toBe('not needed');
     expect(store.nextRunnable()).toEqual([]);

--- a/src/lib/agent/runner/sequence/orchestrator/__tests__/task-notice-timeout.test.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/__tests__/task-notice-timeout.test.ts
@@ -1,28 +1,39 @@
 /**
- * The notice's timeout.
+ * The notice's timeout, and where the notice is asked.
  *
- * The offer sits in front of the run's last steps, so an unanswered one holds
- * the report — and with it the notebook and the outro — behind a modal nobody is
- * looking at. It defaults to declining rather than waiting forever.
+ * The offer defaults to declining rather than waiting forever: a modal nobody
+ * answers would otherwise hold the run behind a screen nobody is looking at.
+ * That default is only safe where the user actually is, which is seconds into
+ * the run — so the offer is made at seed time, and only the work it gates is
+ * deferred to the end of the queue.
  */
 import type { TaskNotice } from '@lib/wizard-session';
 
-const showTaskNotice = vi.fn<[TaskNotice], Promise<boolean>>();
-const cancelTaskNotice = vi.fn();
+// Hoisted: `vi.mock` factories are lifted above the imports, so the analytics
+// factory would otherwise read these before they exist.
+const { showTaskNotice, cancelTaskNotice, wizardCapture, captureException } =
+  vi.hoisted(() => ({
+    showTaskNotice: vi.fn<[TaskNotice], Promise<boolean>>(),
+    cancelTaskNotice: vi.fn(),
+    wizardCapture: vi.fn(),
+    captureException: vi.fn(),
+  }));
 
 vi.mock('@ui', () => ({
   getUI: () => ({ showTaskNotice, cancelTaskNotice }),
 }));
 vi.mock('@utils/analytics', () => ({
   analytics: {
-    wizardCapture: vi.fn(),
+    wizardCapture,
     setTag: vi.fn(),
     capture: vi.fn(),
-    captureException: vi.fn(),
+    captureException,
   },
 }));
 
 import {
+  askSeededConsent,
+  consentSkipReason,
   offerSeededTask,
   TASK_NOTICE_TIMEOUT_MS,
 } from '@lib/agent/runner/sequence/orchestrator/orchestrator-runner';
@@ -36,11 +47,15 @@ const NOTICE: TaskNotice = {
   cancelLabel: 'Skip [Esc]',
 };
 
+const resetMocks = () => {
+  showTaskNotice.mockReset();
+  cancelTaskNotice.mockReset();
+  wizardCapture.mockReset();
+  captureException.mockReset();
+};
+
 describe('task notice timeout', () => {
-  beforeEach(() => {
-    showTaskNotice.mockReset();
-    cancelTaskNotice.mockReset();
-  });
+  beforeEach(resetMocks);
 
   it('waits five minutes before giving up on an answer', () => {
     expect(TASK_NOTICE_TIMEOUT_MS).toBe(5 * 60 * 1000);
@@ -86,7 +101,7 @@ describe('task notice timeout', () => {
       showTaskNotice.mockResolvedValue(false);
 
       // Both decline, but only one of them means "the user was not there" —
-      // the run reports them differently.
+      // the run reports them differently, and now skips them differently too.
       await expect(offerSeededTask(NOTICE, 1000)).resolves.toEqual({
         keep: false,
         timedOut: false,
@@ -99,36 +114,143 @@ describe('task notice timeout', () => {
 });
 
 /**
- * Two hazards created by offering the notice from inside the drain rather than
- * from the seed loop. Seeding awaited its notices sequentially, so neither was
- * reachable before; the executor starts every runnable task at once, so both
- * are now. Both are pinned here because each fails silently — one as a repeated
- * modal, the other as a run that never ends.
+ * Every way of not saying yes maps to its own skip reason.
+ *
+ * The three are different facts about the user: one said no, one was not there,
+ * and one was never asked. Collapsing them is what made a week of auto-declines
+ * look like ordinary skipped steps.
  */
-describe('offering a notice from inside the drain', () => {
-  beforeEach(() => {
-    showTaskNotice.mockReset();
-    cancelTaskNotice.mockReset();
+describe('consentSkipReason', () => {
+  it.each([
+    [
+      'an explicit Skip',
+      { keep: false, timedOut: false, errored: false },
+      'user-declined',
+    ],
+    [
+      'an unanswered offer',
+      { keep: false, timedOut: true, errored: false },
+      'notice-timeout',
+    ],
+    [
+      'an offer that could not be shown',
+      { keep: false, timedOut: false, errored: true },
+      'notice-error',
+    ],
+  ])('maps %s to %s', (_label, consent, expected) => {
+    expect(consentSkipReason(consent)).toBe(expected);
   });
 
-  it('shows a task’s notice at most once, even across a retry', async () => {
-    // The executor requeues a task that ends without reporting, calling runTask
-    // again with the same id. Consent is per task, not per attempt.
-    const notices = new Map<string, TaskNotice>([['task-1', NOTICE]]);
+  it('reports a failed notice as an error, not as a timeout', () => {
+    // Both are "the user did not decline", and only one of them is worth
+    // paging someone about.
+    expect(
+      consentSkipReason({ keep: false, timedOut: true, errored: true }),
+    ).toBe('notice-error');
+  });
+});
+
+/**
+ * Asking for consent at seed time.
+ *
+ * #1103 moved this ask to the moment the task became runnable — a median seven
+ * minutes into the run, after every coding task, with the user long since gone.
+ * The five-minute default then answered for them. Consent belongs where the
+ * user still is; only the work it gates belongs at the end.
+ */
+describe('askSeededConsent', () => {
+  beforeEach(resetMocks);
+
+  it('records an acceptance', async () => {
     showTaskNotice.mockResolvedValue(true);
 
-    const offerOnce = async (taskId: string) => {
-      const notice = notices.get(taskId);
-      if (!notice) return;
-      notices.delete(taskId);
-      await offerSeededTask(notice, 1000);
-    };
-
-    await offerOnce('task-1');
-    await offerOnce('task-1'); // the retry
-
-    expect(showTaskNotice).toHaveBeenCalledTimes(1);
+    await expect(askSeededConsent('warehouse', NOTICE, 1000)).resolves.toEqual({
+      keep: true,
+      timedOut: false,
+      errored: false,
+    });
   });
+
+  it('records an explicit decline', async () => {
+    showTaskNotice.mockResolvedValue(false);
+
+    await expect(askSeededConsent('warehouse', NOTICE, 1000)).resolves.toEqual({
+      keep: false,
+      timedOut: false,
+      errored: false,
+    });
+  });
+
+  it('records a timeout as a decline the user never gave', async () => {
+    vi.useFakeTimers();
+    try {
+      showTaskNotice.mockReturnValue(new Promise<boolean>(() => undefined));
+
+      const promise = askSeededConsent('warehouse', NOTICE, 1000);
+      vi.advanceTimersByTime(1000);
+
+      await expect(promise).resolves.toEqual({
+        keep: false,
+        timedOut: true,
+        errored: false,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports the answer on one event per offer', async () => {
+    showTaskNotice.mockResolvedValue(true);
+
+    await askSeededConsent('warehouse', NOTICE, 1000);
+
+    expect(wizardCapture).toHaveBeenCalledTimes(1);
+    expect(wizardCapture).toHaveBeenCalledWith(
+      'orchestrator task notice answered',
+      { type: 'warehouse', kept: true, timed_out: false, errored: false },
+    );
+  });
+
+  it('is treated as a decline when the notice throws, never as consent', async () => {
+    // The step this gates goes on to ask for live credentials, so a question
+    // that could not be put to the user must never be read as a yes.
+    showTaskNotice.mockRejectedValue(new Error('UI blew up'));
+
+    await expect(askSeededConsent('warehouse', NOTICE, 1000)).resolves.toEqual({
+      keep: false,
+      timedOut: false,
+      errored: true,
+    });
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(wizardCapture).toHaveBeenCalledWith(
+      'orchestrator task notice answered',
+      { type: 'warehouse', kept: false, timed_out: false, errored: true },
+    );
+  });
+});
+
+/**
+ * Two hazards that come from *where* the offer is made.
+ *
+ * #1103 offered notices from inside the drain, which starts every runnable task
+ * at once; that made a second modal and a re-offer on retry reachable for the
+ * first time, and each fails silently — one as a repeated modal, the other as a
+ * run that never ends. Asking from the seed loop instead removes both by
+ * construction, and these pin that the seed loop keeps the properties the
+ * in-drain gate had to build by hand.
+ */
+describe('offering notices from the seed loop', () => {
+  beforeEach(resetMocks);
+
+  /** The seed loop: one entry at a time, each awaited before the next. */
+  const seedLoop = async (entries: readonly { type: string }[]) => {
+    const answers: { keep: boolean; timedOut: boolean; errored: boolean }[] =
+      [];
+    for (const entry of entries) {
+      answers.push(await askSeededConsent(entry.type, NOTICE, 60_000));
+    }
+    return answers;
+  };
 
   it('never puts two notices on screen at once', async () => {
     // The store holds one pending-notice slot: a second showTaskNotice
@@ -136,66 +258,42 @@ describe('offering a notice from inside the drain', () => {
     // its task hangs for the rest of the run.
     let onScreen = 0;
     let maxOnScreen = 0;
-    let releaseFirst: ((v: boolean) => void) | undefined;
 
-    showTaskNotice.mockImplementation(() => {
+    showTaskNotice.mockImplementation(async () => {
       onScreen += 1;
       maxOnScreen = Math.max(maxOnScreen, onScreen);
-      if (!releaseFirst) {
-        return new Promise<boolean>((resolve) => {
-          releaseFirst = (v) => {
-            onScreen -= 1;
-            resolve(v);
-          };
-        });
-      }
+      await Promise.resolve();
       onScreen -= 1;
-      return Promise.resolve(true);
+      return true;
     });
 
-    let gate: Promise<unknown> = Promise.resolve();
-    const offer = (): Promise<{ keep: boolean; timedOut: boolean }> => {
-      const p = gate.then(() => offerSeededTask(NOTICE, 60_000));
-      gate = p.catch(() => undefined);
-      return p;
-    };
-
-    const first = offer();
-    const second = offer();
-    await Promise.resolve();
+    const answers = await seedLoop([{ type: 'warehouse' }, { type: 'other' }]);
 
     expect(maxOnScreen).toBe(1);
-    releaseFirst?.(true);
-
-    await expect(first).resolves.toEqual({ keep: true, timedOut: false });
-    await expect(second).resolves.toEqual({ keep: true, timedOut: false });
-    expect(maxOnScreen).toBe(1);
+    expect(answers).toEqual([
+      { keep: true, timedOut: false, errored: false },
+      { keep: true, timedOut: false, errored: false },
+    ]);
     expect(showTaskNotice).toHaveBeenCalledTimes(2);
   });
-});
 
-/**
- * Which way consent breaks when the offer itself fails.
- *
- * The notice is consumed before it is shown (so a retry cannot re-ask), which
- * means a thrown offer would otherwise leave the executor's retry path with no
- * notice to show — and the step would run, and start asking for credentials,
- * with nobody having agreed to it. It must break towards declining.
- */
-describe('a notice that fails to show', () => {
-  beforeEach(() => {
-    showTaskNotice.mockReset();
-    cancelTaskNotice.mockReset();
-  });
+  it('shows a task’s notice at most once, whatever the drain does later', async () => {
+    // The executor requeues a task that ends without reporting, calling runTask
+    // again with the same id. The offer is no longer in runTask at all, so a
+    // retry cannot re-ask — consent is per task, not per attempt, and it was
+    // taken before the drain started.
+    showTaskNotice.mockResolvedValue(true);
 
-  it('is treated as a decline, never as consent', async () => {
-    showTaskNotice.mockRejectedValue(new Error('UI blew up'));
+    const consent = new Map(
+      (await seedLoop([{ type: 'warehouse' }])).map((answer) => [
+        'task-1',
+        answer,
+      ]),
+    );
+    const runTask = (taskId: string) => consent.get(taskId)?.keep === true;
 
-    const result = await offerSeededTask(NOTICE, 1000).catch(() => ({
-      keep: false,
-      timedOut: false,
-    }));
-
-    expect(result.keep).toBe(false);
+    expect(runTask('task-1')).toBe(true);
+    expect(runTask('task-1')).toBe(true); // the retry
+    expect(showTaskNotice).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -40,6 +40,7 @@ import { getUI } from '@ui';
 import { analytics } from '@utils/analytics';
 import { ciExcludedTaskTypes } from '@utils/ci-flag-overrides';
 import { logToFile } from '@utils/debug';
+import { ringTerminalBell } from '@utils/terminal-bell';
 import { wizardAbort, WizardError } from '@utils/wizard-abort';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { BootstrapResult, ProgramRun } from '../../shared/types';
@@ -55,6 +56,7 @@ import type { AgentHarness } from '../../harness/types';
 import {
   QueueStore,
   QUEUE_DIR_NAME,
+  SkipReason,
   TaskStatus,
   type QueuedTask,
 } from './queue';
@@ -200,9 +202,15 @@ const TASK_ASK_TIMEOUT_MS = 20 * 60 * 1000;
  *
  * Much shorter than the ask timeout above, because it is asking for something
  * much smaller: one keypress to accept or decline, not "go mint a restricted
- * Stripe key". The notice is also the only interactive screen sitting in front
- * of the run's final steps, so an unanswered one holds the report — and with it
- * the notebook and the outro — behind a modal nobody is looking at.
+ * Stripe key". It cannot be unbounded either — the notice is a modal, and a run
+ * that stops forever behind one nobody is looking at is worse than one that
+ * takes the safe answer and carries on.
+ *
+ * The offer is made at seed time, seconds into the run, so five minutes is a
+ * generous allowance for a person who is by then still watching the wizard
+ * start. It was not: from 2.63.0 to 2.65.0 the offer was made at the moment the
+ * step became runnable — a median seven minutes in, after every coding task —
+ * and this timeout became the answer for about a quarter of all runs.
  */
 export const TASK_NOTICE_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -235,6 +243,60 @@ export async function offerSeededTask(
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+/** One seeded task's answer to its notice, taken once, at seed time. */
+export interface SeededConsent {
+  keep: boolean;
+  timedOut: boolean;
+  /** The notice could not be shown at all. Read as a decline, never as a yes. */
+  errored: boolean;
+}
+
+/** Which skip reason a negative {@link SeededConsent} carries onto the event. */
+export function consentSkipReason(consent: SeededConsent): SkipReason {
+  if (consent.errored) return SkipReason.NoticeError;
+  return consent.timedOut ? SkipReason.NoticeTimeout : SkipReason.UserDeclined;
+}
+
+/**
+ * Ask for one seeded task's consent, and record how the answer came about.
+ *
+ * Consent and execution are separate concerns, and this is the consent half.
+ * It runs at seed time — seconds into the run, with the user still watching —
+ * while `seeded-deps.ts` keeps the work itself at the end of the queue. Asking
+ * at the moment of execution instead, as 2.63.0 did, put the question in front
+ * of a user who had long since tabbed away.
+ *
+ * Fails closed. The step this gates goes on to ask for live database and API
+ * credentials, so a question that could not be put to the user is never read as
+ * a yes.
+ */
+export async function askSeededConsent(
+  type: string,
+  notice: TaskNotice,
+  timeoutMs?: number,
+): Promise<SeededConsent> {
+  const consent = await offerSeededTask(notice, timeoutMs).then(
+    (answer): SeededConsent => ({ ...answer, errored: false }),
+    (err: unknown): SeededConsent => {
+      logToFile(
+        `[orchestrator] notice failed for ${type}, declining: ${String(err)}`,
+      );
+      analytics.captureException(
+        err instanceof Error ? err : new Error(String(err)),
+        { step: 'orchestrator_task_notice' },
+      );
+      return { keep: false, timedOut: false, errored: true };
+    },
+  );
+  analytics.wizardCapture('orchestrator task notice answered', {
+    type,
+    kept: consent.keep,
+    timed_out: consent.timedOut,
+    errored: consent.errored,
+  });
+  return consent;
 }
 
 /** Whether a task's prompt lets it ask the user, and so needs the ask bridge. */
@@ -407,6 +469,12 @@ export async function runOrchestrator(
           analytics.wizardCapture('orchestrator task skipped', {
             ...base,
             duration_ms: durationMs(task),
+            // Additive: the event's name and every other property are unchanged,
+            // so existing dashboards keep reading. Without this a step the user
+            // declined, a step nobody answered for, and a step the agent found
+            // did not apply were one number — which is how a regression that
+            // halved the warehouse completion rate stayed invisible for a week.
+            reason: task.skipReason,
           });
           break;
         case 'fail':
@@ -576,15 +644,23 @@ export async function runOrchestrator(
   // Kept so their dependencies can be resolved once the planner has run — they
   // are queued before it, so they cannot name what they wait for yet.
   const seededTasks: QueuedTask[] = [];
-  // A seeded task's notice, held until the moment the task is about to run.
-  // Asked here at seed time it would be the first thing in the run — a modal
-  // before anything has happened, about work that will not start for minutes.
-  // The queue stays product-ignorant, so the copy waits here rather than on the
-  // task.
-  const seededNotices = new Map<
-    string,
-    NonNullable<(typeof seedEntries)[number]['notice']>
-  >();
+  // Each seeded task's answer to its notice, taken here and applied later.
+  //
+  // Consent belongs at seed time: the user is at the keyboard, watching the run
+  // start, and one keypress is all the question needs. The work does not — the
+  // warehouse step asks for credentials, and those questions belong after the
+  // autonomous coding, which is what `seeded-deps.ts` arranges. 2.63.0 collapsed
+  // the two onto one modal at the moment of execution, a median seven minutes
+  // in, by which time the user had gone; the five-minute timeout then answered
+  // for them, and it answers "skip".
+  //
+  // The answer is recorded rather than acted on, so a declined task still enters
+  // the queue as an ordinary pending task. The planner plans around it,
+  // `deferSeededTasks` can still add its edges, and the sink invariant still
+  // covers it — none of which is true of a task that was enqueued and skipped
+  // before the planner ever ran. `runTask` applies the answer when the drain
+  // reaches the task.
+  const seededConsent = new Map<string, SeededConsent>();
   for (const seeded of seedEntries) {
     if (!registry.runnerSeededTypes.includes(seeded.type)) {
       logToFile(
@@ -602,14 +678,33 @@ export async function runOrchestrator(
     });
     seededTypes.push(seeded.type);
     seededTasks.push(task);
-    if (seeded.notice) seededNotices.set(task.id, seeded.notice);
+    if (seeded.notice) {
+      // Awaited inside the loop, so at most one notice is ever on screen. The
+      // store holds a single pending-notice slot: a second `showTaskNotice`
+      // overwrites the first's resolver, the first promise never settles, and
+      // its task hangs for the rest of the run. A serial loop makes that
+      // unreachable; the drain, which starts every runnable task at once, does
+      // not, which is why the offer lives here and not there.
+      seededConsent.set(
+        task.id,
+        await askSeededConsent(seeded.type, seeded.notice),
+      );
+    }
     logToFile(`[orchestrator] runner-seeded task ${seeded.type}`);
   }
 
   // A run that stops to ask a person is not comparable with one that does not
   // — its wall-clock is the user's, not the model's. Tag every event of the run
   // from here on, so those runs filter out cleanly.
-  const askingTypes = seededTypes.filter((type) => canAsk(registry.get(type)));
+  //
+  // A declined step asks nothing, and the answer is known by now, so it leaves
+  // the tag alone. While the offer was made mid-drain this was unknowable here,
+  // and roughly a quarter of runs were tagged as waiting on a user who had in
+  // fact already been auto-declined out of the only step that asks.
+  const askingTypes = seededTasks
+    .filter((task) => seededConsent.get(task.id)?.keep !== false)
+    .map((task) => task.type)
+    .filter((type) => canAsk(registry.get(type)));
   analytics.setTag('orchestrator_awaits_user', askingTypes.length > 0);
   analytics.setTag(
     'orchestrator_runner_seeded_types',
@@ -632,6 +727,12 @@ export async function runOrchestrator(
           // How late the first ask lands is the measure of this run shape: it
           // should follow the autonomous work, not interrupt it.
           metrics.recordAsk(Date.now());
+          // Consent is taken in the first seconds of the run and these questions
+          // arrive at the end of it, so the user who agreed may well be looking
+          // at another window by now. Nothing here waits on the bell — an
+          // unanswered ask still times out into the deep-link fallback — it just
+          // gives a person who stepped away a chance to come back first.
+          ringTerminalBell();
           return getUI().requestQuestion(q);
         },
         cancelQuestion: () => getUI().cancelPendingQuestion(),
@@ -789,83 +890,38 @@ export async function runOrchestrator(
   const preexistingSkills = new Set(
     existsSync(claudeSkillsDir) ? readdirSync(claudeSkillsDir) : [],
   );
-  // One notice on screen at a time. The store keeps a single pending-notice
-  // slot, so a second `showTaskNotice` overwrites the first's resolver: the
-  // first promise never settles, its task hangs forever, and the overlay stack
-  // is left one deep. Seeding used to await its notices in a loop, which made
-  // that impossible; offering them from inside the drain does not, because the
-  // executor starts every runnable task at once. Today's graphs still serialize
-  // seeded tasks — the default deferral makes each wait for the one before —
-  // but that is a property of the current graph, not a guarantee, so gate it
-  // here where it cannot be undone by a future prompt declaring its own deps.
-  let noticeGate: Promise<unknown> = Promise.resolve();
   const runTask: RunTask = async (task) => {
     renderQueue();
 
-    // A task that stops for the user is offered, not imposed — and the offer
-    // belongs here, the moment before it runs, not at the top of the run. By now
-    // everything this task waits for is done, so the notice, the questions, and
-    // the work form one block at the end instead of a modal that interrupts
-    // before anything has happened.
+    // A task that stops for the user is offered, not imposed. The offer was
+    // made at seed time; this applies the answer, now that the drain has
+    // reached the task.
     //
-    // Declining skips the task rather than removing it: the planner has already
-    // wired the sink to depend on it, and `nextRunnable` treats a skipped
-    // dependency as satisfied, so the report still runs.
-    const notice = seededNotices.get(task.id);
-    if (notice) {
-      // Consume the offer so it is shown at most once per run. A requeue keeps
-      // the same task id, so without this delete a first attempt that fails or
-      // ends without reporting would re-offer the notice on retry — re-entering
-      // the very timeout stall this screen exists to prevent, double-firing the
-      // notice analytics, and (on a retry decline) overwriting attempt 1's real
-      // outcome with a skip. Later attempts fall through to the executor's
-      // normal retry flow instead.
-      seededNotices.delete(task.id);
-      // Queue behind any notice already on screen. The catch keeps one
-      // offer's failure from poisoning the gate for the next.
-      const offer = noticeGate.then(() => offerSeededTask(notice));
-      noticeGate = offer.catch(() => undefined);
-      // Fail closed. The offer is consumed above, so letting a thrown error
-      // escape would hand the task to the executor's retry path with no notice
-      // left to show — and the second attempt would run the step, and start
-      // asking for credentials, without anyone ever having agreed to it. No UI
-      // implementation throws here today; this is about which way it breaks if
-      // one ever does.
-      const { keep, timedOut } = await offer.catch((err: unknown) => {
-        logToFile(
-          `[orchestrator] notice failed for ${task.type}, declining: ${String(
-            err,
-          )}`,
-        );
-        analytics.captureException(
-          err instanceof Error ? err : new Error(String(err)),
-          { step: 'orchestrator_task_notice' },
-        );
-        return { keep: false, timedOut: false };
+    // A declined task is skipped here rather than dropped at seed time, for two
+    // reasons. The graph the planner saw is then the graph that ran — the sink
+    // already depends on this task, and `nextRunnable` treats a skipped
+    // dependency as satisfied, so the report still runs and can say the step was
+    // declined. And the decline stays in the funnel: it arrives as a `skipped`
+    // event carrying the reason that caused it, rather than as a task that
+    // silently never existed. `orchestrator task skipped` is only readable that
+    // way because it now carries `reason`; without it, declines and timeouts and
+    // agent no-ops were one indistinguishable number.
+    const consent = seededConsent.get(task.id);
+    if (consent && !consent.keep) {
+      const reason = consentSkipReason(consent);
+      logToFile(`[orchestrator] runner-seeded ${task.type} skipped: ${reason}`);
+      const declinedByUser = reason === SkipReason.UserDeclined;
+      store.skip(task.id, reason, {
+        goals: labelFor(task),
+        did: declinedByUser
+          ? 'Nothing — the user chose to skip this step when offered it.'
+          : 'Nothing — the step was offered at the start of the run and never accepted.',
+        forNextAgent: declinedByUser
+          ? 'This step was offered and declined, so it did no work. Report it as skipped at the user’s request, not as failed.'
+          : 'This step was offered and never accepted, so it did no work. Report it as not set up, and point the user at how to do it later.',
       });
-      analytics.wizardCapture('orchestrator task notice answered', {
-        type: task.type,
-        kept: keep,
-        timed_out: timedOut,
-      });
-      if (!keep) {
-        logToFile(
-          `[orchestrator] runner-seeded ${task.type} declined (${
-            timedOut ? 'timed out' : 'by the user'
-          })`,
-        );
-        store.skip(task.id, {
-          goals: notice.title,
-          did: timedOut
-            ? 'Nothing — the step was offered and the offer timed out with no answer.'
-            : 'Nothing — the user chose to skip this step when offered it.',
-          forNextAgent: timedOut
-            ? 'This step was offered and nobody answered, so it did no work. Report it as not set up, and point the user at how to do it later.'
-            : 'This step was offered and declined, so it did no work. Report it as skipped at the user’s request, not as failed.',
-        });
-        renderQueue();
-        return;
-      }
+      renderQueue();
+      return;
     }
 
     try {

--- a/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue-tools.ts
@@ -13,6 +13,7 @@ import {
   VALID_MODELS,
 } from '@lib/agent/runner/switchboard/models';
 import {
+  SkipReason,
   TaskStatus,
   type QueueStore,
   type QueuedTask,
@@ -301,7 +302,11 @@ export function applyComplete(
       args.handoff,
     );
   } else if (args.status === TaskStatus.Skipped) {
-    ctx.store.skip(id, args.handoff);
+    // The agent's own words stay in the handoff and out of telemetry. This flow
+    // reaches live database and API credentials, and the repo has no redaction
+    // pass for handoff prose, so the event carries the reason and the task type
+    // only — enough to separate an agent no-op from a user decline.
+    ctx.store.skip(id, SkipReason.AgentNotNeeded, args.handoff);
   } else {
     ctx.store.complete(id, args.handoff);
   }

--- a/src/lib/agent/runner/sequence/orchestrator/queue.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/queue.ts
@@ -27,6 +27,31 @@ export const TaskStatus = {
 
 export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
 
+/**
+ * Why a task ended as skipped.
+ *
+ * A skip has several causes that look identical from outside: an agent finding
+ * the step does not apply, a user declining it, and an offer nobody answered.
+ * They mean opposite things — the first is a no-op, the last two are the user
+ * telling us something — and telling them apart needs the reason recorded at
+ * the moment of the skip, not inferred later from timings.
+ *
+ * Recorded on the task like `error` is on a failed one, so it reaches the
+ * skipped-task event and the run's queue.json alike.
+ */
+export const SkipReason = {
+  /** The user answered the step's notice with Skip. */
+  UserDeclined: 'user-declined',
+  /** The notice went unanswered until it timed out. */
+  NoticeTimeout: 'notice-timeout',
+  /** The notice could not be shown at all, so consent failed closed. */
+  NoticeError: 'notice-error',
+  /** The task agent reported `not needed`: the step did not apply here. */
+  AgentNotNeeded: 'agent-not-needed',
+} as const;
+
+export type SkipReason = (typeof SkipReason)[keyof typeof SkipReason];
+
 export interface QueuedTask {
   id: string;
   type: string;
@@ -60,6 +85,8 @@ export interface QueuedTask {
   startedAt?: string;
   finishedAt?: string;
   error?: { type: string; message: string };
+  /** Set when `status` is `not needed`: why. The failed-task `error` of a skip. */
+  skipReason?: SkipReason;
 }
 
 export interface QueueFile {
@@ -294,8 +321,16 @@ export class QueueStore {
     return this.finish(id, TaskStatus.Done, handoff);
   }
 
-  /** Terminal: the agent could not do the task. Not done, not failed. */
-  skip(id: string, handoff?: TaskHandoff): QueuedTask {
+  /**
+   * Terminal: the task was not done, and that is not a failure.
+   *
+   * The reason is required, and sits before the optional handoff for that
+   * reason. A skip carrying no reason is what let a five-minute auto-decline
+   * hide inside the same event as an agent deciding a step did not apply.
+   */
+  skip(id: string, reason: SkipReason, handoff?: TaskHandoff): QueuedTask {
+    const t = this.require(id);
+    t.skipReason = reason;
     return this.finish(id, TaskStatus.Skipped, handoff);
   }
 

--- a/src/lib/programs/__tests__/warehouse-seed-task.test.ts
+++ b/src/lib/programs/__tests__/warehouse-seed-task.test.ts
@@ -106,6 +106,22 @@ describe('warehouse task notice', () => {
     expect(notice()?.body[0]).toContain('at the end');
   });
 
+  it('asks for the answer now, and says the credentials come later', () => {
+    // Two moments, minutes apart. The copy is shown at the first and has to
+    // name the second, or a user who says yes has no idea they will be needed
+    // again — which is how an accepted step still ends in an unanswered prompt.
+    const body = notice()?.body[0] ?? '';
+    expect(body).toContain('Answer now');
+    expect(body).toContain('credentials');
+  });
+
+  it('does not invite the user to leave for the whole run', () => {
+    // The copy written for the old start-of-run modal said "you can leave the
+    // setup to run until it asks". The run does stop and ask, at the end, for
+    // credentials only that person has.
+    expect(notice()?.body.join(' ')).not.toContain('leave the setup to run');
+  });
+
   it('names what was detected', () => {
     expect(notice()?.items).toEqual(['Postgres']);
   });

--- a/src/lib/programs/posthog-integration/index.ts
+++ b/src/lib/programs/posthog-integration/index.ts
@@ -161,8 +161,12 @@ const warehouseSeedTasks: NonNullable<ProgramConfig['seedTasks']> = (sess) => {
       },
       notice: {
         title: 'Connect your data sources',
+        // Two moments, and the copy has to name both. The answer is given here,
+        // at the start of the run. The credential questions arrive at the end of
+        // it, minutes later. So this must not read as "expect a prompt any
+        // moment now", and equally must not read as "walk away for the run".
         body: [
-          'We detected some warehouse sources we can connect to enrich your PostHog data. This runs at the end, once your code changes are done — we’ll prompt you then for the credentials, so you can leave the setup to run until it asks.',
+          'We detected some warehouse sources we can connect to enrich your PostHog data. Answer now, and we connect them at the end of the run, after your code changes. We will ask you for the credentials at that point, and beep when we do.',
           "You can select [Skip] if you'd like to do this later in PostHog.",
         ],
         items: sources.map((s) => s.label),

--- a/src/utils/__tests__/terminal-bell.test.ts
+++ b/src/utils/__tests__/terminal-bell.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The bell is the safeguard for the gap this change opens: consent is taken in
+ * the first seconds of the run, and the credential questions arrive at the end
+ * of it. It has to be audible to a person who stepped away, and invisible
+ * everywhere a bell cannot ring.
+ */
+import { ringTerminalBell } from '@utils/terminal-bell';
+
+const BEL = '\u0007';
+
+describe('ringTerminalBell', () => {
+  let write: ReturnType<typeof vi.spyOn>;
+  const isTTY = process.stderr.isTTY;
+
+  beforeEach(() => {
+    write = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    write.mockRestore();
+    Object.defineProperty(process.stderr, 'isTTY', {
+      value: isTTY,
+      configurable: true,
+    });
+  });
+
+  const setTTY = (value: boolean) =>
+    Object.defineProperty(process.stderr, 'isTTY', {
+      value,
+      configurable: true,
+    });
+
+  it('writes one BEL to stderr on a TTY', () => {
+    setTTY(true);
+    ringTerminalBell();
+    // stderr, not stdout: Ink owns stdout and repaints whole frames, so a byte
+    // written there can land inside one.
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(BEL);
+  });
+
+  it('stays silent when stderr is not a TTY', () => {
+    // A pipe or a CI log cannot ring; the byte would only pollute the capture.
+    setTTY(false);
+    ringTerminalBell();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the write fails', () => {
+    // A bell is a nicety. It must not be the thing that ends a run.
+    setTTY(true);
+    write.mockImplementation(() => {
+      throw new Error('EPIPE');
+    });
+    expect(() => ringTerminalBell()).not.toThrow();
+  });
+});

--- a/src/utils/terminal-bell.ts
+++ b/src/utils/terminal-bell.ts
@@ -1,0 +1,21 @@
+/**
+ * Ring the terminal bell (BEL, U+0007).
+ *
+ * The orchestrator takes consent for the warehouse step at the top of the run
+ * and asks for the credentials at the end of it, several autonomous minutes
+ * later. The person who agreed is often looking at something else by then. A
+ * bell is the one attention signal a terminal in a background tab can still
+ * deliver, and it costs a user who is watching nothing.
+ *
+ * Written to stderr, not stdout: Ink owns stdout and repaints whole frames, so
+ * a byte written there can land inside one. Silent when stderr is not a TTY —
+ * a pipe or a CI log cannot ring, and the byte would only pollute the capture.
+ */
+export function ringTerminalBell(): void {
+  if (!process.stderr.isTTY) return;
+  try {
+    process.stderr.write('\u0007');
+  } catch {
+    // A bell is a nicety. It must never be the thing that ends a run.
+  }
+}


### PR DESCRIPTION
## Problem

This changes the notice timing that #1103 introduced. That PR did the right
thing in principle: it moved the warehouse step to the end of the queue, so its
credential questions follow the autonomous coding instead of interrupting it. It
also moved the consent notice to the same place. The second move is the one this
PR reverses.

Before 2.63.0 the wizard showed "Connect your data sources" in the seed loop,
seconds into the run. After #1103 it shows the notice when the task becomes
runnable. For the warehouse step that is a median 7.1 minutes into the run (p90
12.7), after every coding task. The user has tabbed away. The notice waits five
minutes and then defaults to declining.

Warehouse task, production, 14 days:

| version | kept | declined | timed out | declines+timeouts | skips |
|---|---|---|---|---|---|
| 2.62.0 | 531 | 184 | 0 (pre-enqueue, invisible) | — | 3 |
| 2.63.0 | 70 | 33 | 40 | 73 | 74 |
| 2.64.0 | 36 | 19 | 21 | 40 | 40 |
| 2.64.1 | 216 | 91 | 111 | 202 | 206 |
| 2.65.0 | 88 | 54 | 56 | 110 | 110 |

Skips match declines plus timeouts almost exactly. The signature is the
duration: skipped warehouse tasks on 2.63.0 and later have p50 = p90 = 300s,
which is `TASK_NOTICE_TIMEOUT_MS` to the second. On 2.62.0 the same figure was
31s. Example run `7d640a8c`: coding tasks end 05:15:26, `started` 05:15:31,
`notice answered` with `kept=false, timed_out=true` at 05:20:31, `skipped` the
same instant with `duration_ms=300031`.

Please do not read the whole completion drop (77% to ~44%) as recoverable. It
splits in two.

- **An accounting shift, about half of it.** Explicit declines are 22% of
  offers. On 2.62.0 they were a comparable 26%, but a decline happened before
  the task was enqueued, so it produced no `started` and no `skipped` and never
  entered the funnel. Those users behave the same; only the bookkeeping changed.
- **A real regression, the other half.** Timeouts are 27% of offers. These are
  users who never said no. They were auto-declined out of a step they had no
  chance to answer.

Two things are not the cause, and I checked both. Agent-driven `not needed`
skips are about 2% of the total. And kept tasks now complete at 94% (204/216 on
2.64.1) against 79% on 2.62.0 — the agent itself got better.

## Changes

**Consent moves back to seed time. Execution stays at the end.** These are two
concerns, and #1103 separated them correctly before collapsing them back onto
one modal. `orchestrator-runner.ts` now offers each seeded task's notice in the
seed loop, awaited serially, and records the answer. `seeded-deps.ts` is
untouched, so the work still runs last, just before the report.

**A declined task is enqueued and then skipped, not dropped.** I chose this over
not enqueuing, and the code says why. The task stays an ordinary pending task
through planning, so the planner plans around it, the deferral can still add its
edges, and the sink invariant still covers it — none of which holds for a
terminal task inserted before the planner runs. The decline also stays in the
funnel, as a `skipped` event carrying its reason, rather than becoming a task
that silently never existed. The cost is that a decline now fires a `started`
event, which the reason property makes decomposable.

**The skip event says why.** `QueueStore.skip` takes a required reason, recorded
on the task like `error` is on a failed one, and `onTransition` forwards it onto
`orchestrator task skipped` as `reason`. Four values: `user-declined`,
`notice-timeout`, `notice-error`, `agent-not-needed`. The event name and every
existing property are unchanged, so current dashboards keep working.

The agent's own words stay out of that event. The handoff is LLM free text on a
flow that reaches live database and API credentials, and this repo has no
redaction pass for such prose, so the event carries the reason and the task type
only.

**The notice copy names both moments.** It said "you can leave the setup to run
until it asks". The run does stop and ask, at the end, for credentials only that
person has. It now says the answer is wanted now and the credentials come later.

**One secondary safeguard: a terminal bell.** I judged this worth doing. The old
end-of-run modal was, by accident, an "are you still there?" check right before
the credential questions. Removing it opens a gap: a user can consent at second
five and be absent at minute seven. The runner now rings the bell (BEL to
stderr, TTY only) when a credential question opens. I did not change the ask
timeout or the timeout fallback, because that path already degrades well — an
unanswered `wizard_ask` returns cancelled answers, refunds the per-run ask cap,
and the agent falls back to the deep links.

I also narrowed the `orchestrator_awaits_user` tag. The consent answer is known
before the tag is set now, so a declined run no longer claims to be waiting on a
person.

## Test plan

`pnpm build`, `pnpm test` (142 files, 2041 tests) and `pnpm lint` all pass. Lint
reports 0 errors; the 494 warnings are the pre-existing baseline and none are in
the changed files.

The #1103 tests that encode the old intent are updated, not deleted.

- `task-notice-timeout.test.ts` — the timeout still declines and still closes the
  modal, and an explicit Skip is still separated from a timeout. The two
  in-drain hazard tests become seed-loop tests: the serial loop is what makes a
  second modal and a re-ask on retry unreachable, so both properties are pinned
  against the loop that now provides them.
- `sink-closure.test.ts` — the declined-seeded-task cases now apply an answer
  taken at seed time, and assert the reason lands on the task.
- `queue.test.ts` — a new `skip reasons` block covers all four values, the
  reason reaching the transition listener, the reason staying unset on every
  other terminal transition, and the reason surviving to `queue.json`.
- `seeded-deps.test.ts` — a new `execution still happens last` block drains the
  full planned graph and asserts the warehouse task sits in the last tier before
  the sink, whatever order the coding tasks finish in.
- `queue-tools.test.ts` — `not needed` records `agent-not-needed`, and a handoff
  containing a connection string does not reach the reason.
- `warehouse-seed-task.test.ts` — the copy names both moments and no longer
  invites the user to leave for the whole run.
- `terminal-bell.test.ts` — one BEL on a TTY, silence off one, never throws.
