### PR TITLE
feat(e2e): let the e2e harness drive the warehouse flow

### DIFF
--- a/e2e-harness/ARCHITECTURE.md
+++ b/e2e-harness/ARCHITECTURE.md
@@ -89,6 +89,14 @@ sets `session.e2eAsk` from `E2E_ASK=true`, which keeps the bridge wired (see
 `askAnswers` routes a question to a value, else the first option, else the `'e2e'`
 sentinel. Route credentials with `${ENV_VAR}` values, never literals.
 
+Mark a credential rule `"secret": true`. The skill names its own questions, so a
+rule matches text the agent controls — without the flag, a question called
+`password` takes the value, and by omitting `sensitive: true` gets it back
+unvaulted in plaintext. A secret rule answers only free text flagged sensitive
+and refuses every other question shape; refusals land in the payload's
+`refusedIds` / `refusedAsks`, so a run that withholds a credential says so
+instead of looking like an ordinary sentinel.
+
 Task-notice overlay. `profile.notice` decides `keep` or `decline`. `E2E_NOTICE`
 overrides it per run.
 
@@ -106,6 +114,12 @@ it.
 ever does.** The decision function reports ids and a keep/decline verdict, so the
 recorder never holds an answer. Keep it that way — the workbench scans the file
 for its own injected credentials.
+
+The report file is the one payload field whose *content* comes from the app
+directory, which is a checkout the run does not control. `readReportFile` reads
+only a regular file inside `appDir` — never a symlink, and never through a
+symlinked parent — so a committed `posthog-warehouse-report.md` pointing at a
+host file cannot copy it into the payload.
 
 ## Visual-regression snapshots (the workbench flow)
 

--- a/e2e-harness/ARCHITECTURE.md
+++ b/e2e-harness/ARCHITECTURE.md
@@ -21,7 +21,8 @@ e2e-harness/
   wizard-ci-driver.ts   WizardCiDriver — read_state / perform_action over the store
   action-registry.ts    screen → the actions legal on it (+ NO_ACTION_SCREENS)
   e2e-profile.ts        WizardE2eProfile + decideE2eAction — the scripted walk policy
-  profiles.ts           per-program profiles + profileFor(programId)
+  profiles.ts           per-program profiles + profileFor(programId) + resolveE2eProfile(env)
+  e2e-result.ts         the E2E_RESULT_JSON payload: E2eRunRecorder + buildE2eResult
   tui-capture.ts        run a command in a PTY (node-pty) + read its real screen (@xterm/headless)
 scripts/
   tui-host.no-jest.ts   the real-TUI host: startTUI + WizardCiDriver, MODE=fixed | serve
@@ -77,6 +78,34 @@ not on the program config — so this machinery stays out of production source. 
 the program's entry (typed by `WizardE2eProfile`); the host asks
 `decideE2eAction(state, profile)` what to commit on each screen. The (screen →
 decision) trace is snapshot-tested offline in `__tests__/` (`jest -u` to update).
+
+## Driving the agent-in-the-loop layer
+
+Two decision points ask a person to act, and the harness stands in for them.
+
+`wizard_ask` overlay. A `ci` session normally has no ask bridge at all. The host
+sets `session.e2eAsk` from `E2E_ASK=true`, which keeps the bridge wired (see
+`shouldDisableAsk`). The profile then answers every question in the batch:
+`askAnswers` routes a question to a value, else the first option, else the `'e2e'`
+sentinel. Route credentials with `${ENV_VAR}` values, never literals.
+
+Task-notice overlay. `profile.notice` decides `keep` or `decline`. `E2E_NOTICE`
+overrides it per run.
+
+Both env inputs are folded into the profile by `resolveE2eProfile`, at load.
+`decideE2eAction` must stay pure — it reads no env and no store.
+
+## The result payload
+
+A `MODE=fixed` run writes `E2E_RESULT_JSON`: the run phase and screens walked,
+plus every ask batch, every task notice, the task list, the detected warehouse
+sources, the program's report file, and the abort reason. `e2e-result.ts` builds
+it.
+
+**Only question prompt text and question ids go in the payload. No answer value
+ever does.** The decision function reports ids and a keep/decline verdict, so the
+recorder never holds an answer. Keep it that way — the workbench scans the file
+for its own injected credentials.
 
 ## Visual-regression snapshots (the workbench flow)
 

--- a/e2e-harness/__tests__/__snapshots__/e2e-flow-snapshot.test.ts.snap
+++ b/e2e-harness/__tests__/__snapshots__/e2e-flow-snapshot.test.ts.snap
@@ -86,6 +86,7 @@ exports[`e2e flow snapshot — posthog-integration > Next.js (with a setup quest
     "ask": "first",
     "healthCheck": "dismiss",
     "mcp": "skip",
+    "notice": "keep",
     "setup": "first",
     "skills": "delete",
     "slack": "skip",
@@ -163,6 +164,77 @@ exports[`e2e flow snapshot — posthog-integration > Node (no setup question) wa
     {
       "action": "dismiss_slack",
       "screen": "slack-connect",
+    },
+    {
+      "action": "keep_skills",
+      "screen": "keep-skills",
+    },
+  ],
+}
+`;
+
+exports[`e2e flow snapshot — warehouse-source > walks intro → auth → run → outro → skills 1`] = `
+{
+  "profile": {
+    "ask": "first",
+    "askAnswers": [
+      {
+        "match": "prefix",
+        "value": "\${E2E_SOURCE_PREFIX}",
+      },
+      {
+        "match": "stripe",
+        "value": "\${E2E_STRIPE_API_KEY}",
+      },
+      {
+        "match": "host|hostname|server|endpoint",
+        "value": "\${E2E_PG_HOST}",
+      },
+      {
+        "match": "port",
+        "value": "\${E2E_PG_PORT}",
+      },
+      {
+        "match": "database|db_?name",
+        "value": "\${E2E_PG_DATABASE}",
+      },
+      {
+        "match": "password|passwd|pwd",
+        "value": "\${E2E_PG_PASSWORD}",
+      },
+      {
+        "match": "user|username|role",
+        "value": "\${E2E_PG_USER}",
+      },
+      {
+        "match": "schema",
+        "value": "public",
+      },
+    ],
+    "healthCheck": "dismiss",
+    "mcp": "skip",
+    "notice": "keep",
+    "setup": "first",
+    "skills": "delete",
+    "slack": "skip",
+  },
+  "program": "warehouse-source",
+  "trace": [
+    {
+      "action": "confirm_setup",
+      "screen": "warehouse-intro",
+    },
+    {
+      "action": "(external)",
+      "screen": "auth",
+    },
+    {
+      "action": "(external)",
+      "screen": "run",
+    },
+    {
+      "action": "dismiss_outro",
+      "screen": "outro",
     },
     {
       "action": "keep_skills",

--- a/e2e-harness/__tests__/__snapshots__/e2e-flow-snapshot.test.ts.snap
+++ b/e2e-harness/__tests__/__snapshots__/e2e-flow-snapshot.test.ts.snap
@@ -184,6 +184,7 @@ exports[`e2e flow snapshot — warehouse-source > walks intro → auth → run �
       },
       {
         "match": "stripe",
+        "secret": true,
         "value": "\${E2E_STRIPE_API_KEY}",
       },
       {
@@ -200,6 +201,7 @@ exports[`e2e flow snapshot — warehouse-source > walks intro → auth → run �
       },
       {
         "match": "password|passwd|pwd",
+        "secret": true,
         "value": "\${E2E_PG_PASSWORD}",
       },
       {

--- a/e2e-harness/__tests__/e2e-flow-snapshot.test.ts
+++ b/e2e-harness/__tests__/e2e-flow-snapshot.test.ts
@@ -129,3 +129,26 @@ describe('e2e flow snapshot — metrics', () => {
     expect(trace.length).toBeLessThan(40);
   });
 });
+
+describe('e2e flow snapshot — warehouse-source', () => {
+  it('walks intro → auth → run → outro → skills', () => {
+    expect({
+      program: 'warehouse-source',
+      profile: profileFor(Program.WarehouseSource),
+      trace: traceFlow(Integration.javascriptNode, Program.WarehouseSource),
+    }).toMatchSnapshot();
+  });
+
+  it('reaches a terminal decision instead of stalling on the intro', () => {
+    const trace = traceFlow(
+      Integration.javascriptNode,
+      Program.WarehouseSource,
+    );
+    expect(trace[0]).toEqual({
+      screen: 'warehouse-intro',
+      action: 'confirm_setup',
+    });
+    expect(trace.at(-1)?.action).toBe('keep_skills');
+    expect(trace.length).toBeLessThan(40);
+  });
+});

--- a/e2e-harness/__tests__/e2e-profile-ask.test.ts
+++ b/e2e-harness/__tests__/e2e-profile-ask.test.ts
@@ -1,0 +1,497 @@
+/**
+ * The agent-in-the-loop half of the e2e profile: how a run answers a
+ * `wizard_ask` batch, and how it resolves a task notice.
+ *
+ * These two decision points are the only places a headless run stands in for a
+ * person. Everything below pins the resolution order the cross-repo contract
+ * froze, so a workbench run can rely on it.
+ */
+
+import { Overlay, ScreenId } from '@ui/tui/router';
+import type { AskQuestion } from '@lib/wizard-session';
+import {
+  DEFAULT_E2E_PROFILE,
+  E2E_ANSWER_SENTINEL,
+  E2E_DRIVABLE_SCREENS,
+  answerQuestions,
+  decideE2eAction,
+  type WizardE2eProfile,
+} from '../e2e-profile';
+import { profileFor, resolveE2eProfile } from '../profiles';
+import { Program } from '@lib/programs/program-registry';
+import type { CiState } from '../wizard-ci-driver';
+
+const text = (id: string, prompt = id): AskQuestion => ({
+  id,
+  prompt,
+  kind: 'text',
+});
+
+const single = (id: string, values: string[]): AskQuestion => ({
+  id,
+  prompt: id,
+  kind: 'single',
+  options: values.map((v) => ({ label: v, value: v })),
+});
+
+const multi = (id: string, values: string[]): AskQuestion => ({
+  ...single(id, values),
+  kind: 'multi',
+});
+
+function profile(over: Partial<WizardE2eProfile> = {}): WizardE2eProfile {
+  return { ...DEFAULT_E2E_PROFILE, ...over };
+}
+
+/** A CiState carrying just the fields the two overlay cases read. */
+function state(over: Partial<CiState>): CiState {
+  return {
+    currentScreen: ScreenId.Run,
+    pendingQuestion: null,
+    taskNotice: null,
+    setupQuestions: [],
+    ...over,
+  } as CiState;
+}
+
+describe('answerQuestions — the whole batch', () => {
+  it('answers every question, not just the first', () => {
+    const batch = answerQuestions(
+      [text('host'), text('port'), text('database')],
+      profile(),
+    );
+    expect(Object.keys(batch.answers)).toEqual(['host', 'port', 'database']);
+  });
+
+  it('falls back to the sentinel for free text with no rule and no options', () => {
+    const batch = answerQuestions([text('host')], profile());
+    expect(batch.answers.host).toBe(E2E_ANSWER_SENTINEL);
+    expect(batch.sentinelIds).toEqual(['host']);
+    expect(batch.answeredIds).toEqual([]);
+  });
+
+  it('takes the first option for a single-choice question', () => {
+    const batch = answerQuestions(
+      [single('sync', ['full', 'incremental'])],
+      profile(),
+    );
+    expect(batch.answers.sync).toBe('full');
+    expect(batch.answeredIds).toEqual(['sync']);
+    expect(batch.sentinelIds).toEqual([]);
+  });
+
+  it('gives a multi-choice question an array answer', () => {
+    const batch = answerQuestions([multi('tables', ['a', 'b'])], profile());
+    expect(batch.answers.tables).toEqual(['a']);
+  });
+
+  it('wraps a routed answer in an array for a multi-choice question', () => {
+    const batch = answerQuestions(
+      [multi('tables', ['a', 'b'])],
+      profile({ askAnswers: [{ match: 'tables', value: 'b' }] }),
+    );
+    expect(batch.answers.tables).toEqual(['b']);
+  });
+
+  it('reports answered and sentinel ids separately across a mixed batch', () => {
+    const batch = answerQuestions(
+      [text('prefix'), text('secret'), single('mode', ['cdc'])],
+      profile({ askAnswers: [{ match: '^prefix$', value: 'e2e_42_' }] }),
+    );
+    expect(batch.answeredIds).toEqual(['prefix', 'mode']);
+    expect(batch.sentinelIds).toEqual(['secret']);
+  });
+});
+
+describe('answerQuestions — askAnswers matching', () => {
+  it('matches the question id', () => {
+    const batch = answerQuestions(
+      [text('pg_host', 'Where does it live?')],
+      profile({ askAnswers: [{ match: 'pg_host', value: 'db.internal' }] }),
+    );
+    expect(batch.answers.pg_host).toBe('db.internal');
+  });
+
+  it('falls back to matching the prompt when the id does not match', () => {
+    const batch = answerQuestions(
+      [text('q1', 'Postgres host')],
+      profile({ askAnswers: [{ match: 'host', value: 'db.internal' }] }),
+    );
+    expect(batch.answers.q1).toBe('db.internal');
+  });
+
+  it('tries the id before the prompt, so an id match wins', () => {
+    // Rule order alone cannot decide this: both rules are candidates for this
+    // question. The id is the more specific signal, so it is tested first.
+    const batch = answerQuestions(
+      [text('port', 'the database host and port')],
+      profile({
+        askAnswers: [
+          { match: 'host', value: 'from-prompt' },
+          { match: 'port', value: 'from-id' },
+        ],
+      }),
+    );
+    expect(batch.answers.port).toBe('from-id');
+  });
+
+  it('takes the first matching rule when several match', () => {
+    const batch = answerQuestions(
+      [text('password')],
+      profile({
+        askAnswers: [
+          { match: 'pass', value: 'first' },
+          { match: 'password', value: 'second' },
+        ],
+      }),
+    );
+    expect(batch.answers.password).toBe('first');
+  });
+
+  it('matches case-insensitively', () => {
+    const batch = answerQuestions(
+      [text('q1', 'STRIPE API KEY')],
+      profile({ askAnswers: [{ match: 'stripe', value: 'sk_test' }] }),
+    );
+    expect(batch.answers.q1).toBe('sk_test');
+  });
+
+  it('skips a malformed regex instead of failing the run', () => {
+    const batch = answerQuestions(
+      [text('host')],
+      profile({
+        askAnswers: [
+          { match: '([unclosed', value: 'never' },
+          { match: 'host', value: 'db.internal' },
+        ],
+      }),
+    );
+    expect(batch.answers.host).toBe('db.internal');
+  });
+
+  it('treats an empty resolved value as no match', () => {
+    const batch = answerQuestions(
+      [text('host')],
+      profile({ askAnswers: [{ match: 'host', value: '' }] }),
+    );
+    expect(batch.answers.host).toBe(E2E_ANSWER_SENTINEL);
+    expect(batch.sentinelIds).toEqual(['host']);
+  });
+});
+
+describe('resolveE2eProfile — env interpolation', () => {
+  const base = profile({
+    askAnswers: [
+      { match: 'prefix', value: '${E2E_SOURCE_PREFIX}' },
+      { match: 'host', value: '${E2E_PG_HOST}:${E2E_PG_PORT}' },
+      { match: 'schema', value: 'public' },
+    ],
+  });
+
+  it('expands ${VAR} from the supplied env', () => {
+    const resolved = resolveE2eProfile(base, {
+      env: { E2E_SOURCE_PREFIX: 'e2e_99_' },
+    });
+    expect(resolved.askAnswers?.[0].value).toBe('e2e_99_');
+  });
+
+  it('expands several references in one value', () => {
+    const resolved = resolveE2eProfile(base, {
+      env: { E2E_PG_HOST: 'db', E2E_PG_PORT: '5432' },
+    });
+    expect(resolved.askAnswers?.[1].value).toBe('db:5432');
+  });
+
+  it('resolves an unset var to an empty string, which becomes a sentinel', () => {
+    const resolved = resolveE2eProfile(base, { env: {} });
+    const batch = answerQuestions([text('prefix')], resolved);
+    expect(batch.answers.prefix).toBe(E2E_ANSWER_SENTINEL);
+    expect(batch.sentinelIds).toEqual(['prefix']);
+  });
+
+  it('leaves a literal value alone', () => {
+    const resolved = resolveE2eProfile(base, { env: {} });
+    expect(resolved.askAnswers?.[2].value).toBe('public');
+  });
+
+  it('merges E2E_ANSWERS_FILE rules ahead of the profile rules', () => {
+    const resolved = resolveE2eProfile(base, {
+      env: { E2E_SOURCE_PREFIX: 'from_env_' },
+      extraAskAnswers: [{ match: 'prefix', value: 'from_file_' }],
+    });
+    const batch = answerQuestions([text('prefix')], resolved);
+    expect(batch.answers.prefix).toBe('from_file_');
+  });
+
+  it('interpolates the merged rules too', () => {
+    const resolved = resolveE2eProfile(base, {
+      env: { OVERRIDE: 'yes' },
+      extraAskAnswers: [{ match: 'prefix', value: '${OVERRIDE}' }],
+    });
+    expect(resolved.askAnswers?.[0].value).toBe('yes');
+  });
+
+  it('does not mutate the profile it was given', () => {
+    resolveE2eProfile(base, { env: { E2E_SOURCE_PREFIX: 'x' } });
+    expect(base.askAnswers?.[0].value).toBe('${E2E_SOURCE_PREFIX}');
+  });
+});
+
+describe('resolveE2eProfile — notice policy', () => {
+  it('keeps the profile default when no override is given', () => {
+    expect(resolveE2eProfile(profile({ notice: 'decline' })).notice).toBe(
+      'decline',
+    );
+  });
+
+  it.each(['keep', 'decline'] as const)(
+    'lets E2E_NOTICE=%s override the profile',
+    (notice) => {
+      const other = notice === 'keep' ? 'decline' : 'keep';
+      expect(
+        resolveE2eProfile(profile({ notice: other }), { notice }).notice,
+      ).toBe(notice);
+    },
+  );
+
+  it.each(['', 'maybe', 'KEEP'])(
+    'ignores the unrecognised override %p',
+    (notice) => {
+      expect(
+        resolveE2eProfile(profile({ notice: 'keep' }), { notice }).notice,
+      ).toBe('keep');
+    },
+  );
+});
+
+describe('decideE2eAction — wizard_ask overlay', () => {
+  const pending = {
+    id: 'ask_1',
+    source: 'data-warehouse-source-setup',
+    questions: [text('host'), text('port')],
+  };
+
+  it('answers the whole batch in one commit', () => {
+    const decision = decideE2eAction(
+      state({ currentScreen: Overlay.WizardAsk, pendingQuestion: pending }),
+      profile({ askAnswers: [{ match: 'host', value: 'db' }] }),
+    );
+    expect(decision.action?.id).toBe('answer_question');
+    expect(decision.action?.params?.answers).toEqual({
+      host: 'db',
+      port: E2E_ANSWER_SENTINEL,
+    });
+  });
+
+  it('reports the answered/sentinel split without any answer value', () => {
+    const decision = decideE2eAction(
+      state({ currentScreen: Overlay.WizardAsk, pendingQuestion: pending }),
+      profile({ askAnswers: [{ match: 'host', value: 'db' }] }),
+    );
+    expect(decision.report).toEqual({
+      kind: 'ask',
+      id: 'ask_1',
+      answeredIds: ['host'],
+      sentinelIds: ['port'],
+    });
+    expect(JSON.stringify(decision.report)).not.toContain('db');
+  });
+
+  it('waits when the overlay is up but the question has not landed', () => {
+    const decision = decideE2eAction(
+      state({ currentScreen: Overlay.WizardAsk, pendingQuestion: null }),
+      profile(),
+    );
+    expect(decision).toEqual({ wait: true });
+  });
+
+  it('waits on an empty batch rather than committing an empty answers map', () => {
+    const decision = decideE2eAction(
+      state({
+        currentScreen: Overlay.WizardAsk,
+        pendingQuestion: { ...pending, questions: [] },
+      }),
+      profile(),
+    );
+    expect(decision).toEqual({ wait: true });
+  });
+});
+
+describe('decideE2eAction — task-notice overlay', () => {
+  const notice = {
+    title: 'Connect your data sources',
+    items: ['Postgres', 'Stripe'],
+    prompt: 'Connect these during setup?',
+  };
+
+  it('keeps the step by default', () => {
+    const decision = decideE2eAction(
+      state({ currentScreen: Overlay.TaskNotice, taskNotice: notice }),
+      profile(),
+    );
+    expect(decision.action).toEqual({
+      id: 'resolve_notice',
+      params: { keep: true },
+    });
+    expect(decision.report).toEqual({
+      kind: 'notice',
+      title: notice.title,
+      decision: 'keep',
+    });
+  });
+
+  it('declines the step when the profile says so', () => {
+    const decision = decideE2eAction(
+      state({ currentScreen: Overlay.TaskNotice, taskNotice: notice }),
+      profile({ notice: 'decline' }),
+    );
+    expect(decision.action).toEqual({
+      id: 'resolve_notice',
+      params: { keep: false },
+    });
+    expect(decision.report).toEqual({
+      kind: 'notice',
+      title: notice.title,
+      decision: 'decline',
+    });
+  });
+
+  it('follows E2E_NOTICE once it is resolved into the profile', () => {
+    const resolved = resolveE2eProfile(profile({ notice: 'keep' }), {
+      notice: 'decline',
+    });
+    const decision = decideE2eAction(
+      state({ currentScreen: Overlay.TaskNotice, taskNotice: notice }),
+      resolved,
+    );
+    expect(decision.action?.params).toEqual({ keep: false });
+  });
+
+  it('waits when the overlay is up but the notice has not landed', () => {
+    const decision = decideE2eAction(
+      state({ currentScreen: Overlay.TaskNotice, taskNotice: null }),
+      profile(),
+    );
+    expect(decision).toEqual({ wait: true });
+  });
+});
+
+describe('decideE2eAction purity', () => {
+  it('reads nothing from process.env — the same inputs decide the same way', () => {
+    const args = () =>
+      [
+        state({
+          currentScreen: Overlay.TaskNotice,
+          taskNotice: { title: 't', items: [], prompt: 'p' },
+        }),
+        profile({ notice: 'keep' }),
+      ] as const;
+    const before = decideE2eAction(...args());
+    process.env.E2E_NOTICE = 'decline';
+    try {
+      expect(decideE2eAction(...args())).toEqual(before);
+    } finally {
+      delete process.env.E2E_NOTICE;
+    }
+  });
+});
+
+describe('E2E_DRIVABLE_SCREENS', () => {
+  it('lists the task-notice overlay', () => {
+    expect(E2E_DRIVABLE_SCREENS).toContain(Overlay.TaskNotice);
+  });
+
+  it('has a decideE2eAction case for every screen it lists', () => {
+    // A listed screen with no case would return `{ wait: true }` forever,
+    // stalling the run instead of failing it.
+    const overlayState: Partial<Record<string, Partial<CiState>>> = {
+      [Overlay.WizardAsk]: {
+        pendingQuestion: {
+          id: 'a',
+          source: 's',
+          questions: [text('q')],
+        },
+      },
+      [Overlay.TaskNotice]: {
+        taskNotice: { title: 't', items: [], prompt: 'p' },
+      },
+      [ScreenId.Setup]: {
+        setupQuestions: [
+          {
+            key: 'router',
+            message: 'router?',
+            options: [{ label: 'a', value: 'a' }],
+          },
+        ],
+      },
+    };
+    for (const screen of E2E_DRIVABLE_SCREENS) {
+      const decision = decideE2eAction(
+        state({ currentScreen: screen, ...(overlayState[screen] ?? {}) }),
+        profile(),
+      );
+      expect({ screen, hasAction: Boolean(decision.action) }).toEqual({
+        screen,
+        hasAction: true,
+      });
+    }
+  });
+});
+
+describe('warehouse-source profile', () => {
+  const warehouse = profileFor(Program.WarehouseSource);
+
+  it('is registered, not the happy-path default', () => {
+    expect(warehouse.askAnswers?.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the task notice and deletes installed skills', () => {
+    expect(warehouse.notice).toBe('keep');
+    expect(warehouse.skills).toBe('delete');
+    expect(warehouse.mcp).toBe('skip');
+  });
+
+  it('routes each credential question to its own env var', () => {
+    const env = {
+      E2E_SOURCE_PREFIX: 'e2e_7_',
+      E2E_STRIPE_API_KEY: 'sk_test_7',
+      E2E_PG_HOST: 'db.internal',
+      E2E_PG_PORT: '5432',
+      E2E_PG_DATABASE: 'appdb',
+      E2E_PG_USER: 'app',
+      E2E_PG_PASSWORD: 'hunter2',
+    };
+    const resolved = resolveE2eProfile(warehouse, { env });
+    const batch = answerQuestions(
+      [
+        text('prefix', 'Table prefix'),
+        text('stripe_api_key', 'Stripe API key'),
+        text('host', 'Postgres host'),
+        text('port', 'Port'),
+        text('database', 'Database name'),
+        text('user', 'Username'),
+        text('password', 'Password'),
+      ],
+      resolved,
+    );
+    expect(batch.answers).toEqual({
+      prefix: 'e2e_7_',
+      stripe_api_key: 'sk_test_7',
+      host: 'db.internal',
+      port: '5432',
+      database: 'appdb',
+      user: 'app',
+      password: 'hunter2',
+    });
+    expect(batch.sentinelIds).toEqual([]);
+  });
+
+  it('sentinels every credential when the env is empty', () => {
+    const resolved = resolveE2eProfile(warehouse, { env: {} });
+    const batch = answerQuestions(
+      [text('host', 'Postgres host'), text('password', 'Password')],
+      resolved,
+    );
+    expect(batch.sentinelIds).toEqual(['host', 'password']);
+  });
+});

--- a/e2e-harness/__tests__/e2e-profile-ask.test.ts
+++ b/e2e-harness/__tests__/e2e-profile-ask.test.ts
@@ -27,6 +27,12 @@ const text = (id: string, prompt = id): AskQuestion => ({
   kind: 'text',
 });
 
+/** Free text the skill flagged sensitive — the only shape a secret rule answers. */
+const sensitiveText = (id: string, prompt = id): AskQuestion => ({
+  ...text(id, prompt),
+  sensitive: true,
+});
+
 const single = (id: string, values: string[]): AskQuestion => ({
   id,
   prompt: id,
@@ -179,6 +185,85 @@ describe('answerQuestions — askAnswers matching', () => {
   });
 });
 
+/**
+ * The skill names its own questions, so a rule matching on `id` or `prompt` is
+ * matching agent-controlled text. A rule carrying a real credential therefore
+ * answers only a question shaped so `wizard_ask` will vault the answer — free
+ * text flagged sensitive. Anything else is refused, never answered.
+ */
+describe('answerQuestions — secret rules', () => {
+  const secretRule = { match: 'stripe', value: 'sk_live_real', secret: true };
+
+  it('answers a sensitive text question', () => {
+    const batch = answerQuestions(
+      [sensitiveText('stripe_api_key', 'Stripe API key')],
+      profile({ askAnswers: [secretRule] }),
+    );
+    expect(batch.answers.stripe_api_key).toBe('sk_live_real');
+    expect(batch.answeredIds).toEqual(['stripe_api_key']);
+    expect(batch.refusedIds).toEqual([]);
+  });
+
+  it('refuses a text question the skill did not flag sensitive', () => {
+    const batch = answerQuestions(
+      [text('stripe_api_key', 'Stripe API key')],
+      profile({ askAnswers: [secretRule] }),
+    );
+    expect(batch.answers.stripe_api_key).toBe(E2E_ANSWER_SENTINEL);
+    expect(batch.refusedIds).toEqual(['stripe_api_key']);
+    expect(batch.answeredIds).toEqual([]);
+  });
+
+  it('refuses a picker question wearing a credential name', () => {
+    const batch = answerQuestions(
+      [{ ...single('stripe_key', ['a', 'b']), sensitive: true }],
+      profile({ askAnswers: [secretRule] }),
+    );
+    // Even flagged sensitive: `sensitive` is text-only, so a picker would come
+    // back unvaulted. Refused rather than falling through to option 'a'.
+    expect(batch.answers.stripe_key).toBe(E2E_ANSWER_SENTINEL);
+    expect(batch.refusedIds).toEqual(['stripe_key']);
+  });
+
+  it('refuses on a prompt match too, not just an id match', () => {
+    const batch = answerQuestions(
+      [text('q1', 'Paste your Stripe key here')],
+      profile({ askAnswers: [secretRule] }),
+    );
+    expect(batch.refusedIds).toEqual(['q1']);
+    expect(JSON.stringify(batch.answers)).not.toContain('sk_live_real');
+  });
+
+  it('leaves non-secret rules alone — an ordinary field still answers', () => {
+    const batch = answerQuestions(
+      [text('host', 'Postgres host')],
+      profile({ askAnswers: [secretRule, { match: 'host', value: 'db' }] }),
+    );
+    expect(batch.answers.host).toBe('db');
+    expect(batch.refusedIds).toEqual([]);
+  });
+
+  it('is inert when the credential env var is unset — sentinel, not refusal', () => {
+    const resolved = resolveE2eProfile(
+      profile({ askAnswers: [{ ...secretRule, value: '${NOPE}' }] }),
+      { env: {} },
+    );
+    const batch = answerQuestions([text('stripe_key', 'Stripe key')], resolved);
+    expect(batch.sentinelIds).toEqual(['stripe_key']);
+    expect(batch.refusedIds).toEqual([]);
+  });
+
+  it('survives interpolation with its secret flag intact', () => {
+    const resolved = resolveE2eProfile(
+      profile({ askAnswers: [{ ...secretRule, value: '${KEY}' }] }),
+      { env: { KEY: 'sk_test_1' } },
+    );
+    expect(resolved.askAnswers?.[0].secret).toBe(true);
+    const batch = answerQuestions([text('stripe_key', 'Stripe key')], resolved);
+    expect(batch.refusedIds).toEqual(['stripe_key']);
+  });
+});
+
 describe('resolveE2eProfile — env interpolation', () => {
   const base = profile({
     askAnswers: [
@@ -293,6 +378,7 @@ describe('decideE2eAction — wizard_ask overlay', () => {
       id: 'ask_1',
       answeredIds: ['host'],
       sentinelIds: ['port'],
+      refusedIds: [],
     });
     expect(JSON.stringify(decision.report)).not.toContain('db');
   });
@@ -465,12 +551,12 @@ describe('warehouse-source profile', () => {
     const batch = answerQuestions(
       [
         text('prefix', 'Table prefix'),
-        text('stripe_api_key', 'Stripe API key'),
+        sensitiveText('stripe_api_key', 'Stripe API key'),
         text('host', 'Postgres host'),
         text('port', 'Port'),
         text('database', 'Database name'),
         text('user', 'Username'),
-        text('password', 'Password'),
+        sensitiveText('password', 'Password'),
       ],
       resolved,
     );
@@ -484,14 +570,35 @@ describe('warehouse-source profile', () => {
       password: 'hunter2',
     });
     expect(batch.sentinelIds).toEqual([]);
+    expect(batch.refusedIds).toEqual([]);
+  });
+
+  it('marks its credential-bearing rules secret', () => {
+    const secretMatches = (warehouse.askAnswers ?? [])
+      .filter((r) => r.secret)
+      .map((r) => r.match);
+    expect(secretMatches).toEqual(['stripe', 'password|passwd|pwd']);
+  });
+
+  it('withholds the API key from a question that is not sensitive', () => {
+    const resolved = resolveE2eProfile(warehouse, {
+      env: { E2E_STRIPE_API_KEY: 'sk_test_7' },
+    });
+    const batch = answerQuestions(
+      [text('stripe_api_key', 'Stripe API key')],
+      resolved,
+    );
+    expect(batch.answers.stripe_api_key).toBe(E2E_ANSWER_SENTINEL);
+    expect(batch.refusedIds).toEqual(['stripe_api_key']);
   });
 
   it('sentinels every credential when the env is empty', () => {
     const resolved = resolveE2eProfile(warehouse, { env: {} });
     const batch = answerQuestions(
-      [text('host', 'Postgres host'), text('password', 'Password')],
+      [text('host', 'Postgres host'), sensitiveText('password', 'Password')],
       resolved,
     );
     expect(batch.sentinelIds).toEqual(['host', 'password']);
+    expect(batch.refusedIds).toEqual([]);
   });
 });

--- a/e2e-harness/__tests__/e2e-result.test.ts
+++ b/e2e-harness/__tests__/e2e-result.test.ts
@@ -90,6 +90,7 @@ describe('E2eRunRecorder — ask batches', () => {
       prompts: ['Postgres host', 'Port'],
       answeredIds: [],
       sentinelIds: [],
+      refusedIds: [],
       at: '2026-08-27T10:00:00.000Z',
     });
   });
@@ -132,6 +133,7 @@ describe('E2eRunRecorder — ask batches', () => {
       id: 'a1',
       answeredIds: ['host'],
       sentinelIds: ['password'],
+      refusedIds: [],
     });
     expect(recorder.asks[0].answeredIds).toEqual(['host']);
     expect(recorder.asks[0].sentinelIds).toEqual(['password']);
@@ -145,6 +147,7 @@ describe('E2eRunRecorder — ask batches', () => {
       id: 'ghost',
       answeredIds: [],
       sentinelIds: ['x'],
+      refusedIds: [],
     });
     expect(recorder.asks).toEqual([]);
     expect(recorder.unansweredAsks).toBe(0);
@@ -162,9 +165,32 @@ describe('E2eRunRecorder — ask batches', () => {
         id,
         answeredIds: [],
         sentinelIds: ['p'],
+        refusedIds: [],
       });
     }
     expect(recorder.unansweredAsks).toBe(2);
+  });
+
+  it('records a refusal, and counts it as unanswered', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(
+      observed({
+        pendingQuestion: ask('a1', [
+          question('host', 'Host'),
+          question('password', 'Password'),
+        ]),
+      }),
+    );
+    recorder.applyReport({
+      kind: 'ask',
+      id: 'a1',
+      answeredIds: ['host'],
+      sentinelIds: [],
+      refusedIds: ['password'],
+    });
+    expect(recorder.asks[0].refusedIds).toEqual(['password']);
+    expect(recorder.refusedAsks).toBe(1);
+    expect(recorder.unansweredAsks).toBe(1);
   });
 });
 
@@ -319,6 +345,57 @@ describe('readReportFile', () => {
       text: '# Report\n',
     });
   });
+
+  // The app directory is a checkout the run does not control, so the file at
+  // the report path is attacker-controlled input. A symlink must never be
+  // dereferenced into the payload.
+  it('refuses a report path that is a symlink to a host file', () => {
+    const outside = path.join(os.tmpdir(), `e2e-outside-${process.pid}.txt`);
+    fs.writeFileSync(outside, 'AWS_SECRET_ACCESS_KEY=leak\n');
+    fs.symlinkSync(outside, path.join(dir, 'posthog-warehouse-report.md'));
+    const result = readReportFile(dir, 'posthog-warehouse-report.md');
+    expect(result).toEqual({
+      path: path.join(dir, 'posthog-warehouse-report.md'),
+      exists: false,
+      rejected: 'not-a-regular-file',
+    });
+    expect(JSON.stringify(result)).not.toContain('leak');
+    fs.rmSync(outside, { force: true });
+  });
+
+  it('refuses a symlink that points back inside the app dir', () => {
+    fs.writeFileSync(path.join(dir, 'real.md'), '# Real\n');
+    fs.symlinkSync(
+      path.join(dir, 'real.md'),
+      path.join(dir, 'posthog-warehouse-report.md'),
+    );
+    expect(readReportFile(dir, 'posthog-warehouse-report.md')?.rejected).toBe(
+      'not-a-regular-file',
+    );
+  });
+
+  it('refuses a report reached through a symlinked parent directory', () => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-outside-'));
+    fs.writeFileSync(path.join(outsideDir, 'report.md'), 'host secrets\n');
+    fs.symlinkSync(outsideDir, path.join(dir, 'reports'));
+    const result = readReportFile(dir, 'reports/report.md');
+    expect(result?.exists).toBe(false);
+    expect(result?.rejected).toBe('outside-app-dir');
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it('refuses a report name that escapes the app dir', () => {
+    expect(readReportFile(dir, '../../etc/passwd')?.rejected).toBe(
+      'outside-app-dir',
+    );
+  });
+
+  it('refuses a directory standing in for the report', () => {
+    fs.mkdirSync(path.join(dir, 'posthog-warehouse-report.md'));
+    expect(readReportFile(dir, 'posthog-warehouse-report.md')?.rejected).toBe(
+      'not-a-regular-file',
+    );
+  });
 });
 
 describe('buildE2eResult', () => {
@@ -365,6 +442,7 @@ describe('buildE2eResult', () => {
         'hasPosthogDep',
         'newDeps',
         'notices',
+        'refusedAsks',
         'reportFile',
         'runPhase',
         'screenPath',
@@ -406,6 +484,7 @@ describe('buildE2eResult', () => {
       id: 'a1',
       answeredIds: [],
       sentinelIds: ['p'],
+      refusedIds: [],
     });
     expect(build(recorder).unansweredAsks).toBe(1);
   });
@@ -494,6 +573,7 @@ describe('security rail — no answer value reaches the payload', () => {
       'prompts',
       'questionCount',
       'questionIds',
+      'refusedIds',
       'sentinelIds',
       'source',
       'subject',

--- a/e2e-harness/__tests__/e2e-result.test.ts
+++ b/e2e-harness/__tests__/e2e-result.test.ts
@@ -1,0 +1,502 @@
+/**
+ * The `E2E_RESULT_JSON` payload: what a run records about its asks, notices,
+ * tasks and detected sources — and, above all, what it must never record.
+ *
+ * The security rail is the reason this file exists. The workbench injects known
+ * credential values into a run and scans the payload for them; if one ever
+ * appears, a CI artifact is leaking secrets. The rail is structural here — the
+ * recorder is never handed an answers map — so these tests pin the structure.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { OutroKind, RunPhase } from '@lib/wizard-session';
+import type { AskQuestion, WizardSession } from '@lib/wizard-session';
+import { DETECTED_WAREHOUSE_SOURCES_KEY } from '@lib/programs/warehouse-source/detect';
+import { Overlay } from '@ui/tui/router';
+import {
+  E2eRunRecorder,
+  abortReasonFrom,
+  buildE2eResult,
+  detectedSourcesFrom,
+  readReportFile,
+} from '../e2e-result';
+import { DEFAULT_E2E_PROFILE, decideE2eAction } from '../e2e-profile';
+import type { CiState } from '../wizard-ci-driver';
+
+const SECRET = 'sk_live_do_not_leak_9f2b';
+
+const question = (id: string, prompt: string): AskQuestion => ({
+  id,
+  prompt,
+  kind: 'text',
+});
+
+function observed(over: {
+  pendingQuestion?: WizardSession['pendingQuestion'];
+  taskNotice?: WizardSession['taskNotice'];
+}) {
+  return {
+    pendingQuestion: over.pendingQuestion ?? null,
+    taskNotice: over.taskNotice ?? null,
+  };
+}
+
+const ask = (id: string, questions: AskQuestion[]) => ({
+  id,
+  source: 'data-warehouse-source-setup',
+  questions,
+  askedAt: '2026-08-27T10:00:00.000Z',
+});
+
+const notice = (title: string, items: string[] = []) => ({
+  title,
+  body: ['copy'],
+  items,
+  confirmLabel: 'Continue',
+  cancelLabel: 'Skip',
+  prompt: 'Connect these during setup?',
+});
+
+describe('E2eRunRecorder — ask batches', () => {
+  it('records a batch once, however many commits it survives', () => {
+    const recorder = new E2eRunRecorder();
+    const session = observed({
+      pendingQuestion: ask('a1', [question('h', 'Host')]),
+    });
+    recorder.observe(session);
+    recorder.observe(session);
+    recorder.observe(session);
+    expect(recorder.asks).toHaveLength(1);
+  });
+
+  it('captures the contract fields for the batch', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(
+      observed({
+        pendingQuestion: ask('a1', [
+          question('host', 'Postgres host'),
+          question('port', 'Port'),
+        ]),
+      }),
+    );
+    expect(recorder.asks[0]).toEqual({
+      id: 'a1',
+      source: 'data-warehouse-source-setup',
+      subject: null,
+      questionCount: 2,
+      questionIds: ['host', 'port'],
+      prompts: ['Postgres host', 'Port'],
+      answeredIds: [],
+      sentinelIds: [],
+      at: '2026-08-27T10:00:00.000Z',
+    });
+  });
+
+  it('records a second batch after the first closes', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(
+      observed({ pendingQuestion: ask('a1', [question('h', 'Host')]) }),
+    );
+    recorder.observe(observed({}));
+    recorder.observe(
+      observed({ pendingQuestion: ask('a2', [question('p', 'Port')]) }),
+    );
+    expect(recorder.asks.map((a) => a.id)).toEqual(['a1', 'a2']);
+  });
+
+  it('records back-to-back batches with no null commit between them', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(
+      observed({ pendingQuestion: ask('a1', [question('h', 'Host')]) }),
+    );
+    recorder.observe(
+      observed({ pendingQuestion: ask('a2', [question('p', 'Port')]) }),
+    );
+    expect(recorder.asks.map((a) => a.id)).toEqual(['a1', 'a2']);
+  });
+
+  it('fills in the answered/sentinel split from the decision report', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(
+      observed({
+        pendingQuestion: ask('a1', [
+          question('host', 'Host'),
+          question('password', 'Password'),
+        ]),
+      }),
+    );
+    recorder.applyReport({
+      kind: 'ask',
+      id: 'a1',
+      answeredIds: ['host'],
+      sentinelIds: ['password'],
+    });
+    expect(recorder.asks[0].answeredIds).toEqual(['host']);
+    expect(recorder.asks[0].sentinelIds).toEqual(['password']);
+    expect(recorder.unansweredAsks).toBe(1);
+  });
+
+  it('ignores a report for a batch it never saw', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.applyReport({
+      kind: 'ask',
+      id: 'ghost',
+      answeredIds: [],
+      sentinelIds: ['x'],
+    });
+    expect(recorder.asks).toEqual([]);
+    expect(recorder.unansweredAsks).toBe(0);
+  });
+
+  it('sums sentinel fallbacks across every batch', () => {
+    const recorder = new E2eRunRecorder();
+    for (const id of ['a1', 'a2']) {
+      recorder.observe(
+        observed({ pendingQuestion: ask(id, [question('p', 'P')]) }),
+      );
+      recorder.observe(observed({}));
+      recorder.applyReport({
+        kind: 'ask',
+        id,
+        answeredIds: [],
+        sentinelIds: ['p'],
+      });
+    }
+    expect(recorder.unansweredAsks).toBe(2);
+  });
+});
+
+describe('E2eRunRecorder — task notices', () => {
+  it('records a notice once and takes its decision from the report', () => {
+    const recorder = new E2eRunRecorder(() => '2026-08-27T11:00:00.000Z');
+    const session = observed({
+      taskNotice: notice('Connect your data sources', ['Postgres']),
+    });
+    recorder.observe(session);
+    recorder.observe(session);
+    recorder.applyReport({
+      kind: 'notice',
+      title: 'Connect your data sources',
+      decision: 'keep',
+    });
+    expect(recorder.notices).toEqual([
+      {
+        title: 'Connect your data sources',
+        items: ['Postgres'],
+        decision: 'keep',
+        at: '2026-08-27T11:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('records a declined notice', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(observed({ taskNotice: notice('Optional step') }));
+    recorder.applyReport({
+      kind: 'notice',
+      title: 'Optional step',
+      decision: 'decline',
+    });
+    expect(recorder.notices[0].decision).toBe('decline');
+  });
+
+  it('leaves the decision null when nothing resolved the notice', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(observed({ taskNotice: notice('Optional step') }));
+    expect(recorder.notices[0].decision).toBeNull();
+  });
+
+  it('fills the newest unresolved notice when a title repeats', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(observed({ taskNotice: notice('Optional step') }));
+    recorder.applyReport({
+      kind: 'notice',
+      title: 'Optional step',
+      decision: 'keep',
+    });
+    recorder.observe(observed({}));
+    recorder.observe(observed({ taskNotice: notice('Optional step') }));
+    recorder.applyReport({
+      kind: 'notice',
+      title: 'Optional step',
+      decision: 'decline',
+    });
+    expect(recorder.notices.map((n) => n.decision)).toEqual([
+      'keep',
+      'decline',
+    ]);
+  });
+});
+
+describe('abortReasonFrom', () => {
+  it('is null for a run that did not abort', () => {
+    expect(abortReasonFrom({ outroData: null })).toBeNull();
+  });
+
+  it('is null for a successful outro', () => {
+    expect(
+      abortReasonFrom({
+        outroData: { kind: OutroKind.Success, message: 'Done!' },
+      }),
+    ).toBeNull();
+  });
+
+  it('reads the error outro the abort path left behind', () => {
+    expect(
+      abortReasonFrom({
+        outroData: {
+          kind: OutroKind.Error,
+          message: 'No data source detected',
+        },
+      }),
+    ).toBe('No data source detected');
+  });
+
+  it('falls back to the body when the error outro has no headline', () => {
+    expect(
+      abortReasonFrom({ outroData: { kind: OutroKind.Error, body: 'boom' } }),
+    ).toBe('boom');
+  });
+});
+
+describe('detectedSourcesFrom', () => {
+  it('is empty when detection wrote nothing', () => {
+    expect(detectedSourcesFrom({ frameworkContext: {} })).toEqual([]);
+  });
+
+  it('reads the framework-context key detection writes', () => {
+    const source = {
+      kind: 'Postgres',
+      label: 'PostgreSQL',
+      mode: 'in-cli',
+      matchedSignal: 'pg in package.json',
+    };
+    expect(
+      detectedSourcesFrom({
+        frameworkContext: { [DETECTED_WAREHOUSE_SOURCES_KEY]: [source] },
+      }),
+    ).toEqual([source]);
+  });
+
+  it('ignores a non-array value rather than throwing', () => {
+    expect(
+      detectedSourcesFrom({
+        frameworkContext: { [DETECTED_WAREHOUSE_SOURCES_KEY]: 'nope' },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('readReportFile', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-report-'));
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('is null when the program declares no report file', () => {
+    expect(readReportFile(dir, undefined)).toBeNull();
+  });
+
+  it('reports a missing file without its text', () => {
+    const result = readReportFile(dir, 'posthog-warehouse-report.md');
+    expect(result).toEqual({
+      path: path.join(dir, 'posthog-warehouse-report.md'),
+      exists: false,
+    });
+  });
+
+  it('reads the text when the agent wrote the report', () => {
+    fs.writeFileSync(
+      path.join(dir, 'posthog-warehouse-report.md'),
+      '# Report\n',
+    );
+    expect(readReportFile(dir, 'posthog-warehouse-report.md')).toEqual({
+      path: path.join(dir, 'posthog-warehouse-report.md'),
+      exists: true,
+      text: '# Report\n',
+    });
+  });
+});
+
+describe('buildE2eResult', () => {
+  const base = {
+    runPhase: RunPhase.Completed,
+    hasPosthogDep: true,
+    newDeps: ['posthog-node'],
+    envFile: '/app/.env',
+    screenPath: ['warehouse-intro', 'run'],
+    skillsComplete: true,
+  };
+
+  function build(recorder = new E2eRunRecorder()) {
+    return buildE2eResult({
+      base,
+      recorder,
+      session: {
+        frameworkContext: {
+          [DETECTED_WAREHOUSE_SOURCES_KEY]: [
+            {
+              kind: 'Postgres',
+              label: 'PostgreSQL',
+              mode: 'in-cli',
+              matchedSignal: 'found DATABASE_URL',
+            },
+          ],
+        },
+        outroData: null,
+      },
+      tasks: [
+        { label: 'Connect your data sources', status: 'completed', done: true },
+      ] as never,
+      reportFile: { path: '/app/posthog-warehouse-report.md', exists: false },
+    });
+  }
+
+  it('carries every key the contract names', () => {
+    expect(Object.keys(build()).sort()).toEqual(
+      [
+        'abort',
+        'asks',
+        'detectedSources',
+        'envFile',
+        'hasPosthogDep',
+        'newDeps',
+        'notices',
+        'reportFile',
+        'runPhase',
+        'screenPath',
+        'skillsComplete',
+        'tasks',
+        'unansweredAsks',
+      ].sort(),
+    );
+  });
+
+  it('passes the pre-existing keys through unchanged', () => {
+    expect(build()).toMatchObject(base);
+  });
+
+  it('projects tasks down to label and status', () => {
+    expect(build().tasks).toEqual([
+      { label: 'Connect your data sources', status: 'completed' },
+    ]);
+  });
+
+  it('reports the sources detection found', () => {
+    expect(build().detectedSources).toEqual([
+      {
+        kind: 'Postgres',
+        label: 'PostgreSQL',
+        mode: 'in-cli',
+        matchedSignal: 'found DATABASE_URL',
+      },
+    ]);
+  });
+
+  it('totals the sentinel fallbacks', () => {
+    const recorder = new E2eRunRecorder();
+    recorder.observe(
+      observed({ pendingQuestion: ask('a1', [question('p', 'P')]) }),
+    );
+    recorder.applyReport({
+      kind: 'ask',
+      id: 'a1',
+      answeredIds: [],
+      sentinelIds: ['p'],
+    });
+    expect(build(recorder).unansweredAsks).toBe(1);
+  });
+});
+
+describe('security rail — no answer value reaches the payload', () => {
+  /**
+   * Drive the real decision path with a profile that answers a credential
+   * question with a known secret, record it the way the host does, and scan
+   * the whole payload. Nothing about the answer may survive.
+   */
+  function runOneAsk() {
+    const pending = ask('a1', [
+      {
+        id: 'stripe_api_key',
+        prompt: 'Stripe API key',
+        kind: 'text',
+        sensitive: true,
+      },
+      { id: 'prefix', prompt: 'Table prefix', kind: 'text' },
+    ]);
+    const recorder = new E2eRunRecorder();
+    recorder.observe(observed({ pendingQuestion: pending }));
+
+    const decision = decideE2eAction(
+      {
+        currentScreen: Overlay.WizardAsk,
+        pendingQuestion: pending,
+        taskNotice: null,
+        setupQuestions: [],
+      } as unknown as CiState,
+      {
+        ...DEFAULT_E2E_PROFILE,
+        askAnswers: [{ match: 'stripe', value: SECRET }],
+      },
+    );
+    if (decision.report) recorder.applyReport(decision.report);
+    return { decision, recorder };
+  }
+
+  it('does answer the question with the secret — the rail is not "never answer"', () => {
+    const { decision } = runOneAsk();
+    expect(
+      (decision.action?.params?.answers as Record<string, string>)
+        .stripe_api_key,
+    ).toBe(SECRET);
+  });
+
+  it('keeps the secret out of the serialized result', () => {
+    const { recorder } = runOneAsk();
+    const payload = JSON.stringify(
+      buildE2eResult({
+        base: {
+          runPhase: RunPhase.Completed,
+          hasPosthogDep: false,
+          newDeps: [],
+          envFile: null,
+          screenPath: [],
+          skillsComplete: true,
+        },
+        recorder,
+        session: { frameworkContext: {}, outroData: null },
+        tasks: [],
+        reportFile: null,
+      }),
+    );
+    expect(payload).not.toContain(SECRET);
+  });
+
+  it('keeps the prompt text, so the workbench can still tell what was asked', () => {
+    const { recorder } = runOneAsk();
+    expect(recorder.asks[0].prompts).toEqual([
+      'Stripe API key',
+      'Table prefix',
+    ]);
+    expect(recorder.asks[0].answeredIds).toEqual(['stripe_api_key']);
+    expect(recorder.asks[0].sentinelIds).toEqual(['prefix']);
+  });
+
+  it('records ids only — an ask record has no field that could hold a value', () => {
+    const { recorder } = runOneAsk();
+    expect(Object.keys(recorder.asks[0]).sort()).toEqual([
+      'answeredIds',
+      'at',
+      'id',
+      'prompts',
+      'questionCount',
+      'questionIds',
+      'sentinelIds',
+      'source',
+      'subject',
+    ]);
+  });
+});

--- a/e2e-harness/__tests__/wizard-ci-driver.test.ts
+++ b/e2e-harness/__tests__/wizard-ci-driver.test.ts
@@ -173,6 +173,62 @@ describe('WizardCiDriver — wizard_ask overlay', () => {
   });
 });
 
+describe('WizardCiDriver — task-notice overlay', () => {
+  const notice = {
+    title: 'Connect your data sources',
+    body: ['We detected some warehouse sources.'],
+    items: ['Postgres', 'Stripe'],
+    confirmLabel: 'Continue [Enter]',
+    cancelLabel: 'Skip [Esc]',
+    prompt: 'Connect these during setup?',
+  };
+
+  it('projects the notice into read_state and keeps the step', async () => {
+    const store = freshStore();
+    const driver = new WizardCiDriver(store);
+
+    const kept = store.showTaskNotice(notice);
+
+    const state = driver.readState();
+    expect(state.currentScreen).toBe(Overlay.TaskNotice);
+    expect(state.taskNotice).toEqual({
+      title: 'Connect your data sources',
+      items: ['Postgres', 'Stripe'],
+      prompt: 'Connect these during setup?',
+    });
+    expect(driver.listActions().map((a) => a.id)).toContain('resolve_notice');
+
+    driver.performAction('resolve_notice', { keep: true });
+
+    await expect(kept).resolves.toBe(true);
+    expect(driver.readState().taskNotice).toBeNull();
+    expect(driver.readState().currentScreen).not.toBe(Overlay.TaskNotice);
+  });
+
+  it('skips the step when keep is false', async () => {
+    const store = freshStore();
+    const driver = new WizardCiDriver(store);
+    const kept = store.showTaskNotice(notice);
+    driver.performAction('resolve_notice', { keep: false });
+    await expect(kept).resolves.toBe(false);
+  });
+
+  it('defaults to keeping the step when keep is omitted', async () => {
+    const store = freshStore();
+    const driver = new WizardCiDriver(store);
+    const kept = store.showTaskNotice(notice);
+    driver.performAction('resolve_notice');
+    await expect(kept).resolves.toBe(true);
+  });
+
+  it('projects an empty items list when the notice has none', () => {
+    const store = freshStore();
+    const driver = new WizardCiDriver(store);
+    void store.showTaskNotice({ ...notice, items: undefined });
+    expect(driver.readState().taskNotice?.items).toEqual([]);
+  });
+});
+
 describe('action registry exhaustiveness', () => {
   it('every screen and overlay is either actionable or explicitly no-action', () => {
     const allScreens = [...Object.values(ScreenId), ...Object.values(Overlay)];

--- a/e2e-harness/action-registry.ts
+++ b/e2e-harness/action-registry.ts
@@ -241,6 +241,17 @@ export const ACTION_REGISTRY: Partial<Record<ScreenName, DriverAction[]>> = {
       apply: (store) => store.cancelPendingQuestion(),
     },
   ],
+  [Overlay.TaskNotice]: [
+    {
+      id: 'resolve_notice',
+      description:
+        'Resolve the task-notice overlay a program shows before an optional ' +
+        'step. keep=true runs the step, keep=false skips it. See ' +
+        'read_state.taskNotice.',
+      params: { keep: 'boolean (default true)' },
+      apply: (store, params) => store.resolveTaskNotice(params.keep !== false),
+    },
+  ],
   [Overlay.SettingsOverride]: [
     {
       id: 'backup_and_fix',

--- a/e2e-harness/e2e-profile.ts
+++ b/e2e-harness/e2e-profile.ts
@@ -25,10 +25,20 @@ export const E2E_ANSWER_SENTINEL = 'e2e';
  * against the `prompt`. Within a pass the first matching rule wins. `value` may
  * carry `${ENV_VAR}` references — `resolveE2eProfile` expands them once, at
  * profile load. See {@link answerQuestions}.
+ *
+ * `secret` marks a rule whose value is a real credential. The agent controls
+ * every field the rule matches on, so an unmarked rule will hand its value to
+ * whatever question claims the name — and a question that omits
+ * `sensitive: true` gets that value back unvaulted, in plaintext. A `secret`
+ * rule therefore answers only a `kind: 'text'` question with `sensitive: true`,
+ * and refuses the question outright otherwise. Set it on any rule pointed at an
+ * API key or a password; leave it off for hostnames, ports and prefixes, which
+ * a skill has no reason to flag sensitive.
  */
 export interface AskAnswerRule {
   match: string;
   value: string;
+  secret?: boolean;
 }
 
 export interface WizardE2eProfile {
@@ -113,6 +123,12 @@ export type E2eDecisionReport =
       answeredIds: string[];
       /** Question ids that fell back to the `'e2e'` sentinel. */
       sentinelIds: string[];
+      /**
+       * Question ids a `secret` rule refused — the question claimed a
+       * credential field but was not a sensitive text question. Disjoint from
+       * the other two.
+       */
+      refusedIds: string[];
     }
   | { kind: 'notice'; title: string; decision: 'keep' | 'decline' };
 
@@ -135,6 +151,8 @@ export interface AnsweredBatch {
   answers: AskAnswers;
   answeredIds: string[];
   sentinelIds: string[];
+  /** Ids a `secret` rule refused to answer. See {@link AskAnswerRule}. */
+  refusedIds: string[];
 }
 
 /**
@@ -151,6 +169,12 @@ export interface AnsweredBatch {
  * credential question — one with no options — that lands on the sentinel, which
  * is what the workbench reads to say "this run answered nothing here".
  *
+ * A `secret` rule matching a question that is not sensitive free text refuses
+ * it: the answer is the sentinel and the id lands in `refusedIds` rather than
+ * falling through to an option. The skill names its own questions, so without
+ * that rail a question called `stripe` could take a credential and — by leaving
+ * `sensitive` off — get it back in plaintext instead of a vault ref.
+ *
  * `multi` questions always get an array answer, as the ask bridge expects.
  * Pure: rule values arrive already interpolated (see `resolveE2eProfile`).
  */
@@ -162,17 +186,27 @@ export function answerQuestions(
   const answers: AskAnswers = {};
   const answeredIds: string[] = [];
   const sentinelIds: string[] = [];
+  const refusedIds: string[] = [];
 
   for (const q of questions) {
     const routed = matchRule(q, rules);
-    const value = routed ?? q.options?.[0]?.value ?? E2E_ANSWER_SENTINEL;
-    const isSentinel = routed === null && q.options?.[0] === undefined;
+    if (routed?.refused) {
+      answers[q.id] =
+        q.kind === 'multi' ? [E2E_ANSWER_SENTINEL] : E2E_ANSWER_SENTINEL;
+      refusedIds.push(q.id);
+      continue;
+    }
+    const value = routed?.value ?? q.options?.[0]?.value ?? E2E_ANSWER_SENTINEL;
+    const isSentinel = !routed && q.options?.[0] === undefined;
     answers[q.id] = q.kind === 'multi' ? [value] : value;
     (isSentinel ? sentinelIds : answeredIds).push(q.id);
   }
 
-  return { answers, answeredIds, sentinelIds };
+  return { answers, answeredIds, sentinelIds, refusedIds };
 }
+
+/** What a rule pass produced: a value, a refusal, or nothing. */
+type RuleMatch = { value: string; refused?: false } | { refused: true };
 
 /**
  * The value routed to a question, or null when no rule routes it.
@@ -181,11 +215,14 @@ export function answerQuestions(
  * `prompt`. The id is the field the skill controls, so an id match is the
  * stronger signal — a rule aimed at `host` must not claim the `port` question
  * just because the prompt happens to say "host and port".
+ *
+ * A matching `secret` rule yields its value only for a sensitive text question;
+ * any other question shape gets a refusal, never the value.
  */
 function matchRule(
   question: AskQuestion,
   rules: readonly AskAnswerRule[],
-): string | null {
+): RuleMatch | null {
   for (const field of [question.id, question.prompt]) {
     for (const rule of rules) {
       let re: RegExp;
@@ -194,10 +231,24 @@ function matchRule(
       } catch {
         continue; // a malformed profile regex must not break the whole run
       }
-      if (re.test(field)) return rule.value === '' ? null : rule.value;
+      if (!re.test(field)) continue;
+      // An unset `${ENV_VAR}` leaves nothing to route and nothing to withhold,
+      // so the rule is inert — the question takes the normal fallback.
+      if (rule.value === '') return null;
+      if (rule.secret && !acceptsSecret(question)) return { refused: true };
+      return { value: rule.value };
     }
   }
   return null;
+}
+
+/**
+ * Whether a question may receive a `secret` rule's value: free text the skill
+ * flagged sensitive, so `wizard_ask` vaults the answer and hands the agent a
+ * ref instead of the credential.
+ */
+function acceptsSecret(question: AskQuestion): boolean {
+  return question.kind === 'text' && question.sensitive === true;
 }
 
 /**
@@ -293,6 +344,7 @@ export function decideE2eAction(
           id: pending.id,
           answeredIds: batch.answeredIds,
           sentinelIds: batch.sentinelIds,
+          refusedIds: batch.refusedIds,
         },
       };
     }

--- a/e2e-harness/e2e-profile.ts
+++ b/e2e-harness/e2e-profile.ts
@@ -8,10 +8,28 @@
  */
 
 import { ScreenId, Overlay, type ScreenName } from '@ui/tui/router';
+import type { AskAnswers, AskQuestion } from '@lib/wizard-session';
 import type { CiState } from './wizard-ci-driver.js';
 
 /** Which option to pick for a setup disambiguation question. */
 export type SetupChoice = 'first' | 'last';
+
+/** The literal answer used when a profile has nothing better to offer. */
+export const E2E_ANSWER_SENTINEL = 'e2e';
+
+/**
+ * One routing rule for an agent question.
+ *
+ * `match` is a case-insensitive regex source string. Every rule is tested
+ * against the question `id` first; only if none matches is every rule tested
+ * against the `prompt`. Within a pass the first matching rule wins. `value` may
+ * carry `${ENV_VAR}` references — `resolveE2eProfile` expands them once, at
+ * profile load. See {@link answerQuestions}.
+ */
+export interface AskAnswerRule {
+  match: string;
+  value: string;
+}
 
 export interface WizardE2eProfile {
   /** Setup disambiguation (e.g. Next.js router): which option to commit. */
@@ -29,6 +47,18 @@ export interface WizardE2eProfile {
   skills: 'keep' | 'delete';
   /** Default answer strategy for an agent `wizard_ask` overlay. */
   ask: 'first';
+  /**
+   * Task-notice overlay: `keep` runs the optional step the notice covers,
+   * `decline` skips it. The workbench flips this per run variation through
+   * `E2E_NOTICE` — see {@link ./profiles resolveE2eProfile}.
+   */
+  notice?: 'keep' | 'decline';
+  /**
+   * Per-question answer routing for `wizard_ask`, ahead of the `ask` strategy.
+   * Lets a program point a credential question at an env var instead of taking
+   * a useless first option or the sentinel.
+   */
+  askAnswers?: AskAnswerRule[];
 }
 
 /** Happy-path default: take every screen forward, leave nothing behind. */
@@ -39,6 +69,7 @@ export const DEFAULT_E2E_PROFILE: WizardE2eProfile = {
   slack: 'skip',
   skills: 'delete',
   ask: 'first',
+  notice: 'keep',
 };
 
 /**
@@ -64,10 +95,33 @@ export const DEFAULT_E2E_VARIATION: WizardE2eVariation = {
   summary: 'linear / anthropic / sonnet — parity with main',
 };
 
+/**
+ * What a decision did, for the host's run log.
+ *
+ * The host records *that* an ask or a notice happened by watching the store,
+ * but only the decision function knows how it resolved each one. This is that
+ * report back. It carries question ids and a keep/decline verdict — never an
+ * answer value, so nothing derived from it can leak a credential into the
+ * result payload.
+ */
+export type E2eDecisionReport =
+  | {
+      kind: 'ask';
+      /** PendingQuestion.id of the batch this reports on. */
+      id: string;
+      /** Question ids the profile produced a real answer for. */
+      answeredIds: string[];
+      /** Question ids that fell back to the `'e2e'` sentinel. */
+      sentinelIds: string[];
+    }
+  | { kind: 'notice'; title: string; decision: 'keep' | 'decline' };
+
 /** What the harness should do for the current screen. */
 export interface E2eDecision {
   /** A driver action to commit, if any. */
   action?: { id: string; params?: Record<string, unknown> };
+  /** What this decision resolved, when it resolved an ask or a notice. */
+  report?: E2eDecisionReport;
   /** Set on the keep-skills screen — the orchestrator does the fs deletion. */
   skillsPolicy?: 'keep' | 'delete';
   /** True once the terminal commit has been made. */
@@ -76,11 +130,88 @@ export interface E2eDecision {
   wait?: boolean;
 }
 
+/** The answers for one `wizard_ask` batch, plus which ids fell back. */
+export interface AnsweredBatch {
+  answers: AskAnswers;
+  answeredIds: string[];
+  sentinelIds: string[];
+}
+
+/**
+ * Answer every question in one `wizard_ask` batch.
+ *
+ * Resolution order per question:
+ *   1. the first `askAnswers` rule matching the id, else the first matching
+ *      the prompt;
+ *   2. the first option, for `single` and `multi` questions;
+ *   3. the literal `'e2e'` sentinel.
+ *
+ * A rule that resolves to an empty string (its `${ENV_VAR}` was unset) counts
+ * as no match, so the question falls through to the next step. For a `text`
+ * credential question — one with no options — that lands on the sentinel, which
+ * is what the workbench reads to say "this run answered nothing here".
+ *
+ * `multi` questions always get an array answer, as the ask bridge expects.
+ * Pure: rule values arrive already interpolated (see `resolveE2eProfile`).
+ */
+export function answerQuestions(
+  questions: readonly AskQuestion[],
+  profile: WizardE2eProfile,
+): AnsweredBatch {
+  const rules = profile.askAnswers ?? [];
+  const answers: AskAnswers = {};
+  const answeredIds: string[] = [];
+  const sentinelIds: string[] = [];
+
+  for (const q of questions) {
+    const routed = matchRule(q, rules);
+    const value = routed ?? q.options?.[0]?.value ?? E2E_ANSWER_SENTINEL;
+    const isSentinel = routed === null && q.options?.[0] === undefined;
+    answers[q.id] = q.kind === 'multi' ? [value] : value;
+    (isSentinel ? sentinelIds : answeredIds).push(q.id);
+  }
+
+  return { answers, answeredIds, sentinelIds };
+}
+
+/**
+ * The value routed to a question, or null when no rule routes it.
+ *
+ * Two passes: every rule against the question `id`, then every rule against the
+ * `prompt`. The id is the field the skill controls, so an id match is the
+ * stronger signal — a rule aimed at `host` must not claim the `port` question
+ * just because the prompt happens to say "host and port".
+ */
+function matchRule(
+  question: AskQuestion,
+  rules: readonly AskAnswerRule[],
+): string | null {
+  for (const field of [question.id, question.prompt]) {
+    for (const rule of rules) {
+      let re: RegExp;
+      try {
+        re = new RegExp(rule.match, 'i');
+      } catch {
+        continue; // a malformed profile regex must not break the whole run
+      }
+      if (re.test(field)) return rule.value === '' ? null : rule.value;
+    }
+  }
+  return null;
+}
+
 /**
  * Map the current screen + profile to the commit to make. Pure: no store, no
- * fs — the caller applies the returned action via the driver and handles
- * `skillsPolicy` itself. Returns `{ wait: true }` for screens the runner/agent
- * advances on their own (auth, run, ai-opt-in, a clean health probe).
+ * fs, and no `process.env` — the caller applies the returned action via the
+ * driver and handles `skillsPolicy` itself. Returns `{ wait: true }` for
+ * screens the runner/agent advances on their own (auth, run, ai-opt-in, a
+ * clean health probe).
+ *
+ * Env-var inputs (`E2E_NOTICE`, `${...}` inside `askAnswers`) are folded into
+ * the profile once, at load, by `resolveE2eProfile` in `./profiles`. Reading
+ * `process.env` here would make the same (state, profile) pair return different
+ * decisions in different processes, and the flow-snapshot test depends on it
+ * not doing that.
  */
 export function decideE2eAction(
   state: CiState,
@@ -147,14 +278,35 @@ export function decideE2eAction(
       };
 
     case Overlay.WizardAsk: {
-      const q = state.pendingQuestion?.questions[0];
-      if (!q) return { wait: true };
-      // 'first': first option for single/multi, sentinel for free text.
-      const answer = q.options?.[0]?.value ?? 'e2e';
+      const pending = state.pendingQuestion;
+      if (!pending || pending.questions.length === 0) return { wait: true };
+      // Answer the whole batch. The bridge resolves on one answers map, so a
+      // partial map would leave the unanswered fields empty for the agent.
+      const batch = answerQuestions(pending.questions, profile);
       return {
         action: {
           id: 'answer_question',
-          params: { answers: { [q.id]: answer } },
+          params: { answers: batch.answers },
+        },
+        report: {
+          kind: 'ask',
+          id: pending.id,
+          answeredIds: batch.answeredIds,
+          sentinelIds: batch.sentinelIds,
+        },
+      };
+    }
+
+    case Overlay.TaskNotice: {
+      const notice = state.taskNotice;
+      if (!notice) return { wait: true };
+      const keep = profile.notice !== 'decline';
+      return {
+        action: { id: 'resolve_notice', params: { keep } },
+        report: {
+          kind: 'notice',
+          title: notice.title,
+          decision: keep ? 'keep' : 'decline',
         },
       };
     }
@@ -176,4 +328,5 @@ export const E2E_DRIVABLE_SCREENS: readonly ScreenName[] = [
   ScreenId.SlackConnect,
   ScreenId.KeepSkills,
   Overlay.WizardAsk,
+  Overlay.TaskNotice,
 ];

--- a/e2e-harness/e2e-result.ts
+++ b/e2e-harness/e2e-result.ts
@@ -14,7 +14,9 @@
  * **Security rail.** Only question *prompt text* and question *ids* enter this
  * payload. No answer value ever does. The recorder is never handed an answers
  * map: {@link E2eDecisionReport} carries ids and a keep/decline verdict only,
- * so there is no path for a credential to reach the file.
+ * so there is no path for a credential to reach the file. The one field whose
+ * content comes from outside the wizard is the report file, and
+ * {@link readReportFile} guards what it will read.
  */
 
 import fs from 'fs';
@@ -35,6 +37,11 @@ export interface E2eAskRecord {
   prompts: string[];
   answeredIds: string[];
   sentinelIds: string[];
+  /**
+   * Ids a `secret` askAnswers rule refused — the question claimed a credential
+   * field without being sensitive free text, so the run withheld the value.
+   */
+  refusedIds: string[];
   at: string;
 }
 
@@ -83,6 +90,7 @@ export class E2eRunRecorder {
         prompts: pending.questions.map((q) => q.prompt),
         answeredIds: [],
         sentinelIds: [],
+        refusedIds: [],
         at: pending.askedAt ?? this.now(),
       });
     }
@@ -107,6 +115,7 @@ export class E2eRunRecorder {
       if (!entry) return;
       entry.answeredIds = [...report.answeredIds];
       entry.sentinelIds = [...report.sentinelIds];
+      entry.refusedIds = [...report.refusedIds];
       return;
     }
     const entry = [...this.notices]
@@ -115,9 +124,17 @@ export class E2eRunRecorder {
     if (entry) entry.decision = report.decision;
   }
 
-  /** Total sentinel fallbacks across every ask batch. */
+  /** Questions no real answer reached: sentinel fallbacks plus refusals. */
   get unansweredAsks(): number {
-    return this.asks.reduce((n, a) => n + a.sentinelIds.length, 0);
+    return this.asks.reduce(
+      (n, a) => n + a.sentinelIds.length + a.refusedIds.length,
+      0,
+    );
+  }
+
+  /** Total questions a `secret` rule withheld a credential from. */
+  get refusedAsks(): number {
+    return this.asks.reduce((n, a) => n + a.refusedIds.length, 0);
   }
 }
 
@@ -127,20 +144,57 @@ export interface E2eReportFile {
   exists: boolean;
   /** Present only when the file exists. */
   text?: string;
+  /** Why a path that resolves to something was not read. See below. */
+  rejected?: 'outside-app-dir' | 'not-a-regular-file';
 }
 
-/** Read a program's report file, if it declares one. */
+/**
+ * Read a program's report file, if it declares one.
+ *
+ * The app directory is a checkout the run does not control, and this payload is
+ * collected even from an aborted run — so the file at the report path is
+ * attacker-controlled input, not the wizard's own output. A committed symlink
+ * named `posthog-warehouse-report.md` pointing at `/proc/self/environ` (or any
+ * host file the process can read) would otherwise be copied wholesale into
+ * `E2E_RESULT_JSON`.
+ *
+ * Three rails, all before any read: the joined path must stay under `appDir`
+ * lexically (a `../` in the declared name never reaches the fs), the containing
+ * directory must still resolve inside `appDir` (so no intermediate symlink
+ * walks out), and the final component must be a regular file by `lstat` (so the
+ * last hop is not a link either). A rejected path reports why instead of
+ * masquerading as missing.
+ */
 export function readReportFile(
   appDir: string,
   reportFileName: string | undefined,
 ): E2eReportFile | null {
   if (!reportFileName) return null;
-  const full = path.join(appDir, reportFileName);
+  const root = path.resolve(appDir);
+  const full = path.join(root, reportFileName);
+  const reject = (rejected: E2eReportFile['rejected']): E2eReportFile => ({
+    path: full,
+    exists: false,
+    rejected,
+  });
+  if (!isInside(root, full)) return reject('outside-app-dir');
   try {
+    // realpath the root too: on macOS a tmpdir app dir is itself a symlink, so
+    // comparing a resolved parent against an unresolved root would reject it.
+    const realRoot = fs.realpathSync(root);
+    if (!isInside(realRoot, fs.realpathSync(path.dirname(full))))
+      return reject('outside-app-dir');
+    if (!fs.lstatSync(full).isFile()) return reject('not-a-regular-file');
     return { path: full, exists: true, text: fs.readFileSync(full, 'utf8') };
   } catch {
     return { path: full, exists: false };
   }
+}
+
+/** Whether `child` is `root` or sits beneath it. */
+function isInside(root: string, child: string): boolean {
+  const rel = path.relative(root, child);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
 /**
@@ -191,6 +245,7 @@ export function buildE2eResult(args: {
     ...base,
     asks: recorder.asks,
     unansweredAsks: recorder.unansweredAsks,
+    refusedAsks: recorder.refusedAsks,
     notices: recorder.notices,
     tasks: tasks.map((t) => ({ label: t.label, status: t.status })),
     detectedSources: detectedSourcesFrom(session).map((s) => ({

--- a/e2e-harness/e2e-result.ts
+++ b/e2e-harness/e2e-result.ts
@@ -1,0 +1,205 @@
+/**
+ * The structured record an e2e run writes to `E2E_RESULT_JSON`.
+ *
+ * Split out of `scripts/tui-host.no-jest.ts` so the shape, and the security
+ * rail that guards it, can be unit-tested without booting a TUI.
+ *
+ * Two halves:
+ *   {@link E2eRunRecorder} — watches the session for `pendingQuestion` and
+ *     `taskNotice` transitions and logs each one, then takes the decision
+ *     function's report to fill in how it resolved.
+ *   {@link buildE2eResult} — folds that log, the session and the program's
+ *     report file into the payload the workbench asserts on.
+ *
+ * **Security rail.** Only question *prompt text* and question *ids* enter this
+ * payload. No answer value ever does. The recorder is never handed an answers
+ * map: {@link E2eDecisionReport} carries ids and a keep/decline verdict only,
+ * so there is no path for a credential to reach the file.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { OutroKind, type WizardSession } from '@lib/wizard-session';
+import { DETECTED_WAREHOUSE_SOURCES_KEY } from '@lib/programs/warehouse-source/detect';
+import type { DetectedSource } from '@lib/warehouse-sources/types';
+import type { E2eDecisionReport } from './e2e-profile.js';
+
+/** One `wizard_ask` batch the run was shown. */
+export interface E2eAskRecord {
+  id: string;
+  source: string;
+  subject: string | null;
+  questionCount: number;
+  questionIds: string[];
+  /** Prompt text only — never an answer. */
+  prompts: string[];
+  answeredIds: string[];
+  sentinelIds: string[];
+  at: string;
+}
+
+/** One task-notice overlay the run was shown. */
+export interface E2eNoticeRecord {
+  title: string;
+  items: string[];
+  /** Null until the decision function reports how it resolved the notice. */
+  decision: 'keep' | 'decline' | null;
+  at: string;
+}
+
+/** The session fields the recorder watches. */
+type ObservedSession = Pick<WizardSession, 'pendingQuestion' | 'taskNotice'>;
+
+/**
+ * Log every ask batch and task notice a run passes through.
+ *
+ * `observe` is edge-triggered: it logs when the watched field transitions into
+ * a new value, so calling it on every store commit records each overlay once.
+ * Call it from the store subscription *and* before each decision, so a batch
+ * that opens and closes between two commits is still caught.
+ */
+export class E2eRunRecorder {
+  readonly asks: E2eAskRecord[] = [];
+  readonly notices: E2eNoticeRecord[] = [];
+  private lastAskId: string | null = null;
+  private lastNoticeTitle: string | null = null;
+
+  constructor(
+    private readonly now: () => string = () => new Date().toISOString(),
+  ) {}
+
+  /** Record any new ask batch or task notice on the session. */
+  observe(session: ObservedSession): void {
+    const pending = session.pendingQuestion;
+    if (pending && pending.id !== this.lastAskId) {
+      this.asks.push({
+        id: pending.id,
+        source: pending.source,
+        // The wizard has no `subject` field today. Read it defensively so the
+        // key stays in the payload if one is added, per the contract.
+        subject: (pending as { subject?: string }).subject ?? null,
+        questionCount: pending.questions.length,
+        questionIds: pending.questions.map((q) => q.id),
+        prompts: pending.questions.map((q) => q.prompt),
+        answeredIds: [],
+        sentinelIds: [],
+        at: pending.askedAt ?? this.now(),
+      });
+    }
+    this.lastAskId = pending?.id ?? null;
+
+    const notice = session.taskNotice;
+    if (notice && notice.title !== this.lastNoticeTitle) {
+      this.notices.push({
+        title: notice.title,
+        items: [...(notice.items ?? [])],
+        decision: null,
+        at: this.now(),
+      });
+    }
+    this.lastNoticeTitle = notice?.title ?? null;
+  }
+
+  /** Fill in how a decision resolved the ask batch or notice it acted on. */
+  applyReport(report: E2eDecisionReport): void {
+    if (report.kind === 'ask') {
+      const entry = [...this.asks].reverse().find((a) => a.id === report.id);
+      if (!entry) return;
+      entry.answeredIds = [...report.answeredIds];
+      entry.sentinelIds = [...report.sentinelIds];
+      return;
+    }
+    const entry = [...this.notices]
+      .reverse()
+      .find((n) => n.title === report.title && n.decision === null);
+    if (entry) entry.decision = report.decision;
+  }
+
+  /** Total sentinel fallbacks across every ask batch. */
+  get unansweredAsks(): number {
+    return this.asks.reduce((n, a) => n + a.sentinelIds.length, 0);
+  }
+}
+
+/** The program's report file, resolved against the app directory. */
+export interface E2eReportFile {
+  path: string;
+  exists: boolean;
+  /** Present only when the file exists. */
+  text?: string;
+}
+
+/** Read a program's report file, if it declares one. */
+export function readReportFile(
+  appDir: string,
+  reportFileName: string | undefined,
+): E2eReportFile | null {
+  if (!reportFileName) return null;
+  const full = path.join(appDir, reportFileName);
+  try {
+    return { path: full, exists: true, text: fs.readFileSync(full, 'utf8') };
+  } catch {
+    return { path: full, exists: false };
+  }
+}
+
+/**
+ * The abort reason for a run, or null when it did not abort.
+ *
+ * `wizardAbort` renders an error outro and then exits, so `outroData` is the
+ * only durable trace of *why* by the time the host writes its result.
+ */
+export function abortReasonFrom(
+  session: Pick<WizardSession, 'outroData'>,
+): string | null {
+  const outro = session.outroData;
+  if (!outro || outro.kind !== OutroKind.Error) return null;
+  return outro.message ?? outro.body ?? 'aborted';
+}
+
+/** The warehouse sources detection wrote into frameworkContext. */
+export function detectedSourcesFrom(
+  session: Pick<WizardSession, 'frameworkContext'>,
+): DetectedSource[] {
+  const raw = session.frameworkContext[DETECTED_WAREHOUSE_SOURCES_KEY];
+  return Array.isArray(raw) ? (raw as DetectedSource[]) : [];
+}
+
+/** The keys the result payload carried before the warehouse work. */
+export interface E2eResultBase {
+  runPhase: string;
+  hasPosthogDep: boolean;
+  newDeps: string[];
+  envFile: string | null;
+  screenPath: string[];
+  skillsComplete: boolean;
+}
+
+/**
+ * Build the `E2E_RESULT_JSON` payload. Additive over {@link E2eResultBase} —
+ * the pre-existing keys are copied through byte-identical.
+ */
+export function buildE2eResult(args: {
+  base: E2eResultBase;
+  recorder: E2eRunRecorder;
+  session: Pick<WizardSession, 'frameworkContext' | 'outroData'>;
+  tasks: Array<{ label: string; status: string }>;
+  reportFile: E2eReportFile | null;
+}): Record<string, unknown> {
+  const { base, recorder, session, tasks, reportFile } = args;
+  return {
+    ...base,
+    asks: recorder.asks,
+    unansweredAsks: recorder.unansweredAsks,
+    notices: recorder.notices,
+    tasks: tasks.map((t) => ({ label: t.label, status: t.status })),
+    detectedSources: detectedSourcesFrom(session).map((s) => ({
+      kind: s.kind,
+      label: s.label,
+      mode: s.mode,
+      matchedSignal: s.matchedSignal,
+    })),
+    reportFile,
+    abort: abortReasonFrom(session),
+  };
+}

--- a/e2e-harness/profiles.ts
+++ b/e2e-harness/profiles.ts
@@ -6,12 +6,16 @@
  * (`src/lib/programs/<program>/test/e2e.json`): a `profile` (the options the run
  * auto-takes) plus a documented `path`. {@link profileFor} loads the `profile`
  * and maps it by program id.
+ *
+ * {@link resolveE2eProfile} folds the run's env-var inputs into a profile once,
+ * so `decideE2eAction` stays a pure function of (state, profile).
  */
 
 import { Program, type ProgramId } from '@lib/programs/program-registry';
 import {
   DEFAULT_E2E_PROFILE,
   DEFAULT_E2E_VARIATION,
+  type AskAnswerRule,
   type WizardE2eProfile,
   type WizardE2eVariation,
 } from './e2e-profile.js';
@@ -19,6 +23,7 @@ import posthogIntegrationE2e from '@lib/programs/posthog-integration/test/e2e.js
 import aiObservabilityE2e from '@lib/programs/ai-observability/test/e2e.json';
 import metricsE2e from '@lib/programs/metrics/test/e2e.json';
 import replayVisionE2e from '@lib/programs/replay-vision/test/e2e.json';
+import warehouseSourceE2e from '@lib/programs/warehouse-source/test/e2e.json';
 
 const PROFILES: Partial<Record<ProgramId, WizardE2eProfile>> = {
   [Program.PostHogIntegration]:
@@ -26,6 +31,7 @@ const PROFILES: Partial<Record<ProgramId, WizardE2eProfile>> = {
   [Program.AiObservability]: aiObservabilityE2e.profile as WizardE2eProfile,
   [Program.Metrics]: metricsE2e.profile as WizardE2eProfile,
   [Program.ReplayVision]: replayVisionE2e.profile as WizardE2eProfile,
+  [Program.WarehouseSource]: warehouseSourceE2e.profile as WizardE2eProfile,
 };
 
 const VARIATIONS: Partial<Record<ProgramId, WizardE2eVariation[]>> = {
@@ -35,6 +41,8 @@ const VARIATIONS: Partial<Record<ProgramId, WizardE2eVariation[]>> = {
     aiObservabilityE2e.variations as WizardE2eVariation[],
   [Program.Metrics]: metricsE2e.variations as WizardE2eVariation[],
   [Program.ReplayVision]: replayVisionE2e.variations as WizardE2eVariation[],
+  [Program.WarehouseSource]:
+    warehouseSourceE2e.variations as WizardE2eVariation[],
 };
 
 /** The e2e profile for a program, or the happy-path default if none is set. */
@@ -53,4 +61,66 @@ export function hasProfile(program: ProgramId): boolean {
  */
 export function variationsFor(program: ProgramId): WizardE2eVariation[] {
   return VARIATIONS[program] ?? [DEFAULT_E2E_VARIATION];
+}
+
+/** Env-var inputs a run may layer over a program's declared profile. */
+export interface E2eProfileOverrides {
+  /** `E2E_NOTICE` — `keep` or `decline`. Anything else is ignored. */
+  notice?: string;
+  /**
+   * Extra `askAnswers` rules, from `E2E_ANSWERS_FILE`. Merged *before* the
+   * profile's own rules, so the runner can re-route one question per app
+   * without editing the program's e2e.json.
+   */
+  extraAskAnswers?: AskAnswerRule[];
+  /** Env map used to expand `${VAR}` inside every rule value. */
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Fold a run's env-var inputs into a profile, once, at load.
+ *
+ * `decideE2eAction` is documented pure — same (state, profile) in, same
+ * decision out. Reading `process.env` inside it would break that and make the
+ * flow-snapshot test depend on the shell it runs in. So every env input is
+ * resolved here instead, at the one point that already knows the run's
+ * configuration. In an e2e run the environment is fixed when the wizard child
+ * process starts, so resolving at load and resolving at answer time produce the
+ * same answers.
+ */
+export function resolveE2eProfile(
+  base: WizardE2eProfile,
+  overrides: E2eProfileOverrides = {},
+): WizardE2eProfile {
+  const env = overrides.env ?? {};
+  const rules = [
+    ...(overrides.extraAskAnswers ?? []),
+    ...(base.askAnswers ?? []),
+  ];
+  const resolved: WizardE2eProfile = {
+    ...base,
+    ...(rules.length > 0
+      ? {
+          askAnswers: rules.map((rule) => ({
+            match: rule.match,
+            value: interpolateEnv(rule.value, env),
+          })),
+        }
+      : {}),
+  };
+  if (overrides.notice === 'keep' || overrides.notice === 'decline') {
+    resolved.notice = overrides.notice;
+  }
+  return resolved;
+}
+
+/** Expand `${VAR}` from `env`. An unset var becomes an empty string. */
+function interpolateEnv(
+  value: string,
+  env: Record<string, string | undefined>,
+): string {
+  return value.replace(
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g,
+    (_, name: string) => env[name] ?? '',
+  );
 }

--- a/e2e-harness/profiles.ts
+++ b/e2e-harness/profiles.ts
@@ -101,8 +101,10 @@ export function resolveE2eProfile(
     ...base,
     ...(rules.length > 0
       ? {
+          // Spread the rule: interpolation only rewrites `value`, and dropping
+          // any other field here would silently unset a rule's `secret` flag.
           askAnswers: rules.map((rule) => ({
-            match: rule.match,
+            ...rule,
             value: interpolateEnv(rule.value, env),
           })),
         }

--- a/e2e-harness/wizard-ci-driver.ts
+++ b/e2e-harness/wizard-ci-driver.ts
@@ -38,6 +38,17 @@ export interface ActionView {
 }
 
 /**
+ * A task notice projected for the harness. Title, items and prompt only — the
+ * decision function needs to know a notice is up and what it covers, not the
+ * full body copy the screen renders.
+ */
+export interface TaskNoticeView {
+  title: string;
+  items: string[];
+  prompt: string;
+}
+
+/**
  * The serialized observable state. A whitelist of WizardSession — credentials
  * are reduced to a boolean so secrets never reach a driver LLM.
  */
@@ -65,6 +76,8 @@ export interface CiState {
   eventPlan: Array<{ name: string; description: string }>;
   /** Present iff a wizard_ask overlay is up. */
   pendingQuestion: PendingQuestion | null;
+  /** Present iff a task-notice overlay is up. */
+  taskNotice: TaskNoticeView | null;
   /** Unresolved framework-setup questions when on the setup screen. */
   setupQuestions: SetupQuestionView[];
   /** Commit actions legal on currentScreen. */
@@ -118,6 +131,13 @@ export class WizardCiDriver {
         description: e.description,
       })),
       pendingQuestion: s.pendingQuestion ?? null,
+      taskNotice: s.taskNotice
+        ? {
+            title: s.taskNotice.title,
+            items: [...(s.taskNotice.items ?? [])],
+            prompt: s.taskNotice.prompt,
+          }
+        : null,
       setupQuestions: this.unresolvedSetupQuestions(),
       actions: this.listActions(),
     };

--- a/scripts/tui-host.no-jest.ts
+++ b/scripts/tui-host.no-jest.ts
@@ -30,9 +30,15 @@ import { logToFile } from '@utils/debug';
 import { WizardCiDriver } from '@e2e-harness/wizard-ci-driver';
 import {
   decideE2eAction,
+  type AskAnswerRule,
   type WizardE2eProfile,
 } from '@e2e-harness/e2e-profile';
-import { profileFor } from '@e2e-harness/profiles';
+import { profileFor, resolveE2eProfile } from '@e2e-harness/profiles';
+import {
+  E2eRunRecorder,
+  buildE2eResult,
+  readReportFile,
+} from '@e2e-harness/e2e-result';
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const mark = (m: string) => logToFile(`[tui-host] ${m}`);
@@ -63,6 +69,11 @@ async function main() {
   store.session = buildSession({
     installDir: process.env.APP_DIR!,
     ci: true,
+    // Keep the `wizard_ask` bridge wired despite `ci: true`. The driver loop
+    // below is the answerer — without this the agent-in-the-loop layer of a
+    // flow (credential questions, the orchestrator's seeded warehouse task) is
+    // never exercised. Only this host sets it; see `shouldDisableAsk`.
+    e2eAsk: process.env.E2E_ASK === 'true',
     apiKey,
     projectId,
     region: 'us',
@@ -188,8 +199,18 @@ async function main() {
   // ---- CI route: self-drive the fixed profile, snapshot each screen ----
   async function fixed() {
     const CTRL = process.env.SNAP_CTRL!;
-    const profile: WizardE2eProfile = profileFor(programId);
+    // Fold the run's env inputs into the profile once, here. `decideE2eAction`
+    // stays pure, so the same state + profile always yields the same decision.
+    const profile: WizardE2eProfile = resolveE2eProfile(profileFor(programId), {
+      notice: process.env.E2E_NOTICE,
+      extraAskAnswers: readAnswersFile(process.env.E2E_ANSWERS_FILE),
+      env: process.env,
+    });
+    const recorder = new E2eRunRecorder();
     const screenPath: string[] = [];
+    let resultWritten = false;
+    // An abort exits from inside the runner, so hook `exit` too — see writeResult.
+    process.on('exit', () => writeResult());
     // Snapshot on key moments — a screen change, a task-list update, or a
     // runPhase change — so the run screen's progression (the agent working) is
     // captured, not just screen transitions. The driver loop snaps each screen
@@ -218,12 +239,19 @@ async function main() {
       });
       return chain;
     };
-    const unsub = store.subscribe(() => void snap());
+    // Log every ask batch and task notice as it opens. The store fires on every
+    // commit, so an overlay that opens and closes between two driver-loop turns
+    // is still recorded.
+    const unsub = store.subscribe(() => {
+      recorder.observe(store.session);
+      void snap();
+    });
 
     let stop = false;
     const driverLoop = async () => {
       while (!stop && !store.session.skillsComplete) {
         await snap(); // capture this screen as presented, before acting
+        recorder.observe(store.session);
         const state = driver.readState();
         const before = state.currentScreen;
         let acted = false;
@@ -236,6 +264,9 @@ async function main() {
             );
             acted = true;
           }
+          // Only the decision knows how it resolved an ask or a notice; the
+          // report is ids and a verdict, never an answer value.
+          if (decision.report) recorder.applyReport(decision.report);
           if (decision.done) stop = true;
         } catch (e) {
           mark(`action error on ${before}: ${(e as Error).message}`);
@@ -259,9 +290,20 @@ async function main() {
     await snap(); // the final screen
     await chain; // flush any pending snapshots
 
+    writeResult();
+    process.exit(0);
+
     // Structured result the --e2e assertion path reads: run phase, posthog deps,
-    // env file, and the screens walked.
-    if (process.env.E2E_RESULT_JSON) {
+    // env file, the screens walked, and the agent-in-the-loop record (asks,
+    // notices, tasks, detected sources, report file, abort reason).
+    //
+    // Registered on `exit` as well as called on the happy path: `wizardAbort`
+    // renders the error outro and then exits the process, so an aborted run
+    // would otherwise write nothing at all — and "why did it abort" is exactly
+    // what the workbench needs in that case.
+    function writeResult() {
+      if (!process.env.E2E_RESULT_JSON || resultWritten) return;
+      resultWritten = true;
       const appDir = process.env.APP_DIR!;
       // One dependency-name pattern per ecosystem manifest. A run only needs
       // the names, so a line-level scan beats per-format parsers.
@@ -313,20 +355,37 @@ async function main() {
       fs.writeFileSync(
         process.env.E2E_RESULT_JSON,
         JSON.stringify(
-          {
-            runPhase: store.session.runPhase,
-            hasPosthogDep: posthogDeps.length > 0,
-            newDeps: posthogDeps,
-            envFile,
-            screenPath,
-            skillsComplete: store.session.skillsComplete,
-          },
+          buildE2eResult({
+            base: {
+              runPhase: store.session.runPhase,
+              hasPosthogDep: posthogDeps.length > 0,
+              newDeps: posthogDeps,
+              envFile,
+              screenPath,
+              skillsComplete: store.session.skillsComplete,
+            },
+            recorder,
+            session: store.session,
+            tasks: store.tasks,
+            reportFile: readReportFile(appDir, programConfig.reportFile),
+          }),
           null,
           2,
         ),
       );
     }
-    process.exit(0);
+  }
+}
+
+/** Extra `askAnswers` rules from `E2E_ANSWERS_FILE`, or none. */
+function readAnswersFile(file: string | undefined): AskAnswerRule[] {
+  if (!file) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return Array.isArray(parsed) ? (parsed as AskAnswerRule[]) : [];
+  } catch (e) {
+    mark(`could not read E2E_ANSWERS_FILE ${file}: ${(e as Error).message}`);
+    return [];
   }
 }
 

--- a/src/lib/__tests__/agent-runner-ask.test.ts
+++ b/src/lib/__tests__/agent-runner-ask.test.ts
@@ -1,15 +1,56 @@
 import { shouldDisableAsk } from '@lib/agent/agent-runner';
+import { buildSession } from '@lib/wizard-session';
 
 describe('shouldDisableAsk', () => {
   it('enables wizard_ask in interactive runs by default', () => {
-    expect(shouldDisableAsk({ ci: false, signup: false })).toBe(false);
+    expect(shouldDisableAsk({ ci: false, signup: false, e2eAsk: false })).toBe(
+      false,
+    );
   });
 
   it('auto-disables when running in CI mode', () => {
-    expect(shouldDisableAsk({ ci: true, signup: false })).toBe(true);
+    expect(shouldDisableAsk({ ci: true, signup: false, e2eAsk: false })).toBe(
+      true,
+    );
   });
 
   it('auto-disables during the signup flow (which is non-interactive at the prompt layer)', () => {
-    expect(shouldDisableAsk({ ci: false, signup: true })).toBe(true);
+    expect(shouldDisableAsk({ ci: false, signup: true, e2eAsk: false })).toBe(
+      true,
+    );
+  });
+
+  // The full truth table over the three inputs. `e2eAsk` is the harness escape
+  // hatch: it re-enables the bridge in an otherwise non-interactive run,
+  // because the e2e driver loop answers each batch from the program's profile.
+  it.each([
+    { ci: false, signup: false, e2eAsk: false, disabled: false },
+    { ci: false, signup: false, e2eAsk: true, disabled: false },
+    { ci: true, signup: false, e2eAsk: false, disabled: true },
+    { ci: true, signup: false, e2eAsk: true, disabled: false },
+    { ci: false, signup: true, e2eAsk: false, disabled: true },
+    { ci: false, signup: true, e2eAsk: true, disabled: false },
+    { ci: true, signup: true, e2eAsk: false, disabled: true },
+    { ci: true, signup: true, e2eAsk: true, disabled: false },
+  ])(
+    'ci=$ci signup=$signup e2eAsk=$e2eAsk → disabled=$disabled',
+    ({ ci, signup, e2eAsk, disabled }) => {
+      expect(shouldDisableAsk({ ci, signup, e2eAsk })).toBe(disabled);
+    },
+  );
+
+  it('leaves a plain --ci session disabled — buildSession defaults e2eAsk to false', () => {
+    const session = buildSession({ installDir: '/tmp/ask-policy', ci: true });
+    expect(session.e2eAsk).toBe(false);
+    expect(shouldDisableAsk(session)).toBe(true);
+  });
+
+  it('re-enables the bridge when the harness asks for it', () => {
+    const session = buildSession({
+      installDir: '/tmp/ask-policy',
+      ci: true,
+      e2eAsk: true,
+    });
+    expect(shouldDisableAsk(session)).toBe(false);
   });
 });

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -44,11 +44,20 @@ import type { ProgramRun, BootstrapResult } from './types';
  * answer. Per-program disabling is done by adding WIZARD_ASK_TOOL_NAME to
  * the program's `disallowedTools` so the SDK rejects calls outright.
  * Extracted so the policy can be unit-tested directly.
+ *
+ * `session.e2eAsk` is the one escape hatch. The e2e harness runs a `ci`
+ * session, but it does have an answerer — the driver loop answers each
+ * `wizard_ask` batch from the program's e2e profile. Without the flag the
+ * agent-in-the-loop layer (the ask bridge in both sequence arms, and the
+ * orchestrator's seeded warehouse task) stays unreachable from a test.
+ *
+ * Only the e2e TUI host sets the flag, from the `E2E_ASK` env var. No CLI flag
+ * populates it, so plain `--ci` and `--signup` runs behave exactly as before.
  */
 export function shouldDisableAsk(
-  session: Pick<WizardSession, 'ci' | 'signup'>,
+  session: Pick<WizardSession, 'ci' | 'signup' | 'e2eAsk'>,
 ): boolean {
-  return session.ci || session.signup;
+  return (session.ci || session.signup) && !session.e2eAsk;
 }
 
 export function sessionToOptions(session: WizardSession): WizardRunOptions {

--- a/src/lib/programs/__tests__/warehouse-seed-task.test.ts
+++ b/src/lib/programs/__tests__/warehouse-seed-task.test.ts
@@ -80,6 +80,20 @@ describe('warehouse seed task', () => {
     );
     expect(tasks).toEqual([]);
   });
+
+  it('queues the task in an e2e run, where the harness answers', () => {
+    // The e2e host runs a `ci` session but drives the ask overlay itself, so
+    // the seeded-task path gets pre-merge coverage instead of none.
+    const tasks = seed(
+      session({
+        ci: true,
+        e2eAsk: true,
+        frameworkContext: { [DETECTED_WAREHOUSE_SOURCES_KEY]: [POSTGRES] },
+      }),
+    );
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].type).toBe('warehouse');
+  });
 });
 
 describe('warehouse task notice', () => {

--- a/src/lib/programs/posthog-integration/test/e2e.json
+++ b/src/lib/programs/posthog-integration/test/e2e.json
@@ -7,7 +7,8 @@
     "mcp": "skip",
     "slack": "skip",
     "skills": "delete",
-    "ask": "first"
+    "ask": "first",
+    "notice": "keep"
   },
   "variations": [
     {
@@ -39,6 +40,10 @@
       "auto": "pick the first option — only appears when the framework needs disambiguation (e.g. Next.js router); Node/Express has none"
     },
     { "screen": "auth", "auto": "(external) — the runner injects credentials" },
+    {
+      "screen": "task-notice",
+      "auto": "keep — shown on the orchestrator sequence when detection seeded the warehouse task; keeping it runs that task at the end of the queue"
+    },
     {
       "screen": "run",
       "auto": "(external) — the real agent integrates the SDK + instruments events"

--- a/src/lib/programs/warehouse-source/test/e2e.json
+++ b/src/lib/programs/warehouse-source/test/e2e.json
@@ -1,6 +1,6 @@
 {
   "program": "warehouse-source",
-  "summary": "Happy path: confirm the intro over the detected sources, keep any task notice, answer the agent's credential questions from E2E_* env vars, delete installed skills.",
+  "summary": "Happy path: confirm the intro over the detected sources, keep any task notice, answer the agent's credential questions from E2E_* env vars, delete installed skills. Rules carrying a real credential are marked \"secret\": they answer only a sensitive text question, so a skill cannot name a plain question \"password\" and get the value back unvaulted.",
   "profile": {
     "setup": "first",
     "healthCheck": "dismiss",
@@ -16,7 +16,8 @@
       },
       {
         "match": "stripe",
-        "value": "${E2E_STRIPE_API_KEY}"
+        "value": "${E2E_STRIPE_API_KEY}",
+        "secret": true
       },
       {
         "match": "host|hostname|server|endpoint",
@@ -32,7 +33,8 @@
       },
       {
         "match": "password|passwd|pwd",
-        "value": "${E2E_PG_PASSWORD}"
+        "value": "${E2E_PG_PASSWORD}",
+        "secret": true
       },
       {
         "match": "user|username|role",

--- a/src/lib/programs/warehouse-source/test/e2e.json
+++ b/src/lib/programs/warehouse-source/test/e2e.json
@@ -1,0 +1,81 @@
+{
+  "program": "warehouse-source",
+  "summary": "Happy path: confirm the intro over the detected sources, keep any task notice, answer the agent's credential questions from E2E_* env vars, delete installed skills.",
+  "profile": {
+    "setup": "first",
+    "healthCheck": "dismiss",
+    "mcp": "skip",
+    "slack": "skip",
+    "skills": "delete",
+    "ask": "first",
+    "notice": "keep",
+    "askAnswers": [
+      {
+        "match": "prefix",
+        "value": "${E2E_SOURCE_PREFIX}"
+      },
+      {
+        "match": "stripe",
+        "value": "${E2E_STRIPE_API_KEY}"
+      },
+      {
+        "match": "host|hostname|server|endpoint",
+        "value": "${E2E_PG_HOST}"
+      },
+      {
+        "match": "port",
+        "value": "${E2E_PG_PORT}"
+      },
+      {
+        "match": "database|db_?name",
+        "value": "${E2E_PG_DATABASE}"
+      },
+      {
+        "match": "password|passwd|pwd",
+        "value": "${E2E_PG_PASSWORD}"
+      },
+      {
+        "match": "user|username|role",
+        "value": "${E2E_PG_USER}"
+      },
+      {
+        "match": "schema",
+        "value": "public"
+      }
+    ]
+  },
+  "variations": [
+    {
+      "name": "default",
+      "summary": "linear / anthropic / sonnet — parity with main"
+    }
+  ],
+  "path": [
+    {
+      "screen": "(headless) detect",
+      "auto": "scan installDir for warehouse signals — writes detectedWarehouseSources, or a detectError when the project has none"
+    },
+    {
+      "screen": "warehouse-intro",
+      "auto": "confirm & continue — lists what detection found"
+    },
+    { "screen": "auth", "auto": "(external) — the runner injects credentials" },
+    {
+      "screen": "task-notice",
+      "auto": "keep — only shown on the orchestrator sequence, where the warehouse step is a seeded task the user can decline"
+    },
+    {
+      "screen": "run",
+      "auto": "(external) — the agent runs the data-warehouse-source-setup skill: it collects credentials through wizard_ask, creates in-cli sources over the PostHog MCP, and emits a deep link for the rest"
+    },
+    {
+      "screen": "wizard-ask",
+      "auto": "answer every question in the batch — askAnswers routes each credential field to its E2E_* env var; anything unrouted takes the first option, else the 'e2e' sentinel"
+    },
+    { "screen": "outro", "auto": "dismiss" },
+    {
+      "screen": "keep-skills",
+      "auto": "delete — leave nothing behind (terminal: the run's done-signal)"
+    }
+  ]
+}

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -209,6 +209,15 @@ export interface WizardSession {
   ci: boolean;
   signup: boolean;
   /**
+   * Harness-only escape hatch: keep the `wizard_ask` bridge wired in a `ci`
+   * session so an e2e run can answer the agent's questions.
+   *
+   * Only the e2e TUI host sets it, from the `E2E_ASK` env var. There is no CLI
+   * flag, `bin.ts` never populates it, and nothing in a published build reads
+   * the env var — so a normal `--ci` run is unchanged. See `shouldDisableAsk`.
+   */
+  e2eAsk: boolean;
+  /**
    * `--local-posthog` folds into `baseUrl`, and `--local-context-mill` is read
    * from `getLocalDev()` — neither belongs here. This one stays because
    * `mcp add|remove|tutorial --local` populate it from their own flag.
@@ -400,6 +409,8 @@ export function buildSession(args: {
   installDir?: string;
   ci?: boolean;
   signup?: boolean;
+  /** Harness-only. Set by the e2e TUI host from `E2E_ASK`, never by a flag. */
+  e2eAsk?: boolean;
   localDev?: boolean;
   localMcp?: boolean;
   localPosthog?: boolean;
@@ -425,6 +436,7 @@ export function buildSession(args: {
     installDir: args.installDir ?? process.cwd(),
     ci: args.ci ?? false,
     signup: args.signup ?? false,
+    e2eAsk: args.e2eAsk ?? false,
     localMcp: local.localMcp,
     mcpFeatures: args.mcpFeatures,
     apiKey: args.apiKey,

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -219,6 +219,11 @@ export interface WizardSession {
    * Only the e2e TUI host sets it, from the `E2E_ASK` env var. There is no CLI
    * flag, `bin.ts` never populates it, and nothing in a published build reads
    * the env var — so a normal `--ci` run is unchanged. See `shouldDisableAsk`.
+   *
+   * Guarding `E2E_ASK` is not enough on its own: the CI runner spreads the
+   * whole `POSTHOG_WIZARD_*` bag into `buildSession`, which would let
+   * `POSTHOG_WIZARD_e2e_ask=true` set this field. `readEnvironment` drops it —
+   * see `NEVER_FROM_ENV`, and keep that list in step with this comment.
    */
   e2eAsk: boolean;
   /**

--- a/src/utils/__tests__/environment.test.ts
+++ b/src/utils/__tests__/environment.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The `POSTHOG_WIZARD_*` env bag.
+ *
+ * `read-env` camel-cases every prefixed variable into a session arg, and the CI
+ * runner spreads the whole bag into `buildSession`. That makes the bag a second
+ * way to set any session field — intended for `debug`, and not intended at all
+ * for the harness-only `e2eAsk`, which would re-wire the `wizard_ask` bridge in
+ * a run with nobody to answer.
+ */
+
+import { readEnvironment } from '@utils/environment';
+import { buildSession } from '@lib/wizard-session';
+import { shouldDisableAsk } from '@lib/agent/agent-runner';
+
+/** Every var this file sets, cleared between cases. */
+const TOUCHED = [
+  'POSTHOG_WIZARD_DEBUG',
+  'POSTHOG_WIZARD_E2E_ASK',
+  'POSTHOG_WIZARD_e2e_ask',
+  'POSTHOG_WIZARD_E2e_Ask',
+  'POSTHOG_WIZARD_e2eAsk',
+];
+
+describe('readEnvironment', () => {
+  afterEach(() => {
+    for (const key of TOUCHED) delete process.env[key];
+  });
+
+  it('maps a prefixed variable onto its session arg', () => {
+    process.env.POSTHOG_WIZARD_DEBUG = 'true';
+    expect(readEnvironment()).toEqual({ debug: true });
+  });
+
+  // read-env's camel-casing is the reason this needs a list rather than one
+  // exact-match check: POSTHOG_WIZARD_E2E_ASK yields `e2EAsk`, but the
+  // lower/mixed-case spellings land exactly on the session's `e2eAsk`.
+  it.each([
+    'POSTHOG_WIZARD_E2E_ASK',
+    'POSTHOG_WIZARD_e2e_ask',
+    'POSTHOG_WIZARD_E2e_Ask',
+    'POSTHOG_WIZARD_e2eAsk',
+  ])('drops the harness-only ask flag set as %s', (name) => {
+    process.env[name] = 'true';
+    expect(Object.keys(readEnvironment())).toEqual([]);
+  });
+
+  it('drops only the harness flag, leaving the rest of the bag intact', () => {
+    process.env.POSTHOG_WIZARD_DEBUG = 'true';
+    process.env.POSTHOG_WIZARD_e2e_ask = 'true';
+    expect(readEnvironment()).toEqual({ debug: true });
+  });
+
+  // The composition the CI runner performs: bag spread into buildSession.
+  // Without the guard this flips the gate and the agent starts asking
+  // questions into a run that cannot answer them.
+  it('cannot re-enable wizard_ask in a --ci run', () => {
+    process.env.POSTHOG_WIZARD_e2e_ask = 'true';
+    const session = buildSession({
+      installDir: '/tmp/env-bag',
+      ci: true,
+      ...readEnvironment(),
+    });
+    expect(session.e2eAsk).toBe(false);
+    expect(shouldDisableAsk(session)).toBe(true);
+  });
+});

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -21,8 +21,35 @@ export function isNonInteractiveEnvironment(): boolean {
   return false;
 }
 
+/**
+ * Session fields the environment must never set, matched case-insensitively
+ * against the camel-cased key `read-env` produces.
+ *
+ * `e2eAsk` re-wires the `wizard_ask` bridge in an otherwise non-interactive
+ * run. Only the e2e TUI host may set it: a real `--ci` run has nobody to answer,
+ * so every question would stall for the bridge timeout instead of failing fast
+ * with an actionable error. See `shouldDisableAsk`.
+ */
+const NEVER_FROM_ENV = ['e2eAsk'];
+
+/**
+ * Session args from the `POSTHOG_WIZARD_*` environment variables.
+ *
+ * `read-env` camel-cases every prefixed variable into a key, and the CI runner
+ * spreads the whole bag into `buildSession` — so adding a field to the session
+ * silently adds an environment variable that sets it. Most of them are meant to
+ * work that way (`POSTHOG_WIZARD_DEBUG` → `debug`); the ones in
+ * {@link NEVER_FROM_ENV} are not, and are dropped here rather than at the call
+ * site, so a second caller cannot reopen the door.
+ */
 export function readEnvironment(): Record<string, unknown> {
-  const result = readEnv('POSTHOG_WIZARD');
+  const result = readEnv('POSTHOG_WIZARD') as Record<string, unknown>;
+
+  for (const key of Object.keys(result)) {
+    if (NEVER_FROM_ENV.some((k) => k.toLowerCase() === key.toLowerCase())) {
+      delete result[key];
+    }
+  }
 
   return result;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       // Path aliases — mirror tsconfig `paths`.
       { find: /^@env$/, replacement: r('src/env.ts') },
       { find: /^@lib\/(.*)$/, replacement: `${r('src/lib')}/$1` },
+      { find: /^@e2e-harness\/(.*)$/, replacement: `${r('e2e-harness')}/$1` },
       { find: /^@utils\/(.*)$/, replacement: `${r('src/utils')}/$1` },
       { find: /^@ui$/, replacement: r('src/ui/index.ts') },
       { find: /^@ui\/(.*)$/, replacement: `${r('src/ui')}/$1` },
@@ -71,8 +72,6 @@ export default defineConfig({
       '**/node_modules/**',
       '**/dist/**',
       '**/e2e-tests/**',
-      // The e2e harness and its tests live in a separate stacked PR.
-      '**/e2e-harness/**',
       '**/*.no-jest.*',
       '**/*.d.ts',
     ],


### PR DESCRIPTION
## Problem

The warehouse flow has no pre-merge test coverage of the agent-in-the-loop layer. Unit tests cover the pure logic. Nothing exercises the wizard binary, the downloaded skill, the model and the PostHog MCP together. Every recent warehouse regression lived in that layer.

The e2e harness is the only thing that can drive the real TUI and the real agent. It cannot drive the warehouse flow today, because it runs a `ci` session and a `ci` session disables every ask. The warehouse flow is made of asks.

## Changes

**A harness-only escape hatch.** `shouldDisableAsk` becomes `(ci || signup) && !e2eAsk`. `e2eAsk` is set only by the e2e host from `E2E_ASK`. No CLI flag reaches it and published builds cannot set it. Plain `--ci` behaviour is unchanged. The same change un-gates `warehouseSeedTasks`, which reads the identical predicate.

**Whole ask batches, and task notices.** The profile answered only `questions[0]` of a batch. Credential questions arrive in batches, so a warehouse run stopped at the first one. `answerQuestions` now answers every question. Resolution order per question: an `askAnswers` rule, else the first option, else the `e2e` sentinel. `Overlay.TaskNotice` had no action at all, so the seeded warehouse task could never be accepted; it gains `resolve_notice`, a `taskNotice` projection on `CiState`, and a `notice` profile policy.

`decideE2eAction` stays pure. `resolveE2eProfile` folds `E2E_NOTICE` and `${ENV_VAR}` values into the profile once at load, so a decision never reads env or the store.

**A richer result payload.** `E2E_RESULT_JSON` reported screens walked and dependencies added. It said nothing about what the run was asked, what it answered, or what detection found. It gains `asks`, `unansweredAsks`, `notices`, `tasks`, `detectedSources`, `reportFile` and `abort`. Every pre-existing key is unchanged.

The host also writes the payload from an `exit` hook. An abort exits from inside the runner, so an aborted run wrote nothing at all — and the abort reason is exactly what an assertion needs in that case.

**Security rail.** Only question prompt text and question ids enter the payload. No answer value ever does. The decision function reports ids and a keep or decline verdict, so the recorder never holds an answer.

**One thing worth a second look.** `vitest.config.ts` excluded `**/e2e-harness/**` with a comment saying those tests lived on a stacked branch. That branch landed, so the whole harness suite has not been running. This removes the exclusion. Doing so immediately surfaced the missing task-notice action, which is the gap an exhaustiveness test exists to catch.

## Test plan

- 2347 tests pass, up from 2249 on main. The increase is the new tests plus the newly enabled harness suite.
- `tsc --noEmit` output is byte-identical to a fresh `origin/main` worktree: 36 pre-existing errors before and after.
- Prettier and ESLint clean; the 494 ESLint warnings are pre-existing and none is in a touched file.
- New coverage: the `shouldDisableAsk` truth table; the seeded warehouse task queuing under `ci + e2eAsk`; batch answering, id-before-prompt precedence, case-insensitivity, malformed regex; `${ENV}` interpolation including unset-to-sentinel; notice keep and decline including the `E2E_NOTICE` override; every screen in `E2E_DRIVABLE_SCREENS` yielding an action; and the security rail, which answers a real secret through the decision path and then scans the serialized payload for it.
- End to end: the workbench branch below runs four warehouse fixtures through this harness. Detection runs before auth, so detection and signal-path checks were graded against real wizard output. The post-auth half needs a PostHog key and is not yet verified live.

Companion PRs: PostHog/wizard-workbench (warehouse fixtures, stub MCP and assertions) and the ref-pinning PRs in this repo and PostHog/context-mill.
