### PR TITLE
feat(wizard-ci): let a PR comment pin the context-mill ref

### DIFF
--- a/.github/workflows/wizard-ci-trigger.yml
+++ b/.github/workflows/wizard-ci-trigger.yml
@@ -132,6 +132,11 @@ jobs:
             }
 
             bodyParts.push('');
+            bodyParts.push('**Test against a Context Mill branch:**');
+            bodyParts.push('- `/wizard-ci all context-mill:my-branch`');
+            bodyParts.push('');
+            bodyParts.push('Add `context-mill:<branch>` to any command above to pin the Context Mill branch. It defaults to `main`.');
+            bodyParts.push('');
             bodyParts.push('Results will be posted here when complete.');
 
             const body = bodyParts.join('\n');
@@ -188,7 +193,36 @@ jobs:
 
             const comment = context.payload.comment.body;
             const match = comment.match(/\/wizard-ci\s+(\S+)/);
-            const app = match ? match[1] : 'all';
+            const firstArg = match ? match[1] : 'all';
+
+            // A reviewer can pin the companion repo with `context-mill:<ref>`.
+            // A lone pin is not an app name, so fall back to every app.
+            const app = firstArg.startsWith('context-mill:') ? 'all' : firstArg;
+
+            // The ref arrives in a PR comment, so treat it as untrusted. Accept
+            // git ref characters only. Reject traversal, a leading dash and a
+            // trailing slash.
+            const isPlausibleRef = (ref) =>
+              ref.length <= 200 &&
+              /^[A-Za-z0-9._\/-]+$/.test(ref) &&
+              !ref.includes('..') &&
+              !ref.startsWith('-') &&
+              !ref.startsWith('/') &&
+              !ref.endsWith('/');
+
+            // Read the pin from the command line only, not from later prose.
+            const companion = comment
+              .split(/\r?\n/)[0]
+              .match(/(?:^|\s)context-mill:(\S+)/);
+            const contextMillRef = companion ? companion[1] : null;
+
+            if (contextMillRef && !isPlausibleRef(contextMillRef)) {
+              core.setFailed(
+                'The context-mill ref is not a valid git ref. ' +
+                  'Use `/wizard-ci <app> context-mill:<branch>`.'
+              );
+              return;
+            }
 
             // React with rocket to show we're processing
             await github.rest.reactions.createForIssueComment({
@@ -210,12 +244,15 @@ jobs:
                 source_pr_number: context.payload.issue.number,
                 source_pr_url: pr.data.html_url,
                 wizard_ref: pr.data.head.ref,
+                // Omit the key when unpinned. The workbench then uses `main`.
+                ...(contextMillRef ? { context_mill_ref: contextMillRef } : {}),
                 notify_slack: 'false',
                 notify_pr: 'true'
               }
             });
 
-            console.log(`Triggered wizard-ci for app: ${app}`);
+            const pinNote = contextMillRef ? ` (context-mill ref ${contextMillRef})` : '';
+            console.log(`Triggered wizard-ci for app: ${app}${pinNote}`);
 
   # ============================================================================
   # HANDLE SNAPSHOTS: Parse /wizard-ci-snapshots and trigger the snapshots workflow
@@ -253,12 +290,50 @@ jobs:
               return;
             }
 
-            // /wizard-ci-snapshots <app> [wizard_ref] — ref defaults to this PR's branch.
-            const m = context.payload.comment.body.match(
-              /\/wizard-ci-snapshots\s+(\S+)(?:\s+(\S+))?/
-            );
+            const body = context.payload.comment.body;
+
+            // The ref arrives in a PR comment, so treat it as untrusted. Accept
+            // git ref characters only. Reject traversal, a leading dash and a
+            // trailing slash.
+            const isPlausibleRef = (ref) =>
+              ref.length <= 200 &&
+              /^[A-Za-z0-9._\/-]+$/.test(ref) &&
+              !ref.includes('..') &&
+              !ref.startsWith('-') &&
+              !ref.startsWith('/') &&
+              !ref.endsWith('/');
+
+            // Optional companion pin. Read it from the command line only.
+            const companionToken = /(?:^|\s)context-mill:(\S+)/;
+            const companion = body.split(/\r?\n/)[0].match(companionToken);
+            const contextMillRef = companion ? companion[1] : null;
+
+            if (contextMillRef && !isPlausibleRef(contextMillRef)) {
+              core.setFailed(
+                'The context-mill ref is not a valid git ref. Use ' +
+                  '`/wizard-ci-snapshots <app> context-mill:<branch>`.'
+              );
+              return;
+            }
+
+            // Remove the pin so the positional ref cannot capture it.
+            const args = contextMillRef ? body.replace(companionToken, ' ') : body;
+
+            // /wizard-ci-snapshots <app> [wizard_ref] [context-mill:<ref>] —
+            // wizard_ref defaults to this PR's branch.
+            const m = args.match(/\/wizard-ci-snapshots\s+(\S+)(?:\s+(\S+))?/);
             const app = m ? m[1] : 'basic-integration/javascript-node/express-todo';
-            const wizardRef = m && m[2] ? m[2] : pr.data.head.ref;
+
+            // The positional ref also comes from the comment. Check it too.
+            const wizardRefArg = m && m[2] ? m[2] : null;
+            if (wizardRefArg && !isPlausibleRef(wizardRefArg)) {
+              core.setFailed(
+                'The wizard ref is not a valid git ref. Use ' +
+                  '`/wizard-ci-snapshots <app> <wizard-branch>`.'
+              );
+              return;
+            }
+            const wizardRef = wizardRefArg || pr.data.head.ref;
 
             await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
@@ -282,10 +357,13 @@ jobs:
                 source_pr_number: context.payload.issue.number,
                 source_pr_url: pr.data.html_url,
                 wizard_ref: wizardRef,
+                // Omit the key when unpinned. The workbench then uses `main`.
+                ...(contextMillRef ? { context_mill_ref: contextMillRef } : {}),
                 notify_slack: 'false',
                 notify_pr: 'true',
                 snapshots: true
               }
             });
 
-            console.log(`Triggered snapshots for app: ${app} (ref ${wizardRef})`);
+            const pinNote = contextMillRef ? `, context-mill ref ${contextMillRef}` : '';
+            console.log(`Triggered snapshots for app: ${app} (ref ${wizardRef}${pinNote})`);

--- a/.github/workflows/wizard-ci-trigger.yml
+++ b/.github/workflows/wizard-ci-trigger.yml
@@ -159,6 +159,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       startsWith(github.event.comment.body, '/wizard-ci') &&
       !startsWith(github.event.comment.body, '/wizard-ci-snapshots')
     runs-on: ubuntu-latest
@@ -257,10 +258,13 @@ jobs:
   # ============================================================================
   # HANDLE SNAPSHOTS: Parse /wizard-ci-snapshots and trigger the snapshots workflow
   # ============================================================================
+  # Same write-access restriction as handle-command above. This job matters more:
+  # its positional `[ref]` argument is attacker-chosen, not the PR's own branch.
   handle-snapshots-command:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       startsWith(github.event.comment.body, '/wizard-ci-snapshots')
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Problem

The workbench `wizard-ci` workflow already accepts `wizard_ref` and `context_mill_ref` on the same dispatch channel. This trigger sent only `wizard_ref`, and the context-mill trigger sends only `context_mill_ref`. So a change that spans both repos cannot be exercised before merge.

That is not hypothetical. #1146 changes the credential-prompt cap in the runtime, and PostHog/context-mill#360 changes the skill text that has to match it. They are one contract in two repos, and today a reviewer cannot run them together.

## Changes

`/wizard-ci <app>` and `/wizard-ci-snapshots <app> [ref]` accept an optional `context-mill:<ref>` suffix. The trigger validates the ref, then adds `context_mill_ref` to the dispatch payload. Without the suffix the key is omitted entirely, so the workbench applies its own `main` default and existing behaviour is byte-identical.

The app regex is untouched. One nicety: a lone pin such as `/wizard-ci context-mill:foo` would otherwise read as an app name, so it now falls back to `all`.

**Ref validation matters here.** The workbench interpolates the ref straight into a JS string literal inside `github-script`, in a job that holds the App token. The allowlist is `[A-Za-z0-9._/-]`, max 200 characters, no `..`, no leading `-`, no leading or trailing `/`. That excludes every quote, backtick, backslash, `$` and `;`, so the literal cannot be broken out of. It also blocks path traversal and git option injection such as `--upload-pack=`. An invalid ref calls `core.setFailed` and dispatches nothing, rather than silently falling back to `main`.

`/wizard-ci-snapshots` already accepted a positional `wizard_ref` that was **never validated**, feeding the same interpolation. Since this touches that parser, it now gets the same check. That is the one place an existing input changes behaviour, and only for refs that could never have checked out anyway.

Residual risk is unchanged from what `wizard_ref` already allowed: a commenter can point CI at a branch that exists and burn CI minutes. No token scope is widened.

## Test plan

- `actionlint`: 4 shellcheck findings, byte-identical to the pre-change baseline, all in an untouched bash step. No new findings.
- YAML parses; all three job keys intact.
- Behavioural: the `script:` blocks were extracted from the YAML and executed in Node against stubbed GitHub APIs, capturing the dispatch payload for 27 command forms. All four legacy forms produce identical payloads with no `context_mill_ref` key. All pin forms attach the key. Eleven hostile refs — quote breakout, `../../etc/passwd`, `--upload-pack=`, `$(id)`, backticks, backslash, over-length, absolute, trailing slash — all fail with no dispatch.

Companion PR: PostHog/context-mill mirrors this with a `wizard:<ref>` suffix.
