### PR TITLE
fix(warehouse-e2e): stop the secret rule refusing every credential question

### DIFF
--- a/e2e-harness/__tests__/__snapshots__/e2e-flow-snapshot.test.ts.snap
+++ b/e2e-harness/__tests__/__snapshots__/e2e-flow-snapshot.test.ts.snap
@@ -179,12 +179,19 @@ exports[`e2e flow snapshot — warehouse-source > walks intro → auth → run �
     "ask": "first",
     "askAnswers": [
       {
+        "match": "account[ _-]?id",
+        "value": "acct_e2efixture",
+      },
+      {
         "match": "prefix",
         "value": "\${E2E_SOURCE_PREFIX}",
       },
       {
+        "match": "connection[ _-]?string",
+        "value": "postgresql://\${E2E_PG_USER}:\${E2E_PG_PASSWORD}@\${E2E_PG_HOST}:\${E2E_PG_PORT}/\${E2E_PG_DATABASE}",
+      },
+      {
         "match": "stripe",
-        "secret": true,
         "value": "\${E2E_STRIPE_API_KEY}",
       },
       {
@@ -201,16 +208,19 @@ exports[`e2e flow snapshot — warehouse-source > walks intro → auth → run �
       },
       {
         "match": "password|passwd|pwd",
-        "secret": true,
         "value": "\${E2E_PG_PASSWORD}",
       },
       {
-        "match": "user|username|role",
+        "match": "user|username|role|author",
         "value": "\${E2E_PG_USER}",
       },
       {
         "match": "schema",
         "value": "public",
+      },
+      {
+        "match": "api[ _-]?key|api[ _-]?token|access[ _-]?token|auth[ _-]?token|^token$|secret|credential",
+        "value": "\${E2E_API_TOKEN}",
       },
     ],
     "healthCheck": "dismiss",

--- a/e2e-harness/__tests__/e2e-profile-ask.test.ts
+++ b/e2e-harness/__tests__/e2e-profile-ask.test.ts
@@ -524,6 +524,18 @@ describe('E2E_DRIVABLE_SCREENS', () => {
   });
 });
 
+/** The env the workbench runner injects for a warehouse e2e leg. */
+const WAREHOUSE_ENV = {
+  E2E_SOURCE_PREFIX: 'e2e_7_',
+  E2E_STRIPE_API_KEY: 'sk_test_7',
+  E2E_PG_HOST: 'db.internal',
+  E2E_PG_PORT: '5432',
+  E2E_PG_DATABASE: 'appdb',
+  E2E_PG_USER: 'app',
+  E2E_PG_PASSWORD: 'hunter2',
+  E2E_API_TOKEN: 'hf_e2e_token',
+};
+
 describe('warehouse-source profile', () => {
   const warehouse = profileFor(Program.WarehouseSource);
 
@@ -538,64 +550,136 @@ describe('warehouse-source profile', () => {
   });
 
   it('routes each credential question to its own env var', () => {
-    const env = {
-      E2E_SOURCE_PREFIX: 'e2e_7_',
-      E2E_STRIPE_API_KEY: 'sk_test_7',
-      E2E_PG_HOST: 'db.internal',
-      E2E_PG_PORT: '5432',
-      E2E_PG_DATABASE: 'appdb',
-      E2E_PG_USER: 'app',
-      E2E_PG_PASSWORD: 'hunter2',
-    };
-    const resolved = resolveE2eProfile(warehouse, { env });
+    const resolved = resolveE2eProfile(warehouse, { env: WAREHOUSE_ENV });
     const batch = answerQuestions(
       [
         text('prefix', 'Table prefix'),
-        sensitiveText('stripe_api_key', 'Stripe API key'),
+        text('stripe_secret_key', 'Stripe API key'),
         text('host', 'Postgres host'),
         text('port', 'Port'),
         text('database', 'Database name'),
         text('user', 'Username'),
-        sensitiveText('password', 'Password'),
+        text('password', 'Password'),
+        text('schema', 'Schema'),
       ],
       resolved,
     );
     expect(batch.answers).toEqual({
       prefix: 'e2e_7_',
-      stripe_api_key: 'sk_test_7',
+      stripe_secret_key: 'sk_test_7',
       host: 'db.internal',
       port: '5432',
       database: 'appdb',
       user: 'app',
       password: 'hunter2',
+      schema: 'public',
     });
     expect(batch.sentinelIds).toEqual([]);
     expect(batch.refusedIds).toEqual([]);
   });
 
-  it('marks its credential-bearing rules secret', () => {
-    const secretMatches = (warehouse.askAnswers ?? [])
-      .filter((r) => r.secret)
-      .map((r) => r.match);
-    expect(secretMatches).toEqual(['stripe', 'password|passwd|pwd']);
+  /**
+   * The skill tells the agent to collect a warehouse credential as ordinary
+   * text, because `external-data-sources-create` rejects a `{ secretRef }`. A
+   * `secret` rule answers only a *sensitive* text question, so marking these
+   * rules secret refused every credential the skill asked for — 2 refusals on
+   * the Stripe leg, 3 on the Postgres+Stripe leg, and no create anywhere.
+   */
+  it('marks no rule secret, so a plain credential question is answered', () => {
+    expect((warehouse.askAnswers ?? []).filter((r) => r.secret)).toEqual([]);
+    const resolved = resolveE2eProfile(warehouse, { env: WAREHOUSE_ENV });
+    const batch = answerQuestions([text('password', 'Password')], resolved);
+    expect(batch.answers.password).toBe('hunter2');
+    expect(batch.refusedIds).toEqual([]);
   });
 
-  it('withholds the API key from a question that is not sensitive', () => {
-    const resolved = resolveE2eProfile(warehouse, {
-      env: { E2E_STRIPE_API_KEY: 'sk_test_7' },
-    });
+  /**
+   * The exact batch the 2026-08-28 CI run asked on the Stripe leg. Two of these
+   * three questions fell back to the sentinel then; none may now.
+   */
+  it("answers the Stripe leg's real question ids", () => {
+    const resolved = resolveE2eProfile(warehouse, { env: WAREHOUSE_ENV });
     const batch = answerQuestions(
-      [text('stripe_api_key', 'Stripe API key')],
+      [
+        text('api_key', 'Paste your restricted Stripe API key here:'),
+        text('account_id', 'Stripe Account ID (optional — leave blank)'),
+        text('table_prefix', 'Table name prefix (optional)'),
+      ],
       resolved,
     );
-    expect(batch.answers.stripe_api_key).toBe(E2E_ANSWER_SENTINEL);
-    expect(batch.refusedIds).toEqual(['stripe_api_key']);
+    expect(batch.answers).toEqual({
+      // The credential net claims a vendor-less `api_key` on the id pass,
+      // before the `stripe` rule can claim it on the prompt pass. Both values
+      // are fake placeholders, so the routing costs nothing and the question
+      // never reaches the sentinel.
+      api_key: 'hf_e2e_token',
+      account_id: 'acct_e2efixture',
+      table_prefix: 'e2e_7_',
+    });
+    expect(batch.sentinelIds).toEqual([]);
+    expect(batch.refusedIds).toEqual([]);
+  });
+
+  /** The exact batch the same run asked on the Postgres legs. */
+  it("answers the Postgres leg's real question ids, prefixed or not", () => {
+    const resolved = resolveE2eProfile(warehouse, { env: WAREHOUSE_ENV });
+    const batch = answerQuestions(
+      [
+        text('pg-host', 'PostgreSQL host'),
+        text('pg-port', 'PostgreSQL port'),
+        text('pg-database', 'PostgreSQL database name'),
+        text('pg-user', 'PostgreSQL user'),
+        text('pg-password', 'PostgreSQL password'),
+        text('pg-schema', 'PostgreSQL schema'),
+      ],
+      resolved,
+    );
+    expect(batch.answers).toEqual({
+      'pg-host': 'db.internal',
+      'pg-port': '5432',
+      'pg-database': 'appdb',
+      'pg-user': 'app',
+      'pg-password': 'hunter2',
+      'pg-schema': 'public',
+    });
+    expect(batch.sentinelIds).toEqual([]);
+  });
+
+  /**
+   * Precedence the rule order is built on: `account[ _-]?id` sits ahead of
+   * `stripe`, so an optional account-id question cannot take the API key.
+   */
+  it('gives the Stripe account id an account id, never the API key', () => {
+    const resolved = resolveE2eProfile(warehouse, { env: WAREHOUSE_ENV });
+    const batch = answerQuestions(
+      [text('stripe_account_id', 'Stripe account id (optional)')],
+      resolved,
+    );
+    expect(batch.answers.stripe_account_id).toBe('acct_e2efixture');
+  });
+
+  it('covers the optional fields that used to match no rule at all', () => {
+    const resolved = resolveE2eProfile(warehouse, { env: WAREHOUSE_ENV });
+    const batch = answerQuestions(
+      [
+        text('connection_string', 'Connection string (optional)'),
+        text('api_token', 'Hugging Face access token'),
+        text('author', 'Username or organization'),
+      ],
+      resolved,
+    );
+    expect(batch.answers).toEqual({
+      connection_string: 'postgresql://app:hunter2@db.internal:5432/appdb',
+      api_token: 'hf_e2e_token',
+      author: 'app',
+    });
+    expect(batch.sentinelIds).toEqual([]);
   });
 
   it('sentinels every credential when the env is empty', () => {
     const resolved = resolveE2eProfile(warehouse, { env: {} });
     const batch = answerQuestions(
-      [text('host', 'Postgres host'), sensitiveText('password', 'Password')],
+      [text('host', 'Postgres host'), text('password', 'Password')],
       resolved,
     );
     expect(batch.sentinelIds).toEqual(['host', 'password']);

--- a/src/lib/programs/warehouse-source/test/e2e.json
+++ b/src/lib/programs/warehouse-source/test/e2e.json
@@ -1,6 +1,6 @@
 {
   "program": "warehouse-source",
-  "summary": "Happy path: confirm the intro over the detected sources, keep any task notice, answer the agent's credential questions from E2E_* env vars, delete installed skills. Rules carrying a real credential are marked \"secret\": they answer only a sensitive text question, so a skill cannot name a plain question \"password\" and get the value back unvaulted.",
+  "summary": "Happy path: confirm the intro over the detected sources, keep any task notice, answer the agent's credential questions from E2E_* env vars, delete installed skills. No rule is marked \"secret\". The data-warehouse-source-setup skill tells the agent to collect a warehouse credential as ordinary (non-sensitive) text, because external-data-sources-create rejects a { secretRef }. A secret rule answers only a sensitive text question, so a secret rule refused every credential question the skill asked, and no source could ever be created. Each value here is a fake, unroutable placeholder, and the workbench's \"no secret leakage\" check is what holds those placeholders out of the report, the result payload, the MCP journal and the captured frames.",
   "profile": {
     "setup": "first",
     "healthCheck": "dismiss",
@@ -11,13 +11,20 @@
     "notice": "keep",
     "askAnswers": [
       {
+        "match": "account[ _-]?id",
+        "value": "acct_e2efixture"
+      },
+      {
         "match": "prefix",
         "value": "${E2E_SOURCE_PREFIX}"
       },
       {
+        "match": "connection[ _-]?string",
+        "value": "postgresql://${E2E_PG_USER}:${E2E_PG_PASSWORD}@${E2E_PG_HOST}:${E2E_PG_PORT}/${E2E_PG_DATABASE}"
+      },
+      {
         "match": "stripe",
-        "value": "${E2E_STRIPE_API_KEY}",
-        "secret": true
+        "value": "${E2E_STRIPE_API_KEY}"
       },
       {
         "match": "host|hostname|server|endpoint",
@@ -33,19 +40,29 @@
       },
       {
         "match": "password|passwd|pwd",
-        "value": "${E2E_PG_PASSWORD}",
-        "secret": true
+        "value": "${E2E_PG_PASSWORD}"
       },
       {
-        "match": "user|username|role",
+        "match": "user|username|role|author",
         "value": "${E2E_PG_USER}"
       },
       {
         "match": "schema",
         "value": "public"
+      },
+      {
+        "match": "api[ _-]?key|api[ _-]?token|access[ _-]?token|auth[ _-]?token|^token$|secret|credential",
+        "value": "${E2E_API_TOKEN}"
       }
     ]
   },
+  "askAnswerNotes": [
+    "Rules are first-match-wins. Every rule is tested against the question id before any rule is tested against the prompt, so a rule that claims an id shadows a later rule that would have claimed the prompt.",
+    "The agent writes its own question ids. The 2026-08-28 CI run asked: api_key, account_id, table_prefix and stripe_secret_key for Stripe; host, port, database, user, password, schema and pg-host, pg-port, pg-database, pg-user, pg-password, pg-schema for Postgres.",
+    "account[ _-]?id sits ahead of stripe so \"Stripe Account ID (optional)\" takes an account id instead of the API key.",
+    "The last rule is a net, not a router. It claims a vendor-less id such as api_key on the id pass, ahead of the stripe rule that would claim the same question on the prompt pass. That is deliberate: a placeholder token and a placeholder Stripe key are equally fake, and a question that reaches the sentinel breaks the create it feeds.",
+    "E2E_API_TOKEN comes from the workbench runner. An unset var makes the rule inert, and the question falls through to the sentinel."
+  ],
   "variations": [
     {
       "name": "default",


### PR DESCRIPTION
## Problem

The first real run of the warehouse e2e tier failed the `ask contract` check on all three legs:

| leg | unanswered |
| --- | --- |
| `warehouse/stripe-node` | 2 |
| `warehouse/multi-source-next` | 1 |
| `warehouse/monorepo-env` | 3 |

Run: [wizard-workbench 33128463033](https://github.com/PostHog/wizard-workbench/actions/runs/33128463033).

Every one of those questions was **refused**, not unmatched.

The `data-warehouse-source-setup` skill tells the agent to collect a warehouse credential as ordinary, non-sensitive text, because `external-data-sources-create` rejects a `{ secretRef }`. A `secret` `askAnswers` rule answers only a *sensitive* text question, and refuses every other shape. So the `stripe` and `password` rules refused every credential the skill asked for, the run answered with the `e2e` sentinel, and no source could ever be created.

The LLM trace for the run shows the agent quoting that skill line as its reason:

> Per skill instructions: "For credentials you'll hand straight to those tools, collect them as normal (non-sensitive) text answers so you get the real value." So I should treat all these fields as plain text answers rather than marking them sensitive.

The same traces give the real question ids, which no rule covered either:

| leg | ids the agent asked |
| --- | --- |
| stripe-node | `api_key`, `account_id`, `table_prefix` |
| monorepo-env | `host`, `port`, `database`, `user`, `password`, `schema`; then `stripe_secret_key`, … |
| multi-source-next | `pg-host`, `pg-port`, `pg-database`, `pg-user`, `pg-password`, `pg-schema` |

Replaying the old rules over those batches reproduces 2, 3 and 1 refusals exactly.

## Changes

- **Drop `secret` from both rules.** Every value here is a fake, unroutable placeholder. The workbench's `no secret leakage` check is the rail that keeps them out of the report, the result payload, the MCP journal and the captured frames. The `secret` mechanism itself is untouched, so another program can still use it.
- **`account[ _-]?id` ahead of `stripe`.** The old `stripe` rule matched "Stripe Account ID (optional)" and would have handed it the API key.
- **`connection[ _-]?string`** for the optional Postgres and Supabase field, built from the same `E2E_PG_*` vars.
- **`author`** on the user rule, for the Hugging Face namespace field.
- **A trailing credential net**, so a token question the vendor rules miss takes a placeholder instead of the sentinel.

Rules are first-match-wins, and every rule is tested against the question id before any rule is tested against the prompt. `askAnswerNotes` in the JSON records the precedence the order relies on, including one deliberate trade: the net claims a vendor-less `api_key` on the id pass, ahead of the `stripe` rule that would claim the same question on the prompt pass. A placeholder token and a placeholder Stripe key are equally fake, and a question that reaches the sentinel breaks the create it feeds.

The net reads `E2E_API_TOKEN`, added by the companion workbench PR. An unset var leaves the rule inert, so this degrades to today's behaviour on an older runner.

## Verification

Re-ran the `warehouse/stripe-node` leg on this branch:
[wizard-workbench 33161903184](https://github.com/PostHog/wizard-workbench/actions/runs/33161903184)
(`wizard_ref: tom/warehouse-e2e-ask-rules`).

```
E2E_CHECK PASS ask contract — 1 batch(es), max 3 questions, 0 unanswered
```

Was 2 refusals on the same leg. The agent asked the same three questions and every one was answered.

The leg still fails, on three checks that are **not** about the rules:

```
E2E_CHECK FAIL no silent no-op — Stripe: expected a create, the stub never saw one
E2E_CHECK FAIL report written — no report at /tmp/wizard-e2e-stripe-node/posthog-warehouse-report.md
E2E_CHECK FAIL abort — unexpected abort: "Source creation failed"
```

The agent's tool inventory for that run was `Read`, `Glob`, `Bash`, `Agent`, `Skill`, `TaskCreate`,
`TaskUpdate`, `mcp__wizard-tools__check_env_keys` and `mcp__wizard-tools__wizard_ask`. There is no
PostHog MCP tool in it, so `external-data-sources-create` is unreachable. That is the next blocker,
and it sits upstream of both PRs.

Worth noting the run failed *honestly* this time: it aborted instead of reporting a source it never
created, so `claimedConnected` found nothing to flag.

## Test plan

- `vitest run` — 2419 tests pass. The warehouse profile suite grew from 5 tests to 8; new cases replay the real question ids from each leg and pin the `account_id` / `stripe` and net / vendor precedence.
- `e2e-flow-snapshot` snapshot updated for the new rule list.
- `prettier --check` and `eslint` clean on the touched files. `tsc --noEmit` reports 27 errors, all pre-existing on `main` and none in `e2e-harness` or `warehouse-source`.


Companion: PostHog/wizard-workbench#3627