### PR TITLE
feat(telemetry): stamp wizard_ask outcome events with the ask subject

### DIFF
--- a/src/lib/__tests__/wizard-ask-bridge.test.ts
+++ b/src/lib/__tests__/wizard-ask-bridge.test.ts
@@ -116,6 +116,7 @@ describe('createWizardAskBridge', () => {
           { id: 'a', prompt: 'A', kind: 'text' },
           { id: 'b', prompt: 'B', kind: 'text' },
         ],
+        subject: 'postgres',
       });
       resolveAnswers({ a: 'x', b: 'y' });
       await p;
@@ -124,6 +125,7 @@ describe('createWizardAskBridge', () => {
         'wizard_ask answered',
         expect.objectContaining({
           source: 'product-tours',
+          subject: 'postgres',
           question_count: 2,
           duration_ms: expect.any(Number),
         }),
@@ -142,6 +144,7 @@ describe('createWizardAskBridge', () => {
           { id: 'a', prompt: 'A', kind: 'text' },
           { id: 'b', prompt: 'B', kind: 'text' },
         ],
+        subject: 'stripe',
       });
 
       const cancelledCall = wizardCaptureMock.mock.calls.find(
@@ -150,6 +153,7 @@ describe('createWizardAskBridge', () => {
       expect(cancelledCall).toBeDefined();
       expect(cancelledCall?.[1]).toMatchObject({
         source: 'product-tours',
+        subject: 'stripe',
         question_count: 2,
         timed_out: false,
       });

--- a/src/lib/agent/runner/harness/pi/tools.ts
+++ b/src/lib/agent/runner/harness/pi/tools.ts
@@ -29,6 +29,7 @@ import {
   fetchSkillMenu,
   installSkillById,
   mergeEnvValues,
+  normaliseAskSubject,
   resolveEnvPath,
   resolveEnvSecretRefs,
   templateEnvWriteRefusal,
@@ -375,7 +376,10 @@ export function createWizardPiTools(ctx: PiToolsContext): ToolDefinition[] {
       // mutate files while it's waiting on the user's answer.
       onAskPendingChange?.(true);
       try {
-        const answers = await askBridge.request({ questions: args.questions });
+        const answers = await askBridge.request({
+          questions: args.questions,
+          subject: normaliseAskSubject(args.subject),
+        });
         if (isFullyCancelled(answers)) askAccounting.refund(args.subject);
         // Sensitive answers go to the vault; the agent sees an opaque ref
         // (same contract as the MCP wizard_ask).

--- a/src/lib/wizard-ask-bridge.ts
+++ b/src/lib/wizard-ask-bridge.ts
@@ -21,6 +21,17 @@ import type {
 
 export interface WizardAskRequest {
   questions: AskQuestion[];
+  /**
+   * Normalised `subject` of the originating `wizard_ask` call — the thing the
+   * questions collect for (a data-warehouse source kind like "postgres", an
+   * integration step). Stamped onto the `answered`/`cancelled` events so an
+   * outcome can be attributed to what was being asked, not just the run: the
+   * warehouse task asks one call per detected source, and without this a
+   * cancellation cannot be told apart by source. The caller normalises it
+   * (same `normaliseAskSubject` the cap accounting uses) so the value joins to
+   * the `wizard_ask capped` event's `subject`. Absent when the call declared none.
+   */
+  subject?: string;
 }
 
 export interface WizardAskBridge {
@@ -85,7 +96,7 @@ export function createWizardAskBridge(
   const timeoutMs = opts.timeoutMs ?? DEFAULT_ASK_TIMEOUT_MS;
 
   return {
-    async request({ questions }) {
+    async request({ questions, subject }) {
       const pending: PendingQuestion = {
         id: randomUUID(),
         questions,
@@ -118,6 +129,7 @@ export function createWizardAskBridge(
         if (isFullyCancelled(answers)) {
           analytics.wizardCapture('wizard_ask cancelled', {
             source: pending.source,
+            subject,
             question_count: questions.length,
             duration_ms: durationMs,
             timed_out: durationMs >= timeoutMs,
@@ -125,6 +137,7 @@ export function createWizardAskBridge(
         } else {
           analytics.wizardCapture('wizard_ask answered', {
             source: pending.source,
+            subject,
             question_count: questions.length,
             duration_ms: durationMs,
           });

--- a/src/lib/wizard-tools/mcp.ts
+++ b/src/lib/wizard-tools/mcp.ts
@@ -47,6 +47,7 @@ import {
   fetchSkillMenu,
   checkEnvKeys as checkEnvKeysCore,
   mergeEnvValues,
+  normaliseAskSubject,
   readLedger,
   resolveEnvPath,
   resolveEnvSecretRefs,
@@ -737,7 +738,10 @@ export async function createWizardToolsServer(options: WizardToolsOptions) {
       askAccounting.record(args.subject);
 
       try {
-        const answers = await askBridge.request({ questions: args.questions });
+        const answers = await askBridge.request({
+          questions: args.questions,
+          subject: normaliseAskSubject(args.subject),
+        });
 
         // A fully cancelled/timed-out ask (the user dismissed the overlay or let
         // it time out) shouldn't burn the per-run cap. Otherwise one cancellation


### PR DESCRIPTION
## Problem

The `wizard_ask answered` / `wizard_ask cancelled` events — the primary signal
for how users respond to the in-CLI credential prompt — carried the run
`source` but not the per-call `subject` (the thing the questions collect for,
e.g. a data-warehouse source kind). The seeded warehouse task asks **one
`wizard_ask` call per detected source**, so a cancellation was visible at the
run level but could not be attributed to which source's credentials the user
actually declined.

That is the gap that makes the flow's dominant failure mode hard to act on: the
largest structured signal (users cancelling the credential prompt) cannot be
broken down by the per-source dimension the flow is analysed on, even though the
subject is already known at the call site and already stamped on the sibling
`wizard_ask capped` event.

## Changes

- Add an optional `subject` to `WizardAskRequest` and stamp it onto both
  `wizard_ask answered` and `wizard_ask cancelled` in the ask bridge.
- Thread the subject from both harness facades (MCP `wizard_ask` and the pi
  native mirror), normalised through the same `normaliseAskSubject` the cap
  accounting uses, so the value joins cleanly to `wizard_ask capped`.

Purely additive — no behaviour change, and the two facades are updated
symmetrically so they can't drift.

## Why

The warehouse-connect telemetry breaks outcomes down per provider, but the
cancellation event that drives most of the loss was provider-blind, so the two
couldn't be joined. This closes that gap in the same spirit as the earlier
`reason`-on-skip change.

## Test plan

- Extended `wizard-ask-bridge` unit tests to assert `subject` is stamped on both
  the answered and cancelled events.
- `pnpm build && pnpm test` (ask-bridge + wizard-tools + pi harness suites) and
  `pnpm lint` pass (0 errors).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
