### PR TITLE
fix: allow dev sandboxes to set MCP endpoint

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -28,7 +28,7 @@ node --input-type=module -e "import '$DIST_BIN'" 2>&1 | head -5 | grep -q 'PostH
 # builds and tsdown strips it; its env var name appearing in dist/*.js means
 # dead-code elimination regressed and a prod surface leaked. Sourcemaps keep
 # the original source, so only .js output counts.
-OVERRIDE_MARKERS='WIZARD_CI_FLAG_OVERRIDES WIZARD_CI_EXCLUDE_TASKS MCP_URL'
+OVERRIDE_MARKERS='WIZARD_CI_FLAG_OVERRIDES WIZARD_CI_EXCLUDE_TASKS MCP_URL POSTHOG_MCP_ENDPOINT'
 if [ "${WIZARD_BUILD_NODE_ENV:-production}" = "ci" ]; then
   # CI builds must keep the paths — their absence means the overrides silently
   # stopped working and CI is back to testing live behavior.

--- a/src/env.ts
+++ b/src/env.ts
@@ -67,6 +67,7 @@ type RuntimeEnvKey =
   | 'POSTHOG_TASK_RUN_ID'
   | 'POSTHOG_TASK_ID'
   | 'POSTHOG_HANDOFF_OUTPUT_PATH'
+  | 'POSTHOG_MCP_ENDPOINT'
   // Local/CI escape hatch to disable Warlock scanning without the PostHog flag.
   | 'POSTHOG_WIZARD_WARLOCK_DISABLED'
   | 'DEBUG'

--- a/src/lib/__tests__/host-resolution.test.ts
+++ b/src/lib/__tests__/host-resolution.test.ts
@@ -98,11 +98,25 @@ describe('mcpUrlFor', () => {
     }
   });
 
-  it('ignores MCP_URL entirely in production builds', async () => {
+  it('takes a host-provided MCP endpoint in development builds', () => {
+    const prevEndpoint = process.env.POSTHOG_MCP_ENDPOINT;
+    process.env.POSTHOG_MCP_ENDPOINT = 'http://host.docker.internal:8787/mcp';
+    try {
+      expect(mcpUrlFor(false)).toBe('http://host.docker.internal:8787/mcp');
+      expect(mcpUrlFor(true)).toBe('http://host.docker.internal:8787/mcp');
+    } finally {
+      if (prevEndpoint === undefined) delete process.env.POSTHOG_MCP_ENDPOINT;
+      else process.env.POSTHOG_MCP_ENDPOINT = prevEndpoint;
+    }
+  });
+
+  it('ignores MCP endpoint overrides in production builds', async () => {
     const prevEnv = process.env.NODE_ENV;
     const prevUrl = process.env.MCP_URL;
+    const prevEndpoint = process.env.POSTHOG_MCP_ENDPOINT;
     process.env.NODE_ENV = 'production';
     process.env.MCP_URL = 'https://evil.example.com/mcp';
+    process.env.POSTHOG_MCP_ENDPOINT = 'https://evil.example.com/host-mcp';
     try {
       vi.resetModules();
       const fresh = await import('@lib/host-resolution');
@@ -112,6 +126,8 @@ describe('mcpUrlFor', () => {
       process.env.NODE_ENV = prevEnv;
       if (prevUrl === undefined) delete process.env.MCP_URL;
       else process.env.MCP_URL = prevUrl;
+      if (prevEndpoint === undefined) delete process.env.POSTHOG_MCP_ENDPOINT;
+      else process.env.POSTHOG_MCP_ENDPOINT = prevEndpoint;
       vi.resetModules();
     }
   });

--- a/src/lib/host-resolution.ts
+++ b/src/lib/host-resolution.ts
@@ -66,6 +66,10 @@ function assetHostFromApiHost(apiHost: string): string {
  * smoke-test.sh greps dist/*.js for it, and JSDoc survives bundling.
  */
 export function mcpUrlFor(localMcp: boolean): string {
+  const hostEndpoint = IS_PRODUCTION_BUILD
+    ? undefined
+    : runtimeEnv('POSTHOG_MCP_ENDPOINT');
+  if (hostEndpoint) return hostEndpoint;
   const override = IS_PRODUCTION_BUILD ? undefined : runtimeEnv('MCP_URL');
   if (override) return override;
   return localMcp ? MCP_LOCAL_URL : MCP_PROD_URL;


### PR DESCRIPTION
## Problem

Developers running Wizard in a local sandbox cannot connect to the local PostHog MCP server because Wizard selects the production endpoint.

## Changes

- Development and CI builds can use a host-provided `POSTHOG_MCP_ENDPOINT`.
- Production builds remove the override and continue to use `https://mcp.posthog.com/mcp`.
- The production smoke test fails if the override appears in compiled JavaScript.

## Test plan

- Ran all 2,417 Vitest tests.
- Ran the production smoke test and confirmed the endpoint marker is absent from compiled JavaScript.
- Ran the Warlock smoke test.
- Ran ESLint and Prettier fixes.

## LLM context

An agent implemented and reviewed this change. It used the wizard-development, writing-tests, and writing-pr-descriptions skills. A human verified the local sandbox flow.
