### PR TITLE
feat(gateway): tag events with the gateway edition and fail hollow runs

### DIFF
--- a/src/lib/__tests__/gateway-session.test.ts
+++ b/src/lib/__tests__/gateway-session.test.ts
@@ -7,6 +7,11 @@ import {
   resetGatewaySession,
 } from '@lib/gateway-session';
 import type { HostResolution } from '@lib/host-resolution';
+import { analytics } from '@utils/analytics';
+
+vi.mock('@utils/analytics', () => ({
+  analytics: { setTag: vi.fn(), captureException: vi.fn() },
+}));
 
 const host = {
   apiHost: 'https://us.posthog.com',
@@ -19,6 +24,7 @@ describe('gatewayAuth', () => {
   beforeEach(() => {
     resetGatewaySession();
     fetchMock.mockReset();
+    vi.mocked(analytics.setTag).mockClear();
     vi.stubGlobal('fetch', fetchMock);
   });
 
@@ -45,6 +51,7 @@ describe('gatewayAuth', () => {
       edition: 'v2',
       teamId: 42,
     });
+    expect(analytics.setTag).toHaveBeenCalledWith('gateway_edition', 'v2');
     expect(fetchMock).toHaveBeenCalledWith(
       'https://us.posthog.com/api/wizard/gateway_token/',
       expect.objectContaining({
@@ -177,6 +184,7 @@ describe('gatewayAuth', () => {
     // it would make the flip all-or-nothing.
     const auth = await gatewayAuth(host, 'pha_oauth', 'integration');
     expect(auth.edition).toBe('legacy');
+    expect(analytics.setTag).toHaveBeenCalledWith('gateway_edition', 'legacy');
   });
 
   it.each([500, 502, 503])(

--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -1146,6 +1146,21 @@ export async function runOrchestrator(
     });
   }
 
+  // A drain that produced no tasks at all means the seed step never got a
+  // usable model response (e.g. the gateway returned empty completions).
+  // "0/0 completed" is a dead run, not a success with an empty denominator.
+  if (summary.total === 0) {
+    await wizardAbort({
+      code: ErrorCodes.AgentOrchestratorHollowRun,
+      message: `The wizard was unable to set up PostHog: the planning step produced no work, so nothing ran.\n\nPlease try again — and if it happens again, report it to: ${WIZARD_CONTACT_EMAIL}`,
+      error: new WizardError(
+        'orchestrator drain produced zero tasks',
+        { queue_state: JSON.stringify(store.list()) },
+        ErrorCodes.AgentOrchestratorHollowRun,
+      ),
+    });
+  }
+
   // A failed optional step leaves the denominator and is named instead.
   const optionalFailedCount = verdict.optionalFailedTypes.length;
   const stepNotes = [

--- a/src/lib/errors/catalog.ts
+++ b/src/lib/errors/catalog.ts
@@ -215,6 +215,12 @@ export const ERROR_CATALOG: Record<ErrorCode, ErrorCatalogEntry> = {
     retry: 'case-by-case',
     description: 'The orchestrator queue drained with failed or blocked tasks.',
   },
+  [ErrorCodes.AgentOrchestratorHollowRun]: {
+    group: 'agent',
+    retry: 'yes',
+    description:
+      'The orchestrator drained with zero tasks — the seed step got no usable model output.',
+  },
   [ErrorCodes.AgentOrchestratorSinkInvariant]: {
     group: 'agent',
     retry: 'no',

--- a/src/lib/errors/codes.ts
+++ b/src/lib/errors/codes.ts
@@ -41,6 +41,7 @@ export const ErrorCodes = {
   AgentOrchestratorSkillVariantMissing:
     'PHW_AGENT_ORCHESTRATOR_SKILL_VARIANT_MISSING',
   AgentOrchestratorTasksFailed: 'PHW_AGENT_ORCHESTRATOR_TASKS_FAILED',
+  AgentOrchestratorHollowRun: 'PHW_AGENT_ORCHESTRATOR_HOLLOW_RUN',
   AgentOrchestratorSinkInvariant: 'PHW_AGENT_ORCHESTRATOR_SINK_INVARIANT',
   SettingsUnfixableConflict: 'PHW_SETTINGS_UNFIXABLE_CONFLICT',
   InternalUnhandled: 'PHW_INTERNAL_UNHANDLED',

--- a/src/lib/gateway-session.ts
+++ b/src/lib/gateway-session.ts
@@ -8,6 +8,7 @@
  */
 
 import { logToFile } from '@utils/debug';
+import { analytics } from '@utils/analytics';
 import type { HostResolution } from '@lib/host-resolution';
 
 export type GatewayEdition = 'legacy' | 'v2';
@@ -89,6 +90,7 @@ async function resolveGatewayAuth(
   const minted = await mintGatewayToken(host, accessToken, program);
   if (!minted) {
     // 404 only: this org is not on the new gateway yet.
+    analytics.setTag('gateway_edition', 'legacy');
     const auth = legacyAuth(host, accessToken);
     cached = { key, auth, staleAtMs: Date.now() + LEGACY_RETRY_MS };
     return auth;
@@ -106,6 +108,7 @@ async function resolveGatewayAuth(
     );
   }
   const staleAtMs = Date.now() + ttlMs * REFRESH_AT_FRACTION;
+  analytics.setTag('gateway_edition', 'v2');
   const auth: GatewayAuth = {
     gatewayUrl: minted.gatewayUrl,
     token: minted.token,


### PR DESCRIPTION
Tags every analytics event with the resolved gateway edition (legacy or v2) so new-gateway adoption and failures are countable, and aborts a run whose orchestrator drain produced zero tasks — a dead seed step now shows an error with the contact email instead of a "0/0 completed" success screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)