### PR TITLE
fix(agent): report a dropped PostHog MCP server, and stop promising tools a run does not have

### DIFF
--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -7,8 +7,10 @@ import {
   isWarlockDisabled,
   buildAuthErrorContext,
   buildAgentEnv,
+  reportMcpSetup,
 } from '@lib/agent/agent-interface';
 import { AgentOutputSignals } from '@lib/agent/output-signals';
+import { analytics } from '@utils/analytics';
 import { Sequence } from '@lib/constants';
 import type { WizardRunOptions } from '@utils/types';
 import type { SpinnerHandle } from '@ui';
@@ -704,5 +706,88 @@ describe('auth error context', () => {
     const ctx = buildAuthErrorContext('/test/dir', url);
     expect(ctx.gatewayUrl).toBe(url);
     expect(ctx.region).toBe(region);
+  });
+});
+
+describe('mcp setup reporting', () => {
+  const PH = 'posthog-wizard';
+  const TOOL = `mcp__${PH}__exec`;
+
+  beforeEach(() => {
+    vi.mocked(analytics.wizardCapture).mockClear();
+  });
+
+  const captures = () =>
+    vi
+      .mocked(analytics.wizardCapture)
+      .mock.calls.filter(([name]) => name === 'mcp setup failed');
+
+  /** Properties of the one capture the case expects, narrowed for the asserts. */
+  const firstCaptureProps = (): Record<string, unknown> => {
+    const [call] = captures();
+    if (!call) throw new Error('expected an "mcp setup failed" capture');
+    return call[1] ?? {};
+  };
+
+  it('says nothing when the server connected and gave us its tool', () => {
+    reportMcpSetup({
+      mcp_servers: [{ name: PH, status: 'connected' }],
+      tools: ['Read', 'Bash', TOOL],
+    });
+    expect(captures()).toHaveLength(0);
+  });
+
+  /**
+   * The whole point. The SDK drops a server it cannot reach and the run carries
+   * on without the tool — so the only signal is this init report, and before
+   * this it went to a log file nobody reads. A warehouse run that created
+   * nothing looked identical to one that chose not to.
+   */
+  it.each([
+    ['failed', [{ name: PH, status: 'failed' }], [], /server status: failed/],
+    [
+      'pending',
+      [{ name: PH, status: 'pending' }],
+      [],
+      /server status: pending/,
+    ],
+    [
+      'absent from the report',
+      [{ name: 'wizard-tools', status: 'connected' }],
+      ['mcp__wizard-tools__exec'],
+      /missing from the SDK init report/,
+    ],
+    [
+      'connected but registering no tool',
+      [{ name: PH, status: 'connected' }],
+      ['Read', 'Bash'],
+      /registered no tool/,
+    ],
+  ])(
+    'captures a PostHog MCP server that is %s',
+    (_label, servers, tools, reason) => {
+      reportMcpSetup({ mcp_servers: servers, tools });
+      const props = firstCaptureProps();
+      expect(props).toMatchObject({ harness: 'anthropic', scope: 'run' });
+      expect(props.error).toMatch(reason);
+    },
+  );
+
+  it('carries the whole server roster so one event explains the run', () => {
+    reportMcpSetup({
+      mcp_servers: [
+        { name: PH, status: 'failed' },
+        { name: 'wizard-tools', status: 'connected' },
+      ],
+      tools: [],
+    });
+    expect(firstCaptureProps().mcp_servers).toBe(
+      `${PH}:failed,wizard-tools:connected`,
+    );
+  });
+
+  it('treats an init message with no server list as a failure', () => {
+    reportMcpSetup({});
+    expect(captures()).toHaveLength(1);
   });
 });

--- a/src/lib/agent/__tests__/commandments.test.ts
+++ b/src/lib/agent/__tests__/commandments.test.ts
@@ -135,3 +135,40 @@ describe('commandments by axis', () => {
     });
   });
 });
+
+/**
+ * The prompt must only promise tools the session really mounted.
+ *
+ * `harness/pi/index.ts` used to pass `posthogMcp: true` hardcoded, right after
+ * a try/catch that logs a failed MCP setup and carries on. So a run whose
+ * handshake failed still told the agent to drive everything through
+ * `posthog_exec` — a tool that was never registered. `task.ts` tracked it
+ * properly all along; `index.ts` now does too.
+ */
+describe('runtime caps gate the pi runtime notes', () => {
+  const withCaps = (caps: { bash: boolean; posthogMcp: boolean }) =>
+    assembleCommandments({
+      program: 'warehouse-source',
+      sequence: Sequence.linear,
+      harness: Harness.pi,
+      caps,
+    });
+
+  it('names posthog_exec when the MCP came up', () => {
+    expect(withCaps({ bash: true, posthogMcp: true })).toContain(
+      'posthog_exec',
+    );
+  });
+
+  it('never names posthog_exec when the MCP did not', () => {
+    expect(withCaps({ bash: true, posthogMcp: false })).not.toContain(
+      'posthog_exec',
+    );
+  });
+
+  it('still produces a usable prompt without the MCP', () => {
+    const notes = withCaps({ bash: true, posthogMcp: false });
+    expect(notes.length).toBeGreaterThan(0);
+    expect(notes).toContain(WIZARD_COMMANDMENTS[0]);
+  });
+});

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -617,7 +617,7 @@ export async function initializeAgent(
 
     // Configure MCP server with PostHog authentication
     const mcpServers: McpServersConfig = {
-      'posthog-wizard': {
+      [POSTHOG_MCP_SERVER_NAME]: {
         type: 'http',
         url: config.posthogMcpUrl,
         headers: {
@@ -1391,6 +1391,13 @@ export enum TaskTool {
  * `'Agent'` to opt into subagent dispatch). Skills and PostHog MCP tools
  * are enabled separately (skills option / mcpServers).
  */
+/**
+ * The PostHog MCP server's name in `mcpServers`, and so the prefix of the tool
+ * the agent calls it by (`mcp__posthog-wizard__exec`). Named once because the
+ * init handler has to recognise this server in the SDK's status report.
+ */
+export const POSTHOG_MCP_SERVER_NAME = 'posthog-wizard';
+
 export const BASE_ALLOWED_TOOLS: readonly string[] = [
   'Read',
   'Write',
@@ -1603,6 +1610,55 @@ function extractTokenUsageDelta(message: SDKMessage): TokenUsageDelta | null {
   };
 }
 
+/** A server entry in the SDK's `system/init` report. */
+type McpServerStatus = { name: string; status: string };
+
+/**
+ * Report what the SDK did with our MCP servers, and capture it when the PostHog
+ * one did not come up.
+ *
+ * The SDK connects `mcpServers` itself and drops a server it cannot reach — the
+ * run continues, the tool is simply absent, and the agent finds out only by not
+ * having it. What that looks like from outside is a run that collects every
+ * credential and then tells the user to do the work by hand.
+ *
+ * The pi harness has captured `mcp setup failed` for a while (`harness/pi`), so
+ * a pi run that lost the tool says so. The anthropic harness never did, even
+ * though the SDK hands it a per-server verdict on the init message and this
+ * code already had it in hand — it went to the log file and no further. A
+ * warehouse run with zero creates therefore cost three investigations to
+ * explain. The same event name and property shape as pi's, so one query covers
+ * both harnesses.
+ */
+export function reportMcpSetup(message: {
+  mcp_servers?: McpServerStatus[];
+  tools?: string[];
+}): void {
+  const servers = message.mcp_servers ?? [];
+  const posthog = servers.find((s) => s.name === POSTHOG_MCP_SERVER_NAME);
+  const toolPrefix = `mcp__${POSTHOG_MCP_SERVER_NAME}__`;
+  const hasTool = (message.tools ?? []).some((t) => t.startsWith(toolPrefix));
+
+  // Connected and the tool is there — nothing to say.
+  if (posthog?.status === 'connected' && hasTool) return;
+
+  const reason = !posthog
+    ? 'server missing from the SDK init report'
+    : posthog.status !== 'connected'
+    ? `server status: ${posthog.status}`
+    : 'server connected but registered no tool';
+
+  logToFile(`[anthropic] PostHog MCP unavailable — ${reason}`);
+  analytics.wizardCapture('mcp setup failed', {
+    harness: 'anthropic',
+    scope: 'run',
+    error: reason,
+    // The whole roster, so a run that lost several servers is one event and
+    // the PostHog one can still be told apart.
+    mcp_servers: servers.map((s) => `${s.name}:${s.status}`).join(','),
+  });
+}
+
 function handleSDKMessage(
   message: SDKMessage,
   options: WizardRunOptions,
@@ -1807,6 +1863,7 @@ function handleSDKMessage(
           mcpServers: message.mcp_servers,
           apiKeySource: message.apiKeySource,
         });
+        reportMcpSetup(message);
       }
       break;
     }

--- a/src/lib/agent/runner/harness/pi/index.ts
+++ b/src/lib/agent/runner/harness/pi/index.ts
@@ -41,7 +41,14 @@ import type { TaskStore } from './tasks';
 import { completionFailure } from './completion';
 
 /** Injects the MCP server `instructions` pi-mcp-adapter drops (project env, skill steer, tool domains) into the system prompt, falling back to a bootstrap-derived project block when the warm-connect captured none. */
-function piMcpContext(boot: BootstrapResult, instructions?: string): string {
+function piMcpContext(
+  boot: BootstrapResult,
+  instructions?: string,
+  posthogMcp = true,
+): string {
+  // No tool, no block. The fallback below names `posthog_exec`, so emitting it
+  // after a failed handshake points the agent at a tool that is not registered.
+  if (!posthogMcp) return '';
   if (instructions) {
     // Heading + verbatim server instructions (see PR #862 for a full sample).
     return ['', '## PostHog MCP server', instructions].join('\n');
@@ -305,6 +312,11 @@ export const piBackend: AgentHarness = {
       >;
       let mcpCleanup: (() => void) | undefined;
       let mcpInstructions: string | undefined;
+      // Whether the agent really got the tool. The commandments below claim
+      // `posthog_exec` exists when this is true, so it must track the setup and
+      // not the intent — a hardcoded `true` told the agent to call a tool the
+      // failed handshake never registered. `task.ts` has always done this.
+      let posthogMcp = false;
       try {
         const { setupPostHogMcp, fetchInstructions } = await import('./mcp');
         // Overlaps the network handshake with the adapter's jiti load.
@@ -321,6 +333,7 @@ export const piBackend: AgentHarness = {
         extensionFactories.push(mcp.extensionFactory);
         mcpCleanup = mcp.cleanup;
         mcpInstructions = await instructionsPromise;
+        posthogMcp = true;
       } catch (err) {
         logToFile(`[pi] PostHog MCP setup skipped: ${String(err)}`);
         analytics.wizardCapture('mcp setup failed', {
@@ -338,10 +351,10 @@ export const piBackend: AgentHarness = {
             program: programConfig.id,
             sequence: Sequence.linear,
             harness: Harness.pi,
-            caps: { bash: true, posthogMcp: true },
+            caps: { bash: true, posthogMcp },
           }) +
           '\n' +
-          piMcpContext(boot, mcpInstructions),
+          piMcpContext(boot, mcpInstructions, posthogMcp),
         noExtensions: true,
         noSkills: true,
         noContextFiles: true,

--- a/src/lib/agent/runner/harness/pi/runtime-notes.ts
+++ b/src/lib/agent/runner/harness/pi/runtime-notes.ts
@@ -112,8 +112,13 @@ export function piRuntimeNotes(sequence: Sequence, caps: RuntimeCaps): string {
 
   if (linear) notes.push(SKILL_MENU, SKILL_STEPS);
   notes.push(NO_LITERAL_URL, ENV_VIA_MCP);
-  if (caps.posthogMcp) notes.push(POSTHOG_MCP);
-  if (linear) notes.push(DASHBOARD_STEP);
+  // Both of these name `posthog_exec`, so both need the tool to exist. The
+  // dashboard step is not a separate judgement: it IS a run of `posthog_exec`
+  // calls, and a run whose MCP setup failed carries on without that step.
+  if (caps.posthogMcp) {
+    notes.push(POSTHOG_MCP);
+    if (linear) notes.push(DASHBOARD_STEP);
+  }
 
   notes.push(linear ? STATUS_LINEAR : STATUS_TASK);
   if (!linear) notes.push(COMPLETE_TASK);


### PR DESCRIPTION
## Problem

A warehouse e2e run collected every credential and then wrote a report telling the user to set the sources up by hand. The stub PostHog MCP saw no `external-data-sources-create` at all. Detection, the ask contract, the deep link and the leakage scan all passed. Only the creates were missing.

Working out why took three separate investigations. Nothing anywhere said the PostHog tool was absent.

The anthropic harness never reported its MCP setup. The Claude Agent SDK connects `mcpServers` itself, drops a server it cannot reach, and hands back a per-server verdict on the `system/init` message. `agent-interface.ts` already had that verdict in hand and wrote it to a log file. So a run that lost the PostHog tool looked exactly like a run that decided to create nothing.

The pi harness has captured `mcp setup failed` for a while, which is why a pi run says so. The anthropic path had no equivalent.

Two more defects of the same class turned up while fixing it. Each one tells the agent to call a tool that may not exist:

1. `harness/pi/index.ts` passed `caps: { bash: true, posthogMcp: true }` hardcoded, directly after a try/catch that logs a failed MCP setup and carries on. `task.ts` has always tracked this with a boolean.
2. `piRuntimeNotes` pushed `DASHBOARD_STEP` for every linear run, ungated. That note names `posthog_exec` too.

## Changes

**The capture.** `reportMcpSetup` reads the SDK's `system/init` report and captures `mcp setup failed` when the PostHog server is missing from it, when its status is not `connected`, or when it connects but registers no tool. Same event name and property shape as pi's, so one PostHog query covers both harnesses. The event carries the whole server roster, so a run that lost several servers is one event and the PostHog one can still be told apart.

**The pi capability flags.** `index.ts` now tracks `posthogMcp` from the setup result, like `task.ts` does. Its `piMcpContext` block had the same defect — its fallback names `posthog_exec` — so it is skipped when there is no tool. `DASHBOARD_STEP` moves behind the same capability as the note above it: the dashboard step is not a separate judgement, it IS a run of `posthog_exec` calls, and the setup path already says a failed handshake continues without that step.

None of this changes what a healthy run does. It changes what a broken run tells us, and it stops a broken run from being told to call a tool it has not got.

### What I checked, and what the evidence actually said

The starting theory was that the workbench's stub MCP could not speak to this harness. The stub was written against `StreamableHTTPClientTransport`, which is the **pi** path; the anthropic path connects through the SDK's own `{ type: 'http' }` client.

**That theory is wrong, and I want it on the record so nobody spends a fourth investigation on it.** I drove a real `query()` from this worktree — SDK 0.3.169, this repo's exact `mcpServers` config, its exact `allowedTools`, `permissionMode: 'acceptEdits'` — against the stub:

```
MCP_SERVERS: [{"name":"posthog-wizard","status":"connected"}]
POSTHOG_TOOLS: ["mcp__posthog-wizard__exec"]
```

The server connects and the tool is registered. `allowedTools` does not filter it out. The `Bearer ${POSTHOG_MCP_TOKEN}` env reference expands correctly. The companion workbench PR adds a transport suite that pins this so it stays ruled out.

What held from the original chain: the harness resolution. `wizard-use-pi-harness` is not in `WIZARD_FLAG_KEYS`, so it never routed anything. More to the point, **no harness experiment covers `warehouse-source` at all** — `SELF_DRIVING_EXPERIMENT` is scoped to `self-driving` and `ORCHESTRATOR_HARNESS_ROUTE` to `posthog-integration` — so those runs take `DEFAULT_BINDING` and run on anthropic whatever any flag says. That part is handled in the workbench PR.

I could not reproduce the missing tool locally, so **I am not claiming this PR fixes the zero-creates run.** It fixes the reason that run was unexplainable. The next occurrence reports itself instead of needing an archaeology dig.

## Test plan

- `vitest run` — 2484 tests over 153 files, all passing.
- New cases in `src/lib/__tests__/agent-interface.test.ts` cover each way the PostHog server can fail to arrive, plus the healthy case staying silent.
- New cases in `src/lib/agent/__tests__/commandments.test.ts` pin that `posthog_exec` is never named when the capability is off. This test caught the `DASHBOARD_STEP` leak.
- `eslint .` — 0 errors.
- `prettier --check` — clean.
- `tsc --noEmit` — 27 errors, identical to the stashed `main` baseline. No new ones.
- A real CI leg on `warehouse/multi-source-next` with this branch as `wizard_ref` — see the companion PR for its result.

Companion: PostHog/wizard-workbench#3672
