### PR TITLE
fix(tui): don't let wizard_ask submit an empty required field

### DIFF
--- a/src/ui/tui/__tests__/WizardAskScreen.test.ts
+++ b/src/ui/tui/__tests__/WizardAskScreen.test.ts
@@ -20,7 +20,10 @@ vi.mock('../../../utils/analytics.js', () => ({
 }));
 
 import { WizardStore } from '@ui/tui/store';
-import { handleAskKey } from '@ui/tui/screens/WizardAskScreen';
+import {
+  handleAskKey,
+  isRequiredButEmpty,
+} from '@ui/tui/screens/WizardAskScreen';
 
 const pending = {
   id: 'req-1',
@@ -56,5 +59,28 @@ describe('handleAskKey', () => {
       port: '__cancelled__',
     });
     expect(store.session.pendingQuestion).toBeNull();
+  });
+});
+
+describe('isRequiredButEmpty', () => {
+  it('blocks an empty required text field (required defaults to true)', () => {
+    expect(isRequiredButEmpty({}, '')).toBe(true);
+    expect(isRequiredButEmpty({}, '   ')).toBe(true);
+    expect(isRequiredButEmpty({ required: true }, '')).toBe(true);
+  });
+
+  it('allows a non-empty answer', () => {
+    expect(isRequiredButEmpty({}, 'db.example.com')).toBe(false);
+    expect(isRequiredButEmpty({ required: true }, '5432')).toBe(false);
+  });
+
+  it('never blocks an optional field', () => {
+    expect(isRequiredButEmpty({ required: false }, '')).toBe(false);
+    expect(isRequiredButEmpty({ required: false }, [])).toBe(false);
+  });
+
+  it('treats an empty multi-select selection as unanswered when required', () => {
+    expect(isRequiredButEmpty({}, [])).toBe(true);
+    expect(isRequiredButEmpty({}, ['events'])).toBe(false);
   });
 });

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -37,6 +37,26 @@ export function handleAskKey(
   if (key.escape) store.cancelPendingQuestion();
 }
 
+/**
+ * Whether an answer would leave a required question effectively unanswered.
+ *
+ * The `wizard_ask` schema marks fields `required` (defaulting to true), but the
+ * overlay used to submit whatever the input held — so pressing Enter on an empty
+ * required credential field sent an empty string on to the agent. A blank host
+ * or password is indistinguishable there from a real answer, so the warehouse
+ * task ran on it, failed source creation, and dead-ended with no signal that the
+ * user had in effect declined. Blocking the empty submit keeps the contract the
+ * schema already advertises; Esc stays the way to skip. Optional fields
+ * (`required === false`) are never blocked, and pickers always yield a value.
+ */
+export function isRequiredButEmpty(
+  question: Pick<AskQuestion, 'required'>,
+  value: string | string[],
+): boolean {
+  if (question.required === false) return false;
+  return Array.isArray(value) ? value.length === 0 : value.trim().length === 0;
+}
+
 export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
   useSyncExternalStore(
     (cb) => store.subscribe(cb),
@@ -50,6 +70,9 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
   const [index, setIndex] = useState(0);
   const [answers, setAnswers] = useState<AskAnswers>({});
   const [lastPendingId, setLastPendingId] = useState<string | null>(null);
+  // Set when the user tries to submit an empty required field, cleared once a
+  // real answer goes through. Drives the inline "this field is required" nudge.
+  const [requiredHint, setRequiredHint] = useState(false);
   // What the user last did with the link, so the overlay can confirm it. The
   // auto-copy below seeds 'copied'; pressing `o`/`c` overrides it.
   const [linkStatus, setLinkStatus] = useState<'idle' | 'copied' | 'opened'>(
@@ -138,6 +161,7 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
     setLastPendingId(pending.id);
     setIndex(0);
     setAnswers({});
+    setRequiredHint(false);
     return null;
   }
 
@@ -148,6 +172,13 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
   const progress = total > 1 ? `Question ${index + 1} of ${total}` : null;
 
   const submit = (value: string | string[]) => {
+    // Don't let a required field go through empty — it would reach the agent as
+    // a blank answer it can't tell from a real one. Nudge instead; Esc skips.
+    if (isRequiredButEmpty(question, value)) {
+      setRequiredHint(true);
+      return;
+    }
+    setRequiredHint(false);
     const next: AskAnswers = { ...answers, [question.id]: value };
     if (index + 1 < total) {
       setAnswers(next);
@@ -211,6 +242,14 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
           onSubmit={submit}
         />
       </Box>
+      {requiredHint && (
+        <Box marginTop={1}>
+          <Text color={Colors.accent}>
+            {Icons.warning} This field is required — type an answer, or press
+            ESC to skip.
+          </Text>
+        </Box>
+      )}
       <Box marginTop={1}>
         <Text dimColor>
           <Text color={Colors.accent}>ESC</Text> skip


### PR DESCRIPTION
## Problem

The install wizard's seeded warehouse-connection task collects source
credentials through the `wizard_ask` terminal overlay. The `wizard_ask` schema
marks each field `required` (defaulting to true), but the overlay never enforced
it — pressing Enter on a blank field submitted an empty string.

An empty answer is indistinguishable at the agent from a real one, so a run
where the credential fields were left blank ran the source-creation step on
empty values, failed, and dead-ended with no signal that the user had in effect
declined. In the seeded-task telemetry this shows up as runs reporting that
"all requested credential fields were submitted blank" and as blank answers
returned "without an explicit declined indicator" — the agent couldn't tell a
blank apart from a decline.

**Why:** this came out of reviewing the seeded warehouse task's telemetry for
genuinely broken or lossy behaviour. The overlay silently ignoring its own
`required` contract turns an accidental empty submit into a dead source
connection.

## Changes

- Enforce `required` in the `wizard_ask` overlay: a required field can no longer
  be submitted empty (empty/whitespace text, or an empty multi-select). The user
  types an answer or presses ESC to skip — the existing, intended decline path,
  which the task already handles by falling back to a browser setup link.
- Show a one-line nudge when an empty required submit is blocked, pointing at ESC
  so a user who genuinely can't answer still has a signposted exit.
- Optional fields (`required === false`) and pickers (which always yield a value)
  are unaffected.

The decision is a small pure helper (`isRequiredButEmpty`) so it's unit-testable
without a live Ink render, matching how `handleAskKey` is already tested.

## Test plan

- `pnpm build` passes.
- `vitest run` — 2478 tests pass, including new `isRequiredButEmpty` cases
  (empty/whitespace required text blocked, non-empty allowed, optional never
  blocked, empty required multi-select blocked).
- Prettier + ESLint clean on the touched files.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
