### PR TITLE
fix(auth): refresh the OAuth access token before each agent run

### DIFF
--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -49,6 +49,7 @@ import { classifyToolToStage } from './agent-phase';
 import type { PackageManagerDetector } from '@lib/detection/package-manager';
 import { AgentSignals, AgentErrorType, REMARK_INSTRUCTION } from './signals';
 import { classifyAuthFailure } from '@lib/errors';
+import { isGrantRevoked } from '@lib/auth-session-state';
 import { AgentOutputSignals } from './output-signals';
 
 // Signal vocabulary and the output parser live in dedicated modules; re-export
@@ -1196,19 +1197,28 @@ export async function runAgent(
           os.homedir(),
           signals.apiKeySource,
         );
+        // A refresh that already failed on a dead grant explains this 401
+        // outright; without it the screen falls through to generic key-type
+        // and scope advice that cannot apply.
+        const sessionExpired = isGrantRevoked();
         const authCode = classifyAuthFailure({
           hasSettingsConflict: authError.hasSettingsConflict,
           usingManagedLogin: authError.usingManagedLogin,
+          sessionExpired,
           apiKey: options.apiKey,
           gatewayRegion: authError.region,
           sessionRegion: options.cloudRegion,
         });
-        logToFile('Agent error: 401, showing auth error screen', authError);
+        logToFile('Agent error: 401, showing auth error screen', {
+          ...authError,
+          sessionExpired,
+        });
         getUI().showAuthError({
           hasSettingsConflict: authError.hasSettingsConflict,
           conflicts: authError.conflicts,
           usingManagedLogin: authError.usingManagedLogin,
           credentialPlaces: authError.credentialPlaces,
+          sessionExpired,
           logFilePath: getLogFilePath(),
         });
         await wizardAbort({

--- a/src/lib/agent/runner/shared/__tests__/ensure-fresh-access-token.test.ts
+++ b/src/lib/agent/runner/shared/__tests__/ensure-fresh-access-token.test.ts
@@ -1,0 +1,108 @@
+import { ensureFreshAccessToken } from '../authenticate';
+import { refreshOAuthToken } from '@utils/oauth';
+import type { WizardSession, Credentials } from '@lib/wizard-session';
+
+vi.mock('@utils/oauth', () => ({ refreshOAuthToken: vi.fn() }));
+vi.mock('@utils/debug', () => ({ logToFile: vi.fn() }));
+
+const setCredentials = vi.fn();
+vi.mock('@ui', () => ({
+  getUI: () => ({ setCredentials }),
+}));
+
+const mockedRefresh = refreshOAuthToken as Mock;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function sessionWith(credentials: Partial<Credentials> | null): WizardSession {
+  return {
+    baseUrl: undefined,
+    credentials: credentials as Credentials | null,
+  } as WizardSession;
+}
+
+describe('ensureFreshAccessToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is a no-op without credentials', async () => {
+    await ensureFreshAccessToken(sessionWith(null));
+    expect(mockedRefresh).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op without a refresh token (CI api-key runs, refresh-less grants)', async () => {
+    await ensureFreshAccessToken(
+      sessionWith({ accessToken: 'pha_ci_key', accessTokenExpiresAt: 0 }),
+    );
+    expect(mockedRefresh).not.toHaveBeenCalled();
+  });
+
+  it('skips a token that still has most of its lifetime left', async () => {
+    await ensureFreshAccessToken(
+      sessionWith({
+        accessToken: 'pha_fresh',
+        refreshToken: 'phr_x',
+        accessTokenExpiresAt: Date.now() + HOUR_MS - 60_000,
+      }),
+    );
+    expect(mockedRefresh).not.toHaveBeenCalled();
+  });
+
+  it('refreshes an aging token and stores the rotated refresh token', async () => {
+    mockedRefresh.mockResolvedValueOnce({
+      access_token: 'pha_new',
+      refresh_token: 'phr_rotated',
+      expires_in: 3600,
+      token_type: 'Bearer',
+      scope: 'project:read',
+    });
+    const session = sessionWith({
+      accessToken: 'pha_old',
+      refreshToken: 'phr_old',
+      accessTokenExpiresAt: Date.now() + 20 * 60 * 1000,
+    });
+
+    await ensureFreshAccessToken(session);
+
+    expect(mockedRefresh).toHaveBeenCalledWith('phr_old', undefined);
+    expect(session.credentials!.accessToken).toBe('pha_new');
+    expect(session.credentials!.refreshToken).toBe('phr_rotated');
+    expect(session.credentials!.accessTokenExpiresAt).toBeGreaterThan(
+      Date.now() + 3500 * 1000,
+    );
+    expect(setCredentials).toHaveBeenCalledWith(session.credentials);
+  });
+
+  it('refreshes when the expiry is unknown rather than gambling on a stale token', async () => {
+    mockedRefresh.mockResolvedValueOnce({
+      access_token: 'pha_new',
+      expires_in: 3600,
+      token_type: 'Bearer',
+      scope: 'project:read',
+    });
+    const session = sessionWith({
+      accessToken: 'pha_old',
+      refreshToken: 'phr_old',
+    });
+
+    await ensureFreshAccessToken(session);
+
+    expect(session.credentials!.accessToken).toBe('pha_new');
+    // No rotated token in the response — the old one stays usable.
+    expect(session.credentials!.refreshToken).toBe('phr_old');
+  });
+
+  it('keeps the existing token and does not throw when the refresh fails', async () => {
+    mockedRefresh.mockRejectedValueOnce(new Error('invalid_grant'));
+    const session = sessionWith({
+      accessToken: 'pha_old',
+      refreshToken: 'phr_old',
+      accessTokenExpiresAt: Date.now() + 20 * 60 * 1000,
+    });
+
+    await expect(ensureFreshAccessToken(session)).resolves.toBeUndefined();
+    expect(session.credentials!.accessToken).toBe('pha_old');
+    expect(setCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/agent/runner/shared/__tests__/ensure-fresh-access-token.test.ts
+++ b/src/lib/agent/runner/shared/__tests__/ensure-fresh-access-token.test.ts
@@ -12,13 +12,8 @@ vi.mock('@ui', () => ({
 
 const mockedRefresh = refreshOAuthToken as Mock;
 
-const HOUR_MS = 60 * 60 * 1000;
-
 function sessionWith(credentials: Partial<Credentials> | null): WizardSession {
-  return {
-    baseUrl: undefined,
-    credentials: credentials as Credentials | null,
-  } as WizardSession;
+  return { credentials: credentials as Credentials | null } as WizardSession;
 }
 
 describe('ensureFreshAccessToken', () => {
@@ -26,12 +21,8 @@ describe('ensureFreshAccessToken', () => {
     vi.clearAllMocks();
   });
 
-  it('is a no-op without credentials', async () => {
-    await ensureFreshAccessToken(sessionWith(null));
-    expect(mockedRefresh).not.toHaveBeenCalled();
-  });
-
   it('is a no-op without a refresh token (CI api-key runs, refresh-less grants)', async () => {
+    await ensureFreshAccessToken(sessionWith(null));
     await ensureFreshAccessToken(
       sessionWith({ accessToken: 'pha_ci_key', accessTokenExpiresAt: 0 }),
     );
@@ -43,7 +34,7 @@ describe('ensureFreshAccessToken', () => {
       sessionWith({
         accessToken: 'pha_fresh',
         refreshToken: 'phr_x',
-        accessTokenExpiresAt: Date.now() + HOUR_MS - 60_000,
+        accessTokenExpiresAt: Date.now() + 59 * 60 * 1000,
       }),
     );
     expect(mockedRefresh).not.toHaveBeenCalled();
@@ -68,29 +59,7 @@ describe('ensureFreshAccessToken', () => {
     expect(mockedRefresh).toHaveBeenCalledWith('phr_old', undefined);
     expect(session.credentials!.accessToken).toBe('pha_new');
     expect(session.credentials!.refreshToken).toBe('phr_rotated');
-    expect(session.credentials!.accessTokenExpiresAt).toBeGreaterThan(
-      Date.now() + 3500 * 1000,
-    );
     expect(setCredentials).toHaveBeenCalledWith(session.credentials);
-  });
-
-  it('refreshes when the expiry is unknown rather than gambling on a stale token', async () => {
-    mockedRefresh.mockResolvedValueOnce({
-      access_token: 'pha_new',
-      expires_in: 3600,
-      token_type: 'Bearer',
-      scope: 'project:read',
-    });
-    const session = sessionWith({
-      accessToken: 'pha_old',
-      refreshToken: 'phr_old',
-    });
-
-    await ensureFreshAccessToken(session);
-
-    expect(session.credentials!.accessToken).toBe('pha_new');
-    // No rotated token in the response — the old one stays usable.
-    expect(session.credentials!.refreshToken).toBe('phr_old');
   });
 
   it('keeps the existing token and does not throw when the refresh fails', async () => {

--- a/src/lib/agent/runner/shared/__tests__/refresh-access-token-if-needed.test.ts
+++ b/src/lib/agent/runner/shared/__tests__/refresh-access-token-if-needed.test.ts
@@ -1,13 +1,19 @@
 import { refreshAccessTokenIfNeeded } from '../authenticate';
 import { refreshAccessToken } from '@utils/oauth';
+import { OAuthError } from '@utils/oauth-errors';
+import { isGrantRevoked, resetAuthSessionState } from '@lib/auth-session-state';
 import type { WizardSession, Credentials } from '@lib/wizard-session';
 
 vi.mock('@utils/oauth', () => ({ refreshAccessToken: vi.fn() }));
 vi.mock('@utils/debug', () => ({ logToFile: vi.fn() }));
+vi.mock('@utils/analytics', () => ({
+  analytics: { wizardCapture: vi.fn() },
+  groupsFromUser: vi.fn(),
+}));
 
-const setCredentials = vi.fn();
+const setAccessToken = vi.fn();
 vi.mock('@ui', () => ({
-  getUI: () => ({ setCredentials }),
+  getUI: () => ({ setAccessToken }),
 }));
 
 const mockedRefresh = refreshAccessToken as Mock;
@@ -16,9 +22,18 @@ function sessionWith(credentials: Partial<Credentials> | null): WizardSession {
   return { credentials: credentials as Credentials | null } as WizardSession;
 }
 
+/** Aging enough to be under the 50-minute threshold. */
+const aging = (over: Partial<Credentials> = {}): Partial<Credentials> => ({
+  accessToken: 'pha_old',
+  refreshToken: 'phr_old',
+  expiresAt: Date.now() + 20 * 60 * 1000,
+  ...over,
+});
+
 describe('refreshAccessTokenIfNeeded', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAuthSessionState();
   });
 
   it('is a no-op without a refresh token (CI api-key runs, refresh-less grants)', async () => {
@@ -31,11 +46,15 @@ describe('refreshAccessTokenIfNeeded', () => {
 
   it('skips a token that still has most of its lifetime left', async () => {
     await refreshAccessTokenIfNeeded(
-      sessionWith({
-        accessToken: 'pha_fresh',
-        refreshToken: 'phr_x',
-        expiresAt: Date.now() + 59 * 60 * 1000,
-      }),
+      sessionWith(aging({ expiresAt: Date.now() + 59 * 60 * 1000 })),
+    );
+    expect(mockedRefresh).not.toHaveBeenCalled();
+  });
+
+  // `?? 0` would read as "expired" and spend a rotation on every run.
+  it('skips a credential carrying a refresh token but no expiry', async () => {
+    await refreshAccessTokenIfNeeded(
+      sessionWith({ accessToken: 'pha_old', refreshToken: 'phr_old' }),
     );
     expect(mockedRefresh).not.toHaveBeenCalled();
   });
@@ -48,30 +67,58 @@ describe('refreshAccessTokenIfNeeded', () => {
       token_type: 'Bearer',
       scope: 'project:read',
     });
-    const session = sessionWith({
-      accessToken: 'pha_old',
-      refreshToken: 'phr_old',
-      expiresAt: Date.now() + 20 * 60 * 1000,
-    });
+    const session = sessionWith(aging({ projectId: 7 }));
 
     await refreshAccessTokenIfNeeded(session);
 
     expect(mockedRefresh).toHaveBeenCalledWith('phr_old', undefined);
     expect(session.credentials!.accessToken).toBe('pha_new');
     expect(session.credentials!.refreshToken).toBe('phr_rotated');
-    expect(setCredentials).toHaveBeenCalledWith(session.credentials);
+    // Unrelated fields survive the swap.
+    expect(session.credentials!.projectId).toBe(7);
+    expect(setAccessToken).toHaveBeenCalledWith(session.credentials);
+  });
+
+  it('replaces the credentials object rather than mutating it in place', async () => {
+    mockedRefresh.mockResolvedValueOnce({
+      access_token: 'pha_new',
+      expires_in: 3600,
+      token_type: 'Bearer',
+      scope: 'project:read',
+    });
+    const session = sessionWith(aging());
+    const before = session.credentials;
+
+    await refreshAccessTokenIfNeeded(session);
+
+    expect(session.credentials).not.toBe(before);
+    expect(before!.accessToken).toBe('pha_old');
+    // No rotation in the response: the old refresh token has to carry over.
+    expect(session.credentials!.refreshToken).toBe('phr_old');
   });
 
   it('keeps the existing token and does not throw when the refresh fails', async () => {
-    mockedRefresh.mockRejectedValueOnce(new Error('invalid_grant'));
-    const session = sessionWith({
-      accessToken: 'pha_old',
-      refreshToken: 'phr_old',
-      expiresAt: Date.now() + 20 * 60 * 1000,
-    });
+    mockedRefresh.mockRejectedValueOnce(new Error('network down'));
+    const session = sessionWith(aging());
 
     await expect(refreshAccessTokenIfNeeded(session)).resolves.toBeUndefined();
     expect(session.credentials!.accessToken).toBe('pha_old');
-    expect(setCredentials).not.toHaveBeenCalled();
+    expect(setAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('marks the grant revoked on invalid_grant, so a later 401 can name the cause', async () => {
+    mockedRefresh.mockRejectedValueOnce(new OAuthError('invalid_grant'));
+
+    await refreshAccessTokenIfNeeded(sessionWith(aging()));
+
+    expect(isGrantRevoked()).toBe(true);
+  });
+
+  it('leaves the grant unmarked for a transport failure, which says nothing about the login', async () => {
+    mockedRefresh.mockRejectedValueOnce(new Error('ETIMEDOUT'));
+
+    await refreshAccessTokenIfNeeded(sessionWith(aging()));
+
+    expect(isGrantRevoked()).toBe(false);
   });
 });

--- a/src/lib/agent/runner/shared/__tests__/refresh-access-token-if-needed.test.ts
+++ b/src/lib/agent/runner/shared/__tests__/refresh-access-token-if-needed.test.ts
@@ -71,12 +71,31 @@ describe('refreshAccessTokenIfNeeded', () => {
 
     await refreshAccessTokenIfNeeded(session);
 
-    expect(mockedRefresh).toHaveBeenCalledWith('phr_old', undefined);
+    expect(mockedRefresh).toHaveBeenCalledWith('phr_old', undefined, undefined);
     expect(session.credentials!.accessToken).toBe('pha_new');
     expect(session.credentials!.refreshToken).toBe('phr_rotated');
     // Unrelated fields survive the swap.
     expect(session.credentials!.projectId).toBe(7);
     expect(setAccessToken).toHaveBeenCalledWith(session.credentials);
+  });
+
+  it('refreshes under the minting client id when the credential carries one (provisioning signups)', async () => {
+    mockedRefresh.mockResolvedValueOnce({
+      access_token: 'pha_new',
+      expires_in: 3600,
+      token_type: 'Bearer',
+      scope: 'project:read',
+    });
+
+    await refreshAccessTokenIfNeeded(
+      sessionWith(aging({ oauthClientId: 'client_us_provisioning' })),
+    );
+
+    expect(mockedRefresh).toHaveBeenCalledWith(
+      'phr_old',
+      undefined,
+      'client_us_provisioning',
+    );
   });
 
   it('replaces the credentials object rather than mutating it in place', async () => {

--- a/src/lib/agent/runner/shared/__tests__/refresh-access-token-if-needed.test.ts
+++ b/src/lib/agent/runner/shared/__tests__/refresh-access-token-if-needed.test.ts
@@ -1,8 +1,8 @@
-import { ensureFreshAccessToken } from '../authenticate';
-import { refreshOAuthToken } from '@utils/oauth';
+import { refreshAccessTokenIfNeeded } from '../authenticate';
+import { refreshAccessToken } from '@utils/oauth';
 import type { WizardSession, Credentials } from '@lib/wizard-session';
 
-vi.mock('@utils/oauth', () => ({ refreshOAuthToken: vi.fn() }));
+vi.mock('@utils/oauth', () => ({ refreshAccessToken: vi.fn() }));
 vi.mock('@utils/debug', () => ({ logToFile: vi.fn() }));
 
 const setCredentials = vi.fn();
@@ -10,31 +10,31 @@ vi.mock('@ui', () => ({
   getUI: () => ({ setCredentials }),
 }));
 
-const mockedRefresh = refreshOAuthToken as Mock;
+const mockedRefresh = refreshAccessToken as Mock;
 
 function sessionWith(credentials: Partial<Credentials> | null): WizardSession {
   return { credentials: credentials as Credentials | null } as WizardSession;
 }
 
-describe('ensureFreshAccessToken', () => {
+describe('refreshAccessTokenIfNeeded', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('is a no-op without a refresh token (CI api-key runs, refresh-less grants)', async () => {
-    await ensureFreshAccessToken(sessionWith(null));
-    await ensureFreshAccessToken(
-      sessionWith({ accessToken: 'pha_ci_key', accessTokenExpiresAt: 0 }),
+    await refreshAccessTokenIfNeeded(sessionWith(null));
+    await refreshAccessTokenIfNeeded(
+      sessionWith({ accessToken: 'pha_ci_key', expiresAt: 0 }),
     );
     expect(mockedRefresh).not.toHaveBeenCalled();
   });
 
   it('skips a token that still has most of its lifetime left', async () => {
-    await ensureFreshAccessToken(
+    await refreshAccessTokenIfNeeded(
       sessionWith({
         accessToken: 'pha_fresh',
         refreshToken: 'phr_x',
-        accessTokenExpiresAt: Date.now() + 59 * 60 * 1000,
+        expiresAt: Date.now() + 59 * 60 * 1000,
       }),
     );
     expect(mockedRefresh).not.toHaveBeenCalled();
@@ -51,10 +51,10 @@ describe('ensureFreshAccessToken', () => {
     const session = sessionWith({
       accessToken: 'pha_old',
       refreshToken: 'phr_old',
-      accessTokenExpiresAt: Date.now() + 20 * 60 * 1000,
+      expiresAt: Date.now() + 20 * 60 * 1000,
     });
 
-    await ensureFreshAccessToken(session);
+    await refreshAccessTokenIfNeeded(session);
 
     expect(mockedRefresh).toHaveBeenCalledWith('phr_old', undefined);
     expect(session.credentials!.accessToken).toBe('pha_new');
@@ -67,10 +67,10 @@ describe('ensureFreshAccessToken', () => {
     const session = sessionWith({
       accessToken: 'pha_old',
       refreshToken: 'phr_old',
-      accessTokenExpiresAt: Date.now() + 20 * 60 * 1000,
+      expiresAt: Date.now() + 20 * 60 * 1000,
     });
 
-    await expect(ensureFreshAccessToken(session)).resolves.toBeUndefined();
+    await expect(refreshAccessTokenIfNeeded(session)).resolves.toBeUndefined();
     expect(session.credentials!.accessToken).toBe('pha_old');
     expect(setCredentials).not.toHaveBeenCalled();
   });

--- a/src/lib/agent/runner/shared/authenticate.ts
+++ b/src/lib/agent/runner/shared/authenticate.ts
@@ -71,16 +71,10 @@ export async function authenticate(
   analytics.setGroups(groupsFromUser(user, host.apiHost));
 }
 
-// The agent subprocess freezes its token at spawn and a run can block on a wizard_ask
-// for the rest of the token's life, so each run must start near-full; skip only
-// just-minted 1-hour tokens and long-lived (7-day first-party) grants.
+// Below this remaining lifetime a run risks outliving its token; just-minted and 7-day tokens skip.
 const REFRESH_WHEN_REMAINING_MS = 50 * 60 * 1000;
 
-/**
- * Mint a fresh access token before an agent run when the current one has aged.
- * Best-effort: refresh-less credentials (CI api keys) and failed refreshes
- * leave the existing token in place, so behavior degrades to the status quo.
- */
+// Best-effort pre-run refresh: no refresh token or a failed grant keeps the existing token.
 export async function refreshAccessTokenIfNeeded(
   session: WizardSession,
 ): Promise<void> {

--- a/src/lib/agent/runner/shared/authenticate.ts
+++ b/src/lib/agent/runner/shared/authenticate.ts
@@ -10,10 +10,12 @@
  * back rather than fetching again.
  */
 
-import type { WizardSession } from '@lib/wizard-session';
+import type { Credentials, WizardSession } from '@lib/wizard-session';
 import type { ProgramId } from '@lib/programs/program-registry';
 import { getOrAskForProjectData } from '@utils/setup-utils';
 import { refreshAccessToken } from '@utils/oauth';
+import { OAuthError } from '@utils/oauth-errors';
+import { markGrantRevoked } from '@lib/auth-session-state';
 import { analytics, groupsFromUser } from '@utils/analytics';
 import { getUI } from '@ui';
 import { logToFile } from '@utils/debug';
@@ -72,7 +74,14 @@ export async function authenticate(
 }
 
 // Below this remaining lifetime a run risks outliving its token; just-minted and 7-day tokens skip.
+// Only a second agent run in one invocation can be this old — see self-driving's chained phases.
 const REFRESH_WHEN_REMAINING_MS = 50 * 60 * 1000;
+
+/**
+ * Grants the token endpoint refuses permanently. A dead grant means the login
+ * is gone, not that the network blipped, so only these mark the session.
+ */
+const DEAD_GRANT_CODES = new Set(['invalid_grant', 'invalid_client']);
 
 // Best-effort pre-run refresh: no refresh token or a failed grant keeps the existing token.
 export async function refreshAccessTokenIfNeeded(
@@ -81,20 +90,35 @@ export async function refreshAccessTokenIfNeeded(
   const credentials = session.credentials;
   if (!credentials?.refreshToken) return;
 
-  const remaining = (credentials.expiresAt ?? 0) - Date.now();
-  if (remaining >= REFRESH_WHEN_REMAINING_MS) return;
+  // No expiry means we cannot tell how much life is left, so leave it alone —
+  // refreshing every run would spend a rotation for nothing.
+  if (credentials.expiresAt === undefined) return;
+  if (credentials.expiresAt - Date.now() >= REFRESH_WHEN_REMAINING_MS) return;
 
   try {
     const token = await refreshAccessToken(
       credentials.refreshToken,
       session.baseUrl,
     );
-    credentials.accessToken = token.access_token;
-    // Rotation: keep the returned refresh token or the old one stops working.
-    credentials.refreshToken = token.refresh_token ?? credentials.refreshToken;
-    credentials.expiresAt = Date.now() + token.expires_in * 1000;
-    getUI().setCredentials(credentials);
+    // Replaced, not mutated: readers hold this object, and a new one keeps the
+    // store and the (possibly shallow-copied) session explicitly in step.
+    const refreshed: Credentials = {
+      ...credentials,
+      accessToken: token.access_token,
+      // Rotation: keep the returned refresh token or the old one stops working.
+      refreshToken: token.refresh_token ?? credentials.refreshToken,
+      expiresAt: Date.now() + token.expires_in * 1000,
+    };
+    session.credentials = refreshed;
+    getUI().setAccessToken(refreshed);
   } catch (error) {
+    // A dead grant is recorded but not thrown: the current token may still have
+    // minutes of life, and failing here would break runs that would have worked.
+    // If a 401 does follow, the auth-error screen can finally name the cause.
+    if (error instanceof OAuthError && DEAD_GRANT_CODES.has(error.code)) {
+      markGrantRevoked();
+      analytics.wizardCapture('auth session expired', { reason: error.code });
+    }
     logToFile(
       '[oauth] pre-run token refresh failed, continuing with the existing token:',
       error instanceof Error ? error.message : error,

--- a/src/lib/agent/runner/shared/authenticate.ts
+++ b/src/lib/agent/runner/shared/authenticate.ts
@@ -13,7 +13,7 @@
 import type { WizardSession } from '@lib/wizard-session';
 import type { ProgramId } from '@lib/programs/program-registry';
 import { getOrAskForProjectData } from '@utils/setup-utils';
-import { refreshOAuthToken } from '@utils/oauth';
+import { refreshAccessToken } from '@utils/oauth';
 import { analytics, groupsFromUser } from '@utils/analytics';
 import { getUI } from '@ui';
 import { logToFile } from '@utils/debug';
@@ -30,7 +30,7 @@ export async function authenticate(
     host,
     accessToken,
     refreshToken,
-    accessTokenExpiresAt,
+    expiresAt,
     projectId,
     roleAtOrganization,
     user,
@@ -51,7 +51,7 @@ export async function authenticate(
   session.credentials = {
     accessToken,
     refreshToken,
-    accessTokenExpiresAt,
+    expiresAt,
     projectApiKey,
     host,
     projectId,
@@ -81,24 +81,24 @@ const REFRESH_WHEN_REMAINING_MS = 50 * 60 * 1000;
  * Best-effort: refresh-less credentials (CI api keys) and failed refreshes
  * leave the existing token in place, so behavior degrades to the status quo.
  */
-export async function ensureFreshAccessToken(
+export async function refreshAccessTokenIfNeeded(
   session: WizardSession,
 ): Promise<void> {
   const credentials = session.credentials;
   if (!credentials?.refreshToken) return;
 
-  const remaining = (credentials.accessTokenExpiresAt ?? 0) - Date.now();
+  const remaining = (credentials.expiresAt ?? 0) - Date.now();
   if (remaining >= REFRESH_WHEN_REMAINING_MS) return;
 
   try {
-    const token = await refreshOAuthToken(
+    const token = await refreshAccessToken(
       credentials.refreshToken,
       session.baseUrl,
     );
     credentials.accessToken = token.access_token;
     // Rotation: keep the returned refresh token or the old one stops working.
     credentials.refreshToken = token.refresh_token ?? credentials.refreshToken;
-    credentials.accessTokenExpiresAt = Date.now() + token.expires_in * 1000;
+    credentials.expiresAt = Date.now() + token.expires_in * 1000;
     getUI().setCredentials(credentials);
   } catch (error) {
     logToFile(

--- a/src/lib/agent/runner/shared/authenticate.ts
+++ b/src/lib/agent/runner/shared/authenticate.ts
@@ -71,20 +71,15 @@ export async function authenticate(
   analytics.setGroups(groupsFromUser(user, host.apiHost));
 }
 
-/**
- * The access token is handed to the agent subprocess via its environment at
- * spawn and cannot change mid-run, while a run can block on a wizard_ask for
- * the rest of the token's life — so every run must START with a near-full TTL.
- * Refresh whenever less than this much lifetime remains; a just-minted 1-hour
- * token skips, and a long-lived token (7-day first-party grants) always skips.
- */
+// The agent subprocess freezes its token at spawn and a run can block on a wizard_ask
+// for the rest of the token's life, so each run must start near-full; skip only
+// just-minted 1-hour tokens and long-lived (7-day first-party) grants.
 const REFRESH_WHEN_REMAINING_MS = 50 * 60 * 1000;
 
 /**
- * Mint a fresh access token before an agent run when the current one has
- * meaningfully aged. Best-effort: refresh-less credentials (CI api keys,
- * grants without a refresh token) and failed refreshes leave the existing
- * token in place — the run then behaves exactly as before this existed.
+ * Mint a fresh access token before an agent run when the current one has aged.
+ * Best-effort: refresh-less credentials (CI api keys) and failed refreshes
+ * leave the existing token in place, so behavior degrades to the status quo.
  */
 export async function ensureFreshAccessToken(
   session: WizardSession,
@@ -92,10 +87,7 @@ export async function ensureFreshAccessToken(
   const credentials = session.credentials;
   if (!credentials?.refreshToken) return;
 
-  const remaining =
-    credentials.accessTokenExpiresAt !== undefined
-      ? credentials.accessTokenExpiresAt - Date.now()
-      : 0;
+  const remaining = (credentials.accessTokenExpiresAt ?? 0) - Date.now();
   if (remaining >= REFRESH_WHEN_REMAINING_MS) return;
 
   try {
@@ -104,8 +96,7 @@ export async function ensureFreshAccessToken(
       session.baseUrl,
     );
     credentials.accessToken = token.access_token;
-    // Rotation: the server usually invalidates the old refresh token when it
-    // issues a new one — keep whichever the response carried.
+    // Rotation: keep the returned refresh token or the old one stops working.
     credentials.refreshToken = token.refresh_token ?? credentials.refreshToken;
     credentials.accessTokenExpiresAt = Date.now() + token.expires_in * 1000;
     getUI().setCredentials(credentials);

--- a/src/lib/agent/runner/shared/authenticate.ts
+++ b/src/lib/agent/runner/shared/authenticate.ts
@@ -33,6 +33,7 @@ export async function authenticate(
     accessToken,
     refreshToken,
     expiresAt,
+    oauthClientId,
     projectId,
     roleAtOrganization,
     user,
@@ -54,6 +55,7 @@ export async function authenticate(
     accessToken,
     refreshToken,
     expiresAt,
+    oauthClientId,
     projectApiKey,
     host,
     projectId,
@@ -99,6 +101,7 @@ export async function refreshAccessTokenIfNeeded(
     const token = await refreshAccessToken(
       credentials.refreshToken,
       session.baseUrl,
+      credentials.oauthClientId,
     );
     // Replaced, not mutated: readers hold this object, and a new one keeps the
     // store and the (possibly shallow-copied) session explicitly in step.

--- a/src/lib/agent/runner/shared/authenticate.ts
+++ b/src/lib/agent/runner/shared/authenticate.ts
@@ -13,6 +13,7 @@
 import type { WizardSession } from '@lib/wizard-session';
 import type { ProgramId } from '@lib/programs/program-registry';
 import { getOrAskForProjectData } from '@utils/setup-utils';
+import { refreshOAuthToken } from '@utils/oauth';
 import { analytics, groupsFromUser } from '@utils/analytics';
 import { getUI } from '@ui';
 import { logToFile } from '@utils/debug';
@@ -28,6 +29,8 @@ export async function authenticate(
     projectApiKey,
     host,
     accessToken,
+    refreshToken,
+    accessTokenExpiresAt,
     projectId,
     roleAtOrganization,
     user,
@@ -47,6 +50,8 @@ export async function authenticate(
 
   session.credentials = {
     accessToken,
+    refreshToken,
+    accessTokenExpiresAt,
     projectApiKey,
     host,
     projectId,
@@ -64,4 +69,50 @@ export async function authenticate(
   // target the individual user and not just $app_name.
   if (user) analytics.identifyUser(user);
   analytics.setGroups(groupsFromUser(user, host.apiHost));
+}
+
+/**
+ * The access token is handed to the agent subprocess via its environment at
+ * spawn and cannot change mid-run, while a run can block on a wizard_ask for
+ * the rest of the token's life — so every run must START with a near-full TTL.
+ * Refresh whenever less than this much lifetime remains; a just-minted 1-hour
+ * token skips, and a long-lived token (7-day first-party grants) always skips.
+ */
+const REFRESH_WHEN_REMAINING_MS = 50 * 60 * 1000;
+
+/**
+ * Mint a fresh access token before an agent run when the current one has
+ * meaningfully aged. Best-effort: refresh-less credentials (CI api keys,
+ * grants without a refresh token) and failed refreshes leave the existing
+ * token in place — the run then behaves exactly as before this existed.
+ */
+export async function ensureFreshAccessToken(
+  session: WizardSession,
+): Promise<void> {
+  const credentials = session.credentials;
+  if (!credentials?.refreshToken) return;
+
+  const remaining =
+    credentials.accessTokenExpiresAt !== undefined
+      ? credentials.accessTokenExpiresAt - Date.now()
+      : 0;
+  if (remaining >= REFRESH_WHEN_REMAINING_MS) return;
+
+  try {
+    const token = await refreshOAuthToken(
+      credentials.refreshToken,
+      session.baseUrl,
+    );
+    credentials.accessToken = token.access_token;
+    // Rotation: the server usually invalidates the old refresh token when it
+    // issues a new one — keep whichever the response carried.
+    credentials.refreshToken = token.refresh_token ?? credentials.refreshToken;
+    credentials.accessTokenExpiresAt = Date.now() + token.expires_in * 1000;
+    getUI().setCredentials(credentials);
+  } catch (error) {
+    logToFile(
+      '[oauth] pre-run token refresh failed, continuing with the existing token:',
+      error instanceof Error ? error.message : error,
+    );
+  }
 }

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -252,8 +252,6 @@ export async function bootstrapProgram(
   // the first login; it does not launch another OAuth. authenticate() also
   // identifies the user and sets analytics groups.
   await authenticate(session, programConfig.id);
-  // A later run reuses the first login's aging token; the agent subprocess can't swap tokens mid-run.
-  await refreshAccessTokenIfNeeded(session);
   const project = session.apiProject;
 
   // 4.5. AI opt-in enforcement. Parks here while AiOptInRequiredScreen is
@@ -298,6 +296,9 @@ export async function bootstrapProgram(
     build: analytics.build,
     skillId: config.skillId,
   });
+
+  // The agent can't swap tokens mid-run, so freshness is measured after every park above, right before the mint.
+  await refreshAccessTokenIfNeeded(session);
 
   // Credentials (incl. the resolved host family and its MCP url) live on
   // `session.credentials`; narrow once at this boundary — `authenticate` above

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -10,7 +10,7 @@
 import type { WizardSession } from '@lib/wizard-session';
 import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
-import { authenticate, ensureFreshAccessToken } from './authenticate';
+import { authenticate, refreshAccessTokenIfNeeded } from './authenticate';
 import { createTriageLLMProvider } from '@lib/agent/triage-provider';
 import { gatewayAuth } from '@lib/gateway-session';
 import { resolveHarness } from '../switchboard';
@@ -254,7 +254,7 @@ export async function bootstrapProgram(
   await authenticate(session, programConfig.id);
   // A later run in the same invocation reuses the first login's token, which
   // may be near expiry — and the agent subprocess can't swap tokens mid-run.
-  await ensureFreshAccessToken(session);
+  await refreshAccessTokenIfNeeded(session);
   const project = session.apiProject;
 
   // 4.5. AI opt-in enforcement. Parks here while AiOptInRequiredScreen is

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -252,8 +252,7 @@ export async function bootstrapProgram(
   // the first login; it does not launch another OAuth. authenticate() also
   // identifies the user and sets analytics groups.
   await authenticate(session, programConfig.id);
-  // A later run in the same invocation reuses the first login's token, which
-  // may be near expiry — and the agent subprocess can't swap tokens mid-run.
+  // A later run reuses the first login's aging token; the agent subprocess can't swap tokens mid-run.
   await refreshAccessTokenIfNeeded(session);
   const project = session.apiProject;
 

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -10,7 +10,7 @@
 import type { WizardSession } from '@lib/wizard-session';
 import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
-import { authenticate } from './authenticate';
+import { authenticate, ensureFreshAccessToken } from './authenticate';
 import { createTriageLLMProvider } from '@lib/agent/triage-provider';
 import { gatewayAuth } from '@lib/gateway-session';
 import { resolveHarness } from '../switchboard';
@@ -252,6 +252,9 @@ export async function bootstrapProgram(
   // the first login; it does not launch another OAuth. authenticate() also
   // identifies the user and sets analytics groups.
   await authenticate(session, programConfig.id);
+  // A later run in the same invocation reuses the first login's token, which
+  // may be near expiry — and the agent subprocess can't swap tokens mid-run.
+  await ensureFreshAccessToken(session);
   const project = session.apiProject;
 
   // 4.5. AI opt-in enforcement. Parks here while AiOptInRequiredScreen is

--- a/src/lib/auth-session-state.ts
+++ b/src/lib/auth-session-state.ts
@@ -1,0 +1,34 @@
+/**
+ * Whether this run's OAuth grant is known to be dead.
+ *
+ * Process-global on purpose. A run has exactly one login, but the two sides of
+ * this fact are far apart: the pre-run refresh learns it in `authenticate.ts`,
+ * and the only consumer is the 401 handler inside the agent message loop, which
+ * holds no session. Threading it would mean a field on `AgentConfig` set at four
+ * `initializeAgent` call sites — and the session it would read from may be a
+ * shallow copy (`prepareRunSession`), so the value could be written to one
+ * object and read from another.
+ *
+ * A leaf module with no imports, so either side can depend on it without a cycle.
+ */
+
+let grantRevoked = false;
+
+/**
+ * Record that the token endpoint permanently refused this grant. Not an abort:
+ * the access token in hand may still have minutes of life, so the run continues
+ * and this only decides what a later 401 gets blamed on.
+ */
+export function markGrantRevoked(): void {
+  grantRevoked = true;
+}
+
+/** True once a token refresh failed because the grant itself is gone. */
+export function isGrantRevoked(): boolean {
+  return grantRevoked;
+}
+
+/** Test hook, mirroring `resetGatewaySession`. */
+export function resetAuthSessionState(): void {
+  grantRevoked = false;
+}

--- a/src/lib/errors/__tests__/auth.test.ts
+++ b/src/lib/errors/__tests__/auth.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { classifyAuthFailure } from '../auth';
+import { ErrorCodes } from '../codes';
+
+describe('classifyAuthFailure', () => {
+  it('falls back to invalid-or-expired when nothing is known', () => {
+    expect(classifyAuthFailure({})).toBe(ErrorCodes.AuthInvalidOrExpired);
+  });
+
+  // The one branch backed by a server verdict, so it has to beat every guess.
+  it('reports a dead grant ahead of any inferred cause', () => {
+    expect(classifyAuthFailure({ sessionExpired: true })).toBe(
+      ErrorCodes.AuthSessionExpired,
+    );
+    expect(
+      classifyAuthFailure({
+        sessionExpired: true,
+        usingManagedLogin: true,
+        hasSettingsConflict: true,
+        apiKey: 'phc_project_key',
+        missingScopes: ['llm_gateway:read'],
+        gatewayRegion: 'us',
+        sessionRegion: 'eu',
+      }),
+    ).toBe(ErrorCodes.AuthSessionExpired);
+  });
+
+  it('leaves the existing precedence intact when the grant is fine', () => {
+    expect(classifyAuthFailure({ usingManagedLogin: true })).toBe(
+      ErrorCodes.AuthStoredLoginConflict,
+    );
+    expect(classifyAuthFailure({ hasSettingsConflict: true })).toBe(
+      ErrorCodes.AuthSettingsConflict,
+    );
+    expect(classifyAuthFailure({ apiKey: 'phc_project_key' })).toBe(
+      ErrorCodes.AuthKeyType,
+    );
+    expect(classifyAuthFailure({ missingScopes: ['llm_gateway:read'] })).toBe(
+      ErrorCodes.AuthMissingScope,
+    );
+    expect(
+      classifyAuthFailure({ gatewayRegion: 'us', sessionRegion: 'eu' }),
+    ).toBe(ErrorCodes.AuthRegionMismatch);
+  });
+
+  it('does not treat sessionExpired: false as a signal', () => {
+    expect(classifyAuthFailure({ sessionExpired: false })).toBe(
+      ErrorCodes.AuthInvalidOrExpired,
+    );
+  });
+});

--- a/src/lib/errors/auth.ts
+++ b/src/lib/errors/auth.ts
@@ -3,6 +3,8 @@ import { ErrorCodes, type ErrorCode } from './codes';
 export interface AuthFailureInput {
   hasSettingsConflict?: boolean;
   usingManagedLogin?: boolean;
+  /** A pre-run token refresh already failed on a dead grant this run. */
+  sessionExpired?: boolean;
   apiKey?: string;
   missingScopes?: readonly string[];
   gatewayRegion?: 'us' | 'eu' | 'local';
@@ -10,6 +12,10 @@ export interface AuthFailureInput {
 }
 
 export function classifyAuthFailure(input: AuthFailureInput): ErrorCode {
+  // First: the only branch backed by a server verdict rather than inference.
+  // The token endpoint already told us the grant is dead, so every heuristic
+  // below would be guessing at a cause we know.
+  if (input.sessionExpired) return ErrorCodes.AuthSessionExpired;
   if (input.usingManagedLogin) return ErrorCodes.AuthStoredLoginConflict;
   if (input.hasSettingsConflict) return ErrorCodes.AuthSettingsConflict;
   if (

--- a/src/lib/errors/catalog.ts
+++ b/src/lib/errors/catalog.ts
@@ -53,6 +53,12 @@ export const ERROR_CATALOG: Record<ErrorCode, ErrorCatalogEntry> = {
     retry: 'no',
     description: 'The credential was rejected by the LLM gateway or API.',
   },
+  [ErrorCodes.AuthSessionExpired]: {
+    group: 'auth',
+    // Retryable, unlike its neighbours: a new run means a new login.
+    retry: 'yes',
+    description: 'The OAuth grant expired or was revoked mid-run.',
+  },
   [ErrorCodes.AuthMissingScope]: {
     group: 'auth',
     retry: 'no',

--- a/src/lib/errors/codes.ts
+++ b/src/lib/errors/codes.ts
@@ -11,6 +11,8 @@ export const ErrorCodes = {
   AuthMissingScope: 'PHW_AUTH_MISSING_SCOPE',
   AuthRegionMismatch: 'PHW_AUTH_REGION_MISMATCH',
   AuthInvalidOrExpired: 'PHW_AUTH_INVALID_OR_EXPIRED',
+  /** The OAuth grant itself is gone — distinct from a merely expired token. */
+  AuthSessionExpired: 'PHW_AUTH_SESSION_EXPIRED',
   AuthSettingsConflict: 'PHW_AUTH_SETTINGS_CONFLICT',
   AuthStoredLoginConflict: 'PHW_AUTH_STORED_LOGIN_CONFLICT',
   AuthProjectFetchFailed: 'PHW_AUTH_PROJECT_FETCH_FAILED',

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -24,6 +24,8 @@ export interface Credentials {
   refreshToken?: string;
   /** Epoch ms when `accessToken` expires — drives the pre-run refresh. */
   expiresAt?: number;
+  /** Minting OAuth client when it differs from the default login app (provisioning signups). */
+  oauthClientId?: string;
   projectApiKey: string;
   /** Resolved at auth time and immutable thereafter — see {@link HostResolution}. */
   host: HostResolution;

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -23,7 +23,7 @@ export interface Credentials {
   /** OAuth refresh token when the grant carried one; absent on CI api-key runs. */
   refreshToken?: string;
   /** Epoch ms when `accessToken` expires — drives the pre-run refresh. */
-  accessTokenExpiresAt?: number;
+  expiresAt?: number;
   projectApiKey: string;
   /** Resolved at auth time and immutable thereafter — see {@link HostResolution}. */
   host: HostResolution;

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -20,6 +20,15 @@ import type { HostResolution } from './host-resolution';
 
 export interface Credentials {
   accessToken: string;
+  /**
+   * OAuth refresh token, when the grant carried one — absent on CI api-key
+   * runs and refresh-less grants. Lets a run that outlives the access token's
+   * TTL (a wizard_ask left open, a multi-phase program) mint a fresh token
+   * instead of 401ing. Rotated on every refresh; always store the returned one.
+   */
+  refreshToken?: string;
+  /** Epoch ms when `accessToken` expires — drives the pre-run refresh. */
+  accessTokenExpiresAt?: number;
   projectApiKey: string;
   /** Resolved at auth time and immutable thereafter — see {@link HostResolution}. */
   host: HostResolution;

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -20,12 +20,7 @@ import type { HostResolution } from './host-resolution';
 
 export interface Credentials {
   accessToken: string;
-  /**
-   * OAuth refresh token, when the grant carried one — absent on CI api-key
-   * runs and refresh-less grants. Lets a run that outlives the access token's
-   * TTL (a wizard_ask left open, a multi-phase program) mint a fresh token
-   * instead of 401ing. Rotated on every refresh; always store the returned one.
-   */
+  /** OAuth refresh token when the grant carried one; absent on CI api-key runs. */
   refreshToken?: string;
   /** Epoch ms when `accessToken` expires — drives the pre-run refresh. */
   accessTokenExpiresAt?: number;

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -398,9 +398,13 @@ export interface WizardSession {
   outageDismissed: boolean;
   settingsOverrideKeys: string[] | null;
   settingsConflicts: SettingsConflict[] | null;
+  /** Mirrors `AuthErrorDetail` in `@ui/wizard-ui` — keep the two in step. */
   authErrorDetail: {
     hasSettingsConflict: boolean;
     conflicts?: SettingsConflict[];
+    usingManagedLogin?: boolean;
+    credentialPlaces?: string[];
+    sessionExpired?: boolean;
     logFilePath: string;
   } | null;
   portConflictProcess: {

--- a/src/ui/logging-ui.ts
+++ b/src/ui/logging-ui.ts
@@ -235,6 +235,10 @@ export class LoggingUI implements WizardUI {
     // No-op in CI mode — credentials are handled directly
   }
 
+  setAccessToken(_credentials: Credentials): void {
+    // No-op in CI mode — CI runs on a non-expiring key and never refreshes
+  }
+
   setRoleAtOrganization(_role: string | null): void {
     // No-op in CI mode — there's no TUI to render role-tailored prompts
   }

--- a/src/ui/tui/ink-ui.ts
+++ b/src/ui/tui/ink-ui.ts
@@ -87,6 +87,10 @@ export class InkUI implements WizardUI {
     this.store.setCredentials(credentials);
   }
 
+  setAccessToken(credentials: Credentials): void {
+    this.store.setAccessToken(credentials);
+  }
+
   setRoleAtOrganization(role: string | null): void {
     this.store.setRoleAtOrganization(role);
   }

--- a/src/ui/tui/screens/AuthErrorScreen.tsx
+++ b/src/ui/tui/screens/AuthErrorScreen.tsx
@@ -1,7 +1,10 @@
 /**
  * AuthErrorScreen — Shown when the PostHog LLM Gateway returns a 401.
  *
- * Two distinct causes:
+ * Distinct causes, most specific first:
+ *  0. The OAuth grant is gone — a pre-run refresh already got `invalid_grant`
+ *     from the token endpoint. The only branch backed by a server verdict
+ *     rather than inference, so it wins; re-running is the whole fix.
  *  1. Claude Code settings.json / managed-settings overrides ANTHROPIC_*
  *     env vars — auth conflict. Tell the user to log out of Claude Code.
  *  2. The PostHog API key itself was rejected — bad prefix, missing scope,
@@ -31,6 +34,7 @@ export const AuthErrorScreen = ({ store }: AuthErrorScreenProps) => {
   const conflicts = detail?.conflicts ?? [];
   const usingManagedLogin = detail?.usingManagedLogin ?? false;
   const credentialPlaces = detail?.credentialPlaces ?? [];
+  const sessionExpired = detail?.sessionExpired ?? false;
   const logFilePath = detail?.logFilePath;
 
   return (
@@ -39,7 +43,31 @@ export const AuthErrorScreen = ({ store }: AuthErrorScreenProps) => {
         {'✘'} Authentication error
       </Text>
 
-      {usingManagedLogin ? (
+      {sessionExpired ? (
+        <>
+          <Box flexDirection="column" marginTop={1}>
+            <Text>
+              Your PostHog login expired while the wizard was running, so the
+              LLM Gateway rejected it (401). Nothing on this machine is
+              misconfigured — the session simply ran out.
+            </Text>
+          </Box>
+
+          <Box marginTop={1}>
+            <Text dimColor>Re-run the wizard and log in again:</Text>
+          </Box>
+
+          <Box flexDirection="column" marginTop={1} paddingLeft={2}>
+            <Text color="cyan">npx @posthog/wizard</Text>
+          </Box>
+
+          <Box marginTop={1}>
+            <Text dimColor>
+              Any files the agent already wrote are still in your project.
+            </Text>
+          </Box>
+        </>
+      ) : usingManagedLogin ? (
         <>
           <Box flexDirection="column" marginTop={1}>
             <Text>

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -495,6 +495,12 @@ export class WizardStore {
     this.emitChange();
   }
 
+  /** Post-refresh credential swap. No `auth complete` — see WizardUI. */
+  setAccessToken(credentials: WizardSession['credentials']): void {
+    this.$session.setKey('credentials', credentials);
+    this.emitChange();
+  }
+
   setRoleAtOrganization(role: string | null): void {
     this.$session.setKey('roleAtOrganization', role);
     this.emitChange();

--- a/src/ui/wizard-ui.ts
+++ b/src/ui/wizard-ui.ts
@@ -75,6 +75,12 @@ export interface AuthErrorDetail {
   usingManagedLogin?: boolean;
   /** Human-readable places a conflicting Anthropic credential may live. */
   credentialPlaces?: string[];
+  /**
+   * True when a pre-run refresh already failed on a dead grant. The login is
+   * gone and re-running is the only fix, so this outranks every other branch —
+   * none of the usual advice (key type, scopes, region) applies.
+   */
+  sessionExpired?: boolean;
   logFilePath: string;
 }
 
@@ -117,6 +123,13 @@ export interface WizardUI {
 
   /** Store OAuth/API credentials. Resolves past AuthScreen in TUI. */
   setCredentials(credentials: Credentials): void;
+
+  /**
+   * Replace the credentials after a token refresh. Same store write as
+   * {@link setCredentials} without the `auth complete` capture — the user
+   * authenticated once, and a refresh is not a second login.
+   */
+  setAccessToken(credentials: Credentials): void;
 
   /**
    * Persist the user's `role_at_organization` once it's been fetched from

--- a/src/utils/__tests__/oauth-refresh.test.ts
+++ b/src/utils/__tests__/oauth-refresh.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { refreshOAuthToken } from '@utils/oauth';
+import { refreshAccessToken } from '@utils/oauth';
 import { POSTHOG_PROXY_CLIENT_ID } from '@lib/constants';
 
 vi.mock('axios');
@@ -12,7 +12,7 @@ vi.mock('../debug', () => ({ logToFile: vi.fn() }));
 
 const mockedAxios = axios as Mocked<typeof axios>;
 
-describe('refreshOAuthToken', () => {
+describe('refreshAccessToken', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -28,7 +28,7 @@ describe('refreshOAuthToken', () => {
       },
     });
 
-    const token = await refreshOAuthToken('phr_old');
+    const token = await refreshAccessToken('phr_old');
 
     const [url, body] = mockedAxios.post.mock.calls[0];
     expect(url).toMatch(/\/oauth\/token$/);
@@ -44,7 +44,7 @@ describe('refreshOAuthToken', () => {
   it('propagates a failed refresh instead of returning a stale token', async () => {
     mockedAxios.post.mockRejectedValueOnce(new Error('invalid_grant'));
 
-    await expect(refreshOAuthToken('phr_revoked')).rejects.toThrow(
+    await expect(refreshAccessToken('phr_revoked')).rejects.toThrow(
       'invalid_grant',
     );
   });

--- a/src/utils/__tests__/oauth-refresh.test.ts
+++ b/src/utils/__tests__/oauth-refresh.test.ts
@@ -1,0 +1,64 @@
+import axios from 'axios';
+import { refreshOAuthToken } from '@utils/oauth';
+import { POSTHOG_PROXY_CLIENT_ID } from '@lib/constants';
+
+vi.mock('axios');
+// Return the override verbatim so region-based prod routing applies (no IS_DEV
+// localhost); undefined means no override.
+vi.mock('../urls', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../urls')>()),
+  resolveBaseUrl: (baseUrl?: string) => baseUrl,
+}));
+vi.mock('../debug', () => ({ logToFile: vi.fn() }));
+
+const mockedAxios = axios as Mocked<typeof axios>;
+
+const TOKEN_RESPONSE = {
+  access_token: 'pha_new_access',
+  expires_in: 3600,
+  token_type: 'Bearer',
+  scope: 'project:read event_definition:write',
+  refresh_token: 'phr_rotated',
+  scoped_teams: [521185],
+};
+
+describe('refreshOAuthToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('posts a refresh_token grant with the proxy client id and parses the response', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: TOKEN_RESPONSE });
+
+    const token = await refreshOAuthToken('phr_old');
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    const [url, body] = mockedAxios.post.mock.calls[0];
+    expect(url).toMatch(/\/oauth\/token$/);
+    expect(body).toMatchObject({
+      grant_type: 'refresh_token',
+      refresh_token: 'phr_old',
+      client_id: POSTHOG_PROXY_CLIENT_ID,
+    });
+    expect(token.access_token).toBe('pha_new_access');
+    expect(token.refresh_token).toBe('phr_rotated');
+    expect(token.expires_in).toBe(3600);
+  });
+
+  it('targets the pinned base URL when one is given', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: TOKEN_RESPONSE });
+
+    await refreshOAuthToken('phr_old', 'http://localhost:8010');
+
+    const [url] = mockedAxios.post.mock.calls[0];
+    expect(url).toBe('http://localhost:8010/oauth/token');
+  });
+
+  it('propagates a failed refresh instead of returning a stale token', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('invalid_grant'));
+
+    await expect(refreshOAuthToken('phr_revoked')).rejects.toThrow(
+      'invalid_grant',
+    );
+  });
+});

--- a/src/utils/__tests__/oauth-refresh.test.ts
+++ b/src/utils/__tests__/oauth-refresh.test.ts
@@ -3,8 +3,7 @@ import { refreshOAuthToken } from '@utils/oauth';
 import { POSTHOG_PROXY_CLIENT_ID } from '@lib/constants';
 
 vi.mock('axios');
-// Return the override verbatim so region-based prod routing applies (no IS_DEV
-// localhost); undefined means no override.
+// No base-URL override resolves to prod routing (kills IS_DEV's implicit localhost).
 vi.mock('../urls', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../urls')>()),
   resolveBaseUrl: (baseUrl?: string) => baseUrl,
@@ -13,26 +12,24 @@ vi.mock('../debug', () => ({ logToFile: vi.fn() }));
 
 const mockedAxios = axios as Mocked<typeof axios>;
 
-const TOKEN_RESPONSE = {
-  access_token: 'pha_new_access',
-  expires_in: 3600,
-  token_type: 'Bearer',
-  scope: 'project:read event_definition:write',
-  refresh_token: 'phr_rotated',
-  scoped_teams: [521185],
-};
-
 describe('refreshOAuthToken', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('posts a refresh_token grant with the proxy client id and parses the response', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: TOKEN_RESPONSE });
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        access_token: 'pha_new_access',
+        expires_in: 3600,
+        token_type: 'Bearer',
+        scope: 'project:read event_definition:write',
+        refresh_token: 'phr_rotated',
+      },
+    });
 
     const token = await refreshOAuthToken('phr_old');
 
-    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
     const [url, body] = mockedAxios.post.mock.calls[0];
     expect(url).toMatch(/\/oauth\/token$/);
     expect(body).toMatchObject({
@@ -42,16 +39,6 @@ describe('refreshOAuthToken', () => {
     });
     expect(token.access_token).toBe('pha_new_access');
     expect(token.refresh_token).toBe('phr_rotated');
-    expect(token.expires_in).toBe(3600);
-  });
-
-  it('targets the pinned base URL when one is given', async () => {
-    mockedAxios.post.mockResolvedValueOnce({ data: TOKEN_RESPONSE });
-
-    await refreshOAuthToken('phr_old', 'http://localhost:8010');
-
-    const [url] = mockedAxios.post.mock.calls[0];
-    expect(url).toBe('http://localhost:8010/oauth/token');
   });
 
   it('propagates a failed refresh instead of returning a stale token', async () => {

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -57,6 +57,7 @@ describe('provisionNewAccount', () => {
       accessToken: 'pha_recorded_access',
       refreshToken: 'phr_recorded_refresh',
       expiresAt,
+      oauthClientId: expect.any(String),
       projectApiKey: 'phc_recorded',
       host: 'https://us.posthog.com',
       personalApiKey: 'phx_recorded',

--- a/src/utils/__tests__/provisioning.test.ts
+++ b/src/utils/__tests__/provisioning.test.ts
@@ -39,6 +39,8 @@ describe('provisionNewAccount', () => {
       .mockResolvedValueOnce({ data: TOKEN_RESPONSE })
       .mockResolvedValueOnce({ data: RESOURCE_RESPONSE });
 
+    // Frozen clock: `expiresAt` is derived from Date.now() + expires_in.
+    vi.useFakeTimers();
     const result = await provisionNewAccount(
       'user@example.com',
       'Test User',
@@ -48,10 +50,13 @@ describe('provisionNewAccount', () => {
         projectName: 'my-app',
       },
     );
+    const expiresAt = Date.now() + TOKEN_RESPONSE.expires_in * 1000;
+    vi.useRealTimers();
 
     expect(result).toEqual({
       accessToken: 'pha_recorded_access',
       refreshToken: 'phr_recorded_refresh',
+      expiresAt,
       projectApiKey: 'phc_recorded',
       host: 'https://us.posthog.com',
       personalApiKey: 'phx_recorded',

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -414,27 +414,20 @@ async function exchangeCodeForToken(
   return token;
 }
 
-/**
- * Exchange a refresh token for a fresh access token (RFC 6749 §6). PostHog
- * rotates refresh tokens on use, so the response usually carries a new
- * `refresh_token` — callers must store it or the next refresh fails.
- */
+// Refresh-token grant (RFC 6749 §6); the server rotates, so callers must store the returned refresh_token.
 export async function refreshOAuthToken(
   refreshToken: string,
   baseUrl?: string,
 ): Promise<OAuthTokenResponse> {
-  const clientId = getOAuthClientId(baseUrl);
   const oauthUrl = getOAuthUrl(baseUrl);
-
   logToFile(`[oauth] refreshing access token at ${oauthUrl}/oauth/token`);
-  let response;
   try {
-    response = await axios.post(
+    const response = await axios.post(
       `${oauthUrl}/oauth/token`,
       {
         grant_type: 'refresh_token',
         refresh_token: refreshToken,
-        client_id: clientId,
+        client_id: getOAuthClientId(baseUrl),
       },
       {
         headers: {
@@ -444,22 +437,17 @@ export async function refreshOAuthToken(
         timeout: 30_000,
       },
     );
+    return OAuthTokenResponseSchema.parse(response.data);
   } catch (e) {
-    const status = axios.isAxiosError(e) ? e.response?.status : undefined;
     logToFile(
-      `[oauth] token refresh failed${status ? ` (HTTP ${status})` : ''}:`,
+      '[oauth] token refresh failed:',
       e instanceof Error ? e.message : e,
     );
     const refreshError = axios.isAxiosError(e)
       ? oauthErrorFromTokenBody(e.response?.data)
       : null;
-    if (refreshError) throw refreshError;
-    throw e;
+    throw refreshError ?? e;
   }
-
-  const token = OAuthTokenResponseSchema.parse(response.data);
-  logToFile('[oauth] access token refreshed');
-  return token;
 }
 
 /**

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -418,6 +418,7 @@ async function exchangeCodeForToken(
 export async function refreshAccessToken(
   refreshToken: string,
   baseUrl?: string,
+  clientId?: string,
 ): Promise<OAuthTokenResponse> {
   const oauthUrl = getOAuthUrl(baseUrl);
   logToFile(`[oauth] refreshing access token at ${oauthUrl}/oauth/token`);
@@ -427,7 +428,8 @@ export async function refreshAccessToken(
       {
         grant_type: 'refresh_token',
         refresh_token: refreshToken,
-        client_id: getOAuthClientId(baseUrl),
+        // The grant only refreshes under its minting app — provisioning signups pass their regional client.
+        client_id: clientId ?? getOAuthClientId(baseUrl),
       },
       {
         headers: {

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -415,7 +415,7 @@ async function exchangeCodeForToken(
 }
 
 // Refresh-token grant (RFC 6749 §6); the server rotates, so callers must store the returned refresh_token.
-export async function refreshOAuthToken(
+export async function refreshAccessToken(
   refreshToken: string,
   baseUrl?: string,
 ): Promise<OAuthTokenResponse> {

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -415,6 +415,54 @@ async function exchangeCodeForToken(
 }
 
 /**
+ * Exchange a refresh token for a fresh access token (RFC 6749 §6). PostHog
+ * rotates refresh tokens on use, so the response usually carries a new
+ * `refresh_token` — callers must store it or the next refresh fails.
+ */
+export async function refreshOAuthToken(
+  refreshToken: string,
+  baseUrl?: string,
+): Promise<OAuthTokenResponse> {
+  const clientId = getOAuthClientId(baseUrl);
+  const oauthUrl = getOAuthUrl(baseUrl);
+
+  logToFile(`[oauth] refreshing access token at ${oauthUrl}/oauth/token`);
+  let response;
+  try {
+    response = await axios.post(
+      `${oauthUrl}/oauth/token`,
+      {
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: clientId,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': WIZARD_USER_AGENT,
+        },
+        timeout: 30_000,
+      },
+    );
+  } catch (e) {
+    const status = axios.isAxiosError(e) ? e.response?.status : undefined;
+    logToFile(
+      `[oauth] token refresh failed${status ? ` (HTTP ${status})` : ''}:`,
+      e instanceof Error ? e.message : e,
+    );
+    const refreshError = axios.isAxiosError(e)
+      ? oauthErrorFromTokenBody(e.response?.data)
+      : null;
+    if (refreshError) throw refreshError;
+    throw e;
+  }
+
+  const token = OAuthTokenResponseSchema.parse(response.data);
+  logToFile('[oauth] access token refreshed');
+  return token;
+}
+
+/**
  * Warn — at login, while the user is still watching — when the grant came back
  * narrower than the request, and record the gap so narrowed runs are countable.
  * Non-fatal by design: deselecting an optional scope is the user's call, and

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -437,7 +437,9 @@ export async function refreshOAuthToken(
         timeout: 30_000,
       },
     );
-    return OAuthTokenResponseSchema.parse(response.data);
+    const token = OAuthTokenResponseSchema.parse(response.data);
+    logToFile('[oauth] access token refreshed');
+    return token;
   } catch (e) {
     logToFile(
       '[oauth] token refresh failed:',

--- a/src/utils/provisioning.ts
+++ b/src/utils/provisioning.ts
@@ -270,6 +270,8 @@ export interface ProvisioningResult {
   refreshToken: string;
   /** Epoch ms when `accessToken` expires. */
   expiresAt: number;
+  /** OAuth client the grant was minted under — refreshes must present the same one. */
+  oauthClientId: string;
   projectApiKey: string;
   host: string;
   personalApiKey?: string;
@@ -299,6 +301,7 @@ export async function provisionNewAccount(
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = generateCodeChallenge(codeVerifier);
   const provisioningBaseUrl = getProvisioningBaseUrl(region, opts?.baseUrl);
+  const oauthClientId = getProvisioningClientId(region, opts?.baseUrl);
 
   logToFile('[provisioning] starting account creation');
 
@@ -309,7 +312,7 @@ export async function provisionNewAccount(
       id: crypto.randomUUID(),
       email,
       name,
-      client_id: getProvisioningClientId(region, opts?.baseUrl),
+      client_id: oauthClientId,
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
       scopes: opts?.scopes ?? WIZARD_PROVISIONING_SCOPES,
@@ -431,6 +434,7 @@ export async function provisionNewAccount(
     accessToken: tokenData.access_token,
     refreshToken: tokenData.refresh_token,
     expiresAt: Date.now() + tokenData.expires_in * 1000,
+    oauthClientId,
     projectApiKey: resource.access.api_key,
     host: resource.access.host,
     personalApiKey: resource.access.personal_api_key,

--- a/src/utils/provisioning.ts
+++ b/src/utils/provisioning.ts
@@ -268,6 +268,8 @@ async function readBackResource(
 export interface ProvisioningResult {
   accessToken: string;
   refreshToken: string;
+  /** Epoch ms when `accessToken` expires. */
+  expiresAt: number;
   projectApiKey: string;
   host: string;
   personalApiKey?: string;
@@ -428,6 +430,7 @@ export async function provisionNewAccount(
   return {
     accessToken: tokenData.access_token,
     refreshToken: tokenData.refresh_token,
+    expiresAt: Date.now() + tokenData.expires_in * 1000,
     projectApiKey: resource.access.api_key,
     host: resource.access.host,
     personalApiKey: resource.access.personal_api_key,

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -46,6 +46,10 @@ import { OutroKind } from '@lib/wizard-session';
 interface ProjectData {
   projectApiKey: string;
   accessToken: string;
+  /** OAuth refresh token when the grant carried one; absent on CI/signup paths. */
+  refreshToken?: string;
+  /** Epoch ms when `accessToken` expires; absent on CI/signup paths. */
+  accessTokenExpiresAt?: number;
   host: HostResolution;
   distinctId: string;
   projectId: number;
@@ -425,6 +429,10 @@ export async function getOrAskForProjectData(
   host: HostResolution;
   projectApiKey: string;
   accessToken: string;
+  /** OAuth refresh token when the grant carried one; absent on CI/signup paths. */
+  refreshToken?: string;
+  /** Epoch ms when `accessToken` expires; absent on CI/signup paths. */
+  accessTokenExpiresAt?: number;
   projectId: number;
   roleAtOrganization: string | null;
   user: ApiUser | null;
@@ -495,6 +503,8 @@ export async function getOrAskForProjectData(
     host,
     projectApiKey,
     accessToken,
+    refreshToken,
+    accessTokenExpiresAt,
     projectId,
     roleAtOrganization,
     user,
@@ -527,6 +537,8 @@ ${cloudUrl}/settings/project#variables`);
 
   return {
     accessToken,
+    refreshToken,
+    accessTokenExpiresAt,
     host,
     projectApiKey: projectApiKey || DUMMY_PROJECT_API_KEY,
     projectId,
@@ -687,6 +699,8 @@ async function askForWizardLogin(options: {
 
   const data = {
     accessToken: tokenResponse.access_token,
+    refreshToken: tokenResponse.refresh_token,
+    accessTokenExpiresAt: Date.now() + tokenResponse.expires_in * 1000,
     projectApiKey: projectData.api_token,
     host,
     distinctId: userData.distinct_id,

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -49,7 +49,7 @@ interface ProjectData {
   /** OAuth refresh token when the grant carried one; absent on CI/signup paths. */
   refreshToken?: string;
   /** Epoch ms when `accessToken` expires; absent on CI/signup paths. */
-  accessTokenExpiresAt?: number;
+  expiresAt?: number;
   host: HostResolution;
   distinctId: string;
   projectId: number;
@@ -432,7 +432,7 @@ export async function getOrAskForProjectData(
   /** OAuth refresh token when the grant carried one; absent on CI/signup paths. */
   refreshToken?: string;
   /** Epoch ms when `accessToken` expires; absent on CI/signup paths. */
-  accessTokenExpiresAt?: number;
+  expiresAt?: number;
   projectId: number;
   roleAtOrganization: string | null;
   user: ApiUser | null;
@@ -504,7 +504,7 @@ export async function getOrAskForProjectData(
     projectApiKey,
     accessToken,
     refreshToken,
-    accessTokenExpiresAt,
+    expiresAt,
     projectId,
     roleAtOrganization,
     user,
@@ -538,7 +538,7 @@ ${cloudUrl}/settings/project#variables`);
   return {
     accessToken,
     refreshToken,
-    accessTokenExpiresAt,
+    expiresAt,
     host,
     projectApiKey: projectApiKey || DUMMY_PROJECT_API_KEY,
     projectId,
@@ -700,7 +700,7 @@ async function askForWizardLogin(options: {
   const data = {
     accessToken: tokenResponse.access_token,
     refreshToken: tokenResponse.refresh_token,
-    accessTokenExpiresAt: Date.now() + tokenResponse.expires_in * 1000,
+    expiresAt: Date.now() + tokenResponse.expires_in * 1000,
     projectApiKey: projectData.api_token,
     host,
     distinctId: userData.distinct_id,

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -50,6 +50,8 @@ interface ProjectData {
   refreshToken?: string;
   /** Epoch ms when `accessToken` expires; absent on the CI api-key path. */
   expiresAt?: number;
+  /** Minting OAuth client when it differs from the default login app (provisioning signups). */
+  oauthClientId?: string;
   host: HostResolution;
   distinctId: string;
   projectId: number;
@@ -433,6 +435,8 @@ export async function getOrAskForProjectData(
   refreshToken?: string;
   /** Epoch ms when `accessToken` expires; absent on the CI api-key path. */
   expiresAt?: number;
+  /** Minting OAuth client when it differs from the default login app (provisioning signups). */
+  oauthClientId?: string;
   projectId: number;
   roleAtOrganization: string | null;
   user: ApiUser | null;
@@ -505,6 +509,7 @@ export async function getOrAskForProjectData(
     accessToken,
     refreshToken,
     expiresAt,
+    oauthClientId,
     projectId,
     roleAtOrganization,
     user,
@@ -539,6 +544,7 @@ ${cloudUrl}/settings/project#variables`);
     accessToken,
     refreshToken,
     expiresAt,
+    oauthClientId,
     host,
     projectApiKey: projectApiKey || DUMMY_PROJECT_API_KEY,
     projectId,
@@ -759,6 +765,7 @@ async function askForProvisioningSignup(
       accessToken: result.accessToken,
       refreshToken: result.refreshToken,
       expiresAt: result.expiresAt,
+      oauthClientId: result.oauthClientId,
       projectApiKey: result.projectApiKey,
       host,
       distinctId: email,

--- a/src/utils/setup-utils.ts
+++ b/src/utils/setup-utils.ts
@@ -46,9 +46,9 @@ import { OutroKind } from '@lib/wizard-session';
 interface ProjectData {
   projectApiKey: string;
   accessToken: string;
-  /** OAuth refresh token when the grant carried one; absent on CI/signup paths. */
+  /** OAuth refresh token when the grant carried one; absent on the CI api-key path. */
   refreshToken?: string;
-  /** Epoch ms when `accessToken` expires; absent on CI/signup paths. */
+  /** Epoch ms when `accessToken` expires; absent on the CI api-key path. */
   expiresAt?: number;
   host: HostResolution;
   distinctId: string;
@@ -429,9 +429,9 @@ export async function getOrAskForProjectData(
   host: HostResolution;
   projectApiKey: string;
   accessToken: string;
-  /** OAuth refresh token when the grant carried one; absent on CI/signup paths. */
+  /** OAuth refresh token when the grant carried one; absent on the CI api-key path. */
   refreshToken?: string;
-  /** Epoch ms when `accessToken` expires; absent on CI/signup paths. */
+  /** Epoch ms when `accessToken` expires; absent on the CI api-key path. */
   expiresAt?: number;
   projectId: number;
   roleAtOrganization: string | null;
@@ -757,6 +757,8 @@ async function askForProvisioningSignup(
 
     return {
       accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      expiresAt: result.expiresAt,
       projectApiKey: result.projectApiKey,
       host,
       distinctId: email,


### PR DESCRIPTION
Wizard OAuth access tokens live 1 hour. `wizard self-driving` on an uninstrumented repo runs two agent phases on one login: initialize PostHog in the project, then set up Self-driving. The second phase inherits the first phase's aging token. If it then waits on a user prompt, the token dies mid-run and the run ends in a 401 retry storm (PHW_AUTH_INVALID_OR_EXPIRED). That chained flow is specifically what this PR fixes. The login already returns a refresh token; it was parsed and never used. Now each phase starts with a fresh token.

```
login -> credentials { accessToken, refreshToken, expiresAt }

each agent -> stale? refresh + swap : keep -> spawn agent (token frozen at spawn)
```

Limit: a single phase blocked longer than the full TTL still outlives its token — that needs longer-lived tokens server-side (`is_first_party` on the wizard OAuth app). Naming follows products/desktop. Verified live against prod: refresh fired post-login, gateway v2 mint + agent + task-stream all accepted the refreshed token, zero 401s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)