### PR TITLE
feat(gateway): record a successful mint in the run log

### DIFF
--- a/src/lib/__tests__/gateway-session.test.ts
+++ b/src/lib/__tests__/gateway-session.test.ts
@@ -8,10 +8,13 @@ import {
 } from '@lib/gateway-session';
 import type { HostResolution } from '@lib/host-resolution';
 import { analytics } from '@utils/analytics';
+import { logToFile } from '@utils/debug';
 
 vi.mock('@utils/analytics', () => ({
   analytics: { setTag: vi.fn(), captureException: vi.fn() },
 }));
+
+vi.mock('@utils/debug', () => ({ logToFile: vi.fn() }));
 
 const host = {
   apiHost: 'https://us.posthog.com',
@@ -25,6 +28,7 @@ describe('gatewayAuth', () => {
     resetGatewaySession();
     fetchMock.mockReset();
     vi.mocked(analytics.setTag).mockClear();
+    vi.mocked(logToFile).mockClear();
     vi.stubGlobal('fetch', fetchMock);
   });
 
@@ -65,6 +69,29 @@ describe('gatewayAuth', () => {
     // Second resolve inside the TTL reuses the cache, so no second mint.
     await gatewayAuth(host, 'pha_oauth', 'integration');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a successful mint without ever logging the token', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          token: 'phe_secret_value',
+          expires_at: new Date(Date.now() + 3600_000).toISOString(),
+          gateway_url: 'https://gateway.us.posthog.com',
+          team_id: 42,
+        }),
+    });
+
+    await gatewayAuth(host, 'pha_oauth', 'integration');
+
+    const lines = vi.mocked(logToFile).mock.calls.map((c) => String(c[0]));
+    const minted = lines.filter((l) => l.includes('minted a scoped token'));
+    expect(minted).toHaveLength(1);
+    expect(minted[0]).toContain('program=integration');
+    expect(minted[0]).toContain('team=42');
+    // A run that never reached the mint logs nothing, so success must say so.
+    expect(lines.join('\n')).not.toContain('phe_secret_value');
   });
 
   it('serves a short-lived token from cache instead of re-minting every call', async () => {

--- a/src/lib/__tests__/gateway-session.test.ts
+++ b/src/lib/__tests__/gateway-session.test.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'node:util';
 import {
   GatewayMintFailed,
   GatewayMintRefused,
@@ -15,6 +16,23 @@ vi.mock('@utils/analytics', () => ({
 }));
 
 vi.mock('@utils/debug', () => ({ logToFile: vi.fn() }));
+
+// logToFile is variadic, so a leak in any argument is a leak. Rendered every way the
+// sink might: JSON (which invokes getters and toJSON), an Error's stack, and inspect.
+const renderArg = (a: unknown): string => {
+  if (typeof a === 'string') return a;
+  const parts = [inspect(a, { depth: null })];
+  if (a instanceof Error) parts.push(a.stack ?? String(a));
+  try {
+    parts.push(String(JSON.stringify(a)));
+  } catch {
+    // Cyclic, so JSON.stringify throws and the sink falls back to inspect too.
+  }
+  return parts.join(' ');
+};
+
+const loggedLines = () =>
+  vi.mocked(logToFile).mock.calls.map((call) => call.map(renderArg).join(' '));
 
 const host = {
   apiHost: 'https://us.posthog.com',
@@ -85,12 +103,11 @@ describe('gatewayAuth', () => {
 
     await gatewayAuth(host, 'pha_oauth', 'integration');
 
-    const lines = vi.mocked(logToFile).mock.calls.map((c) => String(c[0]));
+    const lines = loggedLines();
     const minted = lines.filter((l) => l.includes('minted a scoped token'));
     expect(minted).toHaveLength(1);
     expect(minted[0]).toContain('program=integration');
     expect(minted[0]).toContain('team=42');
-    // A run that never reached the mint logs nothing, so success must say so.
     expect(lines.join('\n')).not.toContain('phe_secret_value');
   });
 

--- a/src/lib/gateway-session.ts
+++ b/src/lib/gateway-session.ts
@@ -109,9 +109,8 @@ async function resolveGatewayAuth(
   }
   const staleAtMs = Date.now() + ttlMs * REFRESH_AT_FRACTION;
   analytics.setTag('gateway_edition', 'v2');
-  // The only positive record of a mint. Every other branch here logs a failure,
-  // so without this a successful run and one that never reached this code look
-  // identical in the log. Never log the token itself.
+  // Only failures and fallbacks are logged otherwise, so a successful run leaves no
+  // local trace. Never log the token itself.
   logToFile(
     `[gateway] minted a scoped token: program=${program} team=${
       minted.teamId ?? 'unknown'

--- a/src/lib/gateway-session.ts
+++ b/src/lib/gateway-session.ts
@@ -109,6 +109,14 @@ async function resolveGatewayAuth(
   }
   const staleAtMs = Date.now() + ttlMs * REFRESH_AT_FRACTION;
   analytics.setTag('gateway_edition', 'v2');
+  // The only positive record of a mint. Every other branch here logs a failure,
+  // so without this a successful run and one that never reached this code look
+  // identical in the log. Never log the token itself.
+  logToFile(
+    `[gateway] minted a scoped token: program=${program} team=${
+      minted.teamId ?? 'unknown'
+    } ttl=${Math.round(ttlMs / 1000)}s url=${minted.gatewayUrl}`,
+  );
   const auth: GatewayAuth = {
     gatewayUrl: minted.gatewayUrl,
     token: minted.token,


### PR DESCRIPTION
## Problem

`resolveGatewayAuth` logs on every failure and fallback branch but nothing on success, so `posthog-wizard.log` cannot distinguish a run that minted a scoped token from one that never reached the mint.

## Changes

Adds one log line on the success path.

- Logs **program, team, TTL and gateway host** once a scoped token is adopted. **The token itself is never logged.**
- The test renders every argument of every `logToFile` call the way the sink does, so the no-leak assertion covers a token passed anywhere in a call rather than only in the first argument.

## Test plan

`npx vitest run src/lib/__tests__/gateway-session.test.ts`

The no-leak assertion is pinned by mutation: appending the mint response as a second argument, or hiding the token behind a getter or a `toJSON`, each turn it red. `logToFile` is variadic and renders every argument through `JSON.stringify`, so a guard reading only the first argument passes all three while the token reaches disk.

**Known gap:** nothing redacts at the sink, and `redactSecrets` matches `ph[xspc]_` but not the `phe_` prefix this module mints. That predates this change and is worth a follow-up, since the log is a file users are asked to attach to bug reports.

## LLM context

Authored by Claude Code (Opus 5). Requires human review.
