### PR TITLE
feat(tui): show a red notice when the terminal is too small

### DIFF
--- a/.claude/skills/ink-tui/references/TERMINAL-COMPAT.md
+++ b/.claude/skills/ink-tui/references/TERMINAL-COMPAT.md
@@ -74,6 +74,25 @@ const supportsUnicode = process.env.TERM !== 'dumb'
   && process.platform !== 'win32';
 ```
 
+## Minimum viewport
+
+The wizard has a floor: below `MIN_VIEWPORT_COLUMNS`×`MIN_VIEWPORT_ROWS` (80×28,
+in `primitives/ViewportTooSmall.tsx`) `ScreenContainer` hides the whole screen
+tree and renders a red "make this terminal bigger" notice instead. Screens can
+therefore assume at least that much room — don't add a second, screen-local
+size check, and don't design a layout that only works below the floor. If a
+screen genuinely needs more room than that, raise the constants rather than
+inventing a per-screen threshold.
+
+The 28 is measured, not picked: the framework picker overprints its intro lines
+and drops options at 27 rows and below. Re-measure in a PTY (`captureTui`) if
+you change it.
+
+The tree is hidden with `display="none"`, not unmounted, so a half-typed input
+survives the resize that shrank the window. The gate is skipped entirely when
+stdout isn't a TTY — there are no real dimensions to read and no window to
+resize.
+
 ## Responsive layouts
 
 Adapt to terminal width:

--- a/src/ui/tui/__tests__/viewport-too-small.test.ts
+++ b/src/ui/tui/__tests__/viewport-too-small.test.ts
@@ -47,7 +47,7 @@ describe('isViewportTooSmall', () => {
 describe('viewport notice text', () => {
   it('keeps the copy the product asked for in one place', () => {
     expect(VIEWPORT_TOO_SMALL_MESSAGE).toBe(
-      'Hey, can you make this terminal window a little bigger? The interactive Wizard needs more room to display properly.',
+      'The Wizard needs more room to display required text. Please make this terminal bigger.',
     );
   });
 

--- a/src/ui/tui/__tests__/viewport-too-small.test.ts
+++ b/src/ui/tui/__tests__/viewport-too-small.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The viewport gate is the one thing that has to render correctly in a
+ * terminal too small for everything else — so it wraps its own text and never
+ * emits a line wider than the window it is complaining about.
+ */
+
+import {
+  isViewportTooSmall,
+  viewportNoticeLines,
+  viewportSizeLine,
+  MIN_VIEWPORT_COLUMNS,
+  MIN_VIEWPORT_ROWS,
+  VIEWPORT_TOO_SMALL_MESSAGE,
+} from '@ui/tui/primitives/ViewportTooSmall';
+
+describe('isViewportTooSmall', () => {
+  it('passes a terminal at exactly the minimum', () => {
+    expect(isViewportTooSmall(MIN_VIEWPORT_COLUMNS, MIN_VIEWPORT_ROWS)).toBe(
+      false,
+    );
+  });
+
+  it('fails on either axis alone', () => {
+    expect(
+      isViewportTooSmall(MIN_VIEWPORT_COLUMNS - 1, MIN_VIEWPORT_ROWS),
+    ).toBe(true);
+    expect(
+      isViewportTooSmall(MIN_VIEWPORT_COLUMNS, MIN_VIEWPORT_ROWS - 1),
+    ).toBe(true);
+  });
+
+  it('passes a large terminal', () => {
+    expect(isViewportTooSmall(200, 60)).toBe(false);
+  });
+
+  it('rejects the heights that garble the framework picker (#1111)', () => {
+    // Measured against the real TUI in a PTY: 27 rows and below overprints the
+    // intro lines and drops framework options; 28 renders cleanly.
+    for (const rows of [24, 26, 27]) {
+      expect(isViewportTooSmall(110, rows)).toBe(true);
+    }
+    expect(isViewportTooSmall(110, 28)).toBe(false);
+    expect(isViewportTooSmall(80, 28)).toBe(false);
+  });
+});
+
+describe('viewport notice text', () => {
+  it('keeps the copy the product asked for in one place', () => {
+    expect(VIEWPORT_TOO_SMALL_MESSAGE).toBe(
+      'Hey, can you make this terminal window a little bigger? The interactive Wizard needs more room to display properly.',
+    );
+  });
+
+  it('wraps both lines within the terminal width instead of overflowing', () => {
+    for (const columns of [20, 34, 52, 79]) {
+      const lines = [
+        ...viewportNoticeLines(VIEWPORT_TOO_SMALL_MESSAGE, columns),
+        ...viewportNoticeLines(viewportSizeLine(columns, 10), columns),
+      ];
+      for (const line of lines) {
+        expect(line.length).toBeLessThanOrEqual(columns);
+      }
+    }
+  });
+
+  it('loses no words to the wrap', () => {
+    expect(viewportNoticeLines(VIEWPORT_TOO_SMALL_MESSAGE, 34).join(' ')).toBe(
+      VIEWPORT_TOO_SMALL_MESSAGE,
+    );
+  });
+
+  it('reports the current size against the required one', () => {
+    expect(viewportSizeLine(40, 12)).toBe(
+      `Currently 40×12, needs at least ${MIN_VIEWPORT_COLUMNS}×${MIN_VIEWPORT_ROWS}.`,
+    );
+  });
+});

--- a/src/ui/tui/playground/PlaygroundApp.tsx
+++ b/src/ui/tui/playground/PlaygroundApp.tsx
@@ -24,6 +24,7 @@ import { LearnDeckDemo } from './demos/LearnDeckDemo.js';
 import { EndScreensDemo } from './demos/EndScreensDemo.js';
 import { AiOptInDemo } from './demos/AiOptInDemo.js';
 import { AskModalDemo } from './demos/AskModalDemo.js';
+import { ViewportGuardDemo } from './demos/ViewportGuardDemo.js';
 
 interface PlaygroundAppProps {
   store: WizardStore;
@@ -95,6 +96,11 @@ export const PlaygroundApp = ({ store }: PlaygroundAppProps) => {
       id: 'ai-opt-in-nonadmin',
       label: 'AI opt-in (non-admin)',
       component: <AiOptInDemo variant="non-admin" />,
+    },
+    {
+      id: 'viewport-guard',
+      label: 'Viewport guard',
+      component: <ViewportGuardDemo />,
     },
   ];
 

--- a/src/ui/tui/playground/demos/ViewportGuardDemo.tsx
+++ b/src/ui/tui/playground/demos/ViewportGuardDemo.tsx
@@ -1,0 +1,35 @@
+/**
+ * ViewportGuardDemo — Playground demo for the ViewportTooSmall primitive.
+ *
+ * The real thing only appears when the terminal drops below the minimum, at
+ * which point the playground itself is hidden behind it — so render it here at
+ * a couple of fake sizes to see the copy and the wrapping.
+ */
+
+import { Box, Text } from 'ink';
+import {
+  ViewportTooSmall,
+  MIN_VIEWPORT_COLUMNS,
+  MIN_VIEWPORT_ROWS,
+} from '@ui/tui/primitives/index';
+
+const SAMPLES: Array<[number, number]> = [
+  [70, 8],
+  [40, 7],
+];
+
+export const ViewportGuardDemo = () => {
+  return (
+    <Box flexDirection="column" gap={1} flexGrow={1}>
+      <Text dimColor>
+        {`Shown full-screen whenever the terminal is under ${MIN_VIEWPORT_COLUMNS}×${MIN_VIEWPORT_ROWS} — shrink this window to see it for real.`}
+      </Text>
+      {SAMPLES.map(([columns, rows]) => (
+        <Box key={`${columns}x${rows}`} flexDirection="column">
+          <Text dimColor>{`at ${columns}×${rows}:`}</Text>
+          <ViewportTooSmall columns={columns} rows={rows} />
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/ui/tui/primitives/ScreenContainer.tsx
+++ b/src/ui/tui/primitives/ScreenContainer.tsx
@@ -10,7 +10,7 @@
  * screen content (inside the transition area) so all screens get it.
  */
 
-import { Box, useInput } from 'ink';
+import { Box, useInput, useStdout } from 'ink';
 import { useSyncExternalStore, type ReactNode } from 'react';
 import { TitleBar } from '@ui/tui/components/TitleBar';
 import {
@@ -22,6 +22,10 @@ import { KeyboardHintsProvider } from '@ui/tui/hooks/useKeyboardHints';
 import { DissolveTransition } from './DissolveTransition.js';
 import { KeyboardHintsBar } from './KeyboardHintsBar.js';
 import { ScreenErrorBoundary } from './ScreenErrorBoundary.js';
+import {
+  ViewportTooSmall,
+  isViewportTooSmall,
+} from './ViewportTooSmall.js';
 import type { WizardStore } from '@ui/tui/store';
 
 const MIN_WIDTH = 80;
@@ -40,6 +44,7 @@ interface ScreenContainerProps {
 
 export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
   const [columns, rows] = useStdoutDimensions();
+  const { stdout } = useStdout();
   useSyncExternalStore(
     (cb) => store.subscribe(cb),
     () => store.getSnapshot(),
@@ -71,8 +76,28 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
   const direction = store.lastNavDirection === 'pop' ? 'right' : 'left';
   const activeScreen = screens[store.currentScreen] ?? null;
 
+  // Too small to lay out: hide the screens rather than unmounting them. Yoga
+  // drops display:none subtrees from layout entirely, so the hidden tree can't
+  // overflow into the notice, and staying mounted keeps a half-typed input
+  // alive and — the reason this isn't a plain unmount — stops every screen's
+  // mount effects (browser opens, health checks, detection) from re-firing
+  // each time someone drags the window edge. The cost is that keypresses
+  // still reach the hidden screen; that's how ctrl+c keeps working, and it
+  // beats today's behaviour of typing into a garbled one.
+  //
+  // Only enforced on a real terminal: with stdout piped there are no
+  // dimensions to read (useStdoutDimensions substitutes 80×24) and no window
+  // for anyone to resize, so nagging would be both wrong and unactionable.
+  const tooSmall =
+    Boolean(stdout.isTTY) && isViewportTooSmall(columns, rows);
+
   const inner = (
-    <Box flexDirection="column" height={rows} width={width}>
+    <Box
+      flexDirection="column"
+      height={rows}
+      width={width}
+      display={tooSmall ? 'none' : 'flex'}
+    >
       <TitleBar version={store.version} width={width} />
       <Box height={1} />
       {hudVisible && (
@@ -115,6 +140,7 @@ export const ScreenContainer = ({ store, screens }: ScreenContainerProps) => {
       alignItems="center"
       justifyContent="flex-start"
     >
+      {tooSmall && <ViewportTooSmall columns={columns} rows={rows} />}
       <KeyboardHintsProvider>{inner}</KeyboardHintsProvider>
     </Box>
   );

--- a/src/ui/tui/primitives/ViewportTooSmall.tsx
+++ b/src/ui/tui/primitives/ViewportTooSmall.tsx
@@ -1,0 +1,71 @@
+/**
+ * ViewportTooSmall — The nag shown when the terminal is smaller than the
+ * wizard's layout can survive.
+ *
+ * 80 columns is the width `ScreenContainer` clamps its layout to. 28 rows is
+ * measured, not chosen: the framework picker — the tallest screen — overprints
+ * its intro lines and silently drops framework options at 27 rows and below,
+ * and renders cleanly at 28 (issue #1111). Below either bound the wizard looks
+ * broken rather than small, so say so instead of rendering.
+ */
+
+import { Box, Text } from 'ink';
+import { wordWrap } from './layout-helpers.js';
+import { Colors } from '@ui/tui/styles';
+
+/** Smallest terminal the wizard will render its screens into. */
+export const MIN_VIEWPORT_COLUMNS = 80;
+export const MIN_VIEWPORT_ROWS = 28;
+
+export const VIEWPORT_TOO_SMALL_MESSAGE =
+  'Hey, can you make this terminal window a little bigger? The interactive Wizard needs more room to display properly.';
+
+export function isViewportTooSmall(columns: number, rows: number): boolean {
+  return columns < MIN_VIEWPORT_COLUMNS || rows < MIN_VIEWPORT_ROWS;
+}
+
+/**
+ * Pre-wrap the notice rather than letting Ink wrap it: the whole point of this
+ * screen is that it renders correctly in a terminal too narrow for everything
+ * else. Accounts for the component's own paddingX={1}.
+ */
+export function viewportNoticeLines(text: string, columns: number): string[] {
+  return wordWrap(text, Math.max(20, columns - 2));
+}
+
+/** The "you have this much, you need this much" line under the message. */
+export function viewportSizeLine(columns: number, rows: number): string {
+  return `Currently ${columns}×${rows}, needs at least ${MIN_VIEWPORT_COLUMNS}×${MIN_VIEWPORT_ROWS}.`;
+}
+
+interface ViewportTooSmallProps {
+  columns: number;
+  rows: number;
+}
+
+export const ViewportTooSmall = ({ columns, rows }: ViewportTooSmallProps) => {
+  const message = viewportNoticeLines(VIEWPORT_TOO_SMALL_MESSAGE, columns);
+  const size = viewportNoticeLines(viewportSizeLine(columns, rows), columns);
+
+  return (
+    <Box
+      flexDirection="column"
+      width={columns}
+      height={rows}
+      paddingX={1}
+      justifyContent="center"
+    >
+      {message.map((line, i) => (
+        <Text key={`m${i}`} color={Colors.error} bold>
+          {line}
+        </Text>
+      ))}
+      <Box height={1} />
+      {size.map((line, i) => (
+        <Text key={`s${i}`} color={Colors.muted}>
+          {line}
+        </Text>
+      ))}
+    </Box>
+  );
+};

--- a/src/ui/tui/primitives/ViewportTooSmall.tsx
+++ b/src/ui/tui/primitives/ViewportTooSmall.tsx
@@ -18,7 +18,7 @@ export const MIN_VIEWPORT_COLUMNS = 80;
 export const MIN_VIEWPORT_ROWS = 28;
 
 export const VIEWPORT_TOO_SMALL_MESSAGE =
-  'Hey, can you make this terminal window a little bigger? The interactive Wizard needs more room to display properly.';
+  'The Wizard needs more room to display required text. Please make this terminal bigger.';
 
 export function isViewportTooSmall(columns: number, rows: number): boolean {
   return columns < MIN_VIEWPORT_COLUMNS || rows < MIN_VIEWPORT_ROWS;

--- a/src/ui/tui/primitives/index.ts
+++ b/src/ui/tui/primitives/index.ts
@@ -26,6 +26,13 @@ export { LogViewer } from './LogViewer.js';
 export { EventPlanViewer } from './EventPlanViewer.js';
 export { ScreenContainer } from './ScreenContainer.js';
 export { ScreenErrorBoundary } from './ScreenErrorBoundary.js';
+export {
+  ViewportTooSmall,
+  isViewportTooSmall,
+  MIN_VIEWPORT_COLUMNS,
+  MIN_VIEWPORT_ROWS,
+  VIEWPORT_TOO_SMALL_MESSAGE,
+} from './ViewportTooSmall.js';
 export { TabContainer } from './TabContainer.js';
 export type { TabDefinition } from './TabContainer.js';
 export { HNViewer } from './HNViewer.js';


### PR DESCRIPTION
## Problem

Below a certain size the wizard's screens overflow and get clipped by
`overflow="hidden"`, so the UI looks broken rather than small. The framework
picker is the worst case: it overprints its intro lines and silently drops
framework options once the terminal is short. Users had no signal that the fix
was simply "make the window bigger."

Closes #1111

## Changes

- New `ViewportTooSmall` primitive + `isViewportTooSmall` guard, with the
  minimum viewport as exported constants (`MIN_VIEWPORT_COLUMNS`/`ROWS`).
- `ScreenContainer` renders a red notice — *"Hey, can you make this terminal
  window a little bigger? The interactive Wizard needs more room to display
  properly."* — whenever the terminal is under the floor, and hides the screen
  tree with `display="none"` (not an unmount) so mount effects don't re-fire on
  every resize and in-progress input survives.
- The gate is skipped when stdout isn't a TTY (piped/CI), where there are no
  real dimensions and no window to resize.
- The row floor is **measured**, not guessed: the framework picker garbles at
  27 rows and renders cleanly at 28, so the minimum is 80×28.
- Playground demo + unit tests, and a note in the ink-tui skill's terminal-compat
  reference.

## Test plan

- `pnpm build && pnpm test` (2561 tests pass, typecheck + lint clean).
- Drove the real TUI in a PTY at a range of sizes: notice appears and wraps
  correctly below the floor, screens render above it, and resizing across the
  boundary swaps between them both ways.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1788202430944199?thread_ts=1788202430.944199&cid=C09GTQY5RLZ)*
