### PR TITLE
fix(privacy): stamp wizard_ai_sdk_detected after auth instead of at consent time

### DIFF
--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -11,6 +11,7 @@ import type { WizardSession } from '@lib/wizard-session';
 import { analytics } from '@utils/analytics';
 import { getUI } from '@ui';
 import { authenticate, refreshAccessTokenIfNeeded } from './authenticate';
+import { maybeStampAiSdkDetected } from '@lib/programs/posthog-integration/detect';
 import { createTriageLLMProvider } from '@lib/agent/triage-provider';
 import { gatewayAuth } from '@lib/gateway-session';
 import { resolveHarness } from '../switchboard';
@@ -252,6 +253,7 @@ export async function bootstrapProgram(
   // the first login; it does not launch another OAuth. authenticate() also
   // identifies the user and sets analytics groups.
   await authenticate(session, programConfig.id);
+  maybeStampAiSdkDetected(session);
   const project = session.apiProject;
 
   // 4.5. AI opt-in enforcement. Parks here while AiOptInRequiredScreen is

--- a/src/lib/programs/posthog-integration/__tests__/detect.test.ts
+++ b/src/lib/programs/posthog-integration/__tests__/detect.test.ts
@@ -29,6 +29,7 @@ import { analytics } from '@utils/analytics';
 import { detectWarehouseSources } from '@lib/warehouse-sources/detect';
 import {
   detectPostHogIntegration,
+  maybeStampAiSdkDetected,
   reportWarehouseSourcesDetected,
 } from '@lib/programs/posthog-integration/detect';
 import { posthogIntegrationConfig } from '@lib/programs/posthog-integration/index';
@@ -426,7 +427,7 @@ describe('wizard_ai_sdk_detected group stamp', () => {
     withOrgUser(session);
 
     await detectPostHogIntegration(makeCtx(session));
-    reportWarehouseSourcesDetected(session);
+    maybeStampAiSdkDetected(session);
 
     expect(analytics.groupIdentify).toHaveBeenCalledWith(
       'organization',
@@ -445,7 +446,7 @@ describe('wizard_ai_sdk_detected group stamp', () => {
     withOrgUser(session);
 
     await detectPostHogIntegration(makeCtx(session));
-    reportWarehouseSourcesDetected(session);
+    maybeStampAiSdkDetected(session);
 
     expect(analytics.groupIdentify).toHaveBeenCalledWith(
       'organization',
@@ -463,7 +464,7 @@ describe('wizard_ai_sdk_detected group stamp', () => {
     withOrgUser(session);
 
     await detectPostHogIntegration(makeCtx(session));
-    reportWarehouseSourcesDetected(session);
+    maybeStampAiSdkDetected(session);
 
     expect(analytics.groupIdentify).not.toHaveBeenCalled();
   });
@@ -474,7 +475,7 @@ describe('wizard_ai_sdk_detected group stamp', () => {
     withOrgUser(session);
 
     await detectPostHogIntegration(makeCtx(session));
-    reportWarehouseSourcesDetected(session);
+    maybeStampAiSdkDetected(session);
 
     expect(analytics.groupIdentify).not.toHaveBeenCalled();
   });
@@ -486,7 +487,7 @@ describe('wizard_ai_sdk_detected group stamp', () => {
     withOrgUser(session);
 
     await detectPostHogIntegration(makeCtx(session));
-    reportWarehouseSourcesDetected(session);
+    maybeStampAiSdkDetected(session);
 
     expect(analytics.groupIdentify).not.toHaveBeenCalled();
   });
@@ -497,9 +498,37 @@ describe('wizard_ai_sdk_detected group stamp', () => {
     session.scanConsent = ScanConsent.Granted;
 
     await detectPostHogIntegration(makeCtx(session));
-    reportWarehouseSourcesDetected(session);
+    maybeStampAiSdkDetected(session);
 
     expect(analytics.groupIdentify).not.toHaveBeenCalled();
+  });
+
+  // Reproduces the original dead-code bug: the intro screen resolves consent
+  // before the user has authenticated, so a stamp fired from that path would
+  // always see a null apiUser and silently no-op forever (the ordering
+  // `reportWarehouseSourcesDetected` alone cannot fix, since it only knows
+  // about consent, not login state).
+  it('stamps once authenticate() completes, not when consent resolves first', async () => {
+    withDeps({ openai: '^4.0.0' });
+    const session = buildSession({ installDir: tmpDir });
+    await detectPostHogIntegration(makeCtx(session));
+
+    // Consent resolves on the intro screen, before login — same order as
+    // production. reportWarehouseSourcesDetected runs but apiUser is still null.
+    session.scanConsent = ScanConsent.Granted;
+    reportWarehouseSourcesDetected(session);
+    expect(analytics.groupIdentify).not.toHaveBeenCalled();
+
+    // authenticate() sets apiUser; the post-auth hook runs right after it.
+    withOrgUser(session);
+    maybeStampAiSdkDetected(session);
+
+    expect(analytics.groupIdentify).toHaveBeenCalledTimes(1);
+    expect(analytics.groupIdentify).toHaveBeenCalledWith(
+      'organization',
+      'org-1',
+      { wizard_ai_sdk_detected: true },
+    );
   });
 });
 

--- a/src/lib/programs/posthog-integration/detect.ts
+++ b/src/lib/programs/posthog-integration/detect.ts
@@ -170,9 +170,30 @@ function stampAiSdkDetected(
 }
 
 /**
+ * Fires the org stamp once per session, right after `authenticate()` succeeds
+ * — never from the consent path, since consent on the intro screen resolves
+ * before login and `session.apiUser` is unset there. Called right after
+ * `authenticate()` from run-wizard.ts's auth step and from bootstrap.ts,
+ * whichever completes it first for a given program; a no-op on every call
+ * after that. In the `--ci` path, project-scope.ts authenticates first as a
+ * prerequisite (no evidence gathered yet, so nothing would stamp there
+ * anyway) and this only ever runs from the later, idempotent bootstrap.ts
+ * call — still correctly finding no evidence, since CI skips the detect step.
+ */
+export function maybeStampAiSdkDetected(session: WizardSession): void {
+  if (session.aiSdkStampReported) return;
+  session.aiSdkStampReported = true;
+  if (!mayReportScanResults(session)) return;
+
+  stampAiSdkDetected(session, getDetectedWarehouseSources(session));
+}
+
+/**
  * The single place scan results become telemetry. Called from
  * `WizardStore.completeSetup()`, the point consent becomes final — the privacy
  * panel's choice is reversible until then, so nothing may report earlier.
+ * The org stamp is a separate concern: see `maybeStampAiSdkDetected`, which
+ * runs post-auth rather than at consent resolution.
  *
  * Returns true when consent has resolved and the caller should latch
  * `warehouseSourcesReported`, which is not the same as "this sent something":
@@ -188,7 +209,6 @@ export function reportWarehouseSourcesDetected(
 
   if (mayReportScanResults(session)) {
     const sources = getDetectedWarehouseSources(session);
-    stampAiSdkDetected(session, sources);
 
     // Only an 'ok' scan has something to say. Absent means this program never
     // scanned, and reporting a zero count there would invent a scan that never

--- a/src/lib/programs/posthog-integration/detect.ts
+++ b/src/lib/programs/posthog-integration/detect.ts
@@ -181,6 +181,15 @@ function stampAiSdkDetected(
  * call — still correctly finding no evidence, since CI skips the detect step.
  */
 export function maybeStampAiSdkDetected(session: WizardSession): void {
+  // Direct mutation, not a store setter: unlike `warehouseSourcesReported`
+  // (latched only from TUI-only consent screens), this runs from
+  // `authenticate()`, which also fires in `--ci` mode, where the session is a
+  // plain object with no nanostore — see run-non-interactive.ts. A setter
+  // routed through WizardStore would silently never latch there.
+  //
+  // Depends on consent resolving before auth, same as every program's step
+  // list orders 'intro' before 'auth' today; a program that reversed that
+  // would latch this before consent exists and never stamp even once granted.
   if (session.aiSdkStampReported) return;
   session.aiSdkStampReported = true;
   if (!mayReportScanResults(session)) return;

--- a/src/lib/runners/run-wizard.ts
+++ b/src/lib/runners/run-wizard.ts
@@ -2,6 +2,7 @@ import { VERSION } from '@lib/version';
 import { logToFile, getLogFilePath } from '@utils/debug';
 import { runAgent } from '@lib/agent/agent-runner';
 import { authenticate } from '@lib/agent/runner/shared/authenticate';
+import { maybeStampAiSdkDetected } from '@lib/programs/posthog-integration/detect';
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { Harness, Sequence } from '@lib/constants';
 import type { startTUI as StartTUIFn } from '@ui/tui/start-tui';
@@ -50,6 +51,7 @@ async function advanceStep(
 ): Promise<void> {
   if (step.screenId === 'auth') {
     await authenticate(store.session, config.id);
+    maybeStampAiSdkDetected(store.session);
   } else if (step.run) {
     await step.run(await prepareRunSession(step, store.session));
     store.completeRunStep(step.id);

--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -287,6 +287,12 @@ export interface WizardSession {
   scanConsent: ScanConsent;
   /** Guards against reporting twice; consent resolves from two paths. */
   warehouseSourcesReported: boolean;
+  /**
+   * Guards `maybeStampAiSdkDetected` against running twice: it is called from
+   * both run-wizard.ts's auth step and bootstrap.ts, since either can be the
+   * first real `authenticate()` to complete depending on the program.
+   */
+  aiSdkStampReported: boolean;
   integration: Integration | null;
   frameworkContext: Record<string, unknown>;
   typescript: boolean;
@@ -496,6 +502,7 @@ export function buildSession(args: {
     // headless `--ci --signup` run stays covered by the ci branch above.
     scanConsent: args.ci ? ScanConsent.Granted : ScanConsent.Undecided,
     warehouseSourcesReported: false,
+    aiSdkStampReported: false,
     integration: args.integration ?? null,
     frameworkContext: {},
     typescript: false,


### PR DESCRIPTION
## Problem

PR #1099 added a `groupIdentify` call that sets `wizard_ai_sdk_detected: true` on the organization group. The call ran when the user answered the consent screen, which appears before login, so the session had no organization id yet. The call returned without writing, and a session flag blocked a retry after login. No organization ever received the property.

## Changes

- `maybeStampAiSdkDetected` runs right after `authenticate()` succeeds, called from run-wizard.ts and bootstrap.ts. A session flag stops it firing twice.
- Only wizard versions carrying the original disclosure write the stamp, staying post-consent by construction, unchanged from #1099.
- A `--ci` run grants consent at session build, but `ciPreRun` skips the detect step, so the stamp does not fire.
- Only flows that run posthog-integration's detect step gather AI-SDK evidence. Self-driving runs gather none today, so the stamp stays absent there. This PR does not change that.

## Test plan

A new test resolves consent with `apiUser` null, confirms the old path sends nothing, then authenticates and confirms one `groupIdentify` call. Reverting the fix fails it.

<!-- ## LLM context -->

<!-- If an LLM agent co-authored this PR, uncomment and leave relevant context about the session or tools used. -->
