### PR TITLE
feat(self-driving): show a one-time login link on the GitHub gate for provisioning signups

### DIFF
--- a/src/ui/tui/hooks/__tests__/useGithubConnection.test.ts
+++ b/src/ui/tui/hooks/__tests__/useGithubConnection.test.ts
@@ -1,4 +1,4 @@
-import { fetchSignupLoginUrl } from '@ui/tui/hooks/useGithubConnection';
+import { fetchLoginUrl } from '@ui/tui/hooks/useGithubConnection';
 import { requestDeepLink } from '@utils/provisioning';
 import type { WizardSession, Credentials } from '@lib/wizard-session';
 import type { HostResolution } from '@lib/host-resolution';
@@ -17,37 +17,54 @@ function sessionWith(over: Partial<WizardSession>): WizardSession {
   } as WizardSession;
 }
 
-describe('fetchSignupLoginUrl', () => {
+describe('fetchLoginUrl', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('skips non-signup sessions, whose browser already holds a login', async () => {
-    await expect(fetchSignupLoginUrl(sessionWith({}))).resolves.toBeNull();
+    await expect(fetchLoginUrl(sessionWith({}))).resolves.toBeNull();
     expect(mockedDeepLink).not.toHaveBeenCalled();
   });
 
   it('skips a session without credentials', async () => {
     await expect(
-      fetchSignupLoginUrl(sessionWith({ signup: true, credentials: null })),
+      fetchLoginUrl(sessionWith({ signup: true, credentials: null })),
     ).resolves.toBeNull();
     expect(mockedDeepLink).not.toHaveBeenCalled();
   });
 
-  it('returns a one-time login link for a provisioning signup', async () => {
+  it('prefers a one-time deep link when the partner tier grants one', async () => {
     mockedDeepLink.mockResolvedValueOnce('https://us.posthog.com/login/once');
 
-    await expect(
-      fetchSignupLoginUrl(sessionWith({ signup: true })),
-    ).resolves.toBe('https://us.posthog.com/login/once');
+    await expect(fetchLoginUrl(sessionWith({ signup: true }))).resolves.toBe(
+      'https://us.posthog.com/login/once',
+    );
     expect(mockedDeepLink).toHaveBeenCalledWith('pha_x', host);
   });
 
-  it('returns null when the deep link request fails', async () => {
+  // deep_links is partner-tier gated (403 today), so signups must still get a working link.
+  it('falls back to the login page when the deep link is refused', async () => {
+    mockedDeepLink.mockResolvedValueOnce(null);
+
+    await expect(fetchLoginUrl(sessionWith({ signup: true }))).resolves.toBe(
+      'https://us.posthog.com/login',
+    );
+  });
+
+  it('keeps the fallback on the credential host, so EU accounts land on EU login', async () => {
     mockedDeepLink.mockResolvedValueOnce(null);
 
     await expect(
-      fetchSignupLoginUrl(sessionWith({ signup: true })),
-    ).resolves.toBeNull();
+      fetchLoginUrl(
+        sessionWith({
+          signup: true,
+          credentials: {
+            accessToken: 'pha_x',
+            host: { appHost: 'https://eu.posthog.com' } as HostResolution,
+          } as Credentials,
+        }),
+      ),
+    ).resolves.toBe('https://eu.posthog.com/login');
   });
 });

--- a/src/ui/tui/hooks/__tests__/useGithubConnection.test.ts
+++ b/src/ui/tui/hooks/__tests__/useGithubConnection.test.ts
@@ -1,0 +1,53 @@
+import { fetchSignupLoginUrl } from '@ui/tui/hooks/useGithubConnection';
+import { requestDeepLink } from '@utils/provisioning';
+import type { WizardSession, Credentials } from '@lib/wizard-session';
+import type { HostResolution } from '@lib/host-resolution';
+
+vi.mock('@utils/provisioning', () => ({ requestDeepLink: vi.fn() }));
+
+const mockedDeepLink = requestDeepLink as Mock;
+
+const host = { appHost: 'https://us.posthog.com' } as HostResolution;
+
+function sessionWith(over: Partial<WizardSession>): WizardSession {
+  return {
+    signup: false,
+    credentials: { accessToken: 'pha_x', host } as Credentials,
+    ...over,
+  } as WizardSession;
+}
+
+describe('fetchSignupLoginUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips non-signup sessions, whose browser already holds a login', async () => {
+    await expect(fetchSignupLoginUrl(sessionWith({}))).resolves.toBeNull();
+    expect(mockedDeepLink).not.toHaveBeenCalled();
+  });
+
+  it('skips a session without credentials', async () => {
+    await expect(
+      fetchSignupLoginUrl(sessionWith({ signup: true, credentials: null })),
+    ).resolves.toBeNull();
+    expect(mockedDeepLink).not.toHaveBeenCalled();
+  });
+
+  it('returns a one-time login link for a provisioning signup', async () => {
+    mockedDeepLink.mockResolvedValueOnce('https://us.posthog.com/login/once');
+
+    await expect(
+      fetchSignupLoginUrl(sessionWith({ signup: true })),
+    ).resolves.toBe('https://us.posthog.com/login/once');
+    expect(mockedDeepLink).toHaveBeenCalledWith('pha_x', host);
+  });
+
+  it('returns null when the deep link request fails', async () => {
+    mockedDeepLink.mockResolvedValueOnce(null);
+
+    await expect(
+      fetchSignupLoginUrl(sessionWith({ signup: true })),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/ui/tui/hooks/useGithubConnection.ts
+++ b/src/ui/tui/hooks/useGithubConnection.ts
@@ -17,15 +17,16 @@ import { analytics } from '@utils/analytics';
 
 const POLL_INTERVAL_MS = 3000;
 
-// Provisioning signups have no browser login, so the install link alone strands them on a login wall.
-export async function fetchSignupLoginUrl(
+// Provisioned signups have no browser session for the install link; deep link when the partner tier grants one, else the login page.
+export async function fetchLoginUrl(
   session: WizardSession,
 ): Promise<string | null> {
   if (!session.signup || !session.credentials) return null;
-  return requestDeepLink(
+  const deepLink = await requestDeepLink(
     session.credentials.accessToken,
     session.credentials.host,
   );
+  return deepLink ?? `${session.credentials.host.appHost}/login`;
 }
 
 export function useGithubConnection(store: WizardStore): void {

--- a/src/ui/tui/hooks/useGithubConnection.ts
+++ b/src/ui/tui/hooks/useGithubConnection.ts
@@ -10,10 +10,23 @@
 import { useEffect } from 'react';
 
 import type { WizardStore } from '@ui/tui/store';
+import type { WizardSession } from '@lib/wizard-session';
 import { fetchGithubConnected } from '@lib/api';
+import { requestDeepLink } from '@utils/provisioning';
 import { analytics } from '@utils/analytics';
 
 const POLL_INTERVAL_MS = 3000;
+
+// Provisioning signups have no browser login, so the install link alone strands them on a login wall.
+export async function fetchSignupLoginUrl(
+  session: WizardSession,
+): Promise<string | null> {
+  if (!session.signup || !session.credentials) return null;
+  return requestDeepLink(
+    session.credentials.accessToken,
+    session.credentials.host,
+  );
+}
 
 export function useGithubConnection(store: WizardStore): void {
   const credentials = store.session.credentials;

--- a/src/ui/tui/screens/SelfDrivingGitHubScreen.tsx
+++ b/src/ui/tui/screens/SelfDrivingGitHubScreen.tsx
@@ -25,7 +25,7 @@ import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { useKeyBindings, KeyMatch } from '@ui/tui/hooks/useKeyBindings';
 import {
   useGithubConnection,
-  fetchSignupLoginUrl,
+  fetchLoginUrl,
 } from '@ui/tui/hooks/useGithubConnection';
 import { OutroKind } from '@lib/wizard-session';
 import {
@@ -71,13 +71,13 @@ export const SelfDrivingGitHubScreen = ({
   // is confusing — the poll flips the screen on its own when the install lands.
   const [installOpened, setInstallOpened] = useState(false);
 
-  // One-time login link for provisioning signups, whose browser holds no session for the install link.
+  // One-time login link for browsers without a PostHog session (fresh provisioned accounts).
   const [loginUrl, setLoginUrl] = useState<string | null>(null);
   const loginUrlRequested = useRef(false);
   useEffect(() => {
     if (loginUrlRequested.current) return;
     loginUrlRequested.current = true;
-    void fetchSignupLoginUrl(store.session).then(setLoginUrl);
+    void fetchLoginUrl(store.session).then(setLoginUrl);
   }, [store]);
 
   // Impression fires once the connected state is known, so `already_connected`

--- a/src/ui/tui/screens/SelfDrivingGitHubScreen.tsx
+++ b/src/ui/tui/screens/SelfDrivingGitHubScreen.tsx
@@ -23,7 +23,10 @@ import type { WizardStore } from '@ui/tui/store';
 import { Colors, Icons } from '@ui/tui/styles';
 import { PickerMenu, LoadingBox } from '@ui/tui/primitives/index';
 import { useKeyBindings, KeyMatch } from '@ui/tui/hooks/useKeyBindings';
-import { useGithubConnection } from '@ui/tui/hooks/useGithubConnection';
+import {
+  useGithubConnection,
+  fetchSignupLoginUrl,
+} from '@ui/tui/hooks/useGithubConnection';
 import { OutroKind } from '@lib/wizard-session';
 import {
   GITHUB_REQUIRED_BODY,
@@ -67,6 +70,15 @@ export const SelfDrivingGitHubScreen = ({
   // Once the install link has been opened, re-offering it as the headline CTA
   // is confusing — the poll flips the screen on its own when the install lands.
   const [installOpened, setInstallOpened] = useState(false);
+
+  // One-time login link for provisioning signups, whose browser holds no session for the install link.
+  const [loginUrl, setLoginUrl] = useState<string | null>(null);
+  const loginUrlRequested = useRef(false);
+  useEffect(() => {
+    if (loginUrlRequested.current) return;
+    loginUrlRequested.current = true;
+    void fetchSignupLoginUrl(store.session).then(setLoginUrl);
+  }, [store]);
 
   // Impression fires once the connected state is known, so `already_connected`
   // is real: users who arrive connected segment apart from users who connect
@@ -164,6 +176,15 @@ export const SelfDrivingGitHubScreen = ({
               <Text color="cyan">{Icons.diamond} </Text>
               Grant it the repos you want Self-driving to work with — include
               this project&apos;s repo so it can also watch its issues.
+            </Text>
+          </Box>
+        )}
+
+        {loginUrl && (
+          <Box marginTop={1}>
+            <Text dimColor>
+              {'Log in to your new account first: '}
+              <Text color="cyan">{loginUrl}</Text>
             </Text>
           </Box>
         )}

--- a/src/ui/tui/screens/SelfDrivingIntegrationDetectScreen.tsx
+++ b/src/ui/tui/screens/SelfDrivingIntegrationDetectScreen.tsx
@@ -144,7 +144,7 @@ export const SelfDrivingIntegrationDetectScreen = ({
     return (
       <Box flexDirection="column">
         <Text bold color={Colors.accent}>
-          Detecting your project...
+          Detecting your project. Stick around, this will take a few seconds...
         </Text>
         <Box marginY={1}>
           <LoadingBox message="Scanning the repo for frameworks and PostHog SDKs..." />


### PR DESCRIPTION
Provisioned signup accounts have no browser session, so the GitHub gate stranded them on a login wall; it now shows a login link first (one-time deep link when the partner tier grants one, the regional login page otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)