### PR TITLE
fix(mcp-analytics): accept CI region option

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -318,6 +318,21 @@ describe('CLI argument parsing', () => {
   });
 
   describe('--ci flag', () => {
+    test('accepts --region for a flat program command', async () => {
+      await runCLI([
+        'mcp-analytics',
+        '--ci',
+        '--region',
+        'us',
+        '--api-key',
+        'phx_test',
+        '--install-dir',
+        '/tmp/test',
+      ]);
+
+      expect(process.exit).not.toHaveBeenCalledWith(1);
+    });
+
     test('defaults to false when not specified', async () => {
       await runCLI([]);
 

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -208,14 +208,6 @@ describe('flat skill commands', () => {
 });
 
 describe('yargs parsing for program commands', () => {
-  test('accepts the CI region for mcp-analytics', async () => {
-    const argv = await parseCommand(
-      mcpAnalyticsCommand,
-      'mcp-analytics --region us',
-    );
-    expect(argv.region).toBe('us');
-  });
-
   test('camelCases --install-dir end-to-end', async () => {
     const argv = await parseCommand(
       auditCommand,

--- a/src/__tests__/programs-cli.test.ts
+++ b/src/__tests__/programs-cli.test.ts
@@ -207,7 +207,15 @@ describe('flat skill commands', () => {
   });
 });
 
-describe('yargs parsing for the audit family', () => {
+describe('yargs parsing for program commands', () => {
+  test('accepts the CI region for mcp-analytics', async () => {
+    const argv = await parseCommand(
+      mcpAnalyticsCommand,
+      'mcp-analytics --region us',
+    );
+    expect(argv.region).toBe('us');
+  });
+
   test('camelCases --install-dir end-to-end', async () => {
     const argv = await parseCommand(
       auditCommand,

--- a/src/lib/programs/mcp-analytics/index.ts
+++ b/src/lib/programs/mcp-analytics/index.ts
@@ -1,6 +1,5 @@
 import type { AbortCase } from '@lib/agent/agent-runner';
 import { ErrorCodes } from '@lib/errors';
-import { regionOption } from '@lib/headless-mode';
 import { createSkillProgram } from '@lib/programs/agent-skill/index';
 
 const MCP_ANALYTICS_REPORT_FILE = 'posthog-mcp-analytics-report.md';
@@ -73,6 +72,5 @@ export const mcpAnalyticsConfig = createSkillProgram({
   docsUrl: 'https://posthog.com/docs/mcp-analytics',
   spinnerMessage: 'Setting up MCP analytics...',
   estimatedDurationMinutes: 5,
-  cliOptions: regionOption,
   abortCases: MCP_ANALYTICS_ABORT_CASES,
 });

--- a/src/lib/programs/mcp-analytics/index.ts
+++ b/src/lib/programs/mcp-analytics/index.ts
@@ -1,5 +1,6 @@
 import type { AbortCase } from '@lib/agent/agent-runner';
 import { ErrorCodes } from '@lib/errors';
+import { regionOption } from '@lib/headless-mode';
 import { createSkillProgram } from '@lib/programs/agent-skill/index';
 
 const MCP_ANALYTICS_REPORT_FILE = 'posthog-mcp-analytics-report.md';
@@ -72,5 +73,6 @@ export const mcpAnalyticsConfig = createSkillProgram({
   docsUrl: 'https://posthog.com/docs/mcp-analytics',
   spinnerMessage: 'Setting up MCP analytics...',
   estimatedDurationMinutes: 5,
+  cliOptions: regionOption,
   abortCases: MCP_ANALYTICS_ABORT_CASES,
 });

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -3,6 +3,7 @@ import { hideBin } from 'yargs/helpers';
 import type { Argv } from 'yargs';
 import { IS_PRODUCTION_BUILD } from '@env';
 import { Harness, Sequence } from '@lib/constants';
+import { regionOption } from '@lib/headless-mode';
 import { initLocalDev, localMcpSkillsNotice } from '@lib/local-dev';
 import { toCommandModule, type Command } from './commands/command';
 import { ErrorCodes } from '@lib/errors';
@@ -90,13 +91,13 @@ export class Wizard {
     // it there as an unknown argument — exactly like any other unrecognized
     // flag. init() additionally detects it up front to print a clearer message.
     // The published-build, non-interactive path is the experimental headless
-    // flag — declared per-command on basic integration + audit via
-    // `headlessOption` (see @lib/headless-mode), not globally, so no other
-    // command accepts it. --ci and headless are kept as separate flags so they
-    // can diverge — see basic-integration's dispatch. headless is deliberately
-    // not advertised.
+    // flag, declared per-command on basic integration + audit via
+    // `headlessOption` (see @lib/headless-mode), so no other command accepts
+    // it. CI needs `region` globally because the workbench passes it to every
+    // command. --ci and headless stay separate so their behavior can diverge.
     if (!IS_PRODUCTION_BUILD) {
       cli = cli
+        .options(regionOption)
         .option('ci', {
           default: false,
           describe:


### PR DESCRIPTION
## Problem

Wizard CI cannot run MCP Analytics fixtures because flat program commands reject the shared `--region` option.

The failure affects both MCP Analytics workbench fixtures in [this run](https://github.com/PostHog/wizard-workbench/actions/runs/33540708281).

## Changes

- Dev and test builds now register the existing hidden region option globally, matching how the workbench invokes every command.
- Published CLI behavior stays unchanged; headless region support remains scoped to its supported commands.
- A full CLI regression test protects the built command shape that failed in the workbench.

## Test plan

- `pnpm test` - 2,580 tests passed.
- `pnpm fix` - completed with no errors and existing warnings only.
- `pnpm build:ci` - passed.
- The built CLI accepts `mcp-analytics --ci --region us` and advances to its local-service preflight.

## LLM context

Codex diagnosed the workbench failure, reproduced the built-CLI discrepancy, and replaced the command-level workaround with the shared CI option registration.
