### PR TITLE
fix(replay-vision): clear abort when no framework is detected

### DIFF
--- a/src/lib/programs/replay-vision/index.ts
+++ b/src/lib/programs/replay-vision/index.ts
@@ -68,6 +68,19 @@ async function abortUnsupportedPlatform(
   });
 }
 
+async function abortNoFrameworkDetected(): Promise<void> {
+  await wizardAbort({
+    code: ErrorCodes.DetectNoFramework,
+    message:
+      "Replay vision couldn't detect a framework here, so it has nothing " +
+      'to scope its scanners to.\n\n' +
+      "Make sure you're running this from your app's root directory " +
+      '(where its package.json or framework-equivalent lives), not an ' +
+      'empty or unrelated folder. See what replay supports at:\n' +
+      '  https://posthog.com/docs/session-replay',
+  });
+}
+
 /**
  * `[ABORT]` reasons the replay-vision skill emits when the run can't proceed.
  * Kept in sync with the stop conditions in the skill's `description.md`
@@ -103,14 +116,12 @@ const DETECT_STEP: ProgramStep = {
   onReady: async (ctx: ProgramReadyContext) => {
     const integration = await detectFramework(ctx.session.installDir);
     if (!integration) {
-      // Mirrors ciPreRun below: with nothing to key off of, the orchestrator's
-      // preflight can't resolve any task's mini-skill variants and would
-      // otherwise abort later with a misleading "failed to download" error.
-      // Fail here instead, with a message that names the actual problem.
-      await wizardAbort({
-        code: ErrorCodes.DetectNoFramework,
-        message: 'Could not auto-detect your framework for this project.',
-      });
+      // Same early-abort ciPreRun does below: with nothing to key off of,
+      // the orchestrator's preflight can't resolve any task's mini-skill
+      // variants and would otherwise abort later with a misleading "failed
+      // to download" error. Fail here instead, with a message that names
+      // the actual problem and what to do about it.
+      await abortNoFrameworkDetected();
       return;
     }
     if (!REPLAY_VISION_SUPPORTED.has(integration)) {

--- a/src/lib/programs/replay-vision/index.ts
+++ b/src/lib/programs/replay-vision/index.ts
@@ -102,7 +102,18 @@ const DETECT_STEP: ProgramStep = {
   // be the stale pre-copy object (see the warning in detect.ts).
   onReady: async (ctx: ProgramReadyContext) => {
     const integration = await detectFramework(ctx.session.installDir);
-    if (integration && !REPLAY_VISION_SUPPORTED.has(integration)) {
+    if (!integration) {
+      // Mirrors ciPreRun below: with nothing to key off of, the orchestrator's
+      // preflight can't resolve any task's mini-skill variants and would
+      // otherwise abort later with a misleading "failed to download" error.
+      // Fail here instead, with a message that names the actual problem.
+      await wizardAbort({
+        code: ErrorCodes.DetectNoFramework,
+        message: 'Could not auto-detect your framework for this project.',
+      });
+      return;
+    }
+    if (!REPLAY_VISION_SUPPORTED.has(integration)) {
       await abortUnsupportedPlatform(integration);
       return;
     }


### PR DESCRIPTION
## Summary
- Running `replay-vision` against an empty repo (or one with no recognizable framework) surfaced a misleading "Setup instructions for this project failed to download" error, because `DETECT_STEP.onReady` had no guard for "nothing detected at all" — only for "detected something unsupported." With `session.skillId` left unset, the orchestrator's preflight failed every mini-skill variant lookup and reported it as a download failure.
- `ciPreRun` (the CI/headless path) already handled this correctly by aborting early with `ErrorCodes.DetectNoFramework`. This adds the equivalent guard to the interactive path, `DETECT_STEP.onReady`.
- Since a human is actually present on this path (unlike CI), the abort message goes further than `ciPreRun`'s terse one — it names the problem and what to do about it, matching the tone of the neighboring `abortUnsupportedPlatform` message:

  > Replay vision couldn't detect a framework here, so it has nothing to scope its scanners to.
  >
  > Make sure you're running this from your app's root directory (where its package.json or framework-equivalent lives), not an empty or unrelated folder. See what replay supports at:
  >   https://posthog.com/docs/session-replay

## Test plan
- [x] `pnpm vitest run src/lib/programs/__tests__/replay-vision.test.ts` — all 6 pass
- [x] `pnpm vitest run src/lib/programs/` — all 264 pass, no regressions
- [x] `npx tsc --noEmit` — no new errors introduced by this change
- [x] `eslint` / `prettier --check` — clean
- [x] Manually reproduced via `pnpm try replay-vision --install-dir=<empty-dir>` before/after: old code shows the misleading download-failure message, new code shows the clear framework-detection message