### PR TITLE
feat: fallback to aws after github retries for context mill downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,9 @@ degradedBlocksRun: ['anthropic'],
 GitHub Releases and an AWS mirror under the same filenames, and downloads fail
 over between them (`src/lib/fetch-retry.ts`). Both are probed in parallel, so
 the key only reports **Down** when neither origin answers — a GitHub Releases
-outage on its own doesn't block a run.
+outage on its own doesn't block a run, including a 403 or 404, which is as
+often about the origin (expired asset redirect, blocked region, a publish that
+reached one origin and not the other) as about the asset.
 
 ## Smoke test helper (`scripts/smoke-test-ci.sh`)
 

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ point is `evaluateWizardReadiness()`, which returns one of three values:
 | --- | --- |
 | `types.ts` | Enums, interfaces (`ServiceHealthStatus`, `AllServicesHealth`, etc.) |
 | `statuspage.ts` | Statuspage.io v2 API helpers + checks for Anthropic, PostHog, GitHub, npm, Cloudflare |
-| `endpoints.ts` | Direct endpoint checks for LLM Gateway (`/_liveness`) and MCP (`/`) |
+| `endpoints.ts` | Direct endpoint checks for LLM Gateway (`/_liveness`), MCP (`/`), and the skills origins (`skill-menu.json` on GitHub Releases + the AWS mirror) |
 | `readiness.ts` | `checkAllExternalServices`, `evaluateWizardReadiness`, readiness config |
 | `index.ts` | Barrel re-export |
 | `testme.md` | Test running instructions and endpoint reference |
@@ -632,9 +632,15 @@ two arrays:
 ### Current defaults
 
 ```ts
-downBlocksRun: ['anthropic', 'posthogOverall', 'npmOverall', 'llmGateway', 'mcp'],
+downBlocksRun: ['anthropic', 'npmOverall', 'llmGateway', 'mcp', 'skillsOrigin'],
 degradedBlocksRun: ['anthropic'],
 ```
+
+`skillsOrigin` is one entry covering two origins: skills are published to
+GitHub Releases and an AWS mirror under the same filenames, and downloads fail
+over between them (`src/lib/fetch-retry.ts`). Both are probed in parallel, so
+the key only reports **Down** when neither origin answers — a GitHub Releases
+outage on its own doesn't block a run.
 
 ## Smoke test helper (`scripts/smoke-test-ci.sh`)
 

--- a/src/lib/__tests__/fetch-retry.test.ts
+++ b/src/lib/__tests__/fetch-retry.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  fetchWithRetry,
+  awsUrlFor,
+  resetOriginPreference,
+} from '../fetch-retry';
+import { GITHUB_SKILLS_BASE_URL, AWS_SKILLS_BASE_URL } from '../constants';
+
+const GH_LATEST =
+  'https://github.com/PostHog/context-mill/releases/latest/download';
+const GH_PINNED =
+  'https://github.com/PostHog/context-mill/releases/download/v1.50.0';
+const AWS = 'https://context-mill.posthog.com';
+
+const ok = (body = 'BODY') =>
+  new Response(body, { status: 200, statusText: 'OK' });
+const status = (code: number) =>
+  new Response('', { status: code, statusText: String(code) });
+
+/** Records every URL fetched and answers from a per-host script. */
+function makeFetch(handler: (url: string) => Response | Error) {
+  const calls: string[] = [];
+  const impl = ((url: string) => {
+    calls.push(url);
+    const result = handler(url);
+    return result instanceof Error
+      ? Promise.reject(result)
+      : Promise.resolve(result);
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+/** No real sleeping, no analytics client. */
+const base = {
+  sleepImpl: () => Promise.resolve(),
+  onEvent: () => undefined,
+};
+const events: Array<{ event: string; props: Record<string, unknown> }> = [];
+const capturing = {
+  ...base,
+  onEvent: (event: string, props: Record<string, unknown>) => {
+    events.push({ event, props });
+  },
+};
+
+beforeEach(() => {
+  resetOriginPreference();
+  events.length = 0;
+});
+
+describe('awsUrlFor', () => {
+  it('maps the floating latest URL shape', () => {
+    expect(awsUrlFor(`${GH_LATEST}/skill-menu.json`)).toBe(
+      `${AWS}/latest/skill-menu.json`,
+    );
+  });
+
+  it('maps the version-pinned URL shape', () => {
+    expect(awsUrlFor(`${GH_PINNED}/audit-events.zip`)).toBe(
+      `${AWS}/v1.50.0/audit-events.zip`,
+    );
+  });
+
+  it('returns null for a URL with no second origin, e.g. local dev', () => {
+    expect(awsUrlFor('http://localhost:8080/skill-menu.json')).toBeNull();
+    expect(awsUrlFor('https://example.com/x.zip')).toBeNull();
+  });
+
+  // Locks the property that makes flipping primary a config change.
+  it('keeps the two origin constants the same shape', () => {
+    expect(awsUrlFor(`${GITHUB_SKILLS_BASE_URL}/skill-menu.json`)).toBe(
+      `${AWS_SKILLS_BASE_URL}/skill-menu.json`,
+    );
+  });
+});
+
+describe('fetchWithRetry', () => {
+  it('returns the GitHub response without touching AWS', async () => {
+    const { impl, calls } = makeFetch(() => ok());
+    const resp = await fetchWithRetry(`${GH_LATEST}/skill-menu.json`, {
+      ...base,
+      fetchImpl: impl,
+    });
+    expect(resp.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('github.com');
+  });
+
+  it('retries GitHub with backoff before failing over to AWS', async () => {
+    const { impl, calls } = makeFetch((url) =>
+      url.includes('github.com') ? new Error('ECONNREFUSED') : ok(),
+    );
+    const resp = await fetchWithRetry(`${GH_LATEST}/skill-menu.json`, {
+      ...base,
+      fetchImpl: impl,
+    });
+    expect(resp.status).toBe(200);
+    // Three attempts at GitHub, then one at AWS.
+    expect(calls.filter((u) => u.includes('github.com'))).toHaveLength(3);
+    expect(calls.at(-1)).toBe(`${AWS}/latest/skill-menu.json`);
+  });
+
+  it.each([500, 502, 503, 429, 408])('fails over on HTTP %i', async (code) => {
+    const { impl, calls } = makeFetch((url) =>
+      url.includes('github.com') ? status(code) : ok(),
+    );
+    const resp = await fetchWithRetry(`${GH_PINNED}/audit-events.zip`, {
+      ...base,
+      fetchImpl: impl,
+    });
+    expect(resp.status).toBe(200);
+    expect(calls.at(-1)).toBe(`${AWS}/v1.50.0/audit-events.zip`);
+  });
+
+  it.each([404, 403, 401, 400])(
+    'does NOT fail over or retry on HTTP %i — the asset, not the origin',
+    async (code) => {
+      const { impl, calls } = makeFetch(() => status(code));
+      await expect(
+        fetchWithRetry(`${GH_PINNED}/missing.zip`, {
+          ...base,
+          fetchImpl: impl,
+        }),
+      ).rejects.toThrow(`HTTP ${code}`);
+      // One attempt, one origin: no retry budget spent, AWS never probed.
+      expect(calls).toHaveLength(1);
+      expect(calls.every((u) => u.includes('github.com'))).toBe(true);
+    },
+  );
+
+  it('throws when both origins are exhausted', async () => {
+    const { impl, calls } = makeFetch(() => new Error('ENOTFOUND'));
+    await expect(
+      fetchWithRetry(`${GH_LATEST}/skill-menu.json`, {
+        ...base,
+        fetchImpl: impl,
+      }),
+    ).rejects.toThrow(/github:.*\| aws:/s);
+    expect(calls).toHaveLength(6); // 3 per origin
+  });
+
+  it('is sticky: later fetches go straight to AWS', async () => {
+    const { impl, calls } = makeFetch((url) =>
+      url.includes('github.com') ? new Error('ECONNREFUSED') : ok(),
+    );
+    const opts = { ...base, fetchImpl: impl };
+    await fetchWithRetry(`${GH_LATEST}/skill-menu.json`, opts);
+    const afterFirst = calls.length;
+
+    await fetchWithRetry(`${GH_PINNED}/audit-events.zip`, opts);
+    const second = calls.slice(afterFirst);
+    // No re-probing of dead GitHub — that is the whole point of sticky.
+    expect(second).toEqual([`${AWS}/v1.50.0/audit-events.zip`]);
+  });
+
+  it('falls back to GitHub if AWS dies after a failover', async () => {
+    let awsAlive = true;
+    let githubAlive = false;
+    const { impl } = makeFetch((url) => {
+      if (url.includes('github.com')) {
+        return githubAlive ? ok() : new Error('down');
+      }
+      return awsAlive ? ok() : new Error('aws down');
+    });
+    const opts = { ...base, fetchImpl: impl };
+
+    await fetchWithRetry(`${GH_LATEST}/skill-menu.json`, opts); // sticks to AWS
+    awsAlive = false;
+    githubAlive = true;
+    const resp = await fetchWithRetry(`${GH_PINNED}/audit-events.zip`, opts);
+    expect(resp.status).toBe(200);
+  });
+
+  it('does not reach for AWS when failover is off', async () => {
+    const { impl, calls } = makeFetch(() => new Error('ECONNREFUSED'));
+    await expect(
+      fetchWithRetry(`${GH_LATEST}/skill-menu.json`, {
+        ...base,
+        fetchImpl: impl,
+        failover: false,
+      }),
+    ).rejects.toThrow();
+    expect(calls.every((u) => u.includes('github.com'))).toBe(true);
+  });
+
+  it('does not fail over a URL that has no AWS equivalent', async () => {
+    const { impl, calls } = makeFetch(() => new Error('ECONNREFUSED'));
+    await expect(
+      fetchWithRetry('http://localhost:8080/skill-menu.json', {
+        ...base,
+        fetchImpl: impl,
+      }),
+    ).rejects.toThrow();
+    expect(calls.every((u) => u.startsWith('http://localhost'))).toBe(true);
+  });
+
+  it('reports the origin transition once, not per fetch', async () => {
+    const { impl } = makeFetch((url) =>
+      url.includes('github.com') ? new Error('ECONNREFUSED') : ok(),
+    );
+    const opts = { ...capturing, fetchImpl: impl };
+    await fetchWithRetry(`${GH_LATEST}/skill-menu.json`, opts);
+    await fetchWithRetry(`${GH_PINNED}/audit-events.zip`, opts);
+
+    const failovers = events.filter(
+      (e) => e.event === 'skills fetch failed over',
+    );
+    expect(failovers).toHaveLength(1);
+    expect(failovers[0].props.origin).toBe('aws');
+  });
+
+  it('reports exhaustion when neither origin answers', async () => {
+    const { impl } = makeFetch(() => new Error('ENOTFOUND'));
+    await expect(
+      fetchWithRetry(`${GH_LATEST}/skill-menu.json`, {
+        ...capturing,
+        fetchImpl: impl,
+      }),
+    ).rejects.toThrow();
+    expect(events.map((e) => e.event)).toContain('skills fetch failed');
+  });
+});

--- a/src/lib/__tests__/fetch-retry.test.ts
+++ b/src/lib/__tests__/fetch-retry.test.ts
@@ -116,7 +116,7 @@ describe('fetchWithRetry', () => {
   });
 
   it.each([404, 403, 401, 400])(
-    'does NOT fail over or retry on HTTP %i — the asset, not the origin',
+    'retries HTTP %i at each origin, same as any other failure',
     async (code) => {
       const { impl, calls } = makeFetch(() => status(code));
       await expect(
@@ -125,9 +125,35 @@ describe('fetchWithRetry', () => {
           fetchImpl: impl,
         }),
       ).rejects.toThrow(`HTTP ${code}`);
-      // One attempt, one origin: no retry budget spent, AWS never probed.
-      expect(calls).toHaveLength(1);
-      expect(calls.every(isGitHub)).toBe(true);
+      expect(calls.filter(isGitHub)).toHaveLength(3);
+      expect(calls).toHaveLength(6);
+      expect(calls.at(-1)).toBe(`${AWS}/v1.50.0/missing.zip`);
+    },
+  );
+
+  it('collapses identical attempt failures into one message', async () => {
+    const { impl } = makeFetch(() => status(404));
+    await expect(
+      fetchWithRetry(`${GH_PINNED}/missing.zip`, { ...base, fetchImpl: impl }),
+    ).rejects.toThrow(
+      /github: HTTP 404 404 \(x3\) \| aws: HTTP 404 404 \(x3\)/,
+    );
+  });
+
+  it.each([404, 403])(
+    'recovers when GitHub %is but AWS has the asset',
+    async (code) => {
+      const { impl, calls } = makeFetch((url) =>
+        isGitHub(url) ? status(code) : ok(),
+      );
+      const resp = await fetchWithRetry(`${GH_PINNED}/audit-events.zip`, {
+        ...base,
+        fetchImpl: impl,
+      });
+      expect(resp.status).toBe(200);
+      // GitHub 403s expired asset redirects and blocked regions; the asset is
+      // there, just not for us.
+      expect(calls.at(-1)).toBe(`${AWS}/v1.50.0/audit-events.zip`);
     },
   );
 

--- a/src/lib/__tests__/fetch-retry.test.ts
+++ b/src/lib/__tests__/fetch-retry.test.ts
@@ -12,6 +12,9 @@ const GH_PINNED =
   'https://github.com/PostHog/context-mill/releases/download/v1.50.0';
 const AWS = 'https://context-mill.posthog.com';
 
+/** Host equality, not substring: `evil.com/?u=github.com` is not GitHub. */
+const isGitHub = (url: string) => new URL(url).hostname === 'github.com';
+
 const ok = (body = 'BODY') =>
   new Response(body, { status: 200, statusText: 'OK' });
 const status = (code: number) =>
@@ -83,12 +86,12 @@ describe('fetchWithRetry', () => {
     });
     expect(resp.status).toBe(200);
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain('github.com');
+    expect(isGitHub(calls[0])).toBe(true);
   });
 
   it('retries GitHub with backoff before failing over to AWS', async () => {
     const { impl, calls } = makeFetch((url) =>
-      url.includes('github.com') ? new Error('ECONNREFUSED') : ok(),
+      isGitHub(url) ? new Error('ECONNREFUSED') : ok(),
     );
     const resp = await fetchWithRetry(`${GH_LATEST}/skill-menu.json`, {
       ...base,
@@ -96,13 +99,13 @@ describe('fetchWithRetry', () => {
     });
     expect(resp.status).toBe(200);
     // Three attempts at GitHub, then one at AWS.
-    expect(calls.filter((u) => u.includes('github.com'))).toHaveLength(3);
+    expect(calls.filter(isGitHub)).toHaveLength(3);
     expect(calls.at(-1)).toBe(`${AWS}/latest/skill-menu.json`);
   });
 
   it.each([500, 502, 503, 429, 408])('fails over on HTTP %i', async (code) => {
     const { impl, calls } = makeFetch((url) =>
-      url.includes('github.com') ? status(code) : ok(),
+      isGitHub(url) ? status(code) : ok(),
     );
     const resp = await fetchWithRetry(`${GH_PINNED}/audit-events.zip`, {
       ...base,
@@ -124,7 +127,7 @@ describe('fetchWithRetry', () => {
       ).rejects.toThrow(`HTTP ${code}`);
       // One attempt, one origin: no retry budget spent, AWS never probed.
       expect(calls).toHaveLength(1);
-      expect(calls.every((u) => u.includes('github.com'))).toBe(true);
+      expect(calls.every(isGitHub)).toBe(true);
     },
   );
 
@@ -141,7 +144,7 @@ describe('fetchWithRetry', () => {
 
   it('is sticky: later fetches go straight to AWS', async () => {
     const { impl, calls } = makeFetch((url) =>
-      url.includes('github.com') ? new Error('ECONNREFUSED') : ok(),
+      isGitHub(url) ? new Error('ECONNREFUSED') : ok(),
     );
     const opts = { ...base, fetchImpl: impl };
     await fetchWithRetry(`${GH_LATEST}/skill-menu.json`, opts);
@@ -157,7 +160,7 @@ describe('fetchWithRetry', () => {
     let awsAlive = true;
     let githubAlive = false;
     const { impl } = makeFetch((url) => {
-      if (url.includes('github.com')) {
+      if (isGitHub(url)) {
         return githubAlive ? ok() : new Error('down');
       }
       return awsAlive ? ok() : new Error('aws down');
@@ -180,7 +183,7 @@ describe('fetchWithRetry', () => {
         failover: false,
       }),
     ).rejects.toThrow();
-    expect(calls.every((u) => u.includes('github.com'))).toBe(true);
+    expect(calls.every(isGitHub)).toBe(true);
   });
 
   it('does not fail over a URL that has no AWS equivalent', async () => {
@@ -196,7 +199,7 @@ describe('fetchWithRetry', () => {
 
   it('reports the origin transition once, not per fetch', async () => {
     const { impl } = makeFetch((url) =>
-      url.includes('github.com') ? new Error('ECONNREFUSED') : ok(),
+      isGitHub(url) ? new Error('ECONNREFUSED') : ok(),
     );
     const opts = { ...capturing, fetchImpl: impl };
     await fetchWithRetry(`${GH_LATEST}/skill-menu.json`, opts);

--- a/src/lib/__tests__/local-dev.test.ts
+++ b/src/lib/__tests__/local-dev.test.ts
@@ -14,7 +14,7 @@ import {
 } from '@lib/local-dev';
 import {
   getSkillsBaseUrl,
-  REMOTE_SKILLS_BASE_URL,
+  GITHUB_SKILLS_BASE_URL,
   LOCAL_SKILLS_BASE_URL,
 } from '@lib/constants';
 
@@ -119,7 +119,7 @@ describe('getSkillsBaseUrl', () => {
   // argument precisely so no caller can hand it the MCP flag.
   it('follows the context-mill flag, not the MCP flag', () => {
     initLocalDev({ localMcp: true });
-    expect(getSkillsBaseUrl()).toBe(REMOTE_SKILLS_BASE_URL);
+    expect(getSkillsBaseUrl()).toBe(GITHUB_SKILLS_BASE_URL);
 
     initLocalDev({ localContextMill: true });
     expect(getSkillsBaseUrl()).toBe(LOCAL_SKILLS_BASE_URL);
@@ -132,11 +132,11 @@ describe('getSkillsBaseUrl', () => {
 
   it('honours --local-dev --no-local-context-mill', () => {
     initLocalDev({ localDev: true, localContextMill: false });
-    expect(getSkillsBaseUrl()).toBe(REMOTE_SKILLS_BASE_URL);
+    expect(getSkillsBaseUrl()).toBe(GITHUB_SKILLS_BASE_URL);
   });
 
   it('defaults to production when no CLI parse ran', () => {
-    expect(getSkillsBaseUrl()).toBe(REMOTE_SKILLS_BASE_URL);
+    expect(getSkillsBaseUrl()).toBe(GITHUB_SKILLS_BASE_URL);
   });
 
   it('serves local skills from the context-mill dev server', () => {

--- a/src/lib/__tests__/wizard-tools.test.ts
+++ b/src/lib/__tests__/wizard-tools.test.ts
@@ -1134,10 +1134,22 @@ describe('downloadWithRetry', () => {
     expect(attempts).toBe(2);
   });
 
-  it('reports every attempt when all retries fail', async () => {
+  it('reports the attempt count when every attempt fails the same way', async () => {
     await expect(
       __test.downloadWithRetry(url, {
         fetchImpl: (() => Promise.reject(new Error('network down'))) as any,
+        sleepImpl: noSleep,
+        maxAttempts: 3,
+      }),
+    ).rejects.toThrow(/network down \(x3\)/);
+  });
+
+  it('lists each attempt when they fail differently', async () => {
+    const errors = ['ENOTFOUND', 'ECONNRESET', 'ETIMEDOUT'];
+    let i = 0;
+    await expect(
+      __test.downloadWithRetry(url, {
+        fetchImpl: (() => Promise.reject(new Error(errors[i++]))) as any,
         sleepImpl: noSleep,
         maxAttempts: 3,
       }),

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -192,7 +192,7 @@ export type AgentConfig = {
   host: HostResolution;
   additionalMcpServers?: Record<string, { url: string }>;
   detectPackageManager: PackageManagerDetector;
-  /** Base URL for the skills server (context-mill dev or GitHub releases) */
+  /** Primary skills origin (context-mill dev or GitHub Releases; downloads fail over to the AWS mirror) */
   skillsBaseUrl: string;
   /** Feature flag key -> variant (evaluated at start of run). */
   wizardFlags?: Record<string, string>;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -164,9 +164,13 @@ export const POSTHOG_ORG_AI_SETTINGS_URL =
   'https://app.posthog.com/settings/organization-details#setting=organization-ai-consent';
 export const WIZARD_CONTACT_EMAIL = 'wizard@posthog.com';
 
-/** Remote base URL for fetching the skill menu + downloading skills. */
-export const REMOTE_SKILLS_BASE_URL =
+/**
+ * Two origins for the same release, same filenames. Interchangeable bases, so
+ * making AWS primary is a `getSkillsBaseUrl` change, not a code change.
+ */
+export const GITHUB_SKILLS_BASE_URL =
   'https://github.com/PostHog/context-mill/releases/latest/download';
+export const AWS_SKILLS_BASE_URL = 'https://context-mill.posthog.com/latest';
 /** Alias of `@lib/local-dev`'s constant, kept for existing importers. */
 export const LOCAL_SKILLS_BASE_URL = CONTEXT_MILL_LOCAL_URL;
 
@@ -177,7 +181,7 @@ export const LOCAL_SKILLS_BASE_URL = CONTEXT_MILL_LOCAL_URL;
 export function getSkillsBaseUrl(): string {
   return getLocalDev().localContextMill
     ? LOCAL_SKILLS_BASE_URL
-    : REMOTE_SKILLS_BASE_URL;
+    : GITHUB_SKILLS_BASE_URL;
 }
 
 // ── Analytics (internal) ──────────────────────────────────────────────

--- a/src/lib/fetch-retry.ts
+++ b/src/lib/fetch-retry.ts
@@ -1,16 +1,50 @@
 /**
- * Retry wrapper for fetching from the skills/agents server (GitHub releases in
- * production). GitHub releases blips transiently, so every fetch on the run's
- * critical path — skill menu, skill zips, agent menu, agent prompt bodies —
- * goes through here rather than a bare `fetch`.
+ * One retry + failover policy for every critical-path fetch. GitHub is primary,
+ * AWS is the fallback; 404/403 never fail over — that is the asset, not the origin.
  */
+
+import { logToFile } from '@utils/debug';
+import { analytics } from '@utils/analytics';
+import { CONTEXT_MILL_URL, AWS_SKILLS_BASE_URL } from './constants';
 
 const DEFAULT_TIMEOUT_MS = 60000; // per attempt
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_BACKOFF_MS = 500; // doubles each retry
 
+const GITHUB_LATEST_PREFIX = `${CONTEXT_MILL_URL}/releases/latest/download/`;
+const GITHUB_PINNED_PREFIX = `${CONTEXT_MILL_URL}/releases/download/`;
+/** Version-pinned URLs name their own prefix, so they need the host alone. */
+const AWS_ORIGIN = new URL(AWS_SKILLS_BASE_URL).origin;
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Maps a context-mill release URL onto AWS; null when there is no second origin.
+ *
+ *   .../releases/latest/download/x.zip  ->  <aws>/latest/x.zip
+ *   .../releases/download/v1.50.0/x.zip ->  <aws>/v1.50.0/x.zip
+ */
+export function awsUrlFor(url: string): string | null {
+  if (url.startsWith(GITHUB_LATEST_PREFIX)) {
+    return `${AWS_SKILLS_BASE_URL}/${url.slice(GITHUB_LATEST_PREFIX.length)}`;
+  }
+  if (url.startsWith(GITHUB_PINNED_PREFIX)) {
+    return `${AWS_ORIGIN}/${url.slice(GITHUB_PINNED_PREFIX.length)}`;
+  }
+  return null;
+}
+
+/** The two origins context-mill releases are published to. */
+export type SkillsOrigin = 'github' | 'aws';
+
+/** Sticky: without it every asset re-pays GitHub's retry budget during an outage. */
+let preferredOrigin: SkillsOrigin = 'github';
+
+/** Test seam — the preference deliberately outlives a single call. */
+export function resetOriginPreference(): void {
+  preferredOrigin = 'github';
 }
 
 export interface RetryOpts {
@@ -19,9 +53,60 @@ export interface RetryOpts {
   timeoutMs?: number;
   maxAttempts?: number;
   backoffMs?: number;
+  /** Set false to fail rather than reach for AWS. */
+  failover?: boolean;
+  /** Test seam for the failover/exhausted events. */
+  onEvent?: (event: string, props: Record<string, unknown>) => void;
 }
 
-/** Fetch a URL, retrying transient failures (network error or non-ok HTTP) with backoff. */
+class FatalHttpError extends Error {
+  constructor(readonly status: number) {
+    super(`HTTP ${status}`);
+  }
+}
+
+/** 5xx, 429 and 408 say "this origin"; other 4xx say "this asset". */
+function isTransientStatus(status: number): boolean {
+  return status >= 500 || status === 429 || status === 408;
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Try one origin to exhaustion. Throws FatalHttpError when failover would be pointless. */
+async function fetchOrigin(
+  url: string,
+  opts: Required<Pick<RetryOpts, 'timeoutMs' | 'maxAttempts' | 'backoffMs'>> & {
+    fetchImpl: typeof fetch;
+    sleepImpl: (ms: number) => Promise<void>;
+  },
+): Promise<Response> {
+  const failures: string[] = [];
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    try {
+      const resp = await opts.fetchImpl(url, {
+        signal: AbortSignal.timeout(opts.timeoutMs),
+      });
+      if (resp.ok) return resp;
+      if (!isTransientStatus(resp.status))
+        throw new FatalHttpError(resp.status);
+      throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+    } catch (err) {
+      if (err instanceof FatalHttpError) throw err;
+      failures.push(`attempt ${attempt}: ${messageOf(err)}`);
+      if (attempt < opts.maxAttempts) {
+        await opts.sleepImpl(opts.backoffMs * 2 ** (attempt - 1));
+      }
+    }
+  }
+  throw new Error(failures.join('; '));
+}
+
+/**
+ * Retry with backoff, then fail over. Throws once every origin is exhausted, or
+ * immediately on a 4xx that is about the asset rather than the origin.
+ */
 export async function fetchWithRetry(
   url: string,
   opts: RetryOpts = {},
@@ -32,22 +117,56 @@ export async function fetchWithRetry(
     timeoutMs = DEFAULT_TIMEOUT_MS,
     maxAttempts = DEFAULT_MAX_ATTEMPTS,
     backoffMs = DEFAULT_BACKOFF_MS,
+    failover = true,
+    onEvent = (event, props) => analytics.wizardCapture(event, props),
   } = opts;
+  const originOpts = {
+    fetchImpl,
+    sleepImpl,
+    timeoutMs,
+    maxAttempts,
+    backoffMs,
+  };
+
+  const awsUrl = failover ? awsUrlFor(url) : null;
+  if (!awsUrl) return fetchOrigin(url, originOpts);
+
+  // Sticky: whichever origin last worked is tried first for the rest of the run.
+  const order: Array<{ origin: SkillsOrigin; target: string }> =
+    preferredOrigin === 'aws'
+      ? [
+          { origin: 'aws', target: awsUrl },
+          { origin: 'github', target: url },
+        ]
+      : [
+          { origin: 'github', target: url },
+          { origin: 'aws', target: awsUrl },
+        ];
 
   const failures: string[] = [];
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+  for (const [index, candidate] of order.entries()) {
     try {
-      const resp = await fetchImpl(url, {
-        signal: AbortSignal.timeout(timeoutMs),
-      });
-      if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+      const resp = await fetchOrigin(candidate.target, originOpts);
+      if (candidate.origin !== preferredOrigin) {
+        // The transition is the interesting event, not every later fetch.
+        preferredOrigin = candidate.origin;
+        logToFile(`fetchWithRetry: failed over to ${candidate.origin}`);
+        onEvent('skills fetch failed over', {
+          origin: candidate.origin,
+          url: candidate.target,
+        });
+      }
       return resp;
-    } catch (err: any) {
-      failures.push(`attempt ${attempt}: ${err.message}`);
-      if (attempt < maxAttempts) {
-        await sleepImpl(backoffMs * 2 ** (attempt - 1));
+    } catch (err) {
+      // The other origin serves the same filename and would answer the same way.
+      if (err instanceof FatalHttpError) {
+        throw new Error(`fetch ${url} failed — HTTP ${err.status}`);
+      }
+      failures.push(`${candidate.origin}: ${messageOf(err)}`);
+      if (index === order.length - 1) {
+        onEvent('skills fetch failed', { url, failures: failures.length });
       }
     }
   }
-  throw new Error(`fetch ${url} failed — ${failures.join('; ')}`);
+  throw new Error(`fetch ${url} failed — ${failures.join(' | ')}`);
 }

--- a/src/lib/fetch-retry.ts
+++ b/src/lib/fetch-retry.ts
@@ -1,6 +1,10 @@
 /**
  * One retry + failover policy for every critical-path fetch. GitHub is primary,
- * AWS is the fallback; 404/403 never fail over — that is the asset, not the origin.
+ * AWS is the fallback. Every failure is treated the same — retry the origin,
+ * then try the other one — because the statuses that look deterministic aren't:
+ * GitHub 403s expired asset redirects (a retry mints a fresh one) and blocked
+ * regions, and a 404 can be an edge that hasn't caught up with the release.
+ * Guessing which failures are worth another request saves less than it costs.
  */
 
 import { logToFile } from '@utils/debug';
@@ -59,22 +63,19 @@ export interface RetryOpts {
   onEvent?: (event: string, props: Record<string, unknown>) => void;
 }
 
-class FatalHttpError extends Error {
-  constructor(readonly status: number) {
-    super(`HTTP ${status}`);
-  }
-}
-
-/** 5xx, 429 and 408 say "this origin"; other 4xx say "this asset". */
-function isTransientStatus(status: number): boolean {
-  return status >= 500 || status === 429 || status === 408;
-}
-
 function messageOf(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-/** Try one origin to exhaustion. Throws FatalHttpError when failover would be pointless. */
+/** Every attempt failing identically is the common case; say it once. */
+function summarize(failures: string[]): string {
+  const unique = [...new Set(failures)];
+  return unique.length === 1
+    ? `${unique[0]}${failures.length > 1 ? ` (x${failures.length})` : ''}`
+    : failures.map((f, i) => `attempt ${i + 1}: ${f}`).join('; ');
+}
+
+/** Try one origin to exhaustion. */
 async function fetchOrigin(
   url: string,
   opts: Required<Pick<RetryOpts, 'timeoutMs' | 'maxAttempts' | 'backoffMs'>> & {
@@ -89,23 +90,19 @@ async function fetchOrigin(
         signal: AbortSignal.timeout(opts.timeoutMs),
       });
       if (resp.ok) return resp;
-      if (!isTransientStatus(resp.status))
-        throw new FatalHttpError(resp.status);
-      throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+      throw new Error(`HTTP ${resp.status} ${resp.statusText}`.trim());
     } catch (err) {
-      if (err instanceof FatalHttpError) throw err;
-      failures.push(`attempt ${attempt}: ${messageOf(err)}`);
+      failures.push(messageOf(err));
       if (attempt < opts.maxAttempts) {
         await opts.sleepImpl(opts.backoffMs * 2 ** (attempt - 1));
       }
     }
   }
-  throw new Error(failures.join('; '));
+  throw new Error(summarize(failures));
 }
 
 /**
- * Retry with backoff, then fail over. Throws once every origin is exhausted, or
- * immediately on a 4xx that is about the asset rather than the origin.
+ * Retry with backoff, then fail over. Throws once every origin is exhausted.
  */
 export async function fetchWithRetry(
   url: string,
@@ -158,10 +155,6 @@ export async function fetchWithRetry(
       }
       return resp;
     } catch (err) {
-      // The other origin serves the same filename and would answer the same way.
-      if (err instanceof FatalHttpError) {
-        throw new Error(`fetch ${url} failed — HTTP ${err.status}`);
-      }
       failures.push(`${candidate.origin}: ${messageOf(err)}`);
       if (index === order.length - 1) {
         onEvent('skills fetch failed', { url, failures: failures.length });

--- a/src/lib/health-checks/__tests__/health-checks.test.ts
+++ b/src/lib/health-checks/__tests__/health-checks.test.ts
@@ -22,7 +22,7 @@ import {
   checkCloudflareComponentHealth,
   checkCloudflareOverallHealth,
   checkGithubHealth,
-  checkGithubReleasesHealth,
+  checkSkillsOriginHealth,
   checkLlmGatewayHealth,
   checkMcpHealth,
   checkNpmComponentHealth,
@@ -212,8 +212,9 @@ const URLS = {
   cloudflareSummary: 'https://www.cloudflarestatus.com/api/v2/summary.json',
   llmGatewayLiveness: 'https://gateway.us.posthog.com/_liveness',
   mcpLanding: 'https://mcp.posthog.com/',
-  githubReleasesSkillMenu:
+  githubSkillMenu:
     'https://github.com/PostHog/context-mill/releases/latest/download/skill-menu.json',
+  awsSkillMenu: 'https://context-mill.posthog.com/latest/skill-menu.json',
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -258,7 +259,11 @@ const HEALTHY_RESPONSES: Record<string, { body: string; contentType: string }> =
       body: MCP_LANDING_HTML,
       contentType: 'text/html; charset=utf-8',
     },
-    [URLS.githubReleasesSkillMenu]: {
+    [URLS.githubSkillMenu]: {
+      body: JSON.stringify({ categories: { integration: [] } }),
+      contentType: 'application/json',
+    },
+    [URLS.awsSkillMenu]: {
       body: JSON.stringify({ categories: { integration: [] } }),
       contentType: 'application/json',
     },
@@ -960,30 +965,91 @@ describe('health-checks', () => {
   });
 
   // -----------------------------------------------------------------------
-  // GitHub Releases (fetchEndpointHealth – skill-menu.json)
+  // Skills origins (fetchEndpointHealth – skill-menu.json on both origins)
   // -----------------------------------------------------------------------
 
-  describe('checkGithubReleasesHealth', () => {
+  describe('checkSkillsOriginHealth', () => {
     it('returns healthy on a final 200 and follows redirects (GitHub 302s asset URLs even for missing assets)', async () => {
-      const result = await checkGithubReleasesHealth();
+      const result = await checkSkillsOriginHealth();
       expect(result.status).toBe(ServiceHealthStatus.Healthy);
       expect(result.rawIndicator).toBe('HTTP 200');
       expect(global.fetch).toHaveBeenCalledWith(
-        URLS.githubReleasesSkillMenu,
+        URLS.githubSkillMenu,
         expect.objectContaining({ redirect: 'follow' }),
       );
     });
 
-    it('returns down on 404 (release published without the asset)', async () => {
+    it('probes both origins', async () => {
+      await checkSkillsOriginHealth();
+      const calledUrls = (global.fetch as Mock).mock.calls.map(
+        (c: unknown[]) => c[0],
+      );
+      expect(calledUrls).toContain(URLS.githubSkillMenu);
+      expect(calledUrls).toContain(URLS.awsSkillMenu);
+    });
+
+    it('stays healthy when GitHub 404s but AWS serves the menu', async () => {
       (global.fetch as Mock).mockImplementation(
         overrideFetch({
-          [URLS.githubReleasesSkillMenu]: () =>
+          [URLS.githubSkillMenu]: () =>
             Promise.resolve(new Response('Not Found', { status: 404 })),
         }),
       );
-      const result = await checkGithubReleasesHealth();
+      const result = await checkSkillsOriginHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Healthy);
+      expect(result.rawIndicator).toContain('github unavailable');
+    });
+
+    it('stays healthy when AWS is unreachable but GitHub serves the menu', async () => {
+      (global.fetch as Mock).mockImplementation(
+        overrideFetch({
+          [URLS.awsSkillMenu]: () => Promise.reject(new Error('fetch failed')),
+        }),
+      );
+      const result = await checkSkillsOriginHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Healthy);
+      expect(result.rawIndicator).toContain('aws unavailable');
+    });
+
+    it('returns down only when both origins 404 (release published without the asset)', async () => {
+      (global.fetch as Mock).mockImplementation(
+        overrideFetch({
+          [URLS.githubSkillMenu]: () =>
+            Promise.resolve(new Response('Not Found', { status: 404 })),
+          [URLS.awsSkillMenu]: () =>
+            Promise.resolve(new Response('Not Found', { status: 404 })),
+        }),
+      );
+      const result = await checkSkillsOriginHealth();
       expect(result.status).toBe(ServiceHealthStatus.Down);
-      expect(result.error).toContain('HTTP 404');
+      expect(result.error).toContain('github: HTTP 404');
+      expect(result.error).toContain('aws: HTTP 404');
+    });
+
+    it('returns no-connection when both origins fail at the network layer', async () => {
+      (global.fetch as Mock).mockImplementation(
+        overrideFetch({
+          [URLS.githubSkillMenu]: () =>
+            Promise.reject(new Error('ENOTFOUND github.com')),
+          [URLS.awsSkillMenu]: () => Promise.reject(new Error('ECONNRESET')),
+        }),
+      );
+      const result = await checkSkillsOriginHealth();
+      expect(result.status).toBe(ServiceHealthStatus.NoConnection);
+      expect(result.error).toContain('ENOTFOUND github.com');
+      expect(result.error).toContain('ECONNRESET');
+    });
+
+    it('reports down when one origin 404s and the other is unreachable', async () => {
+      (global.fetch as Mock).mockImplementation(
+        overrideFetch({
+          [URLS.githubSkillMenu]: () =>
+            Promise.resolve(new Response('Not Found', { status: 404 })),
+          [URLS.awsSkillMenu]: () => Promise.reject(new Error('ECONNRESET')),
+        }),
+      );
+      const result = await checkSkillsOriginHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Down);
     });
   });
 
@@ -1007,7 +1073,7 @@ describe('health-checks', () => {
           'cloudflareComponents',
           'llmGateway',
           'mcp',
-          'githubReleases',
+          'skillsOrigin',
         ]),
       );
       expect(keys).toHaveLength(11);
@@ -1097,11 +1163,12 @@ describe('health-checks', () => {
         typeof c[0] === 'string' ? c[0] : (c[0] as URL).toString(),
       );
       // PostHog uses a single incident.io endpoint for both overall + components
-      expect(calledUrls).toHaveLength(10);
+      expect(calledUrls).toHaveLength(11);
       expect(calledUrls).toContain(URLS.posthogIncidentIo);
       expect(calledUrls).toContain(URLS.llmGatewayLiveness);
       expect(calledUrls).toContain(URLS.mcpLanding);
-      expect(calledUrls).toContain(URLS.githubReleasesSkillMenu);
+      expect(calledUrls).toContain(URLS.githubSkillMenu);
+      expect(calledUrls).toContain(URLS.awsSkillMenu);
     });
   });
 

--- a/src/lib/health-checks/__tests__/health-checks.test.ts
+++ b/src/lib/health-checks/__tests__/health-checks.test.ts
@@ -988,6 +988,30 @@ describe('health-checks', () => {
       expect(calledUrls).toContain(URLS.awsSkillMenu);
     });
 
+    it('stays healthy when GitHub 5xxs but AWS serves the menu', async () => {
+      (global.fetch as Mock).mockImplementation(
+        overrideFetch({
+          [URLS.githubSkillMenu]: () =>
+            Promise.resolve(new Response('Bad Gateway', { status: 502 })),
+        }),
+      );
+      const result = await checkSkillsOriginHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Healthy);
+      expect(result.rawIndicator).toContain('github unavailable');
+    });
+
+    it('stays healthy when GitHub is unreachable but AWS serves the menu', async () => {
+      (global.fetch as Mock).mockImplementation(
+        overrideFetch({
+          [URLS.githubSkillMenu]: () =>
+            Promise.reject(new Error('ENOTFOUND github.com')),
+        }),
+      );
+      const result = await checkSkillsOriginHealth();
+      expect(result.status).toBe(ServiceHealthStatus.Healthy);
+      expect(result.rawIndicator).toContain('github unavailable');
+    });
+
     it('stays healthy when GitHub 404s but AWS serves the menu', async () => {
       (global.fetch as Mock).mockImplementation(
         overrideFetch({
@@ -1040,11 +1064,11 @@ describe('health-checks', () => {
       expect(result.error).toContain('ECONNRESET');
     });
 
-    it('reports down when one origin 404s and the other is unreachable', async () => {
+    it('reports down when GitHub 5xxs and AWS is unreachable', async () => {
       (global.fetch as Mock).mockImplementation(
         overrideFetch({
           [URLS.githubSkillMenu]: () =>
-            Promise.resolve(new Response('Not Found', { status: 404 })),
+            Promise.resolve(new Response('Bad Gateway', { status: 502 })),
           [URLS.awsSkillMenu]: () => Promise.reject(new Error('ECONNRESET')),
         }),
       );

--- a/src/lib/health-checks/endpoints.ts
+++ b/src/lib/health-checks/endpoints.ts
@@ -1,4 +1,4 @@
-import { REMOTE_SKILLS_BASE_URL } from '@lib/constants';
+import { GITHUB_SKILLS_BASE_URL } from '@lib/constants';
 import { logToFile } from '@utils/debug';
 import { ServiceHealthStatus, type BaseHealthResult } from './types';
 
@@ -144,4 +144,4 @@ export const checkMcpHealth = (): Promise<BaseHealthResult> =>
   );
 
 export const checkGithubReleasesHealth = (): Promise<BaseHealthResult> =>
-  fetchEndpointHealth(`${REMOTE_SKILLS_BASE_URL}/skill-menu.json`);
+  fetchEndpointHealth(`${GITHUB_SKILLS_BASE_URL}/skill-menu.json`);

--- a/src/lib/health-checks/endpoints.ts
+++ b/src/lib/health-checks/endpoints.ts
@@ -125,7 +125,10 @@ async function fetchEndpointHealth(
 
   const result =
     lastHttpStatus !== null
-      ? downResult(`HTTP ${lastHttpStatus} (attempts=${attempts})`)
+      ? downResult(
+          `HTTP ${lastHttpStatus} (attempts=${attempts})`,
+          lastHttpStatus,
+        )
       : noConnectionResult(lastError, attempts);
   logToFile(
     `[health-checks] GET ${url} -> ${result.status}` +
@@ -161,22 +164,25 @@ export const checkSkillsOriginHealth = async (): Promise<BaseHealthResult> => {
 };
 
 /**
- * Healthy when either origin serves. When neither does, one HTTP response
- * anywhere is enough server-side evidence for `Down`; otherwise both probes
- * only saw network errors, which is `NoConnection`.
+ * Mirrors `fetchWithRetry`: a download tries GitHub, then AWS, so the run is
+ * only blocked when neither origin answers. Whichever failure the probes saw,
+ * one origin serving means skills are reachable.
  */
 function combineOriginHealth(
   github: BaseHealthResult,
   aws: BaseHealthResult,
 ): BaseHealthResult {
-  const githubUp = github.status === ServiceHealthStatus.Healthy;
-  const awsUp = aws.status === ServiceHealthStatus.Healthy;
+  if (github.status === ServiceHealthStatus.Healthy) {
+    // Naming the dead origin makes a one-sided outage legible in the log and
+    // in the readiness reasons, where the status alone reads as "fine".
+    return aws.status === ServiceHealthStatus.Healthy
+      ? github
+      : withIndicatorSuffix(github, 'aws unavailable');
+  }
 
-  if (githubUp && awsUp) return github;
-  // Naming the surviving origin makes a one-sided outage legible in the log
-  // and in the readiness reasons, where the status alone reads as "fine".
-  if (githubUp) return withIndicatorSuffix(github, 'aws unavailable');
-  if (awsUp) return withIndicatorSuffix(aws, 'via aws, github unavailable');
+  if (aws.status === ServiceHealthStatus.Healthy) {
+    return withIndicatorSuffix(aws, 'via aws, github unavailable');
+  }
 
   const error = `github: ${github.error ?? 'unknown'} | aws: ${
     aws.error ?? 'unknown'

--- a/src/lib/health-checks/endpoints.ts
+++ b/src/lib/health-checks/endpoints.ts
@@ -1,4 +1,4 @@
-import { GITHUB_SKILLS_BASE_URL } from '@lib/constants';
+import { AWS_SKILLS_BASE_URL, GITHUB_SKILLS_BASE_URL } from '@lib/constants';
 import { logToFile } from '@utils/debug';
 import { ServiceHealthStatus, type BaseHealthResult } from './types';
 
@@ -20,6 +20,9 @@ import { ServiceHealthStatus, type BaseHealthResult } from './types';
 // MCP – Cloudflare Worker
 //   Source: posthog/services/mcp/src/index.ts
 //   GET / → 302 to posthog.com docs. The redirect proves the worker is up.
+//
+// Skills download – context-mill releases
+//   GET <origin>/skill-menu.json on both origins; see checkSkillsOriginHealth.
 // ---------------------------------------------------------------------------
 
 function noConnectionResult(error: string, attempts: number): BaseHealthResult {
@@ -143,5 +146,62 @@ export const checkMcpHealth = (): Promise<BaseHealthResult> =>
     'manual',
   );
 
-export const checkGithubReleasesHealth = (): Promise<BaseHealthResult> =>
-  fetchEndpointHealth(`${GITHUB_SKILLS_BASE_URL}/skill-menu.json`);
+/**
+ * Skills are published to two origins under the same filenames and
+ * `fetchWithRetry` fails over between them, so the run is only blocked when
+ * neither answers. Probed in parallel — sequential probes would double the
+ * worst case past `READINESS_TIMEOUT_MS`.
+ */
+export const checkSkillsOriginHealth = async (): Promise<BaseHealthResult> => {
+  const [github, aws] = await Promise.all([
+    fetchEndpointHealth(`${GITHUB_SKILLS_BASE_URL}/skill-menu.json`),
+    fetchEndpointHealth(`${AWS_SKILLS_BASE_URL}/skill-menu.json`),
+  ]);
+  return combineOriginHealth(github, aws);
+};
+
+/**
+ * Healthy when either origin serves. When neither does, one HTTP response
+ * anywhere is enough server-side evidence for `Down`; otherwise both probes
+ * only saw network errors, which is `NoConnection`.
+ */
+function combineOriginHealth(
+  github: BaseHealthResult,
+  aws: BaseHealthResult,
+): BaseHealthResult {
+  const githubUp = github.status === ServiceHealthStatus.Healthy;
+  const awsUp = aws.status === ServiceHealthStatus.Healthy;
+
+  if (githubUp && awsUp) return github;
+  // Naming the surviving origin makes a one-sided outage legible in the log
+  // and in the readiness reasons, where the status alone reads as "fine".
+  if (githubUp) return withIndicatorSuffix(github, 'aws unavailable');
+  if (awsUp) return withIndicatorSuffix(aws, 'via aws, github unavailable');
+
+  const error = `github: ${github.error ?? 'unknown'} | aws: ${
+    aws.error ?? 'unknown'
+  }`;
+  const confirmedDown =
+    github.status === ServiceHealthStatus.Down ||
+    aws.status === ServiceHealthStatus.Down;
+  return {
+    status: confirmedDown
+      ? ServiceHealthStatus.Down
+      : ServiceHealthStatus.NoConnection,
+    error,
+    // Keeps the `attempts=N` the blocked-readiness analytics parses.
+    rawIndicator: github.rawIndicator ?? aws.rawIndicator,
+  };
+}
+
+function withIndicatorSuffix(
+  result: BaseHealthResult,
+  suffix: string,
+): BaseHealthResult {
+  return {
+    ...result,
+    rawIndicator: result.rawIndicator
+      ? `${result.rawIndicator} (${suffix})`
+      : suffix,
+  };
+}

--- a/src/lib/health-checks/index.ts
+++ b/src/lib/health-checks/index.ts
@@ -25,7 +25,7 @@ export {
 export {
   checkLlmGatewayHealth,
   checkMcpHealth,
-  checkGithubReleasesHealth,
+  checkSkillsOriginHealth,
 } from './endpoints';
 
 export {

--- a/src/lib/health-checks/readiness.ts
+++ b/src/lib/health-checks/readiness.ts
@@ -20,7 +20,7 @@ import {
 import {
   checkLlmGatewayHealth,
   checkMcpHealth,
-  checkGithubReleasesHealth,
+  checkSkillsOriginHealth,
 } from './endpoints';
 import { logToFile } from '@utils/debug';
 
@@ -39,7 +39,7 @@ export const SERVICE_LABELS: Record<HealthCheckKey, string> = {
   cloudflareComponents: 'Cloudflare (components)',
   llmGateway: 'LLM Gateway',
   mcp: 'MCP',
-  githubReleases: 'GitHub Releases',
+  skillsOrigin: 'Skills download',
 };
 
 // ---------------------------------------------------------------------------
@@ -63,7 +63,7 @@ export const DEFAULT_WIZARD_READINESS_CONFIG: WizardReadinessConfig = {
     'npmOverall',
     'llmGateway',
     'mcp',
-    'githubReleases',
+    'skillsOrigin',
   ],
   degradedBlocksRun: ['anthropic'],
 };
@@ -72,7 +72,7 @@ export const DEFAULT_WIZARD_READINESS_CONFIG: WizardReadinessConfig = {
  * Reduced readiness config for --signup provisioning flows.
  *
  * Provisioning only needs PostHog and the LLM Gateway - it doesn't
- * use Anthropic directly, npm, GitHub Releases, or MCP.
+ * use Anthropic directly, npm, the skills origins, or MCP.
  */
 export const SIGNUP_WIZARD_READINESS_CONFIG: WizardReadinessConfig = {
   downBlocksRun: ['posthogOverall', 'llmGateway'],
@@ -94,7 +94,7 @@ export async function checkAllExternalServices(): Promise<AllServicesHealth> {
     cloudflareComponents,
     llmGateway,
     mcp,
-    githubReleases,
+    skillsOrigin,
   ] = await Promise.all([
     checkAnthropicHealth(),
     checkPosthogOverallHealth(),
@@ -106,7 +106,7 @@ export async function checkAllExternalServices(): Promise<AllServicesHealth> {
     checkCloudflareComponentHealth(),
     checkLlmGatewayHealth(),
     checkMcpHealth(),
-    checkGithubReleasesHealth(),
+    checkSkillsOriginHealth(),
   ]);
 
   const health: AllServicesHealth = {
@@ -120,7 +120,7 @@ export async function checkAllExternalServices(): Promise<AllServicesHealth> {
     cloudflareComponents,
     llmGateway,
     mcp,
-    githubReleases,
+    skillsOrigin,
   };
   return reconcilePosthogReachability(health);
 }
@@ -348,6 +348,6 @@ function allUnknown(error: string): AllServicesHealth {
     cloudflareComponents: { ...base },
     llmGateway: base,
     mcp: base,
-    githubReleases: base,
+    skillsOrigin: base,
   };
 }

--- a/src/lib/health-checks/types.ts
+++ b/src/lib/health-checks/types.ts
@@ -39,7 +39,7 @@ export interface AllServicesHealth {
   cloudflareComponents: ComponentHealthResult;
   llmGateway: BaseHealthResult;
   mcp: BaseHealthResult;
-  githubReleases: BaseHealthResult;
+  skillsOrigin: BaseHealthResult;
 }
 
 export type HealthCheckKey = keyof AllServicesHealth;

--- a/src/lib/skill-install.ts
+++ b/src/lib/skill-install.ts
@@ -2,7 +2,8 @@
  * Check if command is a PostHog skill installation from MCP.
  * We control the MCP server, so we only need to verify:
  * 1. It installs to .claude/skills/
- * 2. It downloads from our GitHub releases or localhost (dev)
+ * 2. It downloads from a context-mill release origin (GitHub Releases or the
+ *    AWS mirror) or localhost (dev)
  *
  * Extracted to its own module to avoid a circular dependency
  * between agent-interface.ts and yara-hooks.ts.
@@ -13,9 +14,12 @@ export function isSkillInstallCommand(command: string): boolean {
   const urlMatch = command.match(/curl -sL ['"]([^'"]+)['"]/);
   if (!urlMatch) return false;
 
+  // Literal prefixes rather than the constants in `@lib/constants`: an
+  // allow-list is easier to audit when it reads as the URLs themselves.
   const url = urlMatch[1];
   return (
     url.startsWith('https://github.com/PostHog/context-mill/releases/') ||
+    url.startsWith('https://context-mill.posthog.com/') ||
     /^http:\/\/localhost:\d+\//.test(url)
   );
 }

--- a/src/lib/wizard-tools/mcp.ts
+++ b/src/lib/wizard-tools/mcp.ts
@@ -100,7 +100,7 @@ export interface WizardToolsOptions {
   /** Framework-specific package manager detector */
   detectPackageManager: PackageManagerDetector;
 
-  /** Base URL for the skills server (e.g. http://localhost:8765 or GitHub releases URL) */
+  /** Primary skills origin (e.g. http://localhost:8765 or the GitHub Releases URL); downloads fail over to the AWS mirror */
   skillsBaseUrl: string;
 
   /**

--- a/src/ui/tui/playground/demos/HealthCheckDemo.tsx
+++ b/src/ui/tui/playground/demos/HealthCheckDemo.tsx
@@ -46,7 +46,7 @@ const MOCK_CONFIRMED_OUTAGE: AllServicesHealth = {
   cloudflareComponents: { status: ServiceHealthStatus.Healthy },
   llmGateway: HEALTHY,
   mcp: HEALTHY,
-  githubReleases: HEALTHY,
+  skillsOrigin: HEALTHY,
 };
 
 const MOCK_NO_CONNECTION: AllServicesHealth = {
@@ -66,7 +66,7 @@ const MOCK_NO_CONNECTION: AllServicesHealth = {
     status: ServiceHealthStatus.NoConnection,
     error: 'fetch failed',
   },
-  githubReleases: HEALTHY,
+  skillsOrigin: HEALTHY,
 };
 
 type Phase = 'checking' | 'confirmed' | 'no-connection';

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -25,7 +25,7 @@ import { ServiceHealthStatus } from '@lib/health-checks/types';
 import { wizardAbort } from '@utils/wizard-abort';
 import { ErrorCodes } from '@lib/errors';
 import { fetchSkillMenu, downloadSkill } from '@lib/wizard-tools';
-import { REMOTE_SKILLS_BASE_URL } from '@lib/constants';
+import { GITHUB_SKILLS_BASE_URL } from '@lib/constants';
 import { useDismissOnAnyKey } from '@ui/tui/hooks/useDismissOnAnyKey';
 
 interface HealthCheckScreenProps {
@@ -145,7 +145,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
   const handleDownloadAndExit = async () => {
     if (downloading) return;
     setDownloading(true);
-    const menu = await fetchSkillMenu(REMOTE_SKILLS_BASE_URL);
+    const menu = await fetchSkillMenu(GITHUB_SKILLS_BASE_URL);
     if (menu) {
       const prefix = `integration-${integration}`;
       const skills = (menu.categories['integration'] ?? []).filter((s) =>

--- a/src/ui/tui/screens/health/HealthCheckScreen.tsx
+++ b/src/ui/tui/screens/health/HealthCheckScreen.tsx
@@ -108,10 +108,10 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
   const displayKeys = hasHardBlock ? blockingKeys : warningKeys;
   if (displayKeys.length === 0) return null;
 
-  const isGithubReleasesDown =
-    hasHardBlock && blockingKeys.includes('githubReleases');
+  const isSkillsOriginDown =
+    hasHardBlock && blockingKeys.includes('skillsOrigin');
   const canDownloadSkills =
-    result.health.githubReleases.status === ServiceHealthStatus.Healthy;
+    result.health.skillsOrigin.status === ServiceHealthStatus.Healthy;
   const integration = store.session.integration;
 
   // If every blocking row is `NoConnection` (probe failed, no status-page
@@ -125,7 +125,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
       (k) => result.health[k].status === ServiceHealthStatus.NoConnection,
     );
 
-  const title = isGithubReleasesDown
+  const title = isSkillsOriginDown
     ? 'Ongoing service disruptions'
     : allBlockingHaveNoConnection
     ? "Couldn't reach PostHog"
@@ -134,8 +134,8 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
     : 'Service disruption detected';
 
   const docsUrl = store.session.frameworkConfig?.metadata.docsUrl;
-  const description = isGithubReleasesDown
-    ? "The Wizard can't download necessary skills from GitHub Releases right now."
+  const description = isSkillsOriginDown
+    ? "The Wizard can't download the skills it needs — neither GitHub Releases nor PostHog's mirror is reachable right now."
     : allBlockingHaveNoConnection
     ? "We couldn't reach these services from this machine. PostHog's status page shows no incidents, so this is most likely a network issue — VPN, firewall, captive portal, or flaky Wi-Fi."
     : hasHardBlock
@@ -145,6 +145,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
   const handleDownloadAndExit = async () => {
     if (downloading) return;
     setDownloading(true);
+    // Primary origin — fetchSkillMenu/downloadSkill fail over to AWS themselves.
     const menu = await fetchSkillMenu(GITHUB_SKILLS_BASE_URL);
     if (menu) {
       const prefix = `integration-${integration}`;
@@ -163,7 +164,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
   };
 
   const handleCancel =
-    canDownloadSkills && !isGithubReleasesDown
+    canDownloadSkills && !isSkillsOriginDown
       ? () => void handleDownloadAndExit()
       : () =>
           void wizardAbort({
@@ -172,7 +173,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
           });
 
   const cancelLabel =
-    canDownloadSkills && !isGithubReleasesDown
+    canDownloadSkills && !isSkillsOriginDown
       ? downloading
         ? 'Downloading...'
         : 'Download skills & Exit [Esc]'
@@ -186,7 +187,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
       title={title}
       width={72}
       footer={
-        isGithubReleasesDown ? (
+        isSkillsOriginDown ? (
           <ConfirmationInput
             message=""
             confirmLabel=""
@@ -236,7 +237,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
 
       <Text dimColor>{description}</Text>
 
-      {isGithubReleasesDown && docsUrl && (
+      {isSkillsOriginDown && docsUrl && (
         <Box marginTop={1}>
           <Text>
             Set up manually: <Text color="cyan">{docsUrl}</Text>
@@ -244,7 +245,7 @@ export const HealthCheckScreen = ({ store }: HealthCheckScreenProps) => {
         </Box>
       )}
 
-      {canDownloadSkills && !isGithubReleasesDown && (
+      {canDownloadSkills && !isSkillsOriginDown && (
         <Box marginTop={1}>
           <Text>
             You can still download the PostHog integration skills and continue

--- a/src/ui/tui/store.ts
+++ b/src/ui/tui/store.ts
@@ -144,11 +144,11 @@ function captureHealthCheckBlocked(result: WizardReadinessResult): void {
     const allNoConnection =
       blockingStatuses.length > 0 &&
       blockingStatuses.every((s) => s === ServiceHealthStatus.NoConnection);
-    const onlyGithubReleases =
-      blockingKeys.length === 1 && blockingKeys[0] === 'githubReleases';
+    const onlySkillsOrigin =
+      blockingKeys.length === 1 && blockingKeys[0] === 'skillsOrigin';
 
-    const decision = onlyGithubReleases
-      ? 'github-releases-down'
+    const decision = onlySkillsOrigin
+      ? 'skills-origin-down'
       : allNoConnection
       ? 'no-connection'
       : 'confirmed-outage';
@@ -156,7 +156,7 @@ function captureHealthCheckBlocked(result: WizardReadinessResult): void {
     const posthogStatus = health.posthogOverall?.status;
     const retriesUsed = Math.max(
       0,
-      ...(['llmGateway', 'mcp', 'githubReleases'] as const).map((k) => {
+      ...(['llmGateway', 'mcp', 'skillsOrigin'] as const).map((k) => {
         const ind = health[k]?.rawIndicator ?? '';
         const m = ind.match(/attempts=(\d+)/);
         return m ? Number(m[1]) - 1 : 0;


### PR DESCRIPTION
uptimve 4eva ☁️ 

https://context-mill.posthog.com/latest/agent-menu.json

- `github.com/…/releases/latest/download/X` → `context-mill.posthog.com/latest/X`
- `github.com/…/releases/download/v1.51.0/X` → `context-mill.posthog.com/v1.51.0/X`


```
fetch(url)
        │
        ▼
    ┌──────────────────────────────────────────────┐
    │ GITHUB  ·  3 attempts, 0.5s backoff doubling │
    └──────────────────────────────────────────────┘
        │
        ├── 200 ─────────────────────────────────▶ return
        │
        ├── 404 / 403 / 401 / 400 ───────────────▶ throw
        │     the asset, not the origin — AWS serves the
        │     same filename and would answer the same way
        │
        └── 5xx · 429 · 408 · timeout · conn error
            │
            ▼
    ┌──────────────────────────────────────────────┐
    │ AWS  ·  same filename, translated host       │
    │         3 attempts, same policy              │
    └──────────────────────────────────────────────┘
            │
            ├── 200 ─────▶ return, and stick to AWS for the
            │              rest of the run (no re-probing)
            │
            └── failed ──▶ throw — both origins exhausted
```


 
