### PR TITLE
fix(tui): name what Esc discards in the ask overlay

### DIFF
--- a/src/ui/tui/__tests__/WizardAskScreen.test.ts
+++ b/src/ui/tui/__tests__/WizardAskScreen.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../../utils/analytics.js', () => ({
 
 import { WizardStore } from '@ui/tui/store';
 import {
+  askEscapeHint,
   handleAskKey,
   isRequiredButEmpty,
 } from '@ui/tui/screens/WizardAskScreen';
@@ -59,6 +60,22 @@ describe('handleAskKey', () => {
       port: '__cancelled__',
     });
     expect(store.session.pendingQuestion).toBeNull();
+  });
+});
+
+describe('askEscapeHint', () => {
+  it('says plain "skip" for a single-question request', () => {
+    expect(askEscapeHint(1, 0)).toBe('skip');
+  });
+
+  it('names the scope on a multi-question request', () => {
+    expect(askEscapeHint(5, 0)).toBe('skip all 5 questions');
+  });
+
+  it('warns that answers already given are discarded', () => {
+    expect(askEscapeHint(5, 4)).toBe(
+      'skip all 5 questions, discarding the 4 you answered',
+    );
   });
 });
 

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -38,6 +38,24 @@ export function handleAskKey(
 }
 
 /**
+ * What pressing Esc actually does, phrased for the footer hint.
+ *
+ * Esc declines the *whole* request — {@link WizardStore.cancelPendingQuestion}
+ * builds a cancelled answer for every question, so the ones already typed are
+ * discarded too. The footer used to label that "skip", which on a multi-question
+ * request reads as "skip this field": the warehouse task walks a source's
+ * credentials one field at a time, several of them optional, and a user who
+ * pressed Esc to pass on an optional field instead threw away the whole source
+ * and dropped the agent onto its browser-handoff fallback. Naming the scope
+ * costs a few characters and makes the destructive key read as destructive.
+ */
+export function askEscapeHint(total: number, answered: number): string {
+  if (total <= 1) return 'skip';
+  if (answered <= 0) return `skip all ${total} questions`;
+  return `skip all ${total} questions, discarding the ${answered} you answered`;
+}
+
+/**
  * Whether an answer would leave a required question effectively unanswered.
  *
  * The `wizard_ask` schema marks fields `required` (defaulting to true), but the
@@ -170,6 +188,11 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
 
   const total = pending.questions.length;
   const progress = total > 1 ? `Question ${index + 1} of ${total}` : null;
+  const escapeHint = askEscapeHint(total, index);
+  // An optional text field already accepts an empty Enter (see
+  // `isRequiredButEmpty`) — it just never said so, leaving Esc as the only
+  // visible exit from a question the user did not want to answer.
+  const canSkipOne = question.kind === 'text' && question.required === false;
 
   const submit = (value: string | string[]) => {
     // Don't let a required field go through empty — it would reach the agent as
@@ -246,13 +269,21 @@ export const WizardAskScreen = ({ store }: WizardAskScreenProps) => {
         <Box marginTop={1}>
           <Text color={Colors.accent}>
             {Icons.warning} This field is required — type an answer, or press
-            ESC to skip.
+            ESC to {escapeHint}.
+          </Text>
+        </Box>
+      )}
+      {canSkipOne && (
+        <Box marginTop={1}>
+          <Text dimColor>
+            Optional — press <Text color={Colors.accent}>ENTER</Text> on an
+            empty answer to skip just this one.
           </Text>
         </Box>
       )}
       <Box marginTop={1}>
         <Text dimColor>
-          <Text color={Colors.accent}>ESC</Text> skip
+          <Text color={Colors.accent}>ESC</Text> {escapeHint}
         </Text>
       </Box>
     </ModalOverlay>


### PR DESCRIPTION
## Problem

The credential prompt (`wizard_ask`) walks a source's fields one question at a
time. Esc declines the **whole** request — `cancelPendingQuestion` builds a
cancelled answer for every question in it, so anything already typed is thrown
away and the agent reads the result as "the user declined" and drops to its
browser-handoff fallback.

The overlay labelled that key `ESC skip`, with no scope, and the
required-field nudge said "press ESC to skip". On a multi-question request
both read as "skip this field". Several of the fields a source asks for are
optional (tunnel settings, an alternative connection string), so a user
passing on one of those had every reason to reach for Esc — and lost the whole
source.

Cancelled prompts are the dominant loss in this flow: a majority of runs that
accepted the offer recorded at least one cancelled `wizard_ask`, and most of
those were user-initiated rather than timeouts. This does not explain all of
them, but a destructive key labelled with a non-destructive word is a defect
either way.

## Changes

- New pure helper `askEscapeHint(total, answered)`, used by both hints:
  `skip` for a single question, `skip all N questions` for more, and
  `skip all N questions, discarding the M you answered` once the user is
  partway through.
- Optional text questions now say so: `isRequiredButEmpty` has always let an
  empty Enter through for `required === false`, it just never told anyone,
  leaving Esc as the only visible exit.

Copy and affordance only — the cancellation contract the ask bridge and the
task skill depend on is unchanged, so a full cancel still reads as a decline
and is still refunded against the per-run ask cap.

## Test plan

- Unit tests for `askEscapeHint` alongside the existing `handleAskKey` /
  `isRequiredButEmpty` cases in `WizardAskScreen.test.ts`.
- `pnpm build && pnpm test && pnpm fix` — 2604 tests pass.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*