### PR TITLE
fix(audit): seed the capture-fires-on-success check

### DIFF
--- a/src/lib/programs/audit/seed.ts
+++ b/src/lib/programs/audit/seed.ts
@@ -79,6 +79,12 @@ export const AUDIT_SEED_CHECKS: AuditCheck[] = [
     status: 'pending',
   },
   {
+    id: 'capture-fires-on-success',
+    area: 'Event Capture',
+    label: 'Completion events fire on success, not intent',
+    status: 'pending',
+  },
+  {
     id: 'live-data-findings',
     // Area is capped at COL_AREA_WIDTH (18) in the checks viewer and never
     // flexes, so it has to fit. Labels get the flexed column.


### PR DESCRIPTION
Companion to [context-mill#388](https://github.com/PostHog/context-mill/pull/388), which adds a new event-capture audit check.

1. **The new `capture-fires-on-success` check would report nothing.** This ledger is pre-seeded wizard-side, so an unseeded id gets rejected as unknown. Fixed: seeded it in the existing `Event Capture` area.

Land this before #388 or the check sits dormant for a release.

## Testing

`pnpm build && pnpm test && pnpm fix` — 2637 passing, lint clean. Verified against wizard-workbench apps with `--local-context-mill`.

## Checklist

- [x] `pnpm build && pnpm test && pnpm fix`
- [x] Verified against real apps

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*