### PR TITLE
fix: don't show (detected) after manual framework pick

### DIFF
--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -70,9 +70,8 @@ export function frameworkRowSuffix({
 }): string | undefined {
   const suffixParts: string[] = [];
   if (!manuallySelected) suffixParts.push('(detected)');
-  // Dead path today — every framework went GA. Kept for re-activation
-  // when the next beta framework lands (set `beta: true` on its config).
-  if (beta) suffixParts.push('[BETA]');
+  // Some frameworks may be marked as beta/early-access in their config.
+  // If so, show a [BETA] tag to set expectations for users.
   return suffixParts.join(' ') || undefined;
 }
 

--- a/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
+++ b/src/ui/tui/screens/PostHogIntegrationIntroScreen.tsx
@@ -57,6 +57,26 @@ export const CONTINUE_MENU_OPTIONS: { label: string; value: string }[] = [
 ];
 
 /**
+ * Suffix for the Framework detection row. Auto-detect gets "(detected)"; a
+ * manual pick from either picker must not — otherwise a failed detection
+ * still claims success (#944).
+ */
+export function frameworkRowSuffix({
+  manuallySelected,
+  beta,
+}: {
+  manuallySelected: boolean;
+  beta?: boolean;
+}): string | undefined {
+  const suffixParts: string[] = [];
+  if (!manuallySelected) suffixParts.push('(detected)');
+  // Dead path today — every framework went GA. Kept for re-activation
+  // when the next beta framework lands (set `beta: true` on its config).
+  if (beta) suffixParts.push('[BETA]');
+  return suffixParts.join(' ') || undefined;
+}
+
+/**
  * A blank, unselectable row. Navigation skips disabled options, so this is a
  * margin the menu can hold rather than one the layout has to special-case.
  */
@@ -172,7 +192,10 @@ export const PostHogIntegrationIntroScreen = ({
         </Box>
         <FrameworkPicker
           store={store}
-          onComplete={() => setPickingFramework(false)}
+          onComplete={() => {
+            setManuallySelected(true);
+            setPickingFramework(false);
+          }}
         />
       </>
     );
@@ -180,7 +203,10 @@ export const PostHogIntegrationIntroScreen = ({
     body = (
       <FrameworkPicker
         store={store}
-        onComplete={() => setPickingFramework(false)}
+        onComplete={() => {
+          setManuallySelected(true);
+          setPickingFramework(false);
+        }}
       />
     );
   } else if (view === 'more-info') {
@@ -230,16 +256,13 @@ export const PostHogIntegrationIntroScreen = ({
 
   const detectionRows: DetectionRow[] = [];
   if (frameworkLabel) {
-    const suffixParts: string[] = [];
-    if (!manuallySelected) suffixParts.push('(detected)');
-    // Dead path today — every framework went GA. Kept for re-activation
-    // when the next beta framework lands (set `beta: true` on its config).
-    if (config?.metadata.beta) suffixParts.push('[BETA]');
-
     detectionRows.push({
       label: 'Framework',
       value: frameworkLabel,
-      suffix: suffixParts.join(' ') || undefined,
+      suffix: frameworkRowSuffix({
+        manuallySelected,
+        beta: config?.metadata.beta,
+      }),
     });
   }
 

--- a/src/ui/tui/screens/__tests__/PostHogIntegrationIntroScreen.test.ts
+++ b/src/ui/tui/screens/__tests__/PostHogIntegrationIntroScreen.test.ts
@@ -8,6 +8,7 @@
 
 import {
   CONTINUE_MENU_OPTIONS,
+  frameworkRowSuffix,
   sharingOptions,
 } from '@ui/tui/screens/PostHogIntegrationIntroScreen';
 
@@ -70,5 +71,26 @@ describe('the sharing choice', () => {
 
     expect(spacer?.disabled).toBe(true);
     expect(spacer?.label).toBe('');
+  });
+});
+
+describe('frameworkRowSuffix', () => {
+  it('shows (detected) after auto-detection', () => {
+    expect(frameworkRowSuffix({ manuallySelected: false })).toBe('(detected)');
+  });
+
+  it('omits (detected) after a manual pick', () => {
+    // Fallback picker after failed detection, or Change framework — both set
+    // manuallySelected so the intro does not claim detection succeeded (#944).
+    expect(frameworkRowSuffix({ manuallySelected: true })).toBeUndefined();
+  });
+
+  it('keeps [BETA] when present, with or without (detected)', () => {
+    expect(frameworkRowSuffix({ manuallySelected: false, beta: true })).toBe(
+      '(detected) [BETA]',
+    );
+    expect(frameworkRowSuffix({ manuallySelected: true, beta: true })).toBe(
+      '[BETA]',
+    );
   });
 });


### PR DESCRIPTION
## Problem

When auto-detection fails and the user picks a framework from the fallback picker, the intro still shows `Framework ✔ <name> (detected)`. That is the one path where detection definitely failed, so the suffix is misleading.

The "Change framework" menu path already sets `manuallySelected` (which suppresses the suffix). The detection-failed `FrameworkPicker` confirm path never did.

## Changes

- On fallback (and change-framework) picker confirm, set `manuallySelected` so the Framework row omits `(detected)`.
- Extract `frameworkRowSuffix` for the row suffix logic and cover it with unit tests.

## Test plan

- [x] `vitest run src/ui/tui/screens/__tests__/PostHogIntegrationIntroScreen.test.ts` (14 tests passed)
- [ ] Manually: force detection failure → pick a framework from the fallback picker → confirm intro shows `Framework ✔ <name>` without `(detected)`
- [ ] Manually: successful auto-detect still shows `(detected)`; Change framework still omits it

Closes #944