### PR TITLE
fix(warehouse): give the standalone command the same credential ask timeout

### DIFF
--- a/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
+++ b/src/lib/agent/runner/sequence/orchestrator/orchestrator-runner.ts
@@ -65,7 +65,10 @@ import { drainQueue, type RunTask } from './executor';
 import { RunMetrics } from './run-metrics';
 import { dependencyClosure, uncoveredBySink } from './queue-tools';
 import { deferSeededTasks } from './seeded-deps';
-import { createWizardAskBridge } from '@lib/wizard-ask-bridge';
+import {
+  createWizardAskBridge,
+  CREDENTIAL_ASK_TIMEOUT_MS,
+} from '@lib/wizard-ask-bridge';
 import { shouldDisableAsk } from '../../shared/bootstrap';
 import {
   agentRunTools,
@@ -196,7 +199,7 @@ function resolveReferenceSkillId(
  * open a database console or mint a restricted API key. The drain waits it out
  * — the executor holds the task's promise — so the only real limit is this one.
  */
-const TASK_ASK_TIMEOUT_MS = 20 * 60 * 1000;
+const TASK_ASK_TIMEOUT_MS = CREDENTIAL_ASK_TIMEOUT_MS;
 
 /**
  * How long an optional step's notice waits for an answer.

--- a/src/lib/programs/__tests__/warehouse-ask-timeout.test.ts
+++ b/src/lib/programs/__tests__/warehouse-ask-timeout.test.ts
@@ -1,0 +1,39 @@
+/**
+ * How long the standalone `wizard warehouse` command waits for a credential.
+ *
+ * The same source credentials are collected two ways: as the orchestrator's
+ * seeded warehouse task, and as this command — the one the outro points at
+ * when the user declines the offer or a source falls back to browser setup.
+ * The command was on the 5-minute default, so the fallback route gave the
+ * user a quarter of the time the in-run prompt does for identical questions.
+ */
+import type { WizardSession } from '@lib/wizard-session';
+
+vi.mock('@utils/analytics', () => ({
+  analytics: {
+    wizardCapture: vi.fn(),
+    setTag: vi.fn(),
+    capture: vi.fn(),
+    captureException: vi.fn(),
+  },
+}));
+
+import { warehouseSourceConfig } from '@lib/programs/warehouse-source/index';
+import {
+  CREDENTIAL_ASK_TIMEOUT_MS,
+  DEFAULT_ASK_TIMEOUT_MS,
+} from '@lib/wizard-ask-bridge';
+
+function session(): WizardSession {
+  return { installDir: '/tmp/app', frameworkContext: {} } as WizardSession;
+}
+
+describe('warehouse command ask timeout', () => {
+  it('gives credential questions the shared allowance, not the default', async () => {
+    const { run } = warehouseSourceConfig;
+    const resolved = typeof run === 'function' ? await run(session()) : run;
+
+    expect(resolved?.askTimeoutMs).toBe(CREDENTIAL_ASK_TIMEOUT_MS);
+    expect(resolved?.askTimeoutMs).toBeGreaterThan(DEFAULT_ASK_TIMEOUT_MS);
+  });
+});

--- a/src/lib/programs/warehouse-source/index.ts
+++ b/src/lib/programs/warehouse-source/index.ts
@@ -1,6 +1,7 @@
 import type { ProgramConfig } from '@lib/programs/program-step';
 import type { ProgramRun } from '@lib/agent/agent-runner';
 import type { WizardSession } from '@lib/wizard-session';
+import { CREDENTIAL_ASK_TIMEOUT_MS } from '@lib/wizard-ask-bridge';
 import { WAREHOUSE_SOURCE_PROGRAM } from './steps.js';
 import {
   WAREHOUSE_ABORT_CASES,
@@ -60,6 +61,11 @@ export const warehouseSourceConfig: ProgramConfig = {
       docsUrl: 'https://posthog.com/docs/data-warehouse',
       spinnerMessage: 'Connecting your data source...',
       estimatedDurationMinutes: 5,
+      // Same questions the orchestrator's seeded warehouse task asks, so the
+      // same allowance. On the 5-minute default a user who went to fetch a
+      // database password came back to a cancelled prompt and the browser
+      // fallback — in the command the outro sends declines to.
+      askTimeoutMs: CREDENTIAL_ASK_TIMEOUT_MS,
       abortCases: WAREHOUSE_ABORT_CASES,
     }),
   requires: ['posthog-integration'],

--- a/src/lib/wizard-ask-bridge.ts
+++ b/src/lib/wizard-ask-bridge.ts
@@ -76,6 +76,22 @@ export const CANCELLED_SENTINEL = '__cancelled__';
 /** Default per-question timeout (5 minutes). */
 export const DEFAULT_ASK_TIMEOUT_MS = 5 * 60 * 1000;
 
+/**
+ * Per-question timeout for a flow that collects source credentials.
+ *
+ * These questions wait on a person, not on a model: opening a database
+ * console, finding a host and port, minting a restricted API key. The default
+ * above is sized for a question the user can answer from memory and expires
+ * long before that errand is done.
+ *
+ * Shared rather than inlined because the same credential prompts are reached
+ * two ways — as the orchestrator's seeded warehouse task and as the standalone
+ * `wizard warehouse` command the outro points declines at — and the two giving
+ * the user different allowances for identical questions is the bug, not a
+ * setting.
+ */
+export const CREDENTIAL_ASK_TIMEOUT_MS = 20 * 60 * 1000;
+
 function buildCancelledAnswers(questions: AskQuestion[]): AskAnswers {
   const out: AskAnswers = {};
   for (const q of questions) {


### PR DESCRIPTION
## Problem

The wizard collects data-source credentials in two places, through the same
skill and the same `wizard_ask` prompts:

1. the orchestrator's seeded warehouse task, inside a normal `wizard` run, and
2. `npx @posthog/wizard warehouse` — the command the outro points at when the
   user declines the in-run offer, and the route every source that falls back
   to browser setup ends up on.

The seeded task allows 20 minutes per question, with an explicit rationale in
`orchestrator-runner.ts`: these questions wait on a person opening a database
console or minting a restricted API key, not on a model. The standalone
command never set `askTimeoutMs`, so it ran on the 5-minute default — a
quarter of the allowance, for identical questions.

Past that timeout every unanswered field resolves to the cancellation
sentinel, which the task reads as "the user declined" and drops to its
browser-handoff fallback. A user who stepped away to fetch a password came
back to a prompt that had already given up. Timeouts at this prompt are
observable even with the 20-minute allowance, so the shorter one is not
theoretical — and it applies precisely to the recovery path we send people to
after the first attempt did not work out.

## Changes

- New shared `CREDENTIAL_ASK_TIMEOUT_MS` (20 min) in `wizard-ask-bridge.ts`,
  next to `DEFAULT_ASK_TIMEOUT_MS`.
- `orchestrator-runner.ts`'s `TASK_ASK_TIMEOUT_MS` now reads it instead of
  inlining the value.
- The warehouse program's `run()` sets `askTimeoutMs` to it, the same way the
  source-map upload and self-driving programs already raise theirs.

Shared rather than inlined on both sides because the drift is the bug: the two
routes ask the same questions and should not offer different allowances.
Nothing else changes — the cancellation contract, the ask cap and its refund,
and the browser fallback are all untouched.

## Test plan

- New `warehouse-ask-timeout.test.ts` asserts the resolved program run carries
  the shared allowance and that it exceeds the default.
- `pnpm build && pnpm test && pnpm fix` — 2638 tests pass, lint clean.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*