### PR TITLE
fix(gateway): show the server's reason when the mint refuses a run

### DIFF
--- a/src/lib/__tests__/gateway-session.test.ts
+++ b/src/lib/__tests__/gateway-session.test.ts
@@ -221,6 +221,37 @@ describe('gatewayAuth', () => {
     },
   );
 
+  it('shows the server detail on a refusal when it sends one', async () => {
+    // The blocklist's 403 names the contact address; the fixed message would
+    // tell a banned user to re-authenticate instead.
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () =>
+        Promise.resolve({
+          detail: 'This account is blocked. Contact wizard@posthog.com.',
+        }),
+    });
+    await expect(gatewayAuth(host, 'pha_oauth', 'integration')).rejects.toThrow(
+      'Contact wizard@posthog.com',
+    );
+  });
+
+  it.each([
+    ['not an object', () => Promise.resolve('nope')],
+    ['an empty detail', () => Promise.resolve({ detail: '   ' })],
+    ['an unparseable body', () => Promise.reject(new SyntaxError('bad json'))],
+    ['an oversized detail', () => Promise.resolve({ detail: 'x'.repeat(501) })],
+  ])(
+    'keeps the fixed message when the refusal body is %s',
+    async (_label, json) => {
+      fetchMock.mockResolvedValue({ ok: false, status: 403, json });
+      await expect(
+        gatewayAuth(host, 'pha_oauth', 'integration'),
+      ).rejects.toThrow(/access to this project/i);
+    },
+  );
+
   it.each([404, 401])(
     'stays on the existing gateway on HTTP %i',
     async (status) => {

--- a/src/lib/gateway-session.ts
+++ b/src/lib/gateway-session.ts
@@ -50,6 +50,8 @@ const LEGACY_RETRY_MS = 10 * 60 * 1000;
 // Exceeds the backend's own 10s gateway timeout: a slow mint that lands after the
 // CLI hangs up spends a daily mint and orphans a live token.
 const MINT_TIMEOUT_MS = 20_000;
+/** Longer than any refusal the mint writes; a body past this is not a message. */
+const MAX_REFUSAL_DETAIL_LENGTH = 500;
 
 /** Resolve this run's gateway auth, minting and re-minting near expiry. */
 export async function gatewayAuth(
@@ -218,7 +220,25 @@ function isMintRefusal(status: number): boolean {
   return status === 400 || status === 403 || status === 429;
 }
 
-function mintRefusalMessage(status: number): string {
+/**
+ * The server's own reason for a refusal, when it sent one. DRF answers every
+ * refusal as `{"detail": "..."}`; the blocklist's detail names the contact
+ * address, which the fixed messages below cannot.
+ */
+async function readRefusalDetail(resp: Response): Promise<string | undefined> {
+  try {
+    const body = (await resp.json()) as { detail?: unknown };
+    const detail = typeof body?.detail === 'string' ? body.detail.trim() : '';
+    return detail.length > 0 && detail.length <= MAX_REFUSAL_DETAIL_LENGTH
+      ? detail
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function mintRefusalMessage(status: number, detail?: string): string {
+  if (detail) return detail;
   switch (status) {
     case 429:
       return 'This wizard program has used its daily run limit. Try again tomorrow.';
@@ -255,7 +275,7 @@ async function mintGatewayToken(
         );
         throw new GatewayMintRefused(
           resp.status,
-          mintRefusalMessage(resp.status),
+          mintRefusalMessage(resp.status, await readRefusalDetail(resp)),
         );
       }
       if (resp.status === 404 || resp.status === 401) {


### PR DESCRIPTION
Render the mint endpoint's `detail` on a 400/403/429 refusal instead of the fixed per-status message.

The blocklist's 403 names wizard@posthog.com; the CLI replaced it with "Your access to this project has changed. Re-authenticate and try again." The fixed message stays as the fallback when the body is not JSON, has no string `detail`, or the detail is over 500 characters.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*