### PR TITLE
fix(models): use supported wizard models

### DIFF
--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -630,7 +630,7 @@ describe('subprocess gateway credentials', () => {
   const config = {
     workingDirectory: '/test/dir',
     mcpServers: {},
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     // Deliberately different from the gateway bearer below: identical values
     // would let either source pass.
     posthogApiKey: 'phx_user_oauth_token',
@@ -715,7 +715,7 @@ describe('gateway re-mint on 401', () => {
   ) => ({
     workingDirectory: '/test/dir',
     mcpServers: {},
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     posthogApiKey: 'phx_user_oauth_token',
     sequence: Sequence.linear,
     triageProvider: () => Promise.resolve('false_positive'),

--- a/src/lib/agent/__tests__/agent-prompt-loader.test.ts
+++ b/src/lib/agent/__tests__/agent-prompt-loader.test.ts
@@ -36,7 +36,7 @@ describe('parseAgentPrompt', () => {
 type: instrument-events
 model_pi: openai/gpt-5.6-terra     # per-profile model targets
 effort_pi: medium
-model_sdk: claude-sonnet-4-6
+model_sdk: claude-sonnet-5
 skills: [instrument-events]
 allowedTools: [Read, Edit, Grep, Glob, Bash]
 disallowedTools: [enqueue_task]
@@ -52,7 +52,7 @@ Add at least one capture call.
     expect(p.type).toBe('instrument-events');
     expect(p.modelPi).toBe('openai/gpt-5.6-terra');
     expect(p.effortPi).toBe('medium');
-    expect(p.modelSdk).toBe('claude-sonnet-4-6');
+    expect(p.modelSdk).toBe('claude-sonnet-5');
     expect(p.skills).toEqual(['instrument-events']);
     expect(p.allowedTools).toEqual(['Read', 'Edit', 'Grep', 'Glob', 'Bash']);
     expect(p.disallowedTools).toEqual(['enqueue_task']);
@@ -86,7 +86,7 @@ Connect the sources.
       effort: 'medium',
     });
     expect(promptModelFor(p, 'anthropic')).toEqual({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       effort: undefined,
     });
   });
@@ -281,7 +281,7 @@ describe('buildRegistry', () => {
         flow: 'f',
         modelPi: 'openai/gpt-5.6-terra',
         effortPi: 'medium',
-        modelSdk: 'claude-sonnet-4-6',
+        modelSdk: 'claude-sonnet-5',
       }),
       prompt({ type: 'install', flow: 'f', modelPi: 'openai/gpt-5.6-luna' }),
     ];
@@ -294,7 +294,7 @@ describe('buildRegistry', () => {
     expect(registry.get('review')).toMatchObject({
       modelPi: 'openai/gpt-5.6-sol',
       effortPi: 'medium',
-      modelSdk: 'claude-sonnet-4-6',
+      modelSdk: 'claude-sonnet-5',
     });
     expect(registry.seed).toMatchObject({
       modelPi: 'openai/gpt-5.6-terra',
@@ -324,7 +324,7 @@ describe('resolveTask', () => {
     runnerSeeded: false,
     modelPi: 'openai/gpt-5.6-luna',
     effortPi: 'low',
-    modelSdk: 'claude-haiku-4-5-20251001',
+    modelSdk: 'claude-haiku-4-5',
     skills: ['instrument-events'],
     allowedTools: ['Read', 'Edit'],
     disallowedTools: ['enqueue_task'],
@@ -356,7 +356,7 @@ describe('resolveTask', () => {
       effort: 'low',
     });
     expect(taskModelSpec(registry, task, 'anthropic').model).toBe(
-      'claude-haiku-4-5-20251001',
+      'claude-haiku-4-5',
     );
   });
 

--- a/src/lib/agent/__tests__/token-pricing.test.ts
+++ b/src/lib/agent/__tests__/token-pricing.test.ts
@@ -7,7 +7,9 @@ import {
 
 describe('pricePerMtokForModel', () => {
   it('defaults to Sonnet pricing (DEFAULT_AGENT_MODEL) when no model is given', () => {
-    expect(pricePerMtokForModel(undefined)).toEqual({
+    expect(
+      pricePerMtokForModel(undefined, new Date('2026-09-01T00:00:00Z')),
+    ).toEqual({
       input: 3,
       output: 15,
       cacheRead: 0.3,
@@ -17,7 +19,7 @@ describe('pricePerMtokForModel', () => {
   });
 
   it('strips a dated release suffix to match the undated table entry', () => {
-    // HAIKU_MODEL is exactly this string.
+    // Resumed sessions can still report a dated model id.
     expect(pricePerMtokForModel('claude-haiku-4-5-20251001')?.input).toBe(1);
   });
 

--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect } from 'vitest';
 import { PROGRAM_REGISTRY } from '@lib/programs/program-registry';
 import {
   DEFAULT_AGENT_MODEL,
+  HAIKU_MODEL,
   GPT5_6_LUNA_MODEL,
   GPT5_6_SOL_MODEL,
   GPT5_6_TERRA_MODEL,
@@ -268,9 +269,8 @@ describe('switchboard composed clamp', () => {
 describe('switchboard modelCapabilities (stage 2: effective effort)', () => {
   it('marks the known reasoning models as reasoning', () => {
     for (const m of [
-      'claude-sonnet-4-6',
-      'claude-opus-4-8',
-      'claude-haiku-4-5-20251001',
+      'claude-sonnet-5',
+      'claude-haiku-4-5',
       'openai/gpt-5.6-terra',
     ]) {
       expect(modelCapabilities(m).reasoning).toBe(true);
@@ -315,18 +315,25 @@ describe('switchboard modelCapabilities (stage 2: effective effort)', () => {
 });
 
 describe('switchboard model allow-list', () => {
-  it('allow-lists the sonnets and the gpt-5.6 line, nothing older', () => {
+  it('allow-lists Sonnet 5, Haiku 4.5 and the gpt-5.6 line', () => {
     for (const m of [
-      DEFAULT_AGENT_MODEL,
       SONNET_5_MODEL,
+      HAIKU_MODEL,
       GPT5_6_LUNA_MODEL,
       GPT5_6_TERRA_MODEL,
       GPT5_6_SOL_MODEL,
     ]) {
       expect(isValidModel(m)).toBe(true);
     }
-    // The retired openai ids are gone — no longer valid to dispatch on.
-    for (const m of ['openai/gpt-5', 'openai/gpt-5.4', 'openai/gpt-5.5']) {
+    // Retired model ids must not reach the gateway.
+    for (const m of [
+      'claude-sonnet-4-6',
+      'claude-opus-4-8',
+      'claude-haiku-4-5-20251001',
+      'openai/gpt-5',
+      'openai/gpt-5.4',
+      'openai/gpt-5.5',
+    ]) {
       expect(isValidModel(m)).toBe(false);
     }
     expect(isValidModel('')).toBe(false);

--- a/src/lib/agent/runner/harness/anthropic/README.md
+++ b/src/lib/agent/runner/harness/anthropic/README.md
@@ -28,7 +28,7 @@ Both entry points are implemented:
 - **Custom headers:** wizard flags (`X-POSTHOG-FLAG-*`) and metadata
   (`X-POSTHOG-PROPERTY-*`) piggyback on every gateway request for tracing.
 - **Model routing:** `AgentConfig.modelOverride` accepts any gateway model id
-  (`DEFAULT_AGENT_MODEL`, `HAIKU_MODEL`, `OPUS_MODEL`, `GPT5_6_TERRA_MODEL`), so
+  (`DEFAULT_AGENT_MODEL`, `HAIKU_MODEL`, `GPT5_6_TERRA_MODEL`), so
   mechanical work (repo classification, source-map detection) can route to
   `HAIKU_MODEL` while integration work stays on Sonnet.
 

--- a/src/lib/agent/runner/harness/pi/__tests__/gateway.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/gateway.test.ts
@@ -61,7 +61,7 @@ describe('buildGatewayProvider transport', () => {
   it('routes anthropic models over anthropic-messages without /v1', () => {
     const { api, baseUrl } = buildGatewayProvider({
       ...base,
-      modelId: 'claude-sonnet-4-6',
+      modelId: 'claude-sonnet-5',
     });
     expect(api).toBe('anthropic-messages');
     expect(baseUrl).toBe('https://ai-gateway.us.posthog.com');

--- a/src/lib/agent/runner/sequence/README.md
+++ b/src/lib/agent/runner/sequence/README.md
@@ -63,7 +63,7 @@ Each step is one markdown file whose frontmatter declares its shape:
 type: dashboard
 flow: integration-v2
 label: Create a starter dashboard
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 skills: [basic-integration-dashboard]
 allowedTools: [Read, Glob, Grep]
 disallowedTools: [Write, Edit, Bash, enqueue_task]

--- a/src/lib/agent/runner/switchboard/flags/schemes.ts
+++ b/src/lib/agent/runner/switchboard/flags/schemes.ts
@@ -6,7 +6,6 @@
  */
 import { z } from 'zod';
 import {
-  DEFAULT_AGENT_MODEL,
   GPT5_6_LUNA_MODEL,
   GPT5_6_SOL_MODEL,
   GPT5_6_TERRA_MODEL,
@@ -25,7 +24,8 @@ const MODEL_FLAG_VARIANTS: Record<string, string> = {
   'gpt-5-6-luna': GPT5_6_LUNA_MODEL,
   'gpt-5-6-terra': GPT5_6_TERRA_MODEL,
   'gpt-5-6-sol': GPT5_6_SOL_MODEL,
-  'sonnet-4-6': DEFAULT_AGENT_MODEL,
+  // Existing flag payloads keep working while dispatching the supported Sonnet.
+  'sonnet-4-6': SONNET_5_MODEL,
   'sonnet-5': SONNET_5_MODEL,
 };
 

--- a/src/lib/agent/runner/switchboard/models.ts
+++ b/src/lib/agent/runner/switchboard/models.ts
@@ -10,9 +10,7 @@
  * are silent when wrong, so they live here as one configurable table.
  */
 import {
-  DEFAULT_AGENT_MODEL,
   SONNET_5_MODEL,
-  OPUS_MODEL,
   HAIKU_MODEL,
   GPT5_6_LUNA_MODEL,
   GPT5_6_SOL_MODEL,
@@ -52,9 +50,7 @@ export interface ModelCapabilities {
 
 /** Explicit per-model traits. Anything absent falls back to `defaultCaps`. */
 export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
-  [DEFAULT_AGENT_MODEL]: { reasoning: true }, // claude-sonnet-4-6
   [SONNET_5_MODEL]: { reasoning: true },
-  [OPUS_MODEL]: { reasoning: true },
   [HAIKU_MODEL]: { reasoning: true },
   // The openai 5.6 line; all reasoning models, so they must opt in past the
   // openai-completions default (reasoning off). Luna stays low for cheap,
@@ -100,8 +96,7 @@ function defaultCaps(modelId: string): ModelCapabilities {
 /**
  * Scan-triage classifier per harness: the cheapest tier of the line that harness
  * already speaks. Undated ids on purpose — triage is a boolean classifier, so it
- * should follow the current release rather than pin one, and these are not
- * dispatchable agent models (absent from MODEL_CAPABILITIES by design).
+ * should follow the current release rather than pin one.
  */
 export const TRIAGE_MODELS: Record<Harness, string> = {
   [Harness.anthropic]: HAIKU_TRIAGE_MODEL,

--- a/src/lib/agent/token-pricing.ts
+++ b/src/lib/agent/token-pricing.ts
@@ -64,11 +64,9 @@ function pricingFromInput(input: number, output: number): PricePerMtok {
 /**
  * Exact-match price table, keyed by the *undated* model id prefix —
  * `pricePerMtokForModel` strips a dated suffix before falling back to this
- * table, so e.g. `HAIKU_MODEL` (`claude-haiku-4-5-20251001`) resolves via
- * the `'claude-haiku-4-5'` entry without needing its own duplicate key.
- * `DEFAULT_AGENT_MODEL` (`claude-sonnet-4-6`) has no date suffix, so it's
- * keyed directly. The rest are additional real Anthropic model ids kept
- * priced correctly in case a subagent or a future default ever reports one
+ * table. Historical dated Haiku ids resolve via the `'claude-haiku-4-5'`
+ * entry without needing duplicate keys. Historical model ids stay priced
+ * correctly in case a resumed session or subagent reports one
  * (a turn on an id NOT in this table contributes $0 to the live estimate
  * rather than guessing — see `pricePerMtokForModel`).
  *
@@ -77,8 +75,8 @@ function pricingFromInput(input: number, output: number): PricePerMtok {
  * `pricePerMtokForModel` via `SONNET_5_PRICE`.
  */
 const PRICE_TABLE: Record<string, PricePerMtok> = {
-  [DEFAULT_AGENT_MODEL]: pricingFromInput(3, 15),
-  'claude-haiku-4-5': pricingFromInput(1, 5), // HAIKU_MODEL + a date suffix
+  'claude-sonnet-4-6': pricingFromInput(3, 15),
+  'claude-haiku-4-5': pricingFromInput(1, 5),
   'claude-opus-4-5': pricingFromInput(5, 25),
 };
 
@@ -88,7 +86,7 @@ const PRICE_TABLE: Record<string, PricePerMtok> = {
  * — not a coincidence, Anthropic prices it identically to 4.6 once the
  * promo ends. Re-verify against https://models.dev/api.json if this ever
  * looks off, and delete this special case once the promo window has
- * passed (its `PRICE_TABLE[DEFAULT_AGENT_MODEL]` price is the same anyway).
+ * passed.
  */
 const SONNET_5_PROMO_ENDS_UTC = new Date('2026-09-01T00:00:00Z');
 
@@ -123,10 +121,10 @@ export function pricePerMtokForModel(
   model?: string,
   now: Date = new Date(),
 ): PricePerMtok | undefined {
-  if (!model) return PRICE_TABLE[DEFAULT_AGENT_MODEL];
-  const undated = stripDateSuffix(model);
+  const resolvedModel = model || DEFAULT_AGENT_MODEL;
+  const undated = stripDateSuffix(resolvedModel);
   if (undated === 'claude-sonnet-5') return sonnet5Price(now);
-  return PRICE_TABLE[model] ?? PRICE_TABLE[undated];
+  return PRICE_TABLE[resolvedModel] ?? PRICE_TABLE[undated];
 }
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,29 +6,17 @@ import { VERSION } from './version';
 
 // ── Models ──────────────────────────────────────────────────────────
 
-/**
- * Default model for agent runs. Bare model IDs (no `anthropic/` prefix) so the
- * LLM gateway's Bedrock fallback can match map_to_bedrock_model().
- */
-export const DEFAULT_AGENT_MODEL = 'claude-sonnet-4-6';
-
-/** Next sonnet generation (a `MODEL_FLAG_VARIANTS` key in the switchboard). */
+/** Bare model IDs let the gateway match its provider routing aliases. */
 export const SONNET_5_MODEL = 'claude-sonnet-5';
+export const DEFAULT_AGENT_MODEL = SONNET_5_MODEL;
 
 /**
  * Cheaper, faster model for mechanical agent work (e.g. repo classification
  * during source-map detection). Passed via AgentConfig.modelOverride.
  */
-export const HAIKU_MODEL = 'claude-haiku-4-5-20251001';
+export const HAIKU_MODEL = 'claude-haiku-4-5';
 
-/** Undated haiku, for scan triage — the alias tracks the current 4.5 release rather than pinning one. */
-export const HAIKU_TRIAGE_MODEL = 'claude-haiku-4-5';
-
-/**
- * Larger model for planning / hard work. Named the switchboard could route to
- * from `PROGRAM_BINDINGS[id].model` or `contextMillOverride`.
- */
-export const OPUS_MODEL = 'claude-opus-4-8';
+export const HAIKU_TRIAGE_MODEL = HAIKU_MODEL;
 
 // The only openai models the wizard runs.
 export const GPT5_6_LUNA_MODEL = 'openai/gpt-5.6-luna';

--- a/src/ui/tui/__tests__/store.test.ts
+++ b/src/ui/tui/__tests__/store.test.ts
@@ -808,7 +808,7 @@ describe('WizardStore', () => {
         cacheCreationTokens: 0,
         cacheCreation5m: 0,
         cacheCreation1h: 0,
-        model: 'claude-haiku-4-5-20251001',
+        model: 'claude-haiku-4-5',
       });
       store.addTokenUsage({
         inputTokens: 1_000_000,

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -122,7 +122,7 @@ export class Wizard {
         })
         .option('model', {
           describe:
-            'Override the agent model (gateway id, e.g. claude-sonnet-4-6 | openai/gpt-5). Wins over the binding default.\nenv: POSTHOG_WIZARD_MODEL',
+            'Override the agent model (gateway id, e.g. claude-sonnet-5 | openai/gpt-5.6-terra). Wins over the binding default.\nenv: POSTHOG_WIZARD_MODEL',
           type: 'string',
           hidden: true,
         })


### PR DESCRIPTION
## Problem

Wizard defaults and selectable models include IDs outside the proposed five-model gateway allowlist. Narrowing the backend allowlist would reject those requests.

## Changes

- Default agent runs to Sonnet 5 and use the undated Haiku 4.5 ID for detection and triage.
- Remove the unused Opus 4.8 model constant and selectable entry. No built-in spell or context-mill prompt selected it.
- Retain the old Sonnet flag variant as an alias to Sonnet 5 so existing payloads keep their routing settings.
- Update dispatch fixtures and CLI examples, while preserving historical model pricing and date-aware default pricing.

Stacked on #1224. Coordinates with PostHog/posthog#96851 and the context-mill prompt migration.

## Test plan

- Formatting and ESLint checks on changed TypeScript files passed (no lint errors).
- `git diff --check` passed.
- `tsc --noEmit` reports the same 29 errors on this branch and the unchanged #1224 head with the same local dependencies; no new typecheck diagnostics.
- Unit, integration, and live-stack tests were not run, as requested.

## LLM context

Codex inspected Wizard and context-mill model selections and made the migration. Historical pricing references are intentionally retained; this changes built-in selections and the model registry, not arbitrary developer model overrides.
