### PR TITLE
fix(ci): fall back to the legacy gateway under --ci

### DIFF
--- a/src/lib/__tests__/agent-interface.test.ts
+++ b/src/lib/__tests__/agent-interface.test.ts
@@ -607,7 +607,7 @@ describe('buildAgentEnv header shape', () => {
   const flags = { 'wizard-orchestrator': 'test' };
 
   it('sends one properties blob and no per-key or bedrock headers', () => {
-    const encoded = buildAgentEnv(metadata, flags, 42);
+    const encoded = buildAgentEnv(metadata, flags, { teamId: 42 });
     const [name, json] = encoded.split(': ', 2);
     expect(name).toBe('X-PostHog-Properties');
     // Fallback is native in the gateway's routing chain, and the run tags ride
@@ -621,6 +621,14 @@ describe('buildAgentEnv header shape', () => {
     });
     expect(encoded).not.toContain('x-posthog-use-bedrock-fallback');
     expect(encoded).not.toContain('X-POSTHOG-PROPERTY-');
+  });
+
+  it('sends per-key headers and the bedrock opt-in on the legacy gateway', () => {
+    const encoded = buildAgentEnv(metadata, flags, { legacy: true });
+    expect(encoded).toContain('x-posthog-use-bedrock-fallback: true');
+    expect(encoded).toContain('X-POSTHOG-PROPERTY-run_id: r1');
+    expect(encoded).toContain('X-POSTHOG-FLAG-WIZARD-ORCHESTRATOR: test');
+    expect(encoded).not.toContain('X-PostHog-Properties');
   });
 });
 

--- a/src/lib/__tests__/gateway-session.test.ts
+++ b/src/lib/__tests__/gateway-session.test.ts
@@ -38,7 +38,10 @@ const renderArg = (a: unknown): string => {
 const loggedLines = () =>
   vi.mocked(logToFile).mock.calls.map((call) => call.map(renderArg).join(' '));
 
-const host = { apiHost: 'https://us.posthog.com' } as unknown as HostResolution;
+const host = {
+  region: 'us',
+  apiHost: 'https://us.posthog.com',
+} as unknown as HostResolution;
 
 describe('gatewayAuth', () => {
   const fetchMock = vi.fn();
@@ -469,6 +472,24 @@ describe('gatewayAuth', () => {
         legacy: true,
       });
       expect(isPastRefresh(auth)).toBe(false);
+    });
+
+    it('picks the legacy gateway for the region, or the local one for a dev host', async () => {
+      fetchMock.mockResolvedValue(refused(401));
+      const urlFor = async (region: string, apiHost: string) => {
+        resetGatewaySession();
+        const h = { region, apiHost } as unknown as HostResolution;
+        return (await gatewayAuth(h, 'phx_personal', 'integration')).gatewayUrl;
+      };
+      expect(await urlFor('eu', 'https://eu.i.posthog.com')).toBe(
+        'https://gateway.eu.posthog.com/wizard',
+      );
+      expect(await urlFor('us', 'http://localhost:8010')).toBe(
+        'http://localhost:3308/wizard',
+      );
+      expect(await urlFor('us', 'http://host.docker.internal:8010')).toBe(
+        'http://host.docker.internal:3308/wizard',
+      );
     });
 
     it('stays on the legacy gateway when the instance has no mint', async () => {

--- a/src/lib/__tests__/gateway-session.test.ts
+++ b/src/lib/__tests__/gateway-session.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@lib/gateway-session';
 import type { HostResolution } from '@lib/host-resolution';
 import { ErrorCodes } from '@lib/errors';
+import { setLegacyGatewayFallback } from '@lib/legacy-gateway';
 import { WizardError } from '@utils/wizard-abort';
 import { analytics } from '@utils/analytics';
 import { logToFile } from '@utils/debug';
@@ -446,6 +447,73 @@ describe('gatewayAuth', () => {
     await expect(
       gatewayAuth(host, 'pha_oauth', 'integration'),
     ).rejects.toBeInstanceOf(GatewayMintRefused);
+  });
+
+  describe('CI legacy fallback', () => {
+    const refused = (status: number) => ({
+      ok: false,
+      status,
+      json: () => Promise.resolve({}),
+    });
+
+    beforeEach(() => setLegacyGatewayFallback(true));
+    afterEach(() => setLegacyGatewayFallback(false));
+
+    it('stays on the legacy gateway when the mint does not take the credential', async () => {
+      // A personal API key 401s at the mint; the legacy gateway authenticates it itself.
+      fetchMock.mockResolvedValue(refused(401));
+      const auth = await gatewayAuth(host, 'phx_personal', 'integration');
+      expect(auth).toMatchObject({
+        gatewayUrl: 'https://gateway.us.posthog.com/wizard',
+        token: 'phx_personal',
+        legacy: true,
+      });
+      expect(isPastRefresh(auth)).toBe(false);
+    });
+
+    it('stays on the legacy gateway when the instance has no mint', async () => {
+      fetchMock.mockResolvedValue(refused(404));
+      const auth = await gatewayAuth(host, 'phx_personal', 'integration');
+      expect(auth.legacy).toBe(true);
+    });
+
+    it('caches the fallback instead of re-asking the mint per caller', async () => {
+      fetchMock.mockResolvedValue(refused(401));
+      await gatewayAuth(host, 'phx_personal', 'integration');
+      await gatewayAuth(host, 'phx_personal', 'integration');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('still fails a policy refusal', async () => {
+      // 403/429/400 are decisions about the run, which the legacy gateway would not enforce.
+      fetchMock.mockResolvedValue(refused(403));
+      await expect(
+        gatewayAuth(host, 'phx_personal', 'integration'),
+      ).rejects.toBeInstanceOf(GatewayMintRefused);
+    });
+
+    it('still mints when the mint accepts the credential', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            token: 'phe_minted',
+            expires_at: new Date(Date.now() + 3600_000).toISOString(),
+            gateway_url: 'https://gateway.us.posthog.com',
+          }),
+      });
+      const auth = await gatewayAuth(host, 'pha_app', 'integration');
+      expect(auth.token).toBe('phe_minted');
+      expect(auth.legacy).toBeUndefined();
+    });
+
+    it('does not fall back outside CI', async () => {
+      setLegacyGatewayFallback(false);
+      fetchMock.mockResolvedValue(refused(401));
+      await expect(
+        gatewayAuth(host, 'phx_personal', 'integration'),
+      ).rejects.toBeInstanceOf(GatewayMintRefused);
+    });
   });
 
   it("names the run's program in the mint request", async () => {

--- a/src/lib/agent/__tests__/tutorial-run-tags.test.ts
+++ b/src/lib/agent/__tests__/tutorial-run-tags.test.ts
@@ -48,6 +48,7 @@ describe('buildTutorialRunTags', () => {
     const encoded = buildAgentEnv(
       buildTutorialRunTags({ programId: 'mcp-tutorial' }),
       {},
+      {},
     );
 
     expect(encoded).toContain('X-PostHog-Properties: ');
@@ -55,7 +56,7 @@ describe('buildTutorialRunTags', () => {
   });
 
   it('sends only product attribution when there is no program', () => {
-    const encoded = buildAgentEnv(buildTutorialRunTags({}), {});
+    const encoded = buildAgentEnv(buildTutorialRunTags({}), {}, {});
 
     expect(encoded).toBe('X-PostHog-Properties: {"ai_product":"wizard"}');
   });

--- a/src/lib/agent/agent-interface.ts
+++ b/src/lib/agent/agent-interface.ts
@@ -30,6 +30,7 @@ import {
 import { wizardAbort, WizardError } from '@utils/wizard-abort';
 import { createCustomHeaders } from '@utils/custom-headers';
 import type { HostResolution } from '@lib/host-resolution';
+import { legacyGatewayHeaders } from '@lib/legacy-gateway';
 import {
   buildWizardPropertiesBlob,
   gatewayAuth,
@@ -396,18 +397,25 @@ export function isWarlockDisabled(): boolean {
 /**
  * Build ANTHROPIC_CUSTOM_HEADERS for the SDK subprocess: the run's metadata and
  * flags as one `X-PostHog-Properties` JSON blob. Bedrock fallback is native to
- * the gateway, so there is no opt-in header.
+ * the gateway, so there is no opt-in header. The CI fallback sends the legacy
+ * gateway's shape instead.
  */
 export function buildAgentEnv(
   wizardMetadata: Record<string, string>,
   wizardFlags: Record<string, string>,
-  teamId?: number,
+  auth: Pick<GatewayAuth, 'teamId' | 'legacy'>,
 ): string {
   const headers = createCustomHeaders();
-  headers.add(
-    'X-PostHog-Properties',
-    buildWizardPropertiesBlob(wizardMetadata, wizardFlags, teamId),
-  );
+  const shaped = auth.legacy
+    ? legacyGatewayHeaders(wizardMetadata, wizardFlags)
+    : {
+        'X-PostHog-Properties': buildWizardPropertiesBlob(
+          wizardMetadata,
+          wizardFlags,
+          auth.teamId,
+        ),
+      };
+  for (const [key, value] of Object.entries(shaped)) headers.add(key, value);
   const encoded = headers.encode();
   logToFile('ANTHROPIC_CUSTOM_HEADERS', encoded);
   return encoded;
@@ -562,6 +570,7 @@ export async function initializeAgent(
         baseURL: current.gatewayUrl,
         authToken: current.token,
         teamId: current.teamId,
+        legacy: current.legacy,
         wizardMetadata: triageMetadata,
         wizardFlags: config.wizardFlags ?? {},
       };
@@ -1055,7 +1064,7 @@ export async function runAgent(
             ANTHROPIC_CUSTOM_HEADERS: buildAgentEnv(
               agentConfig.wizardMetadata ?? {},
               agentConfig.wizardFlags ?? {},
-              agentConfig.gatewayAuth.teamId,
+              agentConfig.gatewayAuth,
             ),
           },
           canUseTool: (toolName: string, input: unknown) => {

--- a/src/lib/agent/mcp-prompt-streaming.ts
+++ b/src/lib/agent/mcp-prompt-streaming.ts
@@ -385,7 +385,7 @@ export async function* runMcpPromptViaSdk(args: {
           ANTHROPIC_CUSTOM_HEADERS: buildAgentEnv(
             wizardMetadata ?? {},
             {},
-            auth.teamId,
+            auth,
           ),
         },
       },

--- a/src/lib/agent/runner/harness/pi/__tests__/gateway.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/gateway.test.ts
@@ -58,6 +58,17 @@ describe('buildGatewayProvider transport', () => {
     expect(baseUrl).toBe('https://ai-gateway.us.posthog.com/v1');
   });
 
+  it('routes openai models over chat completions on the legacy gateway', () => {
+    const { api, baseUrl } = buildGatewayProvider({
+      ...base,
+      gatewayUrl: 'https://gateway.us.posthog.com/wizard',
+      legacy: true,
+      modelId: 'openai/gpt-5.6-terra',
+    });
+    expect(api).toBe('openai-completions');
+    expect(baseUrl).toBe('https://gateway.us.posthog.com/wizard/v1');
+  });
+
   it('routes anthropic models over anthropic-messages without /v1', () => {
     const { api, baseUrl } = buildGatewayProvider({
       ...base,
@@ -83,6 +94,20 @@ describe('buildGatewayHeaders', () => {
     });
     expect(headers['x-posthog-use-bedrock-fallback']).toBeUndefined();
     expect(headers['X-POSTHOG-PROPERTY-run_id']).toBeUndefined();
+  });
+
+  it('carries per-key headers and the bedrock opt-in on the legacy gateway', () => {
+    const headers = buildGatewayHeaders(
+      { run_id: 'r1' },
+      { 'wizard-orchestrator': 'test', unrelated: 'x' },
+      42,
+      true,
+    );
+    expect(headers['X-POSTHOG-PROPERTY-run_id']).toBe('r1');
+    expect(headers['X-POSTHOG-FLAG-WIZARD-ORCHESTRATOR']).toBe('test');
+    expect(headers['X-POSTHOG-FLAG-UNRELATED']).toBeUndefined();
+    expect(headers['x-posthog-use-bedrock-fallback']).toBe('true');
+    expect(headers['X-PostHog-Properties']).toBeUndefined();
   });
 });
 

--- a/src/lib/agent/runner/harness/pi/gateway.ts
+++ b/src/lib/agent/runner/harness/pi/gateway.ts
@@ -11,6 +11,7 @@ import {
   isPastRefresh,
   type GatewayAuth,
 } from '@lib/gateway-session';
+import { legacyGatewayHeaders } from '@lib/legacy-gateway';
 import {
   modelCapabilities,
   type ThinkingLevel,
@@ -35,10 +36,10 @@ export type GatewayApi =
  * OpenAI models take the Responses API because OpenAI rejects function tools
  * combined with `reasoning_effort` on chat completions and every task sends both.
  */
-export function gatewayApiFor(modelId: string): GatewayApi {
-  return modelId.startsWith('openai/')
-    ? 'openai-responses'
-    : 'anthropic-messages';
+export function gatewayApiFor(modelId: string, legacy?: boolean): GatewayApi {
+  if (!modelId.startsWith('openai/')) return 'anthropic-messages';
+  // The legacy gateway routes openai models through chat completions itself.
+  return legacy ? 'openai-completions' : 'openai-responses';
 }
 
 /**
@@ -51,14 +52,19 @@ export function buildGatewayHeaders(
   wizardMetadata: Record<string, string>,
   wizardFlags: Record<string, string>,
   teamId?: number,
+  legacy?: boolean,
 ): Record<string, string> {
   return {
     'anthropic-beta': 'context-1m-2025-08-07',
-    'X-PostHog-Properties': buildWizardPropertiesBlob(
-      wizardMetadata,
-      wizardFlags,
-      teamId,
-    ),
+    ...(legacy
+      ? legacyGatewayHeaders(wizardMetadata, wizardFlags)
+      : {
+          'X-PostHog-Properties': buildWizardPropertiesBlob(
+            wizardMetadata,
+            wizardFlags,
+            teamId,
+          ),
+        }),
   };
 }
 
@@ -67,6 +73,8 @@ export interface GatewayProviderInputs {
   accessToken: string;
   /** Customer team for the properties blob (from the mint response). */
   teamId?: number;
+  /** Set only by the CI fallback in legacy-gateway.ts. */
+  legacy?: boolean;
   wizardMetadata: Record<string, string>;
   wizardFlags: Record<string, string>;
   modelId: string;
@@ -82,8 +90,9 @@ export interface GatewayProviderInputs {
  * callers (scan triage) hand it straight to `completeSimple`.
  */
 export function buildGatewayModel(inputs: GatewayProviderInputs) {
-  const { gatewayUrl, wizardMetadata, wizardFlags, modelId, teamId } = inputs;
-  const api = gatewayApiFor(modelId);
+  const { gatewayUrl, wizardMetadata, wizardFlags, modelId, teamId, legacy } =
+    inputs;
+  const api = gatewayApiFor(modelId, legacy);
   return {
     id: modelId,
     name: `${modelId} (PostHog Gateway)`,
@@ -99,7 +108,7 @@ export function buildGatewayModel(inputs: GatewayProviderInputs) {
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 1_000_000,
     maxTokens: 64_000,
-    headers: buildGatewayHeaders(wizardMetadata, wizardFlags, teamId),
+    headers: buildGatewayHeaders(wizardMetadata, wizardFlags, teamId, legacy),
   };
 }
 
@@ -114,8 +123,8 @@ export function buildGatewayProvider(inputs: GatewayProviderInputs): {
   gatewayUrl: string;
   baseUrl: string;
 } {
-  const { gatewayUrl, accessToken, modelId, effort } = inputs;
-  const api = gatewayApiFor(modelId);
+  const { gatewayUrl, accessToken, modelId, effort, legacy } = inputs;
+  const api = gatewayApiFor(modelId, legacy);
   // One resolution point for the model's traits and the run's effort override.
   // pi clamps whatever comes out of here against the levels this spec declares,
   // so a level the spec doesn't carry is silently reduced by the session.

--- a/src/lib/agent/runner/harness/pi/index.ts
+++ b/src/lib/agent/runner/harness/pi/index.ts
@@ -263,6 +263,7 @@ export const piBackend: AgentHarness = {
         gatewayUrl: current.gatewayUrl,
         accessToken: current.token,
         teamId: current.teamId,
+        legacy: current.legacy,
         wizardMetadata: boot.wizardMetadata,
         wizardFlags: boot.wizardFlags,
         modelId,

--- a/src/lib/agent/runner/harness/pi/task.ts
+++ b/src/lib/agent/runner/harness/pi/task.ts
@@ -230,6 +230,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
       gatewayUrl: current.gatewayUrl,
       accessToken: current.token,
       teamId: current.teamId,
+      legacy: current.legacy,
       wizardMetadata: boot.wizardMetadata,
       wizardFlags: boot.wizardFlags,
       modelId,

--- a/src/lib/agent/runner/shared/bootstrap.ts
+++ b/src/lib/agent/runner/shared/bootstrap.ts
@@ -333,6 +333,7 @@ export async function bootstrapProgram(
           baseURL: auth.gatewayUrl,
           authToken: auth.token,
           teamId: auth.teamId,
+          legacy: auth.legacy,
           // `call_type` splits scan spend out of the program's agent cost,
           // the same tag the in-run triage provider carries.
           wizardMetadata: { ...wizardMetadata, call_type: CallType.yaraTriage },

--- a/src/lib/agent/triage-provider.ts
+++ b/src/lib/agent/triage-provider.ts
@@ -29,6 +29,8 @@ export interface TriageGatewayAuth {
   authToken: string;
   /** Customer team for the properties blob. */
   teamId?: number;
+  /** Set only by the CI fallback in legacy-gateway.ts. */
+  legacy?: boolean;
   /** The run's trace tags, with `call_type` overridden to
    *  `CallType.yaraTriage` so scan spend is separable from agent work. */
   wizardMetadata?: Record<string, string>;
@@ -67,6 +69,7 @@ export function createTriageLLMProvider(
       gatewayUrl: current.baseURL,
       accessToken: authToken,
       teamId: current.teamId,
+      legacy: current.legacy,
       wizardMetadata: current.wizardMetadata ?? {},
       wizardFlags: current.wizardFlags ?? {},
       modelId,

--- a/src/lib/gateway-session.ts
+++ b/src/lib/gateway-session.ts
@@ -2,8 +2,9 @@
  * Gateway auth for a wizard run: a `phe_` scoped token the backend mints, with
  * pinned attribution, a spend cap and an expiry.
  *
- * Every mint failure throws. There is no other gateway to fall back to, and a
- * silent downgrade would spend uncapped, unattributed money to hide an outage.
+ * Every mint failure throws, since a silent downgrade would spend uncapped,
+ * unattributed money to hide an outage. The CI-only exception lives in
+ * legacy-gateway.ts.
  */
 
 import { logToFile } from '@utils/debug';
@@ -11,6 +12,7 @@ import { analytics } from '@utils/analytics';
 import { WizardError } from '@utils/wizard-abort';
 import { ErrorCodes } from '@lib/errors';
 import type { HostResolution } from '@lib/host-resolution';
+import { legacyGatewayAuth } from '@lib/legacy-gateway';
 
 export interface GatewayAuth {
   /** Base URL for model calls (no `/v1`; transports append their route). */
@@ -19,6 +21,8 @@ export interface GatewayAuth {
   token: string;
   /** The team the mint verified; rides the blob so dashboards keep a breakdown. */
   teamId?: number;
+  /** Set only by the CI fallback in legacy-gateway.ts. */
+  legacy?: boolean;
   /**
    * Instant past which a 401 on this bearer is age rather than a bad
    * credential: the cache re-mints past it, and a session still holding the
@@ -92,7 +96,19 @@ async function resolveGatewayAuth(
       'this run has no program to attribute its spend to',
     );
   }
-  const minted = await mintGatewayToken(host, accessToken, program);
+  let minted: MintedToken;
+  try {
+    minted = await mintGatewayToken(host, accessToken, program);
+  } catch (e) {
+    if (!(e instanceof GatewayMintRefused)) throw e;
+    const legacy = legacyGatewayAuth(host, accessToken, e.status);
+    if (!legacy) throw e;
+    logToFile(
+      `[gateway] mint refused this credential (HTTP ${e.status}); CI run staying on the legacy gateway`,
+    );
+    cached = { key, auth: legacy, staleAtMs: legacy.refreshAtMs };
+    return legacy;
+  }
   const expiresAtMs = Date.parse(minted.expiresAt);
   const ttlMs = expiresAtMs - Date.now();
   if (!Number.isFinite(expiresAtMs) || ttlMs < MIN_USABLE_TTL_MS) {

--- a/src/lib/legacy-gateway.ts
+++ b/src/lib/legacy-gateway.ts
@@ -1,0 +1,61 @@
+// CI-only fallback to the legacy Python gateway for the personal API key the mint refuses; delete this file and every `legacy` reference to rip it out.
+
+import type { GatewayAuth } from '@lib/gateway-session';
+import type { HostResolution } from '@lib/host-resolution';
+
+let enabled = false;
+
+/** Only the `--ci` runner turns this on. */
+export function setLegacyGatewayFallback(on: boolean): void {
+  enabled = on;
+}
+
+/** Legacy auth when the fallback is on and the mint cannot serve this credential (401, or 404 without the endpoint). */
+export function legacyGatewayAuth(
+  host: HostResolution,
+  accessToken: string,
+  mintStatus: number,
+): GatewayAuth | undefined {
+  if (!enabled || (mintStatus !== 401 && mintStatus !== 404)) return undefined;
+  return {
+    gatewayUrl: legacyGatewayUrl(host.apiHost),
+    token: accessToken,
+    legacy: true,
+    // Nothing re-mints this bearer, so a 401 on it is always a bad credential.
+    refreshAtMs: Number.POSITIVE_INFINITY,
+  };
+}
+
+function legacyGatewayUrl(apiHost: string): string {
+  if (apiHost.includes('host.docker.internal')) {
+    return 'http://host.docker.internal:3308/wizard';
+  }
+  if (apiHost.includes('localhost')) return 'http://localhost:3308/wizard';
+  if (
+    apiHost.includes('eu.posthog.com') ||
+    apiHost.includes('eu.i.posthog.com')
+  ) {
+    return 'https://gateway.eu.posthog.com/wizard';
+  }
+  return 'https://gateway.us.posthog.com/wizard';
+}
+
+/** The legacy gateway reads per-key metadata and flag headers and needs an explicit Bedrock opt-in. */
+export function legacyGatewayHeaders(
+  wizardMetadata: Record<string, string>,
+  wizardFlags: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'x-posthog-use-bedrock-fallback': 'true',
+  };
+  for (const [key, value] of Object.entries(wizardMetadata)) {
+    headers[
+      key.startsWith('X-POSTHOG-PROPERTY-') ? key : `X-POSTHOG-PROPERTY-${key}`
+    ] = value;
+  }
+  for (const [flagKey, variant] of Object.entries(wizardFlags)) {
+    if (!flagKey.toLowerCase().startsWith('wizard')) continue;
+    headers[`X-POSTHOG-FLAG-${flagKey.toUpperCase()}`] = variant;
+  }
+  return headers;
+}

--- a/src/lib/legacy-gateway.ts
+++ b/src/lib/legacy-gateway.ts
@@ -18,7 +18,7 @@ export function legacyGatewayAuth(
 ): GatewayAuth | undefined {
   if (!enabled || (mintStatus !== 401 && mintStatus !== 404)) return undefined;
   return {
-    gatewayUrl: legacyGatewayUrl(host.apiHost),
+    gatewayUrl: legacyGatewayUrl(host),
     token: accessToken,
     legacy: true,
     // Nothing re-mints this bearer, so a 401 on it is always a bad credential.
@@ -26,18 +26,15 @@ export function legacyGatewayAuth(
   };
 }
 
-function legacyGatewayUrl(apiHost: string): string {
-  if (apiHost.includes('host.docker.internal')) {
+function legacyGatewayUrl(host: HostResolution): string {
+  const { hostname } = new URL(host.apiHost);
+  if (hostname === 'host.docker.internal') {
     return 'http://host.docker.internal:3308/wizard';
   }
-  if (apiHost.includes('localhost')) return 'http://localhost:3308/wizard';
-  if (
-    apiHost.includes('eu.posthog.com') ||
-    apiHost.includes('eu.i.posthog.com')
-  ) {
-    return 'https://gateway.eu.posthog.com/wizard';
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return 'http://localhost:3308/wizard';
   }
-  return 'https://gateway.us.posthog.com/wizard';
+  return `https://gateway.${host.region}.posthog.com/wizard`;
 }
 
 /** The legacy gateway reads per-key metadata and flag headers and needs an explicit Bedrock opt-in. */

--- a/src/lib/runners/run-non-interactive.ts
+++ b/src/lib/runners/run-non-interactive.ts
@@ -1,4 +1,5 @@
 import { POSTHOG_DOCS_URL, type Harness, type Sequence } from '@lib/constants';
+import { setLegacyGatewayFallback } from '@lib/legacy-gateway';
 import {
   checkLocalServices,
   getLocalDev,
@@ -99,6 +100,8 @@ export function runNonInteractive(
   // (cloud / CI/CD) tags 'headless'; a dev/test `--ci` run upgrades 'dev' to
   // 'ci'. The mode string is the tag value.
   analytics.setTag('build', mode);
+  // Only `--ci` may fall back to the legacy gateway; see legacy-gateway.ts.
+  setLegacyGatewayFallback(mode === 'ci');
 
   void (async () => {
     const path = await import('path');


### PR DESCRIPTION
Under `--ci` only, a mint that refuses the credential (401/404) resolves to the legacy gateway instead of failing the run, with the whole fallback in `src/lib/legacy-gateway.ts` so it can be deleted in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)