### PR TITLE
fix(models): pin every model to an effort the mint allows

### DIFF
--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -233,7 +233,11 @@ describe('switchboard composed clamp', () => {
               thinkingLevel: undefined,
             }
           : program === 'metrics'
-          ? { ...DEFAULT_RESOLVED, model: DEFAULT_AGENT_MODEL, thinkingLevel: undefined }
+          ? {
+              ...DEFAULT_RESOLVED,
+              model: DEFAULT_AGENT_MODEL,
+              thinkingLevel: undefined,
+            }
           : program === 'replay-vision'
           ? {
               ...DEFAULT_RESOLVED,

--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -41,9 +41,9 @@ import { runBindingCases } from '@lib/agent/runner/switchboard/flags/__tests__/b
 const PROGRAM_IDS = PROGRAM_REGISTRY.map((c) => c.id);
 const DEFAULT_RESOLVED = {
   sequence: Sequence.linear,
-  harness: Harness.anthropic,
-  model: DEFAULT_AGENT_MODEL,
-  thinkingLevel: undefined,
+  harness: Harness.pi,
+  model: GPT5_6_SOL_MODEL,
+  thinkingLevel: 'medium',
 } as const;
 
 describe('switchboard PROGRAM_BINDINGS', () => {
@@ -124,7 +124,7 @@ describe('switchboard PROGRAM_BINDINGS', () => {
         sequence: DEFAULT_BINDING.sequence,
         harness: DEFAULT_BINDING.harness,
         model: DEFAULT_BINDING.model,
-        thinkingLevel: undefined,
+        thinkingLevel: DEFAULT_BINDING.thinkingLevel,
       },
       trace: { harness: 'binding', model: 'binding', sequence: 'binding' },
     },
@@ -154,7 +154,7 @@ describe('switchboard CLI precedence (dev builds)', () => {
         sequence: Sequence.orchestrator,
         harness: Harness.pi,
         model: 'openai/o4-mini',
-        thinkingLevel: undefined,
+        thinkingLevel: 'medium',
       },
       trace: { harness: 'flag', model: 'cli', sequence: 'flag' },
     },
@@ -170,7 +170,7 @@ describe('switchboard CLI precedence (dev builds)', () => {
         sequence: Sequence.linear,
         harness: Harness.pi,
         model: 'openai/gpt-5',
-        thinkingLevel: undefined,
+        thinkingLevel: 'medium',
       },
       trace: { harness: 'cli', model: 'cli', sequence: 'binding' },
     },
@@ -204,8 +204,8 @@ describe('switchboard decision trace', () => {
       binding: {
         sequence: Sequence.orchestrator,
         harness: Harness.pi,
-        model: DEFAULT_AGENT_MODEL,
-        thinkingLevel: undefined,
+        model: GPT5_6_SOL_MODEL,
+        thinkingLevel: 'medium',
       },
       trace: { harness: 'flag', model: 'binding', sequence: 'flag' },
     },
@@ -225,19 +225,22 @@ describe('switchboard composed clamp', () => {
       // clamp holds every sequence at linear — the orchestrator bindings
       // (metrics, replay-vision) included; other axes keep their bindings.
       expect(resolveBinding(ctx)).toEqual(
-        program === 'posthog-integration'
-          ? { ...DEFAULT_RESOLVED, harness: Harness.pi }
-          : program === 'ai-observability'
-          ? { ...DEFAULT_RESOLVED, model: SONNET_5_MODEL }
-          : program === 'error-tracking-upload-source-maps'
+        program === 'ai-observability'
           ? {
               ...DEFAULT_RESOLVED,
-              harness: Harness.pi,
-              model: GPT5_6_SOL_MODEL,
-              thinkingLevel: 'medium',
+              harness: Harness.anthropic,
+              model: SONNET_5_MODEL,
+              thinkingLevel: undefined,
             }
           : program === 'metrics'
-          ? { ...DEFAULT_RESOLVED, harness: Harness.pi }
+          ? { ...DEFAULT_RESOLVED, model: DEFAULT_AGENT_MODEL, thinkingLevel: undefined }
+          : program === 'replay-vision'
+          ? {
+              ...DEFAULT_RESOLVED,
+              harness: Harness.anthropic,
+              model: DEFAULT_AGENT_MODEL,
+              thinkingLevel: undefined,
+            }
           : DEFAULT_RESOLVED,
       );
       expect(ctx.trace?.sequence).toBe('composed');

--- a/src/lib/agent/runner/__tests__/switchboard.test.ts
+++ b/src/lib/agent/runner/__tests__/switchboard.test.ts
@@ -30,6 +30,7 @@ import {
 } from '@lib/agent/runner/switchboard';
 import {
   modelCapabilities,
+  MINT_ALLOWED_EFFORTS,
   isValidModel,
   requireKnownModel,
   TRIAGE_MODELS,
@@ -286,14 +287,29 @@ describe('switchboard modelCapabilities (stage 2: effective effort)', () => {
     for (const m of [GPT5_6_LUNA_MODEL, GPT5_6_TERRA_MODEL, GPT5_6_SOL_MODEL]) {
       expect(modelCapabilities(m).reasoning).toBe(true);
     }
-    // luna/sol stay low (fast); terra runs medium as the sonnet-tier parallel.
+    // luna stays low (fast); terra and sol run medium, the level the mint pins.
     expect(modelCapabilities(GPT5_6_LUNA_MODEL).thinkingLevel).toBe('low');
     expect(modelCapabilities(GPT5_6_TERRA_MODEL).thinkingLevel).toBe('medium');
-    expect(modelCapabilities(GPT5_6_SOL_MODEL).thinkingLevel).toBe('low');
-    // Anthropic default carries no explicit effort — the harness default stands.
-    expect(
-      modelCapabilities(DEFAULT_AGENT_MODEL).thinkingLevel,
-    ).toBeUndefined();
+    expect(modelCapabilities(GPT5_6_SOL_MODEL).thinkingLevel).toBe('medium');
+    // The anthropic default carries an explicit effort: an unpinned reasoning
+    // model leaves the level to the harness, which the mint then refuses.
+    expect(modelCapabilities(DEFAULT_AGENT_MODEL).thinkingLevel).toBe('high');
+  });
+
+  // The mint pins effort per model, so a reasoning model resolving to a level
+  // outside its pin is refused mid-run with no tool calls.
+  it('resolves every model to an effort the mint allows', () => {
+    for (const model of VALID_MODELS) {
+      const { reasoning, thinkingLevel } = modelCapabilities(model);
+      const allowed = MINT_ALLOWED_EFFORTS[model] ?? [];
+      // A reasoning model with no pinned level sends the harness default, which
+      // is never one of the mint's levels; no reasoning at all is its "none".
+      const declared = reasoning ? thinkingLevel ?? 'harness-default' : 'off';
+      expect([model, allowed.includes(declared as never)]).toEqual([
+        model,
+        true,
+      ]);
+    }
   });
 
   it('defaults unknown models by transport: anthropic on, openai off', () => {

--- a/src/lib/agent/runner/switchboard/flags/__tests__/binding-cases.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/binding-cases.ts
@@ -4,7 +4,7 @@
  * `runBindingCases` turns a table into `it` blocks — specs stay declarative.
  */
 import { describe, it, expect } from 'vitest';
-import { DEFAULT_AGENT_MODEL, Harness, Sequence } from '@lib/constants';
+import { GPT5_6_SOL_MODEL, Harness, Sequence } from '@lib/constants';
 import {
   resolveBinding,
   type SwitchboardCtx,
@@ -57,9 +57,9 @@ describe('runBindingCases', () => {
       ctx: { program: 'posthog-integration', flags: {} },
       binding: {
         sequence: Sequence.linear,
-        harness: Harness.anthropic,
-        model: DEFAULT_AGENT_MODEL,
-        thinkingLevel: undefined,
+        harness: Harness.pi,
+        model: GPT5_6_SOL_MODEL,
+        thinkingLevel: 'medium',
       },
       trace: { harness: 'binding', model: 'binding', sequence: 'binding' },
     },

--- a/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
+++ b/src/lib/agent/runner/switchboard/flags/__tests__/flags.test.ts
@@ -44,17 +44,17 @@ const PROGRAM_IDS = PROGRAM_REGISTRY.map((c) => c.id);
 const ORCH = WIZARD_ORCHESTRATOR_FLAG_KEY;
 const SD = WIZARD_SELF_DRIVING_USE_PI_HARNESS_FLAG_KEY;
 
-const LINEAR_ANTHROPIC_DEFAULT = {
+const LINEAR_DEFAULT = {
   sequence: Sequence.linear,
-  harness: Harness.anthropic,
-  model: DEFAULT_AGENT_MODEL,
-  thinkingLevel: undefined,
+  harness: Harness.pi,
+  model: GPT5_6_SOL_MODEL,
+  thinkingLevel: 'medium',
 } as const;
 const ORCHESTRATOR_PI_DEFAULT = {
   sequence: Sequence.orchestrator,
   harness: Harness.pi,
-  model: DEFAULT_AGENT_MODEL,
-  thinkingLevel: undefined,
+  model: GPT5_6_SOL_MODEL,
+  thinkingLevel: 'medium',
 } as const;
 
 describe('flag declarations', () => {
@@ -79,18 +79,18 @@ describe('the truth table — posthog-integration × wizard-orchestrator', () =>
       {
         name: 'off/absent → linear on anthropic, default model',
         ctx: { program: 'posthog-integration', flags: {} },
-        binding: LINEAR_ANTHROPIC_DEFAULT,
+        binding: LINEAR_DEFAULT,
         trace: { harness: 'binding', model: 'binding', sequence: 'binding' },
       },
       {
         name: "'false' → identical to absent",
         ctx: { program: 'posthog-integration', flags: { [ORCH]: 'false' } },
-        binding: LINEAR_ANTHROPIC_DEFAULT,
+        binding: LINEAR_DEFAULT,
       },
       {
         name: "garbage ('banana') → identical to absent",
         ctx: { program: 'posthog-integration', flags: { [ORCH]: 'banana' } },
-        binding: LINEAR_ANTHROPIC_DEFAULT,
+        binding: LINEAR_DEFAULT,
       },
       {
         name: "'true' → orchestrator on pi; model stays the binding default (frontmatter decides per task)",
@@ -110,7 +110,7 @@ describe('the truth table — self-driving × its pi payload flag', () => {
       {
         name: 'off/absent → linear on anthropic, default model',
         ctx: { program: 'self-driving', flags: {} },
-        binding: LINEAR_ANTHROPIC_DEFAULT,
+        binding: LINEAR_DEFAULT,
       },
       {
         name: 'on + full payload → pi on the payload model/effort, payload may pin the sequence too',
@@ -127,7 +127,7 @@ describe('the truth table — self-driving × its pi payload flag', () => {
         },
       },
       {
-        name: 'on + model-only payload → pi on that model, table-default effort, linear',
+        name: "on + model-only payload → pi on that model, the binding's effort, linear",
         ctx: {
           program: 'self-driving',
           flags: { [SD]: 'true' },
@@ -137,7 +137,7 @@ describe('the truth table — self-driving × its pi payload flag', () => {
           sequence: Sequence.linear,
           harness: Harness.pi,
           model: GPT5_6_TERRA_MODEL,
-          thinkingLevel: undefined,
+          thinkingLevel: 'medium',
         },
       },
       {
@@ -161,12 +161,12 @@ describe('the truth table — self-driving × its pi payload flag', () => {
           flags: { [SD]: 'true' },
           flagPayloads: { [SD]: { model: 'banana' } },
         },
-        binding: LINEAR_ANTHROPIC_DEFAULT,
+        binding: LINEAR_DEFAULT,
       },
       {
         name: 'on + missing payload → fail closed to the default',
         ctx: { program: 'self-driving', flags: { [SD]: 'true' } },
-        binding: LINEAR_ANTHROPIC_DEFAULT,
+        binding: LINEAR_DEFAULT,
       },
     ],
     setSurface,
@@ -275,14 +275,18 @@ describe('isolation — everything on at once', () => {
         });
       } else if (program === 'ai-observability') {
         expect(resolved).toEqual({
-          ...LINEAR_ANTHROPIC_DEFAULT,
+          ...LINEAR_DEFAULT,
+          harness: Harness.anthropic,
           model: SONNET_5_MODEL,
+          thinkingLevel: undefined,
         });
       } else if (program === 'metrics') {
         // Orchestrator + pi from its OWN binding, not the flag; stage models
         // are pinned context-mill side in the flow frontmatter.
         expect(resolved).toEqual({
           ...ORCHESTRATOR_PI_DEFAULT,
+          model: DEFAULT_AGENT_MODEL,
+          thinkingLevel: undefined,
         });
       } else if (program === 'error-tracking-upload-source-maps') {
         // Pi + sol medium from its OWN binding, not the flag.
@@ -297,8 +301,11 @@ describe('isolation — everything on at once', () => {
         // wizard-orchestrator experiment does not cover this program, so it
         // lands here whether the flag is on or off. Anthropic, not pi.
         expect(resolved).toEqual({
-          ...LINEAR_ANTHROPIC_DEFAULT,
+          ...LINEAR_DEFAULT,
           sequence: Sequence.orchestrator,
+          harness: Harness.anthropic,
+          model: DEFAULT_AGENT_MODEL,
+          thinkingLevel: undefined,
         });
         expect(ctx.trace).toEqual({
           harness: 'binding',
@@ -306,7 +313,7 @@ describe('isolation — everything on at once', () => {
           sequence: 'binding',
         });
       } else {
-        expect(resolved).toEqual(LINEAR_ANTHROPIC_DEFAULT);
+        expect(resolved).toEqual(LINEAR_DEFAULT);
         expect(ctx.trace).toEqual({
           harness: 'binding',
           model: 'binding',

--- a/src/lib/agent/runner/switchboard/index.ts
+++ b/src/lib/agent/runner/switchboard/index.ts
@@ -105,8 +105,9 @@ export interface ProgramBinding {
 // Legacy fallback; new programs should explicitly choose Pi and prefer orchestration.
 export const DEFAULT_BINDING: ProgramBinding = {
   sequence: Sequence.linear,
-  harness: Harness.anthropic,
-  model: DEFAULT_AGENT_MODEL,
+  harness: Harness.pi,
+  model: GPT5_6_SOL_MODEL,
+  thinkingLevel: 'medium',
 };
 
 /**

--- a/src/lib/agent/runner/switchboard/models.ts
+++ b/src/lib/agent/runner/switchboard/models.ts
@@ -38,17 +38,40 @@ export interface ModelCapabilities {
   thinkingLevel?: ThinkingLevel;
 }
 
-/** Explicit per-model traits. Anything absent falls back to `defaultCaps`. */
+/**
+ * Explicit per-model traits. Anything absent falls back to `defaultCaps`.
+ *
+ * A reasoning model without a `thinkingLevel` leaves the effort to the harness,
+ * and the mint pins effort per model (posthog `WIZARD_MODEL_ALLOWLIST`), so an
+ * unpinned reasoning model is refused with no tool calls. Every level below is
+ * one the mint allows for that model.
+ */
 export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
-  [SONNET_5_MODEL]: { reasoning: true },
-  [HAIKU_MODEL]: { reasoning: true },
+  // The mint takes sonnet 5 at `none` or `high`; high is the only level it
+  // serves once reasoning is on.
+  [SONNET_5_MODEL]: { reasoning: true, thinkingLevel: 'high' },
+  // The mint takes haiku with no effort parameter at all, which is `off`.
+  [HAIKU_MODEL]: { reasoning: true, thinkingLevel: 'off' },
   // The openai 5.6 line; all reasoning models, so they must opt in past the
   // openai-completions default (reasoning off). Luna stays low for cheap,
   // short-context mechanical work; terra runs medium as the sonnet-tier parallel
   // — enough reasoning depth for the judgment tasks without high's latency blowup.
   [GPT5_6_LUNA_MODEL]: { reasoning: true, thinkingLevel: 'low' },
   [GPT5_6_TERRA_MODEL]: { reasoning: true, thinkingLevel: 'medium' },
-  [GPT5_6_SOL_MODEL]: { reasoning: true, thinkingLevel: 'low' },
+  [GPT5_6_SOL_MODEL]: { reasoning: true, thinkingLevel: 'medium' },
+};
+
+/**
+ * The mint's per-model effort pin, mirrored from posthog
+ * `WIZARD_MODEL_ALLOWLIST`. `'off'` is the CLI's spelling of the mint's
+ * `"none"` — a call carrying no effort parameter.
+ */
+export const MINT_ALLOWED_EFFORTS: Record<string, readonly ThinkingLevel[]> = {
+  [SONNET_5_MODEL]: ['off', 'high'],
+  [HAIKU_MODEL]: ['off'],
+  [GPT5_6_LUNA_MODEL]: ['low'],
+  [GPT5_6_SOL_MODEL]: ['medium'],
+  [GPT5_6_TERRA_MODEL]: ['low', 'medium', 'high'],
 };
 
 // Local model choices; gateway admission also requires allowed models, efforts, and prompt compatibility.


### PR DESCRIPTION
Sonnet 5 dispatched with no pinned reasoning effort, so pi sent the harness default and the gateway mint's per-model effort pin refused it, failing every pi run with zero tool calls.