### PR TITLE
fix(tui): mask a vaulted answer as the user types it

### DIFF
--- a/src/lib/wizard-session.ts
+++ b/src/lib/wizard-session.ts
@@ -162,8 +162,8 @@ export interface AskQuestion {
    * Only meaningful for kind='text'. When true, the wizard-tools `wizard_ask`
    * tool stores the user's answer in the session secret vault and returns
    * `{ secretRef }` to the agent instead of the plain string — so the value
-   * never enters the LLM conversation. The TUI may also mask input
-   * accordingly. See `secret-vault.ts`.
+   * never enters the LLM conversation. The TUI masks the input as it is typed
+   * (see `shouldMaskAnswer`). See `secret-vault.ts`.
    */
   sensitive?: boolean;
 }

--- a/src/ui/tui/__tests__/WizardAskScreen.test.ts
+++ b/src/ui/tui/__tests__/WizardAskScreen.test.ts
@@ -23,6 +23,7 @@ import { WizardStore } from '@ui/tui/store';
 import {
   handleAskKey,
   isRequiredButEmpty,
+  shouldMaskAnswer,
 } from '@ui/tui/screens/WizardAskScreen';
 
 const pending = {
@@ -59,6 +60,22 @@ describe('handleAskKey', () => {
       port: '__cancelled__',
     });
     expect(store.session.pendingQuestion).toBeNull();
+  });
+});
+
+describe('shouldMaskAnswer', () => {
+  it('masks a text answer the agent asked to vault', () => {
+    expect(shouldMaskAnswer({ kind: 'text', sensitive: true })).toBe(true);
+  });
+
+  it('leaves an ordinary text answer visible', () => {
+    expect(shouldMaskAnswer({ kind: 'text' })).toBe(false);
+    expect(shouldMaskAnswer({ kind: 'text', sensitive: false })).toBe(false);
+  });
+
+  it('never masks a picker, which has nothing to type', () => {
+    expect(shouldMaskAnswer({ kind: 'single', sensitive: true })).toBe(false);
+    expect(shouldMaskAnswer({ kind: 'multi', sensitive: true })).toBe(false);
   });
 });
 

--- a/src/ui/tui/screens/WizardAskScreen.tsx
+++ b/src/ui/tui/screens/WizardAskScreen.tsx
@@ -7,7 +7,7 @@
  */
 
 import { Box, Text, useInput } from 'ink';
-import { TextInput } from '@inkjs/ui';
+import { PasswordInput, TextInput } from '@inkjs/ui';
 import { useEffect, useState, useSyncExternalStore } from 'react';
 import type { WizardStore } from '@ui/tui/store';
 import {
@@ -35,6 +35,28 @@ export function handleAskKey(
   store: Pick<WizardStore, 'cancelPendingQuestion'>,
 ): void {
   if (key.escape) store.cancelPendingQuestion();
+}
+
+/**
+ * Whether the overlay must mask what the user types for this question.
+ *
+ * A `sensitive` answer is one the wizard has already promised to treat as a
+ * secret: `wizard_ask` vaults it and hands the agent an opaque `secretRef`, so
+ * the raw string never enters the model's conversation. Every other boundary
+ * guards it the same way — the skip events carry no free text, handoff prose is
+ * kept out of telemetry — but the overlay that collects it echoed it back in
+ * plain text as it was typed, which is the one place a database password or an
+ * API key is read by a person other than its owner: a shared screen, a pairing
+ * session, a recorded terminal.
+ *
+ * `kind` is checked as well as the flag. The tool already rejects `sensitive`
+ * on a picker, and a picker has nothing to mask, so this keeps the predicate
+ * total over a question rather than relying on that rejection.
+ */
+export function shouldMaskAnswer(
+  question: Pick<AskQuestion, 'kind' | 'sensitive'>,
+): boolean {
+  return question.kind === 'text' && question.sensitive === true;
 }
 
 /**
@@ -303,14 +325,15 @@ const QuestionInput = ({ question, onSubmit }: QuestionInputProps) => {
       );
     }
 
-    case 'text':
+    case 'text': {
+      const Input = shouldMaskAnswer(question) ? PasswordInput : TextInput;
       return (
         // `width="100%"` on both the column and the hint row anchors them to
         // the modal's content width — without it, Ink/Yoga shrinks the column
         // to fit its widest child, so the right-aligned hint walks left/right
         // as the typed text changes width.
         <Box flexDirection="column" width="100%">
-          <TextInput
+          <Input
             placeholder="Type your answer"
             onSubmit={(value) => onSubmit(value)}
           />
@@ -322,5 +345,6 @@ const QuestionInput = ({ question, onSubmit }: QuestionInputProps) => {
           </Box>
         </Box>
       );
+    }
   }
 };


### PR DESCRIPTION
## Problem

`wizard_ask` lets a question declare itself `sensitive`. When it does, the tool
stores the user's answer in the session secret vault and returns an opaque
`{ secretRef }` to the agent, so the raw string never enters the model's
conversation.

The overlay that collects it did not honour that. Every `kind: 'text'` question
rendered through the plain `TextInput`, so a vaulted answer was echoed on screen
character by character while it was typed — the one place a credential is read
by someone other than its owner: a shared screen, a pairing session, a recorded
terminal.

It is the only unguarded boundary left around these values. The vault keeps them
out of the conversation, the orchestrator's skip events carry a closed set of
reasons rather than free text, and handoff prose is deliberately kept out of
telemetry for the same reason. `AskQuestion.sensitive` even documented the
overlay behaviour as "the TUI may also mask input accordingly" — it never did.

## Why

Found while reading the telemetry for the wizard's data-source setup task — the
flow whose credential prompt is the step users most often back out of. Masking
does not change that funnel on its own; it closes a straightforward exposure on
the prompt that collects the values.

## Changes

- Route a masked question to `@inkjs/ui`'s `PasswordInput` instead of
  `TextInput`. Same props, same submit contract; only the rendering differs.
- `shouldMaskAnswer` is exported and unit-tested rather than inlined in the
  switch, and checks `kind` as well as the flag so it stays total over a
  question (the tool already rejects `sensitive` on a picker, and a picker has
  nothing to type).
- Correct the `AskQuestion.sensitive` doc comment, which described masking as
  optional.

Nothing else changes: an ordinary text question renders exactly as before.

## Test plan

- `shouldMaskAnswer` unit tests added to `WizardAskScreen.test.ts` (masked
  text, unmasked text, pickers).
- `vitest run src/ui` — 306 tests pass.
- `tsc --noEmit` clean for the touched files; prettier and eslint clean.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
