### PR TITLE
fix(pi): name why an agent run aborted

### DIFF
--- a/src/lib/agent/runner/harness/pi/__tests__/completion.test.ts
+++ b/src/lib/agent/runner/harness/pi/__tests__/completion.test.ts
@@ -1,4 +1,4 @@
-import { completionFailure } from '../completion';
+import { completionFailure, runErrorType } from '../completion';
 import { AgentErrorType } from '@lib/agent/signals';
 
 describe('completionFailure', () => {
@@ -38,5 +38,22 @@ describe('completionFailure', () => {
         completionFailure({ toolCalls: 5, openTasks: false }),
       ).toBeUndefined();
     });
+  });
+});
+
+describe('runErrorType', () => {
+  it('reads a rate limit out of the thrown message', () => {
+    expect(runErrorType('429 Too Many Requests')).toBe(
+      AgentErrorType.RATE_LIMIT,
+    );
+    expect(runErrorType('Gateway rate limit exceeded')).toBe(
+      AgentErrorType.RATE_LIMIT,
+    );
+    expect(runErrorType('RATE LIMIT reached')).toBe(AgentErrorType.RATE_LIMIT);
+  });
+
+  it('falls back to a generic API error', () => {
+    expect(runErrorType('socket hang up')).toBe(AgentErrorType.API_ERROR);
+    expect(runErrorType('')).toBe(AgentErrorType.API_ERROR);
   });
 });

--- a/src/lib/agent/runner/harness/pi/completion.ts
+++ b/src/lib/agent/runner/harness/pi/completion.ts
@@ -11,3 +11,20 @@ export function completionFailure(args: {
   if (args.openTasks) return AgentErrorType.INCOMPLETE_TASKS;
   return undefined;
 }
+
+/**
+ * Which error type a thrown pi run reports.
+ *
+ * Both pi entry points classified the caught message inline with the same two
+ * needles, and both did it *after* firing `agent aborted` — so the event that
+ * announces the abort could not name it. Pulling the classification out lets
+ * each entry point decide the type first and hand it to the event, and keeps
+ * the one rule in one place.
+ */
+export function runErrorType(message: string): AgentErrorType {
+  const lower = message.toLowerCase();
+  if (lower.includes('rate limit') || lower.includes('429')) {
+    return AgentErrorType.RATE_LIMIT;
+  }
+  return AgentErrorType.API_ERROR;
+}

--- a/src/lib/agent/runner/harness/pi/index.ts
+++ b/src/lib/agent/runner/harness/pi/index.ts
@@ -42,7 +42,7 @@ import type {
 } from '../types';
 import type { BootstrapResult } from '@lib/agent/runner/shared/types';
 import type { TaskStore } from './tasks';
-import { completionFailure } from './completion';
+import { completionFailure, runErrorType } from './completion';
 
 /** Injects the MCP server `instructions` pi-mcp-adapter drops (project env, skill steer, tool domains) into the system prompt, falling back to a bootstrap-derived project block when the warm-connect captured none. */
 function piMcpContext(
@@ -226,8 +226,13 @@ export const piBackend: AgentHarness = {
         duration_seconds: Math.round(durationMs / 1000),
       };
     };
-    const captureAborted = () =>
+    // `reason` is the closed AgentErrorType this run is about to return. Without
+    // it every terminal path below — a security termination, a no-op run, a plan
+    // left open, a gateway error — arrived as the same unlabelled event, so a
+    // run that died could be counted but not diagnosed.
+    const captureAborted = (reason: AgentErrorType) =>
       analytics.wizardCapture('agent aborted', {
+        reason,
         ...runDurations(),
         model: modelId,
       });
@@ -588,7 +593,7 @@ export const piBackend: AgentHarness = {
         logToFile(
           `[pi] terminated: YARA violation (blocked ${security.state.blockedCount} call(s))`,
         );
-        captureAborted();
+        captureAborted(AgentErrorType.YARA_VIOLATION);
         return { error: AgentErrorType.YARA_VIOLATION };
       }
 
@@ -604,14 +609,14 @@ export const piBackend: AgentHarness = {
         analytics.wizardCapture('agent no progress', {
           assistant_turns: assistantTurns,
         });
-        captureAborted();
+        captureAborted(failure);
         return { error: failure };
       }
       if (failure === AgentErrorType.INCOMPLETE_TASKS) {
         spinner.stop('Agent stopped before finishing');
         logToFile('[pi] incomplete: tasks left open');
         analytics.wizardCapture('agent incomplete tasks', { open_tasks: true });
-        captureAborted();
+        captureAborted(failure);
         return { error: failure };
       }
 
@@ -658,13 +663,9 @@ export const piBackend: AgentHarness = {
       logToFile(`[pi] run error: ${message}`);
       spinner.stop(config.errorMessage ?? `${config.integrationLabel} failed`);
       getUI().log.error(`pi backend error: ${message}`);
-      captureAborted();
-
-      const lower = message.toLowerCase();
-      if (lower.includes('rate limit') || lower.includes('429')) {
-        return { error: AgentErrorType.RATE_LIMIT, message };
-      }
-      return { error: AgentErrorType.API_ERROR, message };
+      const error = runErrorType(message);
+      captureAborted(error);
+      return { error, message };
     }
   },
 

--- a/src/lib/agent/runner/harness/pi/task.ts
+++ b/src/lib/agent/runner/harness/pi/task.ts
@@ -42,6 +42,7 @@ import {
   GATEWAY_PROVIDER,
   withGatewayRemint,
 } from './gateway';
+import { runErrorType } from './completion';
 import { assembleCommandments } from '../../switchboard/commandments';
 import {
   applyOutroMarkers,
@@ -194,8 +195,13 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
       duration_seconds: Math.round(durationMs / 1000),
     };
   };
-  const captureAborted = () =>
+  // `reason` is the closed AgentErrorType this run is about to return. Without
+  // it every terminal path below — a security termination, a rate limit, a
+  // gateway error — arrived as the same unlabelled event, so a task agent that
+  // died could be counted but not diagnosed.
+  const captureAborted = (reason: AgentErrorType) =>
     analytics.wizardCapture('agent aborted', {
+      reason,
       ...runDurations(),
       model: modelId,
       ...analyticsProperties,
@@ -490,7 +496,7 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
       logToFile(
         `[pi-task] terminated: YARA violation (blocked ${security.state.blockedCount} call(s))`,
       );
-      captureAborted();
+      captureAborted(AgentErrorType.YARA_VIOLATION);
       return { error: AgentErrorType.YARA_VIOLATION };
     }
 
@@ -529,11 +535,8 @@ export async function runPiTask(inputs: TaskRunInputs): Promise<AgentResult> {
     if (errorMessage || spinnerMessage) {
       spinner.stop(errorMessage ?? 'Task failed');
     }
-    captureAborted();
-    const lower = message.toLowerCase();
-    if (lower.includes('rate limit') || lower.includes('429')) {
-      return { error: AgentErrorType.RATE_LIMIT, message };
-    }
-    return { error: AgentErrorType.API_ERROR, message };
+    const error = runErrorType(message);
+    captureAborted(error);
+    return { error, message };
   }
 }


### PR DESCRIPTION
## Problem

Both pi entry points — `piBackend.run` and `runPiTask`, the one the orchestrator
drives — fire a single `agent aborted` event from several unrelated terminal
paths:

- a YARA security termination,
- a run that made no tool call at all,
- a run that left its own plan open,
- a rate limit,
- a generic gateway error.

The event carried only `duration_*` and `model`, so all five arrived as the same
unlabelled abort. In the current data for the data-source setup flow, `agent
aborted` shows up with an empty reason dimension, alongside an equal number of
tasks failed as `no-report` — the same runs, seen from the queue's side. A task
agent that died can be counted but not diagnosed, and one of the five causes is a
security termination on the one step that handles live credentials.

The linear sequence's own `agent aborted` has carried a `reason` all along; only
the pi harness omits it.

## Why

Came out of reading the telemetry for the wizard's data-source setup task. This
does not change the funnel — it makes the handful of runs that end this way
attributable, so the next read of that telemetry can tell a security stop from a
rate limit instead of guessing.

## Changes

- `captureAborted` takes the `AgentErrorType` the path is about to return and
  stamps it as `reason`. The discriminator was already in hand at every call
  site — each returns that type on the next line. It is a closed enum, so no
  free text reaches telemetry.
- Both entry points classified a thrown message with the same two needles,
  inline and *after* the capture, which is why the type was not available to the
  event. That moves to `runErrorType` in `completion.ts`, beside
  `completionFailure`, and is unit-tested there.

No behaviour changes for the user: every path returns exactly the same
`AgentResult` as before.

Related but not the same fix: [#1109](https://github.com/PostHog/wizard/pull/1109)
touches these two lines to add an `abort_kind` that separates a pi run-incomplete
event from the linear `[ABORT]` one. It is a constant per site, so it does not
say *which* pi path fired. The two are complementary.

## Test plan

- `runErrorType` unit tests added to the existing `completion.test.ts`.
- `vitest run src/lib/agent/runner/harness/pi` — 127 tests pass.
- `tsc --noEmit` introduces no new errors in the harness; prettier and eslint
  clean on the touched files.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
